### PR TITLE
Apply styling on MD container

### DIFF
--- a/src/pages/over.module.scss
+++ b/src/pages/over.module.scss
@@ -21,10 +21,6 @@
   h2:not(:first-child) {
     margin-top: 2em;
   }
-
-  h3 {
-    font-size: 1.125em;
-  }
 }
 
 .maxwidth {

--- a/src/pages/over.module.scss
+++ b/src/pages/over.module.scss
@@ -15,11 +15,15 @@
   padding-bottom: 3em;
 
   p {
-    font-size: 1.125em;
+    font-size: 1em;
   }
 
   h2:not(:first-child) {
     margin-top: 2em;
+  }
+
+  h3 {
+    font-size: 1.125em;
   }
 }
 

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -71,7 +71,7 @@ const Over: FunctionComponentWithLayout<{ text: any }> = (props) => {
             <h2>{text.over_disclaimer.title}</h2>
             <p>{text.over_disclaimer.text}</p>
             <h2>{text.over_veelgestelde_vragen.text}</h2>
-            <div className={styles.faqList}>
+            <article className={styles.faqList}>
               {text.over_veelgestelde_vragen.vragen.map(
                 (item: IVraagEnAntwoord) => (
                   <Fragment key={`item-${item.vraag}`}>
@@ -84,7 +84,7 @@ const Over: FunctionComponentWithLayout<{ text: any }> = (props) => {
                   </Fragment>
                 )
               )}
-            </div>
+            </article>
           </div>
         </MaxWidth>
       </div>

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -71,12 +71,12 @@ const Over: FunctionComponentWithLayout<{ text: any }> = (props) => {
             <h2>{text.over_disclaimer.title}</h2>
             <p>{text.over_disclaimer.text}</p>
             <h2>{text.over_veelgestelde_vragen.text}</h2>
-            <dl className={styles.faqList}>
+            <div className={styles.faqList}>
               {text.over_veelgestelde_vragen.vragen.map(
                 (item: IVraagEnAntwoord) => (
                   <Fragment key={`item-${item.vraag}`}>
-                    <dt>{item.vraag}</dt>
-                    <dd
+                    <h3>{item.vraag}</h3>
+                    <div
                       dangerouslySetInnerHTML={{
                         __html: item.antwoord,
                       }}
@@ -84,7 +84,7 @@ const Over: FunctionComponentWithLayout<{ text: any }> = (props) => {
                   </Fragment>
                 )
               )}
-            </dl>
+            </div>
           </div>
         </MaxWidth>
       </div>

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -68,18 +68,18 @@ const Verantwoording: FunctionComponentWithLayout<{ text: any }> = (props) => {
           <div className={styles.maxwidth}>
             <h2>{text.verantwoording.title}</h2>
             <p>{text.verantwoording.paragraaf}</p>
-            <dl className={styles.faqList}>
+            <div className={styles.faqList}>
               {text.verantwoording.cijfers.map((item: ICijfer) => (
                 <Fragment key={`item-${item.cijfer}`}>
-                  <dt>{item.cijfer}</dt>
-                  <dd
+                  <h3>{item.cijfer}</h3>
+                  <div
                     dangerouslySetInnerHTML={{
                       __html: item.verantwoording,
                     }}
-                  ></dd>
+                  />
                 </Fragment>
               ))}
-            </dl>
+            </div>
           </div>
         </MaxWidth>
       </div>

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -68,7 +68,7 @@ const Verantwoording: FunctionComponentWithLayout<{ text: any }> = (props) => {
           <div className={styles.maxwidth}>
             <h2>{text.verantwoording.title}</h2>
             <p>{text.verantwoording.paragraaf}</p>
-            <div className={styles.faqList}>
+            <article className={styles.faqList}>
               {text.verantwoording.cijfers.map((item: ICijfer) => (
                 <Fragment key={`item-${item.cijfer}`}>
                   <h3>{item.cijfer}</h3>
@@ -79,7 +79,7 @@ const Verantwoording: FunctionComponentWithLayout<{ text: any }> = (props) => {
                   />
                 </Fragment>
               ))}
-            </div>
+            </article>
           </div>
         </MaxWidth>
       </div>


### PR DESCRIPTION
## Summary

The Markdown text was placed in `<dd>`, wrapped in a `<dl>`. But since the Markdown paragraphs automatically export to a `<p>` the DOM looked like `<dd><p>markdown text</p></dd>`, conflicting with the set styles and causing the text to appear large and inconsistent.

## Motivation

Have the copy look consistent throughout the product

## Detailed design

The titles are now `<h3>` elements, and the paragraphs are `<p>` (Markdown default), wrapped in a `<div>` using `dangerouslySetInnerHTML`. 

