### PR TITLE
fix: dropdown reset issues in SelectRegio on Edge < 18

### DIFF
--- a/src/components/selectRegio/selectRegio.module.scss
+++ b/src/components/selectRegio/selectRegio.module.scss
@@ -51,6 +51,10 @@
     z-index: 1000;
     box-shadow: inset 0 1px 0 0 rgba(0, 0, 0, 0.15);
 
+    [aria-expanded='false'] + & {
+      overflow-y: hidden;
+    }
+
     li {
       padding: $default-padding/2 $default-padding $default-padding/2
         $default-padding;


### PR DESCRIPTION
# Summary

This PR fixes a bug in Edge versions < 18, where, if the `blur` event occurred on the `SelectRegio` dropdown component, the internal state of downshift would sometimes be reset to the default state. The bug is fixed by overriding the `InputBlur` event in a custom state reducer to return the current state with `isOpen` set to `false`, to close the dropdown menu.

An existing fix for a height overflow bug on IE11 was moved from JS to CSS.