### PR TITLE
fix: make sure paragraphs in .graphContent can't overflow the container

### DIFF
--- a/src/components/graphContent/graphContent.scss
+++ b/src/components/graphContent/graphContent.scss
@@ -3,4 +3,8 @@
 .graphContent {
   padding: 0 $default-padding;
   margin-bottom: $default-margin;
+
+  p {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
# Summary

This PR adds a `max-width` of `100%` to paragraphs in elements that have class `.graphContent`. This fixes a bug in IE11.