### PR TITLE
Add schema for municipalities data that will be used to draw the chloropleths

### DIFF
--- a/schema/municipalities/deceased.json
+++ b/schema/municipalities/deceased.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "deceased",
+  "additionalProperties": false,
+  "required": [
+    "date_of_report_unix",
+    "gmcode",
+    "deceased",
+    "date_of_insertion_unix"
+  ],
+  "properties": {
+    "date_of_report_unix": {
+      "type": "integer"
+    },
+    "gmcode": {
+      "type": "string",
+      "pattern": "^GM[0-9]+$"
+    },
+    "deceased": {
+      "type": "number"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    }
+  }
+}

--- a/schema/municipalities/hospital_admissions.json
+++ b/schema/municipalities/hospital_admissions.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "hospital_admissions",
+  "additionalProperties": false,
+  "required": [
+    "date_of_report_unix",
+    "gmcode",
+    "hospital_admissions",
+    "date_of_insertion_unix"
+  ],
+  "properties": {
+    "date_of_report_unix": {
+      "type": "integer"
+    },
+    "gmcode": {
+      "type": "string",
+      "pattern": "^GM[0-9]+$"
+    },
+    "hospital_admissions": {
+      "type": "number"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    }
+  }
+}

--- a/schema/municipalities/municipalities.json
+++ b/schema/municipalities/municipalities.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "title": "municipal",
+  "title": "municipalities",
   "additionalProperties": false,
   "required": [
     "last_generated",
@@ -10,7 +10,7 @@
     "code",
     "hospital_admissions",
     "positive_tested_people",
-    "sewer_measurements"
+    "deceased"
   ],
   "properties": {
     "last_generated": {
@@ -18,24 +18,33 @@
     },
     "proto_name": {
       "type": "string",
-      "pattern": "^GM[0-9]+$"
+      "enum": ["MUNICIPALITIES"]
     },
     "name": {
       "type": "string",
-      "pattern": "^GM[0-9]+$"
+      "enum": ["MUNICIPALITIES"]
     },
     "code": {
       "type": "string",
-      "pattern": "^GM[0-9]+$"
+      "enum": ["MUNICIPALITIES"]
     },
     "hospital_admissions": {
-      "$ref": "hospital_admissions.json"
+      "type": "array",
+      "items": {
+        "$ref": "hospital_admissions.json"
+      }
     },
     "positive_tested_people": {
-      "$ref": "positive_tested_people.json"
+      "type": "array",
+      "items": {
+        "$ref": "positive_tested_people.json"
+      }
     },
-    "sewer_measurements": {
-      "$ref": "sewer_measurements.json"
+    "deceased": {
+      "type": "array",
+      "items": {
+        "$ref": "deceased.json"
+      }
     }
   }
 }

--- a/schema/municipalities/positive_tested_people.json
+++ b/schema/municipalities/positive_tested_people.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "positive_tested_people",
+  "additionalProperties": false,
+  "required": [
+    "date_of_report_unix",
+    "gmcode",
+    "positive_tested_people",
+    "date_of_insertion_unix"
+  ],
+  "properties": {
+    "date_of_report_unix": {
+      "type": "integer"
+    },
+    "gmcode": {
+      "type": "string",
+      "pattern": "^GM[0-9]+$"
+    },
+    "positive_tested_people": {
+      "type": "number"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    }
+  }
+}

--- a/schema/regional/results_per_region.json
+++ b/schema/regional/results_per_region.json
@@ -11,7 +11,6 @@
         "hospital_total_counts_per_region",
         "infected_increase_per_region",
         "hospital_increase_per_region",
-        "infected_moving_avg_per_region",
         "hospital_moving_avg_per_region",
         "date_of_insertion_unix"
       ],
@@ -23,10 +22,6 @@
         "hospital_total_counts_per_region": { "type": "number" },
         "infected_increase_per_region": { "type": "number" },
         "hospital_increase_per_region": { "type": "number" },
-        "infected_moving_avg_per_region": {
-          "type": ["number", "null"],
-          "nullable": true
-        },
         "hospital_moving_avg_per_region": { "type": "number" },
         "date_of_insertion_unix": { "type": "integer" }
       }

--- a/schema/validator/validate-json.js
+++ b/schema/validator/validate-json.js
@@ -12,6 +12,7 @@ const schemaToJsonLookup = {
   ranges: ['RANGES.json'],
   regional: filterFilenames(allJsonFiles, new RegExp('^VR[0-9]+\\.json$')),
   municipal: filterFilenames(allJsonFiles, new RegExp('^GM[0-9]+\\.json$')),
+  municipalities: ['municipalities.json'],
 };
 
 // The validations are asynchronous so this reducer gathers all the Promises in one array.


### PR DESCRIPTION
## Summary

As the title suggest this PR adds a schema for the chloropleth data

## Motivation

Required for the new choropleth maps

## Detailed design

This schema describes a dataset that consists of three keys:
- hospital_admissions
- positive_tested_people
- deceased

Each of these properties is an array of structs that look roughly like this:
```
{
  "date_of_report_unix": 1586131200,
  "gmcode": "GM0014",
  "THIS_PROPERTY_DIFFERS_PER_KEY": 100,
  "date_of_insertion_unix": 1598281329
}
```

Given that each array will have an item for every municipality in the Netherlands (if that particular metric is available for that municipality)

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a