### PR TITLE
chore: only use the TS linter for .ts and .tsx files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,19 +22,6 @@
     "react/react-in-jsx-scope": 0,
     "react/display-name": 0,
     "react/prop-types": 0,
-    "@typescript-eslint/explicit-function-return-type": 0,
-    "@typescript-eslint/explicit-member-accessibility": 0,
-    "@typescript-eslint/indent": 0,
-    "@typescript-eslint/member-delimiter-style": 0,
-    "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/no-var-requires": 0,
-    "@typescript-eslint/no-use-before-define": 0,
-    "@typescript-eslint/no-unused-vars": [
-      2,
-      {
-        "argsIgnorePattern": "^_"
-      }
-    ],
     "no-console": [
       2,
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,5 @@
 {
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "prettier/@typescript-eslint"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
   "settings": {
     "react": {
       "version": "16.13.1"
@@ -18,6 +10,13 @@
     "browser": true,
     "jest": true,
     "node": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
   "rules": {
     "react/react-in-jsx-scope": 0,
@@ -42,5 +41,37 @@
         "allow": ["warn", "error"]
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "parser": "@typescript-eslint/parser",
+      "plugins": ["@typescript-eslint"],
+      "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended",
+        "plugin:@typescript-eslint/recommended",
+        "prettier",
+        "prettier/@typescript-eslint"
+      ],
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "react/react-in-jsx-scope": 0,
+        "react/display-name": 0,
+        "react/prop-types": 0,
+        "@typescript-eslint/explicit-function-return-type": 0,
+        "@typescript-eslint/explicit-member-accessibility": 0,
+        "@typescript-eslint/indent": 0,
+        "@typescript-eslint/member-delimiter-style": 0,
+        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/no-var-requires": 0,
+        "@typescript-eslint/no-use-before-define": 0,
+        "@typescript-eslint/no-unused-vars": [
+          2,
+          {
+            "argsIgnorePattern": "^_"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "jest --watch",
     "test:ci": "jest --ci",
     "format": "prettier --write **/*.{js,ts,tsx}",
-    "lint": "eslint . --ext ts --ext tsx --ext js",
+    "lint": "eslint .",
     "type-check": "tsc --pretty --noEmit"
   }
 }

--- a/src/lib/piwik.ts
+++ b/src/lib/piwik.ts
@@ -11,7 +11,7 @@ if (process.browser) {
   }
 }
 
-export const pageview = (url: string, documentTitle: string) => {
+export const pageview = (url: string, documentTitle: string): void => {
   if (process.browser) {
     if (window) {
       window._paq.push(['setCustomUrl', '/' + url]);
@@ -31,7 +31,7 @@ type EventTypes = {
   dimensions: any;
 };
 
-export function event(eventOptions: EventTypes) {
+export function event(eventOptions: EventTypes): void {
   const { category, action, name, value, dimensions } = eventOptions;
   if (process.browser) {
     if (window) {


### PR DESCRIPTION
# Summary

This PR updates the ESLint config to only use the `@typescript-eslint` ecosystem for linting `.ts` and `.tsx` files. For other files the regular ESLint parser is used.