### PR TITLE
Fix: Typo in workflow for `develop` branch

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - master
-      - developer
+      - develop
 
 jobs:
   build:


### PR DESCRIPTION
Fixes a typo that may prevent tests from running on the `develop` branch.