### PR TITLE
Fix to municipal schema

### DIFF
--- a/schema/municipal/municipal.json
+++ b/schema/municipal/municipal.json
@@ -28,6 +28,9 @@
     },
     "sewer_measurements": {
       "$ref": "sewer_measurements.json"
+    },
+    "results_per_sewer_installation_per_municipality": {
+      "$ref": "results_per_sewer_installation_per_municipality.json"
     }
   }
 }

--- a/schema/municipal/results_per_sewer_installation_per_municipality.json
+++ b/schema/municipal/results_per_sewer_installation_per_municipality.json
@@ -1,0 +1,84 @@
+{
+  "definitions": {
+    "item": {
+      "title": "results_per_sewer_installation_per_municipality_last_value",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "date_measurement_unix",
+        "week_start_unix",
+        "week_end_unix",
+        "week",
+        "rwzi_awzi_code",
+        "rwzi_awzi_name",
+        "gm_code",
+        "rna_per_ml",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "date_measurement_unix": {
+          "type": "integer"
+        },
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
+          "type": "integer"
+        },
+        "week": {
+          "type": "integer"
+        },
+        "rwzi_awzi_code": {
+          "type": "string"
+        },
+        "rwzi_awzi_name": {
+          "type": "string"
+        },
+        "gm_code": {
+          "type": "string",
+          "pattern": "^GM[0-9]+$"
+        },
+        "rna_per_ml": {
+          "type": "number"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    },
+    "installation_item": {
+      "title": "results_per_sewer_installation_per_municipality_item",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rwzi_awzi_code", "values", "last_value"],
+      "properties": {
+        "rwzi_awzi_code": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/item"
+          }
+        },
+        "last_value": {
+          "$ref": "#/definitions/item"
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "results_per_sewer_installation_per_municipality.json",
+  "title": "results_per_sewer_installation_per_municipality",
+  "type": "object",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/installation_item"
+      }
+    }
+  }
+}

--- a/schema/municipalities/municipalities.json
+++ b/schema/municipalities/municipalities.json
@@ -30,18 +30,21 @@
     },
     "hospital_admissions": {
       "type": "array",
+      "maxItems": 355,
       "items": {
         "$ref": "hospital_admissions.json"
       }
     },
     "positive_tested_people": {
       "type": "array",
+      "maxItems": 355,
       "items": {
         "$ref": "positive_tested_people.json"
       }
     },
     "deceased": {
       "type": "array",
+      "maxItems": 355,
       "items": {
         "$ref": "deceased.json"
       }

--- a/schema/regional/results_per_region.json
+++ b/schema/regional/results_per_region.json
@@ -11,7 +11,6 @@
         "hospital_total_counts_per_region",
         "infected_increase_per_region",
         "hospital_increase_per_region",
-        "infected_moving_avg_per_region",
         "hospital_moving_avg_per_region",
         "date_of_insertion_unix"
       ],
@@ -23,10 +22,6 @@
         "hospital_total_counts_per_region": { "type": "number" },
         "infected_increase_per_region": { "type": "number" },
         "hospital_increase_per_region": { "type": "number" },
-        "infected_moving_avg_per_region": {
-          "type": ["number", "null"],
-          "nullable": true
-        },
         "hospital_moving_avg_per_region": { "type": "number" },
         "date_of_insertion_unix": { "type": "integer" }
       }


### PR DESCRIPTION
## Summary

Small fix to the municipal schema that adds a property and a minor addition to the municipalities schema where the max length of the arrays is set to 355 (the maximum number of Dutch municipalities)

## Motivation

Getting the schema collection as complete as possible

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a
