### PR TITLE
Correct date format for EN short dates

### DIFF
--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,6 +2,7 @@ import { isToday, isYesterday } from 'date-fns';
 
 import siteText from 'locale';
 import getLocale from 'utils/getLocale';
+import replaceVariablesInText from './replaceVariablesInText';
 
 const locale = getLocale();
 
@@ -35,6 +36,8 @@ const Day = new Intl.DateTimeFormat(locale, {
   day: 'numeric',
 });
 
+const shortFormat = locale === 'nl' ? '{{day}} {{month}}' : '{{month}} {{day}}';
+
 function formatDate(
   value: number | Date,
   style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
@@ -51,5 +54,8 @@ function formatDate(
   }
 
   // short or relative
-  return `${Day.format(value)} ${Month.format(value)}`; // '23 juli'
+  return replaceVariablesInText(shortFormat, {
+    day: Day.format(value),
+    month: Month.format(value),
+  });
 }


### PR DESCRIPTION
## Summary & Motivation

The English date format was in the wrong order.

## Detailed design

Based on the locale I set a string for the date format, that can then be used by filling in the template for day and month.

## Drawbacks / Alternatives

We use both imports from date-fns and the webplatform's Intl.DateTimeFormat. Perhaps there is a cleaner way to determine the proper format for the locale.

## Unresolved questions

n/a
