### PR TITLE
refactor: Signaalwaarde is now a constant single-source-of-truth

### DIFF
--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -16,7 +16,7 @@ type BarscaleProps = {
   min: number;
   max: number;
   value: number | null | undefined;
-  kritiekeWaarde?: number;
+  signaalwaarde?: number;
   gradient: GradientStop[];
   id: string;
   screenReaderText: string;
@@ -27,7 +27,7 @@ const BarScale: FunctionComponent<BarscaleProps> = ({
   min,
   max,
   value,
-  kritiekeWaarde,
+  signaalwaarde,
   gradient,
   id,
   screenReaderText,
@@ -61,7 +61,7 @@ const BarScale: FunctionComponent<BarscaleProps> = ({
       <ScreenReaderOnly>
         {replaceVariablesInText(screenReaderText, {
           value: String(value),
-          kritiekeWaarde: String(kritiekeWaarde),
+          signaalwaarde: String(signaalwaarde),
         })}
       </ScreenReaderOnly>
 
@@ -133,11 +133,11 @@ const BarScale: FunctionComponent<BarscaleProps> = ({
             >{`${formatNumber(value)}`}</text>
           </g>
 
-          {kritiekeWaarde && (
+          {signaalwaarde && (
             <g>
               <line
-                x1={`${x(kritiekeWaarde)}%`}
-                x2={`${x(kritiekeWaarde)}%`}
+                x1={`${x(signaalwaarde)}%`}
+                x2={`${x(signaalwaarde)}%`}
                 y1={56}
                 y2={46}
                 strokeWidth="3"
@@ -145,10 +145,10 @@ const BarScale: FunctionComponent<BarscaleProps> = ({
               />
               <text
                 className={styles.criticalValue}
-                x={`${x(kritiekeWaarde)}%`}
+                x={`${x(signaalwaarde)}%`}
                 y={72}
-                textAnchor={textAlign(x(kritiekeWaarde)) as any}
-              >{`Signaalwaarde: ${kritiekeWaarde}`}</text>
+                textAnchor={textAlign(x(signaalwaarde)) as any}
+              >{`Signaalwaarde: ${signaalwaarde}`}</text>
             </g>
           )}
 

--- a/src/components/tiles/IntakeHospital.tsx
+++ b/src/components/tiles/IntakeHospital.tsx
@@ -14,6 +14,8 @@ import siteText from 'locale';
 
 import { IntakeHospitalMa } from 'types/data';
 
+const SIGNAAL_WAARDE = 40;
+
 export const IntakeHospital: React.FC = () => {
   const { data: state } = useSWR(`/json/NL.json`);
 
@@ -32,7 +34,7 @@ export const IntakeHospital: React.FC = () => {
           <BarScale
             min={0}
             max={100}
-            kritiekeWaarde={40}
+            signaalwaarde={SIGNAAL_WAARDE}
             screenReaderText={text.screen_reader_graph_content}
             value={data.last_value.moving_average_hospital}
             id="opnames"
@@ -44,7 +46,7 @@ export const IntakeHospital: React.FC = () => {
               },
               {
                 color: '#D3A500',
-                value: 40,
+                value: SIGNAAL_WAARDE,
               },
               {
                 color: '#f35065',
@@ -79,7 +81,7 @@ export const IntakeHospital: React.FC = () => {
                 value: value.moving_average_hospital,
                 date: value.date_of_report_unix,
               }))}
-              signaalwaarde={Number(text.signaalwaarde)}
+              signaalwaarde={SIGNAAL_WAARDE}
             />
 
             <Metadata dataSource={text.bron} />

--- a/src/components/tiles/IntakeIntensiveCare.tsx
+++ b/src/components/tiles/IntakeIntensiveCare.tsx
@@ -14,6 +14,8 @@ import siteText from 'locale';
 
 import { IntakeIntensivecareMa } from 'types/data';
 
+const SIGNAAL_WAARDE = 10;
+
 export const IntakeIntensiveCare: React.FC = () => {
   const { data: state } = useSWR(`/json/NL.json`);
 
@@ -38,7 +40,7 @@ export const IntakeIntensiveCare: React.FC = () => {
               },
               {
                 color: '#D3A500',
-                value: 10,
+                value: SIGNAAL_WAARDE,
               },
               {
                 color: '#f35065',
@@ -47,7 +49,7 @@ export const IntakeIntensiveCare: React.FC = () => {
             ]}
             dataKey="moving_average_ic"
             screenReaderText={text.screen_reader_graph_content}
-            kritiekeWaarde={10}
+            signaalwaarde={SIGNAAL_WAARDE}
             value={data.last_value.moving_average_ic}
             id="ic"
           />
@@ -79,7 +81,7 @@ export const IntakeIntensiveCare: React.FC = () => {
                 value: value.moving_average_ic,
                 date: value.date_of_report_unix,
               }))}
-              signaalwaarde={Number(text.signaalwaarde)}
+              signaalwaarde={SIGNAAL_WAARDE}
             />
 
             <Metadata dataSource={text.bron} />

--- a/src/components/tiles/ReproductionIndex.tsx
+++ b/src/components/tiles/ReproductionIndex.tsx
@@ -15,6 +15,8 @@ import siteText from 'locale';
 
 import { ReproductionIndex as ReproductionIndexData } from 'types/data';
 
+const SIGNAAL_WAARDE = 1;
+
 export const ReproductionIndex: React.FC = () => {
   const { data: state } = useSWR(`/json/NL.json`);
 
@@ -34,7 +36,7 @@ export const ReproductionIndex: React.FC = () => {
             min={0}
             max={2}
             screenReaderText={text.screen_reader_graph_content}
-            kritiekeWaarde={1}
+            signaalwaarde={SIGNAAL_WAARDE}
             value={lastKnownValidData?.last_value?.reproduction_index_avg}
             id="repro"
             dataKey="reproduction_index_avg"
@@ -45,7 +47,7 @@ export const ReproductionIndex: React.FC = () => {
               },
               {
                 color: '#69c253',
-                value: 1,
+                value: SIGNAAL_WAARDE,
               },
               {
                 color: '#D3A500',
@@ -95,7 +97,7 @@ export const ReproductionIndex: React.FC = () => {
             }))}
             minY={0}
             maxY={4}
-            signaalwaarde={1}
+            signaalwaarde={SIGNAAL_WAARDE}
             rangeLegendLabel={text.rangeLegendLabel}
             lineLegendLabel={text.lineLegendLabel}
           />

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -52,8 +52,7 @@
     "graph_title": "Verloop over tijd",
     "open": "Verberg uitleg",
     "sluit": "Meer uitleg en data",
-    "signaalwaarde": "10",
-    "screen_reader_graph_content": "{{value}} intensive care-opnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
+    "screen_reader_graph_content": "{{value}} intensive care-opnames per dag. Signaalwaarde: {{signaalwaarde}} opnames per dag.",
     "bron": {
       "href": "https://stichting-nice.nl/",
       "text": "Stichting NICE"
@@ -83,8 +82,7 @@
     "graph_title": "Verloop over tijd",
     "open": "Verberg uitleg",
     "sluit": "Meer uitleg en data",
-    "signaalwaarde": "40",
-    "screen_reader_graph_content": "{{value}} ziekenhuisopnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
+    "screen_reader_graph_content": "{{value}} ziekenhuisopnames per dag. Signaalwaarde: {{signaalwaarde}} opnames per dag.",
     "bron": {
       "href": "https://www.rivm.nl/documenten/dagelijkse-update-epidemiologische-situatie-covid-19-in-nederland",
       "text": "RIVM"
@@ -131,7 +129,7 @@
     "title": "Reproductiegetal",
     "text": "Aantal mensen dat besmet wordt door één besmettelijke persoon.",
     "datums": "Waarde van {{dateOfReport}}. Verkregen op {{dateOfInsertion}}. Wordt wekelijks bijgewerkt.",
-    "screen_reader_graph_content": "{{value}} mensen. Signaalwaarde: {{kritiekeWaarde}}.",
+    "screen_reader_graph_content": "{{value}} mensen. Signaalwaarde: {{signaalwaarde}}.",
     "fold_title": "Wat betekent dit?",
     "fold": "Het reproductiegetal laat zien hoe snel het virus zich verspreidt. Dit getal geeft aan hoeveel mensen gemiddeld besmet worden door één patiënt met COVID-19. Bij een reproductiegetal van rond de 1 blijft het aantal besmettingen ongeveer gelijk. Als het reproductiegetal lager is dan 1, dan daalt het aantal besmettingen. Bij een getal hoger dan 1 stijgt het aantal besmettingen.",
     "graph_title": "Verloop over tijd",
@@ -139,7 +137,6 @@
     "sluit": "Meer uitleg en data",
     "rangeLegendLabel": "Onzekerheidsmarge",
     "lineLegendLabel": "Effectieve R",
-    "signaalwaarde": "1",
     "bron": {
       "href": "https://www.rivm.nl/documenten/dagelijkse-update-epidemiologische-situatie-covid-19-in-nederland",
       "text": "RIVM"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -52,7 +52,7 @@
     "graph_title": "Verloop over tijd",
     "open": "Verberg uitleg",
     "sluit": "Meer uitleg en data",
-    "screen_reader_graph_content": "{{value}} intensive care-opnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
+    "screen_reader_graph_content": "{{value}} intensive care-opnames per dag. Signaalwaarde: {{signaalwaarde}} opnames per dag.",
     "bron": {
       "href": "https://stichting-nice.nl/",
       "text": "Stichting NICE"
@@ -82,7 +82,7 @@
     "graph_title": "Verloop over tijd",
     "open": "Verberg uitleg",
     "sluit": "Meer uitleg en data",
-    "screen_reader_graph_content": "{{value}} ziekenhuisopnames per dag. Signaalwaarde: {{kritiekeWaarde}} opnames per dag.",
+    "screen_reader_graph_content": "{{value}} ziekenhuisopnames per dag. Signaalwaarde: {{signaalwaarde}} opnames per dag.",
     "bron": {
       "href": "https://www.rivm.nl/documenten/dagelijkse-update-epidemiologische-situatie-covid-19-in-nederland",
       "text": "RIVM"
@@ -129,7 +129,7 @@
     "title": "Reproductiegetal",
     "text": "Aantal mensen dat besmet wordt door één besmettelijke persoon.",
     "datums": "Waarde van {{dateOfReport}}. Verkregen op {{dateOfInsertion}}. Wordt wekelijks bijgewerkt.",
-    "screen_reader_graph_content": "{{value}} mensen. Signaalwaarde: {{kritiekeWaarde}}.",
+    "screen_reader_graph_content": "{{value}} mensen. Signaalwaarde: {{signaalwaarde}}.",
     "fold_title": "Wat betekent dit?",
     "fold": "Het reproductiegetal laat zien hoe snel het virus zich verspreidt. Dit getal geeft aan hoeveel mensen gemiddeld besmet worden door één patiënt met COVID-19. Bij een reproductiegetal van rond de 1 blijft het aantal besmettingen ongeveer gelijk. Als het reproductiegetal lager is dan 1, dan daalt het aantal besmettingen. Bij een getal hoger dan 1 stijgt het aantal besmettingen.",
     "graph_title": "Verloop over tijd",


### PR DESCRIPTION
This PR:

- Ensures we use constants in the top of the tile files to declare `signaalwaardes`
- If those values are needed in the gradients, we use a reference to that constant
- Removes all mentions of the term `kritieke waarde`, replacing it with the correct term `signaalwaarde`.