### PR TITLE
chore: remove Piwik cookie domains

### DIFF
--- a/public/piwik.js
+++ b/public/piwik.js
@@ -1,7 +1,4 @@
 var _paq = _paq || [];
-_paq.push(['setCookieDomain', '*.rijksoverheid.nl']);
-_paq.push(['setDomains', ['*.rijksoverheid.nl']]);
-_paq.push(['enableHeartBeatTimer', 10]);
 _paq.push(['setLinkTrackingTimer', 750]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
# Summary

This PR removes Piwik cookie domain settings. These settings currently cause duplicate page hits to be reported to Piwik.