### PR TITLE
chore: Laying the groundwork for a multi-language site

### DIFF
--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -15,4 +15,4 @@ services:
       args:
         NEXT_PUBLIC_LOCALE: 'en'
     ports:
-      - '8080:8081'
+      - '8081:8080'

--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -1,8 +1,18 @@
 version: '3'
 
 services:
-  web:
-    build: .
+  web-nl:
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_LOCALE: 'nl'
     ports:
       - '8080:8080'
-      - '443:443'
+
+  web-en:
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_LOCALE: 'en'
+    ports:
+      - '8080:8081'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Stage 1
+
 FROM node:12 as react-build
+
+ARG language
+
 WORKDIR /app
 COPY . ./
 RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:12 as react-build
 
-ARG language
+ARG NEXT_PUBLIC_LOCALE
 
 WORKDIR /app
 COPY . ./

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 
 import styles from './layout.module.scss';
 import MaxWidth from 'components/maxWidth';
-import text from 'locale/nl.json';
+import text from 'locale';
 import useMediaQuery from 'utils/useMediaQuery';
 import SEOHead from 'components/seoHead';
 import { Translation } from 'types/data';

--- a/src/components/tiles/index.tsx
+++ b/src/components/tiles/index.tsx
@@ -20,7 +20,7 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 
 import formatDecimal from 'utils/formatDec';
 
-import siteText from 'locale/nl.json';
+import siteText from 'locale';
 
 import {
   IntakeIntensivecareMa,

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -1,0 +1,13 @@
+import nl from './nl.json';
+import en from './en.json';
+
+interface ILocale {
+  [prop: string]: any;
+}
+
+const languages: any = { en, nl };
+
+const targetLanguage: string = process.env.NEXT_PUBLIC_LOCALE || 'nl';
+const dictionary = languages[targetLanguage];
+
+export default dictionary;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import Layout, { FunctionComponentWithLayout } from 'components/layout';
 import MaxWidth from 'components/maxWidth';
 
-import text from 'locale/nl.json';
+import text from 'locale';
 import styles from './over.module.scss';
 
 const NotFound: FunctionComponentWithLayout = () => {

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,7 +1,7 @@
 import Layout, { FunctionComponentWithLayout } from 'components/layout';
 import MaxWidth from 'components/maxWidth';
 
-import text from 'locale/nl.json';
+import text from 'locale';
 import styles from './error.module.scss';
 
 const ErrorPage: FunctionComponentWithLayout = () => {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -13,8 +13,10 @@ class MyDocument extends Document {
   }
 
   render(): React.ReactElement {
+    const locale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
+
     return (
-      <Html lang="nl-NL">
+      <Html lang={locale}>
         <Head />
         <body>
           <Main />

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,7 +1,7 @@
 import Layout, { FunctionComponentWithLayout } from 'components/layout';
 import MaxWidth from 'components/maxWidth';
 
-import text from 'locale/nl.json';
+import text from 'locale';
 import styles from './error.module.scss';
 
 const ErrorPage: FunctionComponentWithLayout = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ import VerpleegHuisZorg from '../assets/verpleeghuiszorg.svg';
 import MedischeScreening from '../assets/medische-screening.svg';
 
 import { store } from 'store';
-import siteText from 'locale/nl.json';
+import siteText from 'locale';
 import GraphHeader from 'components/graphHeader';
 import IconList from 'components/iconList';
 

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -3,12 +3,23 @@ import Head from 'next/head';
 import Layout, { FunctionComponentWithLayout } from 'components/layout';
 import MaxWidth from 'components/maxWidth';
 
-import text from 'locale/nl.json';
+import text from 'locale';
 import styles from './over.module.scss';
 import ReplaceLinks from 'components/replaceLinks';
 
 import openGraphImage from 'assets/sharing/og-over.png?url';
 import twitterImage from 'assets/sharing/twitter-over.png?url';
+
+interface IVraagEnAntwoord {
+  vraag: {
+    translation: string;
+    notes: string;
+  };
+  antwoord: {
+    translation: string;
+    notes: string;
+  };
+}
 
 const Over: FunctionComponentWithLayout = () => {
   return (
@@ -36,14 +47,16 @@ const Over: FunctionComponentWithLayout = () => {
             <p>{text.over_disclaimer.text.translation}</p>
             <h2>{text.over_veelgestelde_vragen.text.translation}</h2>
             <dl className={styles.faqList}>
-              {text.over_veelgestelde_vragen.vragen.map((item) => (
-                <>
-                  <dt>{item.vraag.translation}</dt>
-                  <dd>
-                    <ReplaceLinks>{item.antwoord.translation}</ReplaceLinks>
-                  </dd>
-                </>
-              ))}
+              {text.over_veelgestelde_vragen.vragen.map(
+                (item: IVraagEnAntwoord) => (
+                  <>
+                    <dt>{item.vraag.translation}</dt>
+                    <dd>
+                      <ReplaceLinks>{item.antwoord.translation}</ReplaceLinks>
+                    </dd>
+                  </>
+                )
+              )}
             </dl>
           </div>
         </MaxWidth>

--- a/src/pages/regio/index.tsx
+++ b/src/pages/regio/index.tsx
@@ -21,7 +21,7 @@ import GraphContent from 'components/graphContent';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
 import Getest from 'assets/test.svg';
 
-import siteText from 'locale/nl.json';
+import siteText from 'locale';
 
 const LineChart = dynamic(() => import('components/lineChart'));
 const SvgMap = dynamic(() => import('components/mapChart/svgMap'));

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -3,12 +3,23 @@ import Head from 'next/head';
 import Layout, { FunctionComponentWithLayout } from 'components/layout';
 import MaxWidth from 'components/maxWidth';
 
-import text from 'locale/nl.json';
+import text from 'locale';
 import styles from './over.module.scss';
 import ReplaceLinks from 'components/replaceLinks';
 
 import openGraphImage from 'assets/sharing/og-cijferverantwoording.png?url';
 import twitterImage from 'assets/sharing/twitter-cijferverantwoording.png?url';
+
+interface ICijfer {
+  cijfer: {
+    translation: string;
+    notes: string;
+  };
+  verantwoording: {
+    translation: string;
+    notes: string;
+  };
+}
 
 const Verantwoording: FunctionComponentWithLayout = () => {
   return (
@@ -32,7 +43,7 @@ const Verantwoording: FunctionComponentWithLayout = () => {
           <div className={styles.maxwidth}>
             <h2>{text.verantwoording.title.translation}</h2>
             <dl className={styles.faqList}>
-              {text.verantwoording.cijfers.map((item) => (
+              {text.verantwoording.cijfers.map((item: ICijfer) => (
                 <>
                   <dt>{item.cijfer.translation}</dt>
                   <dd>


### PR DESCRIPTION
This PR adds the groundwork for publishing translated versions of the website.

## Technical details
We store our translations and source strings in locale files. Based on a new ENV var `NEXT_PUBLIC_LOCALE` we determine which language file to load while building the application. If you don't provide this ENV variable, we use `nl` as default value.

- [x] Update _document.js to provide correct locale in DOM
