### PR TITLE
Lang=EN: Add language switcher

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -73,23 +73,23 @@ const Layout: FunctionComponentWithLayout<LayoutProps> = (props) => {
         <MaxWidth>
           <div className={styles.languageSwitcher}>
             <a
-              href={`${text.language_switcher.nl_base_url}${router.asPath}`}
+              href={`https://coronadashboard.rijksoverheid.nl${router.asPath}`}
               lang="nl"
               hrefLang="nl"
               className={locale === 'nl' ? styles.languageActive : undefined}
-              title={text.language_switcher.nl_title}
+              title="Website in het Nederlands"
             >
-              {text.language_switcher.nl}
+              NL
             </a>
             |
             <a
-              href={`${text.language_switcher.en_base_url}${router.asPath}`}
+              href={`https://coronadashboard.government.nl${router.asPath}`}
               lang="en-GB"
               hrefLang="en-GB"
               className={locale === 'en-GB' ? styles.languageActive : undefined}
-              title={text.language_switcher.en_title}
+              title="Website in English"
             >
-              {text.language_switcher.en}
+              EN
             </a>
           </div>
           <h1>{text.header.title}</h1>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -8,6 +8,7 @@ import MaxWidth from 'components/maxWidth';
 import text from 'locale';
 import useMediaQuery from 'utils/useMediaQuery';
 import SEOHead from 'components/seoHead';
+import getLocale from 'utils/getLocale';
 
 export interface LayoutProps {
   url?: string;
@@ -35,6 +36,7 @@ const Layout: FunctionComponentWithLayout<LayoutProps> = (props) => {
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
 
+  const locale = getLocale();
   const showSmallLogo = useMediaQuery('(max-width: 480px)', true);
 
   return (
@@ -69,6 +71,27 @@ const Layout: FunctionComponentWithLayout<LayoutProps> = (props) => {
         </div>
 
         <MaxWidth>
+          <div className={styles.languageSwitcher}>
+            <a
+              href={`${text.language_switcher.nl_base_url}${router.asPath}`}
+              lang="nl"
+              hrefLang="nl"
+              className={locale === 'nl' ? styles.languageActive : undefined}
+              title={text.language_switcher.nl_title}
+            >
+              {text.language_switcher.nl}
+            </a>
+            |
+            <a
+              href={`${text.language_switcher.en_base_url}${router.asPath}`}
+              lang="en-GB"
+              hrefLang="en-GB"
+              className={locale === 'en-GB' ? styles.languageActive : undefined}
+              title={text.language_switcher.en_title}
+            >
+              {text.language_switcher.en}
+            </a>
+          </div>
           <h1>{text.header.title}</h1>
           <p>
             {text.header.text}{' '}

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,5 +1,7 @@
 @import 'scss/variables.scss';
 
+$language-switcher-offset: 55px;
+
 .logoWrapper {
   display: flex;
   flex-flow: row wrap;
@@ -30,6 +32,34 @@
 
   p {
     margin-bottom: $default-margin * 2;
+  }
+}
+
+.languageActive {
+  font-weight: 700;
+}
+
+.languageSwitcher {
+  height: $language-switcher-offset;
+  margin-top: -1 * $language-switcher-offset;
+  text-align: right;
+  color: $text-color;
+
+  a {
+    border-bottom-color: transparent;
+    border-bottom: 2px solid transparent;
+    color: inherit;
+    display: inline-block;
+    margin: 0 4px;
+    text-align: center;
+    text-decoration: none;
+    min-width: 24px;
+
+    &.languageActive,
+    &:hover,
+    &:focus {
+      border-color: $button-color;
+    }
   }
 }
 

--- a/src/components/tiles/ReproductionIndex.tsx
+++ b/src/components/tiles/ReproductionIndex.tsx
@@ -98,6 +98,7 @@ export const ReproductionIndex: React.FC = () => {
             signaalwaarde={SIGNAAL_WAARDE}
             rangeLegendLabel={text.rangeLegendLabel}
             lineLegendLabel={text.lineLegendLabel}
+            timeframeOptions={['all', '5weeks']}
           />
         )}
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -525,5 +525,13 @@
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
     "default_title": "Dashboard Coronavirus COVID-19 | Rijksoverheid.nl",
     "default_url": "https://coronadashboard.rijksoverheid.nl"
+  },
+  "language_switcher": {
+    "en": "EN",
+    "en_title": "Website in English",
+    "en_base_url": "https://coronadashboard.government.nl",
+    "nl": "NL",
+    "nl_title": "Website in het Nederlands",
+    "nl_base_url": "https://coronadashboard.rijksoverheid.nl"
   }
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -525,13 +525,5 @@
     "default_description": "Information on the development of the coronavirus in The Netherlands.",
     "default_title": "Dashboard Coronavirus COVID-19 | Government.nl",
     "default_url": "https://coronadashboard.government.nl"
-  },
-  "language_switcher": {
-    "en": "EN",
-    "en_title": "Website in English",
-    "en_base_url": "https://coronadashboard.government.nl",
-    "nl": "NL",
-    "nl_title": "Website in het Nederlands",
-    "nl_base_url": "https://coronadashboard.rijksoverheid.nl"
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -525,5 +525,13 @@
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
     "default_title": "Dashboard Coronavirus COVID-19 | Rijksoverheid.nl",
     "default_url": "https://coronadashboard.rijksoverheid.nl"
+  },
+  "language_switcher": {
+    "en": "EN",
+    "en_title": "Website in English",
+    "en_base_url": "https://coronadashboard.government.nl",
+    "nl": "NL",
+    "nl_title": "Website in het Nederlands",
+    "nl_base_url": "https://coronadashboard.rijksoverheid.nl"
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -525,13 +525,5 @@
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
     "default_title": "Dashboard Coronavirus COVID-19 | Rijksoverheid.nl",
     "default_url": "https://coronadashboard.rijksoverheid.nl"
-  },
-  "language_switcher": {
-    "en": "EN",
-    "en_title": "Website in English",
-    "en_base_url": "https://coronadashboard.government.nl",
-    "nl": "NL",
-    "nl_title": "Website in het Nederlands",
-    "nl_base_url": "https://coronadashboard.rijksoverheid.nl"
   }
 }


### PR DESCRIPTION
## Summary & Motivation

For the lang=en launch:
* Adds the language switcher to the header.
* Adjusts the areachart for reproduction index to exclude the week data.

## Detailed design

The route subpath is added to a base url, to maintain the current page that the user is on (eg when to receive a link from someone else)

Links use the proper lang / hreflang attributes to indicate language changes

The language strings are added to the locale files; yet they are not intended to be translated. It's merely for copy control. (The english text "Website in English" eg should be on the NL site when hovering the EN link.)

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

No specific mobile design was provided; perhaps a more elaborate implementation is wanted there (to occupy less screen estate)
