### PR TITLE
Adding a loading state on 'regio' page, and added some accessibility tweaks

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "singleQuote": true }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@next/bundle-analyzer": "^9.4.4",
     "@svgr/webpack": "^5.4.0",
     "cross-env": "^7.0.2",
-    "node-sass": "^4.14.1"
+    "node-sass": "^4.14.1",
+    "prettier": "^2.0.5"
   },
   "scripts": {
     "analyze": "cross-env ANALYZE=true yarn build",

--- a/src/components/barScale/index.js
+++ b/src/components/barScale/index.js
@@ -1,7 +1,17 @@
 import React from 'react';
 import formatNumber from 'utils/formatNumber';
+import ScreenReaderOnly from 'components/screenReaderOnly';
+import replaceVariablesInText from 'utils/replaceVariablesInText';
 
-const BarScale = ({ min, max, value, kritiekeWaarde, gradient, id }) => {
+const BarScale = ({
+  min,
+  max,
+  value,
+  kritiekeWaarde,
+  gradient,
+  id,
+  screenReaderText,
+}) => {
   let valueOffset = ((value - min) / (max - min)) * 100;
   const rand = React.useRef(Math.random().toString(36).substring(2, 15));
 
@@ -82,74 +92,84 @@ const BarScale = ({ min, max, value, kritiekeWaarde, gradient, id }) => {
   };
 
   return (
-    <div className="barScale">
-      <svg xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <clipPath id={`cut-off${id}-${rand.current}`}>
-            <rect
-              x="0"
-              y="20"
-              rx="2"
-              ry="2"
-              width={`${valueOffset}%`}
-              height="10"
-              fill="red"
-            />
-          </clipPath>
-          <linearGradient
-            id={`barColor${id}-${rand.current}`}
-            gradientUnits="userSpaceOnUse"
-          >
-            {gradient.map((stop) => {
-              return (
-                <stop
-                  key={`stop${stop.offset}`}
-                  stopColor={stop.color}
-                  offset={stop.offset}
-                />
-              );
-            })}
-          </linearGradient>
-        </defs>
+    <>
+      {screenReaderText && (
+        <ScreenReaderOnly>
+          {replaceVariablesInText(screenReaderText, {
+            value,
+            kritiekeWaarde,
+          })}
+        </ScreenReaderOnly>
+      )}
+      <div className="barScale" aria-hidden>
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <clipPath id={`cut-off${id}-${rand.current}`}>
+              <rect
+                x="0"
+                y="20"
+                rx="2"
+                ry="2"
+                width={`${valueOffset}%`}
+                height="10"
+                fill="red"
+              />
+            </clipPath>
+            <linearGradient
+              id={`barColor${id}-${rand.current}`}
+              gradientUnits="userSpaceOnUse"
+            >
+              {gradient.map((stop) => {
+                return (
+                  <stop
+                    key={`stop${stop.offset}`}
+                    stopColor={stop.color}
+                    offset={stop.offset}
+                  />
+                );
+              })}
+            </linearGradient>
+          </defs>
 
-        <rect
-          x="0"
-          y="20"
-          rx="2"
-          ry="2"
-          width="100%"
-          height="10"
-          clipPath={`url(#cut-off${id}-${rand.current})`}
-          fill={`url(#barColor${id}-${rand.current})`}
-        />
-        <rect
-          x="0"
-          y="26"
-          rx="2"
-          ry="2"
-          width="100%"
-          height="4"
-          fill={`url(#barColor${id}-${rand.current})`}
-        />
-        <line
-          x1={`${valueOffset}%`}
-          x2={`${valueOffset}%`}
-          y1="30"
-          y2="10"
-          r={valueOffset}
-          strokeWidth="3"
-          stroke="#000"
-        />
-        {drawKritiekeWaarde(kritiekeWaarde)}
-        {drawKritiekeWaardeLabel(kritiekeWaarde)}
-        {drawValue(value)}
-      </svg>
+          <rect
+            x="0"
+            y="20"
+            rx="2"
+            ry="2"
+            width="100%"
+            height="10"
+            clipPath={`url(#cut-off${id}-${rand.current})`}
+            fill={`url(#barColor${id}-${rand.current})`}
+          />
+          <rect
+            x="0"
+            y="26"
+            rx="2"
+            ry="2"
+            width="100%"
+            height="4"
+            fill={`url(#barColor${id}-${rand.current})`}
+          />
+          <line
+            x1={`${valueOffset}%`}
+            x2={`${valueOffset}%`}
+            y1="30"
+            y2="10"
+            r={valueOffset}
+            strokeWidth="3"
+            stroke="#000"
+          />
+          {drawKritiekeWaarde(kritiekeWaarde)}
+          {drawKritiekeWaardeLabel(kritiekeWaarde)}
+          {drawValue(value)}
+        </svg>
 
-      <div className="scale">
-        <div className="minValue">{min}</div>
-        <div className="maxValue">{max}</div>
+        <div className="scale">
+          <div className="minValue">{min}</div>
+          <div className="maxValue">{max}</div>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/graphHeader/index.js
+++ b/src/components/graphHeader/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import styles from './graphHeader.module.scss';
+import ScreenReaderOnly from 'components/screenReaderOnly';
 
-const GraphHeader = ({ Icon, title }) => {
+const GraphHeader = ({ Icon, title, regio, headingRef }) => {
   return (
     <div className={styles.graphHeader}>
       {Icon && (
@@ -9,7 +10,15 @@ const GraphHeader = ({ Icon, title }) => {
           <Icon />
         </div>
       )}
-      <h3>{title}</h3>
+      {/*
+        An optional ref and the tabIndex makes it focussable via JS,
+        this is used on the region page to focus the first graph header
+        after the region is changed.
+       */}
+      <h3 ref={headingRef} tabIndex={headingRef ? 0 : undefined}>
+        {title}
+        {regio && <ScreenReaderOnly>in {regio}</ScreenReaderOnly>}
+      </h3>
     </div>
   );
 };

--- a/src/components/loadingPlaceholder/index.js
+++ b/src/components/loadingPlaceholder/index.js
@@ -1,0 +1,11 @@
+import styles from './loadingPlaceholder.module.scss';
+
+import * as React from 'react';
+
+export default function LoadingPlaceholder({ width, children }) {
+  return (
+    <span className={styles.loadingPlaceholder} aria-hidden="true">
+      {children ? children : null}
+    </span>
+  );
+}

--- a/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
+++ b/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
@@ -1,0 +1,27 @@
+@import 'scss/variables.scss';
+
+.loadingPlaceholder {
+  opacity: 0.05;
+  background-color: $text-color-grey;
+  animation: loadingPlaceholderPulse 1200ms infinite;
+  display: block;
+  height: 80px;
+  margin: 1rem 0;
+
+  /* Spacing between two placeholders */
+  & + & {
+    margin-top: 0.5rem;
+  }
+}
+
+@keyframes loadingPlaceholderPulse {
+  0% {
+    opacity: 0.05;
+  }
+  50% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0.05;
+  }
+}

--- a/src/components/screenReaderOnly/index.js
+++ b/src/components/screenReaderOnly/index.js
@@ -1,0 +1,12 @@
+import styles from './screenReaderOnly.module.scss';
+
+/**
+ * A small utility component that renders text which is only
+ * present for visually impaired users, alias it will be read out
+ * loud by screenreaders without being visible on the screen.
+ */
+const ScreenReaderOnly = ({ children }) => {
+  return <span className={styles.screenReaderOnly}>{children}</span>;
+};
+
+export default ScreenReaderOnly;

--- a/src/components/screenReaderOnly/screenReaderOnly.module.scss
+++ b/src/components/screenReaderOnly/screenReaderOnly.module.scss
@@ -1,0 +1,10 @@
+.screenReaderOnly {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+}

--- a/src/data/textNationaal.json
+++ b/src/data/textNationaal.json
@@ -5,6 +5,7 @@
   "ic_opnames_per_dag": {
     "title": "Intensive care-opnames per dag",
     "text": "Aantal opnames per dag, gemiddeld over de afgelopen 3 dagen.",
+    "screen_reader_graph_content": "{{value}} intensive care-opnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
     "fold_title": "Wat betekent dit?",
     "fold": "Aantal mensen met COVID-19 dat per dag op een intensive care-afdeling van een ziekenhuis is opgenomen. Dit cijfer is een gemiddelde van de afgelopen drie dagen.",
     "graph_title": "Verloop over tijd",
@@ -26,6 +27,7 @@
   "ziekenhuisopnames_per_dag": {
     "title": "Ziekenhuisopnames per dag",
     "text": "Aantal opnames per dag, gemiddeld over de afgelopen 3 dagen.",
+    "screen_reader_graph_content": "{{value}} ziekenhuisopnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
     "fold_title": "Wat betekent dit?",
     "fold": "Aantal mensen met COVID-19 dat per dag in een ziekenhuis is opgenomen. Dit cijfer is een gemiddelde van de gemelde ziekenhuisopnames over de afgelopen 3 dagen.",
     "graph_title": "Verloop over tijd",
@@ -47,6 +49,7 @@
   "positief_geteste_personen": {
     "title": "Positief geteste mensen",
     "text": "Aantal positief geteste mensen per 100.000 inwoners per dag.",
+    "screen_reader_graph_content": "{{value}} positief geteste mensen per dag.",
     "fold_title": "Wat betekent dit?",
     "fold": "Dit getal laat zien van hoeveel mensen gisteren per 100.000 inwoners gemeld is dat ze positief getest zijn en COVID-19 hebben.",
     "graph_title": "Verdeling naar leeftijd (totaal aantal mensen)",
@@ -63,6 +66,7 @@
   "besmettelijke_personen": {
     "title": "Aantal besmettelijke mensen",
     "text": "Een berekening van hoeveel mensen met COVID-19 per 100.000 inwoners besmettelijk zijn voor anderen. Dit getal wordt door het RIVM berekend.",
+    "screen_reader_graph_content": "{{value}} besmettelijke personen per 100.000 inwoners.",
     "fold_title": "Wat betekent dit?",
     "fold": "Als iemand het coronavirus oploopt, dan is deze persoon een tijd lang besmettelijk voor anderen. Hoe lang dit duurt verschilt van persoon tot persoon. Dit getal is een schatting.",
     "metric_title": "Geschat aantal besmettelijke mensen in Nederland:",
@@ -80,6 +84,7 @@
   "reproductiegetal": {
     "title": "Reproductiegetal",
     "text": "Aantal mensen dat besmet wordt door één besmettelijke persoon.",
+    "screen_reader_graph_content": "{{value}} mensen. Signaalwaarde: {{kritiekeWaarde}}.",
     "fold_title": "Wat betekent dit?",
     "fold": "Het reproductiegetal laat zien hoe snel het virus zich verspreidt. Als dat getal bijvoorbeeld 2 is, dan besmet iemand die het coronavirus heeft gemiddeld twee andere mensen binnen 5 dagen. Die twee mensen besmetten ieder ook weer twee mensen binnen 5 dagen. En zo gaat het door. Bij een reproductiegetal van rond de 1 blijft het aantal besmettingen ongeveer gelijk. Als het reproductiegetal lager is dan 1, dan daalt het aantal besmettingen. Dit reproductiegetal is een gemiddelde voor heel Nederland. Het getal dat gepresenteerd wordt is een schatting op basis van een aantal gegevensbronnen. Het exacte getal is onbekend, maar we kunnen met vrij veel zekerheid zeggen tussen welke waarden zich dat bevindt.",
     "graph_title": "Verloop over tijd",
@@ -158,6 +163,7 @@
   "verpleeghuis_positief_geteste_personen": {
     "title": "Aantal positief geteste bewoners",
     "text": "Aantal positief geteste bewoners in verpleeghuizen per dag.",
+    "screen_reader_graph_content": "{{value}} positief geteste bewoners.",
     "fold_title": "Wat betekent dit?",
     "fold": "Dit getal is een inschatting van het aantal gemelde bewoners in verpleeghuizen dat in Nederland positief getest is en COVID-19 heeft. Dit getal verwijst naar de datum vóór de datum van de laatste update.",
     "graph_title": "Verloop over tijd",
@@ -175,6 +181,7 @@
   "verpleeghuis_oversterfte": {
     "title": "Sterfte",
     "text": "Aantal overleden bewoners in verpleeghuizen met een vastgestelde COVID-19-besmetting dat overleden is per dag.",
+    "screen_reader_graph_content": "{{value}} overleden bewoners.",
     "fold_title": "Wat betekent dit?",
     "fold": "Dit getal is een inschatting van het aantal gemelde verpleeghuisbewoners dat in Nederland overlijdt aan de gevolgen van het nieuwe coronavirus. Dit getal verwijst naar de datum vóór de datum van de laatste update.",
     "graph_title": "Verloop over tijd",

--- a/src/data/textRegionaal.json
+++ b/src/data/textRegionaal.json
@@ -5,6 +5,7 @@
   "regionaal_ziekenhuisopnames_per_dag": {
     "title": "Ziekenhuisopnames per dag",
     "text": "Aantal opnames per dag, gemiddeld over de afgelopen 3 dagen.",
+    "screen_reader_graph_content": "{{value}} opnames.",
     "fold_title": "Wat betekent dit?",
     "fold": "Aantal mensen met COVID-19 dat per dag in een ziekenhuis is opgenomen. Dit cijfer is een gemiddelde van de gemelde ziekenhuisopnames over de afgelopen 3 dagen.",
     "graph_title": "Verloop over tijd",
@@ -25,6 +26,7 @@
   "regionaal_positief_geteste_personen": {
     "title": "Positief geteste mensen",
     "text": "Aantal positief geteste mensen per 100.000 inwoners per dag.",
+    "screen_reader_graph_content": "{{value}} positief geteste personen.",
     "fold_title": "Wat betekent dit?",
     "fold": "Dit getal laat zien van hoeveel mensen gisteren per 100.000 inwoners gemeld is dat ze positief getest zijn en COVID-19 hebben. Dit getal verwijst naar de datum vóór de datum van de laatste update.",
     "graph_title": "Verloop over tijd",
@@ -58,5 +60,8 @@
   },
   "geen_selectie": {
     "text": "Selecteer uw regio bovenaan deze pagina"
+  },
+  "terug_naar_regio_selectie": {
+    "text": "Terug naar regio selectie"
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,6 +87,9 @@ export default function Home() {
                 <BarScale
                   min={siteText.ic_opnames_per_dag.min}
                   max={siteText.ic_opnames_per_dag.max}
+                  screenReaderText={
+                    siteText.ic_opnames_per_dag.screen_reader_graph_content
+                  }
                   kritiekeWaarde={siteText.ic_opnames_per_dag.signaalwaarde}
                   value={state.NL?.intake_intensivecare_ma.value}
                   id="ic"
@@ -129,6 +132,10 @@ export default function Home() {
                   min={0}
                   max={100}
                   kritiekeWaarde={40}
+                  screenReaderText={
+                    siteText.ziekenhuisopnames_per_dag
+                      .screen_reader_graph_content
+                  }
                   value={state.NL?.intake_hospital_ma.value}
                   id="opnames"
                   gradient={siteText.ziekenhuisopnames_per_dag.gradient}
@@ -165,6 +172,10 @@ export default function Home() {
                 <BarScale
                   min={siteText.positief_geteste_personen.min}
                   max={siteText.positief_geteste_personen.max}
+                  screenReaderText={
+                    siteText.positief_geteste_personen
+                      .screen_reader_graph_content
+                  }
                   value={state.NL?.infected_people_delta_normalized.value}
                   id="positief"
                   gradient={siteText.positief_geteste_personen.gradient}
@@ -211,6 +222,9 @@ export default function Home() {
                 <BarScale
                   min={siteText.besmettelijke_personen.min}
                   max={siteText.besmettelijke_personen.max}
+                  screenReaderText={
+                    siteText.besmettelijke_personen.screen_reader_graph_content
+                  }
                   value={state.NL?.infectious_people_count_normalized.value}
                   id="besmettelijk"
                   gradient={siteText.besmettelijke_personen.gradient}
@@ -257,6 +271,9 @@ export default function Home() {
                 <BarScale
                   min={siteText.reproductiegetal.min}
                   max={siteText.reproductiegetal.max}
+                  screenReaderText={
+                    siteText.reproductiegetal.screen_reader_graph_content
+                  }
                   kritiekeWaarde={siteText.reproductiegetal.signaalwaarde}
                   value={state.NL?.reproduction_index.value}
                   id="repro"
@@ -368,6 +385,10 @@ export default function Home() {
                 <BarScale
                   min={siteText.verpleeghuis_positief_geteste_personen.min}
                   max={siteText.verpleeghuis_positief_geteste_personen.max}
+                  screenReaderText={
+                    siteText.verpleeghuis_positief_geteste_personen
+                      .screen_reader_graph_content
+                  }
                   value={state.NL?.infected_people_nursery_count_daily.value}
                   id="positief_verpleeghuis"
                   gradient={
@@ -430,6 +451,10 @@ export default function Home() {
                 <BarScale
                   min={siteText.verpleeghuis_oversterfte.min}
                   max={siteText.verpleeghuis_oversterfte.max}
+                  screenReaderText={
+                    siteText.verpleeghuis_oversterfte
+                      .screen_reader_graph_content
+                  }
                   value={state.NL?.deceased_people_nursery_count_daily.value}
                   id="over"
                   gradient={siteText.verpleeghuis_oversterfte.gradient}

--- a/src/utils/replaceVariablesInText.js
+++ b/src/utils/replaceVariablesInText.js
@@ -1,0 +1,28 @@
+const curlyBracketRegex = /\{\{(.+?)\}\}/g;
+
+/**
+ * Small utility that accepts a translation string with placeholders
+ * for variabels. For example:
+ * "An example placeholder string with {{type}} brackets"
+ * Where everything between curly brackets is accepted as a placeholder
+ * for a variable. The second argument is an object with keys representing
+ * the string between curly brackets. In this case it would be:
+ * { type: 'curly' }
+ *
+ * - If a specific variable is NOT given, it will replace it with an empty string.
+ * - If no translation is given, an empty string will be returned.
+ *
+ * @param {string} translation - Translation string with curly brackets for variables.
+ * @param {object} variables - An object with keys representing any variable available for replacement.
+ */
+const replaceVariablesInText = (translation, variables) => {
+  if (!translation) return '';
+
+  return translation.replace(curlyBracketRegex, (_string, variableName) => {
+    if (!variables) return '';
+
+    return variables[variableName] ?? '';
+  });
+};
+
+export default replaceVariablesInText;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,6 +6447,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-format@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"


### PR DESCRIPTION
Hi there! 

I really like to work that is being done on the dashboard. I took some time today to improve a few things I noticed, which because of the short timeline might not have made it into the first version yet. Let me know if you would like to merge these changes or have some feedback. I'd love to help, also with any other more pressing issues. 

This PR has been split into #6 , #7 , #8 and #9 and will probably be closed. 

~~**The changes I made:**~~

~~1. Added a small simple skeleton loading state for the graphs on the region page. That way the container doesn't jump around when the data is loaded.
2. Added screen reader only labels describing what the BarCharts show, for visually impaired users. (The content might need to be checked though).
3. Extended the graph titles on the region page with a (only for screen readers visible) text repeating the region this data is for.
4. Added some focus management which after selecting a region moves the focus to the heading of the first graph, so a user immediately can read the related data. 
5. Added a screen reader only button at the end of the content bringing the user back to the region selector. This way a visually impaired user can switch easier between regions multiple times.~~ 