### PR TITLE
Adds signal value to number of infected people in nursing homes component

### DIFF
--- a/src/components/tiles/NursingHomeInfectedPeople.tsx
+++ b/src/components/tiles/NursingHomeInfectedPeople.tsx
@@ -33,6 +33,7 @@ export const NursingHomeInfectedPeople: React.FC = () => {
             min={0}
             max={100}
             screenReaderText={text.screen_reader_graph_content.translation}
+            kritiekeWaarde={Number(text.signaalwaarde.translation)}
             value={data.last_value.infected_nursery_daily}
             id="positief_verpleeghuis"
             gradient={[
@@ -69,6 +70,7 @@ export const NursingHomeInfectedPeople: React.FC = () => {
                 value: value.infected_nursery_daily,
                 date: value.date_of_report_unix,
               }))}
+              signaalwaarde={Number(text.signaalwaarde.translation)}
             />
             <Metadata dataSource={text.bron} />
           </>


### PR DESCRIPTION
As described in #96, this PR adds the signal value for number of infected people in nursing homes following the definition in the locale (see #90). This has been implemented based on other components that already have a signal value described in the component. 