### PR TITLE
Added a loadingplaceholder component for graphs on region page

### DIFF
--- a/src/components/loadingPlaceholder/index.js
+++ b/src/components/loadingPlaceholder/index.js
@@ -1,0 +1,11 @@
+import styles from './loadingPlaceholder.module.scss';
+
+import * as React from 'react';
+
+export default function LoadingPlaceholder({ width, children }) {
+  return (
+    <span className={styles.loadingPlaceholder} aria-hidden="true">
+      {children ? children : null}
+    </span>
+  );
+}

--- a/src/components/loadingPlaceholder/index.js
+++ b/src/components/loadingPlaceholder/index.js
@@ -1,7 +1,5 @@
 import styles from './loadingPlaceholder.module.scss';
 
-import * as React from 'react';
-
 export default function LoadingPlaceholder({ width, children }) {
   return (
     <span className={styles.loadingPlaceholder} aria-hidden="true">

--- a/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
+++ b/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
@@ -1,0 +1,27 @@
+@import 'scss/variables.scss';
+
+.loadingPlaceholder {
+  opacity: 0.05;
+  background-color: $text-color-grey;
+  animation: loadingPlaceholderPulse 1200ms infinite;
+  display: block;
+  height: 80px;
+  margin: 1rem 0;
+
+  /* Spacing between two placeholders */
+  & + & {
+    margin-top: 0.5rem;
+  }
+}
+
+@keyframes loadingPlaceholderPulse {
+  0% {
+    opacity: 0.05;
+  }
+  50% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 0.05;
+  }
+}

--- a/src/pages/regio/index.js
+++ b/src/pages/regio/index.js
@@ -12,6 +12,7 @@ import LastUpdated from 'components/lastUpdated';
 import SelectRegio from 'components/selectRegio';
 import Warning from 'assets/warn.svg';
 import Metadata from 'components/metadata';
+import LoadingPlaceholder from 'components/loadingPlaceholder';
 import regioData from 'data';
 
 import { store } from 'store';
@@ -138,6 +139,9 @@ function Regio() {
               />
 
               <p>{siteText.regionaal_ziekenhuisopnames_per_dag.text}</p>
+              {!state[selectedRegio?.code]?.intake_hospital_ma && (
+                <LoadingPlaceholder />
+              )}
               {state[selectedRegio?.code]?.intake_hospital_ma && (
                 <BarScale
                   min={siteText.regionaal_ziekenhuisopnames_per_dag.min}
@@ -182,6 +186,8 @@ function Regio() {
                 title={siteText.regionaal_positief_geteste_personen.title}
               />
               <p>{siteText.regionaal_positief_geteste_personen.text}</p>
+              {!state[selectedRegio?.code]
+                ?.infected_people_delta_normalized && <LoadingPlaceholder />}
               {state[selectedRegio.code]?.infected_people_delta_normalized && (
                 <BarScale
                   min={siteText.regionaal_positief_geteste_personen.min}


### PR DESCRIPTION
Hi there!

I initially created a PR #4 that included mulitple changes. In this PR I split the loadingPlaceholder into a separate PR.

**The changes made:**
Added a small simple skeleton loading state for the graphs on the region page. 

**Why?**
This way the container of the graphs doesn't jump around when the data isn't loaded yet. The user will also have a more visual indication that something is still in progress and nothing is broken. 

![loading-skeleton](https://user-images.githubusercontent.com/2969573/84231452-78921780-aaee-11ea-9bc3-dd370596c27b.gif)

(The framerate in the GIF is not completely up to par ;) ) 