### PR TITLE
Visit util (to be used for Markdown support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",
     "swr": "^0.3.1",
+    "traverse": "^0.6.6",
     "unfetch": "^4.1.0",
     "unified": "^9.2.0"
   },
@@ -41,6 +42,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
+    "@types/traverse": "^0.6.32",
     "@types/unist": "^2.0.3",
     "@types/webpack": "^4.41.21",
     "@typescript-eslint/eslint-plugin": "^3.9.1",

--- a/src/utils/__tests__/visit.spec.ts
+++ b/src/utils/__tests__/visit.spec.ts
@@ -1,0 +1,15 @@
+import { visit } from '../visit';
+
+const raw = {
+  foo: 'bar',
+};
+
+const fn = (str: string) => str.toUpperCase();
+
+describe('Visit Function', () => {
+  it('Should apply traverse to object', () => {
+    expect(visit(raw, fn)).toStrictEqual({
+      foo: 'BAR',
+    });
+  });
+});

--- a/src/utils/visit.ts
+++ b/src/utils/visit.ts
@@ -1,0 +1,9 @@
+import traverse from 'traverse';
+
+const isText = (value: string) => typeof value === 'string';
+
+export const visit = (obj: any, visitor: (para: string) => string) => {
+  return traverse(obj).forEach(function (x) {
+    if (isText(x)) this.update(visitor(x));
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,18 @@
   dependencies:
     "@types/react" "*"
 
+"@types/lodash.foreach@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.foreach/-/lodash.foreach-4.5.6.tgz#24735299139a739e436ab4fb8a6a31ca3d54bbb3"
+  integrity sha512-A8+157A+27zwJSstmW/eWPc9lHLJNEer4jiMlsyxWieBxEx0arwB9vgQm+iai6DEDYYQuufHrzVhQOiapCalQQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.160"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.160.tgz#2f1bba6500bc3cb9a732c6d66a083378fb0b0b29"
+  integrity sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==
+
 "@types/mdast@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -1820,6 +1832,11 @@
   integrity sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==
   dependencies:
     "@types/jest" "*"
+
+"@types/traverse@^0.6.32":
+  version "0.6.32"
+  resolved "https://registry.yarnpkg.com/@types/traverse/-/traverse-0.6.32.tgz#f9fdfa40cd4898deaa975a14511aec731de8235e"
+  integrity sha512-RBz2uRZVCXuMg93WD//aTS5B120QlT4lR/gL+935QtGsKHLS6sCtZBaKfWjIfk7ZXv/r8mtGbwjVIee6/3XTow==
 
 "@types/uglify-js@*":
   version "3.9.3"
@@ -7011,6 +7028,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -10409,7 +10431,7 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-traverse@0.6.6:
+traverse@0.6.6, traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=


### PR DESCRIPTION
## Summary

This PR will improve overall Markdown support by implementing a visitor function that searches `siteText` objects and parses all `string` entries using the `MDToHTMLString` function.

## Motivation

Allow for easy implementation of Markdown throughout the codebase.

## Detailed design

Uses [traverse](https://github.com/substack/js-traverse) to look into layered objects and uses its `update()` function to update specific entries.

## Drawbacks

WIP

## Alternatives

WIP

## Unresolved questions

WIP