### PR TITLE
feat: Add linechart to "positief geteste mensen"

### DIFF
--- a/src/data/textNationaal.json
+++ b/src/data/textNationaal.json
@@ -49,6 +49,7 @@
     "text": "Aantal positief geteste mensen per 100.000 inwoners per dag.",
     "fold_title": "Wat betekent dit?",
     "fold": "Dit getal laat zien van hoeveel mensen gisteren per 100.000 inwoners gemeld is dat ze positief getest zijn en COVID-19 hebben.",
+    "linechart_title": "Verloop over tijd",
     "graph_title": "Verdeling naar leeftijd (totaal aantal mensen)",
     "open": "Verberg uitleg",
     "sluit": "Meer uitleg en data",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -179,6 +179,14 @@ const Home: FunctionComponentWithLayout<HomeLayoutProps> = () => {
             >
               <h4>{siteText.positief_geteste_personen.fold_title}</h4>
               <p>{siteText.positief_geteste_personen.fold}</p>
+
+              <h4>{siteText.positief_geteste_personen.linechart_title}</h4>
+              {state.NL?.infected_people_delta_normalized?.list && (
+                <LineChart
+                  data={state.NL?.infected_people_delta_normalized?.list}
+                />
+              )}
+
               <h4>{siteText.positief_geteste_personen.graph_title}</h4>
               {state.NL?.intake_share_age_groups && (
                 <BarChart


### PR DESCRIPTION
This PR adds "verloop over tijd" to "positief geteste mensen" on the national page.

![Verloop over tijd bij positief geteste mensen](https://user-images.githubusercontent.com/66416946/85124777-c1527a80-b22a-11ea-9b59-476c8c80fa33.png)


Before merging:

- [x] Check if descriptions needs to be updated in this tile
- [x] Verify the chart communicates intent correctly