### PR TITLE
Fix rel noopener noreferrer

### DIFF
--- a/src/components/replaceLinks/index.tsx
+++ b/src/components/replaceLinks/index.tsx
@@ -5,7 +5,12 @@ import Linkify, { LinkifyProps } from 'linkifyjs/react';
  */
 
 const ReplaceLinks: React.FC<IProps> = (props) => {
-  const { children, tagName, options } = props;
+  const { children, tagName } = props;
+
+  const options = {
+    ...props?.options,
+    attributes: { rel: 'noopener noreferrer', ...props?.options?.attributes },
+  };
 
   return (
     <Linkify tagName={tagName} options={options}>


### PR DESCRIPTION
## Summary & Motivation

Fix external links opened in a new tab by providing the security measure `rel="noopener noreferrer"`

## Detailed design

Rewrite the way the options for linkify are handled to always have the rel as default in there.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a
