### PR TITLE
chore: move IconList out of collapsed content

### DIFF
--- a/src/components/iconList/iconList.module.scss
+++ b/src/components/iconList/iconList.module.scss
@@ -19,7 +19,7 @@
     max-width: 2rem;
     height: auto;
     margin-left: $default-margin / 2;
-    margin-right: $default-margin * 1.5;
+    margin-right: $default-margin / 2;
     margin-bottom: 0;
   }
 
@@ -78,7 +78,7 @@
 .hiddenContent {
   flex-basis: 100%;
   transition: hidden 120ms ease-in;
-  padding-left: $default-padding * 4 + $default-padding / 2;
+  padding-left: $default-padding * 3 + $default-padding / 2;
 
   p {
     margin: 0.5rem 0;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -362,28 +362,18 @@ const Home: FunctionComponentWithLayout<HomeLayoutProps> = () => {
             <GraphContent>
               <GraphHeader title={siteText.overige_gegevens.title} />
               <p>{siteText.overige_gegevens.text}</p>
-            </GraphContent>
-            <Collapse
-              openText={siteText.overige_gegevens.open}
-              sluitText={siteText.overige_gegevens.sluit}
-            >
               <p>{siteText.overige_gegevens.fold}</p>
               <IconList list={siteText.overige_gegevens.list} />
-            </Collapse>
+            </GraphContent>
           </GraphContainer>
 
           <GraphContainer>
             <GraphContent>
               <GraphHeader title={siteText.gedragsignalering.title} />
               <p>{siteText.gedragsignalering.text}</p>
-            </GraphContent>
-            <Collapse
-              openText={siteText.gedragsignalering.open}
-              sluitText={siteText.gedragsignalering.sluit}
-            >
               <p>{siteText.gedragsignalering.fold}</p>
               <IconList list={siteText.gedragsignalering.list} />
-            </Collapse>
+            </GraphContent>
           </GraphContainer>
         </Masonry>
       </section>


### PR DESCRIPTION
# Summary

For 'Andere cijfers' and 'Informatie over gedrag', this PR moves the IconList component out of the card's collapsed content.