### PR TITLE
feat: Add signwaalwaardes to Linecharts

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, FunctionComponent } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import months from 'data/months.js';
@@ -8,8 +8,24 @@ if (typeof Highcharts === 'object') {
   require('highcharts/highcharts-more')(Highcharts);
 }
 
-const AreaChart = (props) => {
-  const { rangeLegendLabel, lineLegendLabel, min, max, data, baseline } = props;
+type AreaChartProps = {
+  rangeLegendLabel: string;
+  lineLegendLabel: string;
+  min: number;
+  max: number;
+  data: Record<string, unknown>;
+  signaalwaarde: number;
+};
+
+const AreaChart: FunctionComponent<AreaChartProps> = (props) => {
+  const {
+    rangeLegendLabel,
+    lineLegendLabel,
+    min,
+    max,
+    data,
+    signaalwaarde,
+  } = props;
 
   const formatDate = (value) => {
     const date = new Date(value);
@@ -21,16 +37,9 @@ const AreaChart = (props) => {
     return `${date.getDate()} ${months[date.getMonth()]} ${date.getFullYear()}`;
   };
 
-  const baseArray = [];
-  if (baseline !== undefined) {
-    for (let x = 0; x < Object.keys(min).length; x += 1) {
-      baseArray.push(baseline);
-    }
-  }
-
   const rangeData = useMemo(() => {
     const dates = Object.keys(min);
-    dates.sort((a, b) => a - b);
+    dates.sort((a: any, b: any) => a - b);
 
     return dates.map((date) => [
       new Date(parseInt(date) * 1000), // parse Unix timestamp to JS timestamp
@@ -94,6 +103,7 @@ const AreaChart = (props) => {
         title: {
           text: null,
         },
+        plotLines: [],
         accessibility: {
           rangeDescription: 'Range: 2010 to 2017',
         },
@@ -110,7 +120,9 @@ const AreaChart = (props) => {
         formatter() {
           const rangePoint = rangeData.find((el) => el[0].getTime() === this.x);
           const [, minRangePoint, maxRangePoint] = rangePoint;
-          const linePoint = lineData.find((el) => el[0].getTime() === this.x);
+          const linePoint = lineData.find(
+            (el: any) => el[0].getTime() === this.x
+          );
           return `
             ${formatDateLong(this.x)}<br/>
             <strong>Bandbreedte</strong> ${formatNumber(
@@ -134,18 +146,6 @@ const AreaChart = (props) => {
           },
         },
         {
-          name: 'baseline',
-          data: baseArray,
-          dashStyle: 'dash',
-          type: 'line',
-          lineColor: '#4f5458',
-          lineWidth: 1,
-          enableMouseTracking: false,
-          marker: {
-            enabled: false,
-          },
-        },
-        {
           name: lineLegendLabel,
           data: lineData.map((el) => el[1]),
           type: 'line',
@@ -157,8 +157,17 @@ const AreaChart = (props) => {
         },
       ],
     }),
-    [lineLegendLabel, rangeLegendLabel, rangeData, lineData, baseArray]
+    [lineLegendLabel, rangeLegendLabel, rangeData, lineData]
   );
+
+  if (signaalwaarde) {
+    options.yAxis.plotLines.push({
+      value: signaalwaarde,
+      dashStyle: 'dash',
+      width: 1,
+      color: '#4f5458',
+    });
+  }
 
   return (
     <div>

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -14,8 +14,7 @@ const LineChart: FunctionComponent<LineChartProps> = ({
   signaalwaarde,
 }) => {
   const formatDate = (value: number) => {
-    const dateObj = new Date(parseInt(value * 1000));
-    dateObj.toLocaleString();
+    const dateObj = new Date(value * 1000);
     return `${dateObj.getDate()} ${months[dateObj.getMonth()]}`;
   };
 
@@ -50,7 +49,7 @@ const LineChart: FunctionComponent<LineChartProps> = ({
         rotation: '0',
         formatter: function () {
           if (this.isFirst || this.isLast) {
-            const valueDate = new Date(parseInt(this.value * 1000));
+            const valueDate = new Date(this.value * 1000);
             return `${valueDate.getDate()} ${months[valueDate.getMonth()]}`;
           }
         },

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import months from 'data/months.js';
 import formatNumber from 'utils/formatNumber';
 
-const LineChart = ({ data }) => {
-  const formatDate = (value) => {
-    let dateObj = new Date(parseInt(value * 1000));
+type LineChartProps = {
+  data: Record<string, unknown>;
+  signaalwaarde?: number;
+};
+
+const LineChart: FunctionComponent<LineChartProps> = ({
+  data,
+  signaalwaarde,
+}) => {
+  const formatDate = (value: number) => {
+    const dateObj = new Date(parseInt(value * 1000));
     dateObj.toLocaleString();
     return `${dateObj.getDate()} ${months[dateObj.getMonth()]}`;
   };
@@ -42,8 +50,7 @@ const LineChart = ({ data }) => {
         rotation: '0',
         formatter: function () {
           if (this.isFirst || this.isLast) {
-            let valueDate = new Date(parseInt(this.value * 1000));
-            valueDate.toLocaleString();
+            const valueDate = new Date(parseInt(this.value * 1000));
             return `${valueDate.getDate()} ${months[valueDate.getMonth()]}`;
           }
         },
@@ -67,6 +74,7 @@ const LineChart = ({ data }) => {
       accessibility: {
         rangeDescription: 'Range: 2010 to 2017',
       },
+      plotLines: [],
     },
     title: {
       text: null,
@@ -83,6 +91,15 @@ const LineChart = ({ data }) => {
       },
     ],
   };
+
+  if (signaalwaarde) {
+    options.yAxis.plotLines.push({
+      value: signaalwaarde,
+      dashStyle: 'dash',
+      width: 1,
+      color: '#d33',
+    });
+  }
 
   return <HighchartsReact highcharts={Highcharts} options={options} />;
 };

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -96,7 +96,7 @@ const LineChart: FunctionComponent<LineChartProps> = ({
       value: signaalwaarde,
       dashStyle: 'dash',
       width: 1,
-      color: '#d33',
+      color: '#4f5458',
     });
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -104,7 +104,10 @@ const Home: FunctionComponentWithLayout<HomeLayoutProps> = () => {
               <p>{siteText.ic_opnames_per_dag.fold}</p>
               <h4>{siteText.ic_opnames_per_dag.graph_title}</h4>
               {state.NL?.intake_intensivecare_ma?.list && (
-                <LineChart data={state.NL?.intake_intensivecare_ma.list} />
+                <LineChart
+                  data={state.NL?.intake_intensivecare_ma.list}
+                  signaalwaarde={siteText.ic_opnames_per_dag.signaalwaarde}
+                />
               )}
 
               <Metadata
@@ -146,7 +149,10 @@ const Home: FunctionComponentWithLayout<HomeLayoutProps> = () => {
 
               <h4>{siteText.ziekenhuisopnames_per_dag.graph_title}</h4>
               {state.NL?.intake_hospital_ma?.list && (
-                <LineChart data={state.NL?.intake_hospital_ma.list} />
+                <LineChart
+                  data={state.NL?.intake_hospital_ma.list}
+                  signaalwaarde={40}
+                />
               )}
 
               <Metadata
@@ -287,7 +293,7 @@ const Home: FunctionComponentWithLayout<HomeLayoutProps> = () => {
                   data={state.NL?.reproduction_index.list}
                   min={state.NL?.reproduction_index.min}
                   max={state.NL?.reproduction_index.max}
-                  baseline={1}
+                  signaalwaarde={1}
                   rangeLegendLabel={siteText.reproductiegetal.rangeLegendLabel}
                   lineLegendLabel={siteText.reproductiegetal.lineLegendLabel}
                 />


### PR DESCRIPTION
This PR

- Adds _signaalwaardes_ to all linecharts that have a _kritieke waarde_
- Refactors the reproduction area chart from using a hacked series object to an official Linecharts API for showing lines on the grid.