### PR TITLE
Feature/chart time improvements

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -182,7 +182,7 @@ const AreaChart: React.FC<AreaChartProps> = (props) => {
     });
   }, [data]);
 
-  const [timeframe, setTimeframe] = useState<TimeframeOption>('month');
+  const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
 
   const chartOptions = useMemo(() => {
     const getOptionsThunk = (rangeData: TRange[], lineData: TLine[]) =>

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -2,17 +2,20 @@ import { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import ChartTimeControls from 'components/chartTimeControls';
+import ChartTimeControls, {
+  TimeframeOption,
+} from 'components/chartTimeControls';
 
 import formatNumber from 'utils/formatNumber';
 import formatDate from 'utils/formatDate';
+import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
 
 if (typeof Highcharts === 'object') {
   require('highcharts/highcharts-more')(Highcharts);
 }
 
-type TRangeData = [Date, number | null, number | null][];
-type TLineData = [Date, number | null][];
+type TRange = [Date, number | null, number | null];
+type TLine = [Date, number | null];
 
 interface AreaChartProps {
   rangeLegendLabel: string;
@@ -24,11 +27,12 @@ interface AreaChartProps {
     max: number | null;
   }>;
   signaalwaarde?: number;
+  timeframeOptions?: TimeframeOption[];
 }
 
 type IGetOptions = Omit<AreaChartProps, 'data'> & {
-  rangeData: TRangeData;
-  lineData: TLineData;
+  rangeData: TRange[];
+  lineData: TLine[];
 };
 
 function getOptions(props: IGetOptions): Highcharts.Options {
@@ -158,27 +162,30 @@ function getOptions(props: IGetOptions): Highcharts.Options {
 }
 
 const AreaChart: React.FC<AreaChartProps> = (props) => {
-  const { rangeLegendLabel, lineLegendLabel, data, signaalwaarde } = props;
+  const {
+    rangeLegendLabel,
+    lineLegendLabel,
+    data,
+    signaalwaarde,
+    timeframeOptions,
+  } = props;
 
-  const rangeData: TRangeData = useMemo(() => {
+  const rangeData: TRange[] = useMemo(() => {
     return data
       .sort((a, b) => a.date - b.date)
       .map((d) => [new Date(d.date * 1000), d.min, d.max]);
   }, [data]);
 
-  const lineData: TLineData = useMemo(() => {
+  const lineData: TLine[] = useMemo(() => {
     return data.map((value) => {
       return [new Date(value.date * 1000), value.avg];
     });
   }, [data]);
 
-  const [timeframe, setTimeframe] = useState('month');
+  const [timeframe, setTimeframe] = useState<TimeframeOption>('month');
 
   const chartOptions = useMemo(() => {
-    const week = 7;
-    const month = 30;
-    const days = rangeData.length;
-    const getOptionsThunk = (rangeData: TRangeData, lineData: TLineData) =>
+    const getOptionsThunk = (rangeData: TRange[], lineData: TLine[]) =>
       getOptions({
         rangeData,
         lineData,
@@ -187,21 +194,19 @@ const AreaChart: React.FC<AreaChartProps> = (props) => {
         lineLegendLabel,
       });
 
-    if (timeframe === 'all') {
-      return getOptionsThunk(rangeData, lineData);
-    }
-    if (timeframe === 'month') {
-      const range = rangeData.slice(days - month, days);
-      const line = lineData.slice(days - month, days);
+    const filteredRange = getFilteredValues<TRange>(
+      rangeData,
+      timeframe,
+      (value: TRange) => value[0].getTime()
+    );
 
-      return getOptionsThunk(range, line);
-    }
-    if (timeframe === 'week') {
-      const range = rangeData.slice(days - week, days);
-      const line = lineData.slice(days - week, days);
+    const filteredLine = getFilteredValues<TLine>(
+      lineData,
+      timeframe,
+      (value: TLine) => value[0].getTime()
+    );
 
-      return getOptionsThunk(range, line);
-    }
+    return getOptionsThunk(filteredRange, filteredLine);
   }, [
     lineData,
     rangeData,
@@ -216,7 +221,8 @@ const AreaChart: React.FC<AreaChartProps> = (props) => {
       <HighchartsReact highcharts={Highcharts} options={chartOptions} />
       <ChartTimeControls
         timeframe={timeframe}
-        onChange={(evt) => setTimeframe(evt.target.value)}
+        timeframeOptions={timeframeOptions}
+        onChange={(evt) => setTimeframe(evt.target.value as TimeframeOption)}
       />
     </>
   );

--- a/src/components/chartTimeControls/chartTimeControlUtils.ts
+++ b/src/components/chartTimeControls/chartTimeControlUtils.ts
@@ -1,16 +1,20 @@
 import { TimeframeOption } from '.';
 
 const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
+  // adds 1 extra day to capture the intended amount of days
   if (timeframe === 'week') {
     return 8;
   }
-  if (timeframe === 'month') {
-    return 32;
+  if (timeframe === '5weeks') {
+    return 36;
   }
   return Infinity;
 };
 
 const getMinimumUnixForTimeframe = (timeframe: TimeframeOption): number => {
+  if (timeframe === 'all') {
+    return 0;
+  }
   const days = getDaysForTimeframe(timeframe);
   const oneDay = 24 * 60 * 60 * 1000;
   return new Date().getTime() - days * oneDay;

--- a/src/components/chartTimeControls/chartTimeControlUtils.ts
+++ b/src/components/chartTimeControls/chartTimeControlUtils.ts
@@ -1,0 +1,37 @@
+import { TimeframeOption } from '.';
+
+const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
+  if (timeframe === 'week') {
+    return 8;
+  }
+  if (timeframe === 'month') {
+    return 32;
+  }
+  return Infinity;
+};
+
+const getMinimumUnixForTimeframe = (timeframe: TimeframeOption): number => {
+  const days = getDaysForTimeframe(timeframe);
+  const oneDay = 24 * 60 * 60 * 1000;
+  return new Date().getTime() - days * oneDay;
+};
+
+type CompareCallbackFunction<T> = (value: T) => number;
+
+/**
+ * Filter arrays of any provided types based on the timeframe.
+ * Uses a callcack to retrieve the unix time zone to compare with.
+ * @param values
+ * @param timeframe
+ * @param compareCallback
+ */
+export const getFilteredValues = <T>(
+  values: T[],
+  timeframe: TimeframeOption,
+  compareCallback: CompareCallbackFunction<T>
+): T[] => {
+  const minimumUnix = getMinimumUnixForTimeframe(timeframe);
+  return values.filter((value: T): boolean => {
+    return compareCallback(value) >= minimumUnix;
+  });
+};

--- a/src/components/chartTimeControls/chartTimeControls.module.scss
+++ b/src/components/chartTimeControls/chartTimeControls.module.scss
@@ -19,10 +19,11 @@
     text-align: center;
     padding: 0.2em 0;
     border: 1px solid $button-color;
+    border-width: 1px 0 1px 1px;
     color: $button-color;
 
-    &:nth-of-type(even) {
-      border-width: 1px 0;
+    &:last-child {
+      border-right-width: 1px;
     }
   }
 }

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -3,7 +3,7 @@ import styles from './chartTimeControls.module.scss';
 
 import text from 'locale';
 
-export type TimeframeOption = 'all' | 'month' | 'week';
+export type TimeframeOption = 'all' | '5weeks' | 'week';
 
 interface IProps {
   timeframe: string;
@@ -17,7 +17,7 @@ const ChartTimeControls: React.FC<IProps> = ({
   onChange,
 }) => {
   if (!timeframeOptions) {
-    timeframeOptions = ['all', 'month', 'week'];
+    timeframeOptions = ['all', '5weeks', 'week'];
   }
 
   const id = useMemo(() => Math.random().toString(36).substr(2), []);

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -1,46 +1,43 @@
-import { useMemo } from 'react';
+import { useMemo, Fragment } from 'react';
 import styles from './chartTimeControls.module.scss';
 
 import text from 'locale';
 
+export type TimeframeOption = 'all' | 'month' | 'week';
+
 interface IProps {
   timeframe: string;
   onChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
+  timeframeOptions?: TimeframeOption[];
 }
 
-const ChartTimeControls: React.FC<IProps> = (props) => {
-  const { timeframe, onChange } = props;
+const ChartTimeControls: React.FC<IProps> = ({
+  timeframe,
+  timeframeOptions,
+  onChange,
+}) => {
+  if (!timeframeOptions) {
+    timeframeOptions = ['all', 'month', 'week'];
+  }
 
   const id = useMemo(() => Math.random().toString(36).substr(2), []);
 
   return (
     <div className={styles['chart-radio-group']} onChange={onChange}>
-      <input
-        id={`all-${id}`}
-        type="radio"
-        name={`timeframe-${id}`}
-        value="all"
-        checked={timeframe === 'all'}
-      />
-      <label htmlFor={`all-${id}`}>{text.charts.time_controls.all}</label>
-
-      <input
-        id={`month-${id}`}
-        type="radio"
-        name={`timeframe-${id}`}
-        value="month"
-        checked={timeframe === 'month'}
-      />
-      <label htmlFor={`month-${id}`}>{text.charts.time_controls.month}</label>
-
-      <input
-        id={`week-${id}`}
-        type="radio"
-        name={`timeframe-${id}`}
-        value="week"
-        checked={timeframe === 'week'}
-      />
-      <label htmlFor={`week-${id}`}>{text.charts.time_controls.week}</label>
+      {timeframeOptions.map((option) => (
+        <Fragment key={`${option}-${id}`}>
+          <input
+            id={`${option}-${id}`}
+            type="radio"
+            name={`timeframe-${id}`}
+            value={option}
+            defaultChecked={timeframe === option}
+          />
+          <label htmlFor={`${option}-${id}`}>
+            {text.charts.time_controls[option]}
+          </label>
+        </Fragment>
+      ))}
     </div>
   );
 };

--- a/src/components/lastUpdated/index.tsx
+++ b/src/components/lastUpdated/index.tsx
@@ -6,10 +6,11 @@ import formatDate from 'utils/formatDate';
 
 type LastUpdatedProps = {
   lastUpdated?: number;
+  loadingText?: string | null;
 };
 
 const LastUpdated: FunctionComponent<LastUpdatedProps> = (props) => {
-  const { lastUpdated } = props;
+  const { lastUpdated, loadingText } = props;
 
   return (
     <p className={styles.text}>
@@ -21,7 +22,7 @@ const LastUpdated: FunctionComponent<LastUpdatedProps> = (props) => {
           </time>
         </>
       ) : (
-        siteText.laatst_bijgewerkt.loading
+        loadingText || siteText.laatst_bijgewerkt.loading
       )}
     </p>
   );

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -2,10 +2,13 @@ import React, { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import ChartTimeControls from 'components/chartTimeControls';
+import ChartTimeControls, {
+  TimeframeOption,
+} from 'components/chartTimeControls';
 
 import formatNumber from 'utils/formatNumber';
 import formatDate from 'utils/formatDate';
+import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
 
 interface Value {
   date: number;
@@ -15,6 +18,7 @@ interface Value {
 type LineChartProps = {
   values: Value[];
   signaalwaarde?: number;
+  timeframeOptions?: TimeframeOption[];
 };
 
 function getOptions(
@@ -117,31 +121,33 @@ function getOptions(
   return options;
 }
 
-const LineChart: React.FC<LineChartProps> = ({ values, signaalwaarde }) => {
-  const [timeframe, setTimeframe] = useState('month');
+const LineChart: React.FC<LineChartProps> = ({
+  values,
+  signaalwaarde,
+  timeframeOptions,
+}) => {
+  const [timeframe, setTimeframe] = useState<TimeframeOption>('month');
 
   const chartOptions = useMemo(() => {
-    const week = 7;
-    const month = 30;
-    const days = values.length;
-
-    if (timeframe === 'all') {
-      return getOptions(values, signaalwaarde);
-    }
-    if (timeframe === 'month') {
-      return getOptions(values.slice(days - month, days), signaalwaarde);
-    }
-    if (timeframe === 'week') {
-      return getOptions(values.slice(days - week, days), signaalwaarde);
-    }
+    const filteredValues = getFilteredValues<Value>(
+      values,
+      timeframe,
+      (value: Value) => value.date * 1000
+    );
+    return getOptions(filteredValues, signaalwaarde);
   }, [values, timeframe, signaalwaarde]);
+
+  if (!timeframeOptions) {
+    timeframeOptions = ['all', 'month', 'week'];
+  }
 
   return (
     <>
       <HighchartsReact highcharts={Highcharts} options={chartOptions} />
       <ChartTimeControls
         timeframe={timeframe}
-        onChange={(evt) => setTimeframe(evt.target.value)}
+        timeframeOptions={timeframeOptions}
+        onChange={(evt) => setTimeframe(evt.target.value as TimeframeOption)}
       />
     </>
   );

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -126,7 +126,7 @@ const LineChart: React.FC<LineChartProps> = ({
   signaalwaarde,
   timeframeOptions,
 }) => {
-  const [timeframe, setTimeframe] = useState<TimeframeOption>('month');
+  const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
 
   const chartOptions = useMemo(() => {
     const filteredValues = getFilteredValues<Value>(
@@ -138,7 +138,7 @@ const LineChart: React.FC<LineChartProps> = ({
   }, [values, timeframe, signaalwaarde]);
 
   if (!timeframeOptions) {
-    timeframeOptions = ['all', 'month', 'week'];
+    timeframeOptions = ['all', '5weeks', 'week'];
   }
 
   return (

--- a/src/components/tiles/InfectiousPeople.tsx
+++ b/src/components/tiles/InfectiousPeople.tsx
@@ -100,7 +100,7 @@ export const InfectiousPeople: React.FC = () => {
             }))}
             rangeLegendLabel={text.rangeLegendLabel}
             lineLegendLabel={text.lineLegendLabel}
-            timeframeOptions={['all', 'month']}
+            timeframeOptions={['all', '5weeks']}
           />
         )}
 

--- a/src/components/tiles/InfectiousPeople.tsx
+++ b/src/components/tiles/InfectiousPeople.tsx
@@ -100,6 +100,7 @@ export const InfectiousPeople: React.FC = () => {
             }))}
             rangeLegendLabel={text.rangeLegendLabel}
             lineLegendLabel={text.lineLegendLabel}
+            timeframeOptions={['all', 'month']}
           />
         )}
 

--- a/src/components/tiles/SewerWater.tsx
+++ b/src/components/tiles/SewerWater.tsx
@@ -67,6 +67,7 @@ export const SewerWater: React.FC = () => {
         {data?.values && (
           <>
             <LineChart
+              timeframeOptions={['all', 'month']}
               values={data.values.map((value) => ({
                 value: Number(value.average),
                 date: value.week_unix,

--- a/src/components/tiles/SewerWater.tsx
+++ b/src/components/tiles/SewerWater.tsx
@@ -67,7 +67,7 @@ export const SewerWater: React.FC = () => {
         {data?.values && (
           <>
             <LineChart
-              timeframeOptions={['all', 'month']}
+              timeframeOptions={['all', '5weeks']}
               values={data.values.map((value) => ({
                 value: Number(value.average),
                 date: value.week_unix,

--- a/src/components/tiles/SuspectedPatients.tsx
+++ b/src/components/tiles/SuspectedPatients.tsx
@@ -78,7 +78,7 @@ export const SuspectedPatients: React.FC = () => {
         {data && (
           <>
             <LineChart
-              timeframeOptions={['all', 'month']}
+              timeframeOptions={['all', '5weeks']}
               values={data.values.map((value) => ({
                 value: value.incidentie,
                 date: value.week_unix,

--- a/src/components/tiles/SuspectedPatients.tsx
+++ b/src/components/tiles/SuspectedPatients.tsx
@@ -78,6 +78,7 @@ export const SuspectedPatients: React.FC = () => {
         {data && (
           <>
             <LineChart
+              timeframeOptions={['all', 'month']}
               values={data.values.map((value) => ({
                 value: value.incidentie,
                 date: value.week_unix,

--- a/src/components/tiles/regio/SewerWater.tsx
+++ b/src/components/tiles/regio/SewerWater.tsx
@@ -91,6 +91,8 @@ export const SewerWater: React.FC<IProps> = ({ data, selectedRegio }) => {
           piwikName="Rioolwatermeting"
           piwikAction="regionaal"
         >
+          <h4>{text.fold_title}</h4>
+          <p>{text.fold}</p>
           {data?.average_sewer_installation_per_region?.values &&
             data?.results_per_sewer_installation_per_region?.values && (
               <>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -468,7 +468,8 @@
     "time_controls": {
       "all": "Show everything",
       "month": "Last month",
-      "week": "Last week"
+      "week": "Last week",
+      "5weeks": "Last 5 weeks"
     }
   },
   "utils": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -468,7 +468,8 @@
     "time_controls": {
       "all": "Toon alles",
       "month": "Laatste maand",
-      "week": "Laatste week"
+      "week": "Laatste week",
+      "5weeks": "Laatste 5 weken"
     }
   },
   "utils": {

--- a/src/pages/regio/index.tsx
+++ b/src/pages/regio/index.tsx
@@ -151,7 +151,10 @@ const Regio: FunctionComponentWithLayout<RegioProps> = (props) => {
   return (
     <>
       <MaxWidth>
-        <LastUpdated lastUpdated={data?.last_generated * 1000} />
+        <LastUpdated
+          lastUpdated={data?.last_generated * 1000}
+          loadingText={selectedRegio ? null : '\u00A0'}
+        />
         <div className={styles['regio-grid']}>
           <div className={styles['map-column']} ref={selectRegioWrapperRef}>
             <SelectMunicipality


### PR DESCRIPTION
## Summary

Fixes a few issues with the chart time control and the control of the values inside it from LineChart and AreaChart.

## Motivation

Some charts display data tied to dates way in the past, when eg month or week is selected. This is unified to filter to a date X days in the past, based on the chosen option.

Also changed is the possibility to provide which time slots are visible in the chart time control. This is now used only to remove the Week value for some tile that do not make sense to use it (eg measurement once every week or less frequent).

Then there is the Month. That's in a month? 30 days, 31, 29? The label is adjusted to "Last 5 weeks".

## Detailed design

In ChartTimeControl there is now a type TimeframeOption, used to pass it's value around in a secure manner. The component uses the default all/5weeks/week to render the controls dynamically.

LineChart and Area chart used to slice data from arrays to then render it. Now there is a check on the actual date value. For this I have written a generic util in the ChartTimeControl that can be used in LineChart and AreaChart to filter the correct (typed) data. The util file also contains methods to retrieve the amount of days for the provided TimeframeOption.

TimeframeOptions can be passed to LineChart, AreaChart and ChartTimeControl as an optional parameter.

## Drawbacks

Tradeoffs are that the charts can look messy and inconsistent in date values; and that some charts will only display 1 or 2 values.

## Alternatives

The change of "last 5 weeks" could be tweaked, or a definition could be provided elsewhere.

## Unresolved questions

-
