### PR TITLE
Fix/Add exit code when validation fails (so that CI will also fail)

### DIFF
--- a/schema/validator/validate-json.js
+++ b/schema/validator/validate-json.js
@@ -34,6 +34,7 @@ Promise.all(results)
   })
   .catch((error) => {
     console.error(error);
+    process.exit(1);
   });
 
 /** This function creates a SchemaValidator instance for the given schema

--- a/schema/validator/validate-single.js
+++ b/schema/validator/validate-single.js
@@ -18,7 +18,7 @@ Where schema name must be one of these values: ${validSchemaNames.join(', ')}
 
 and json filename must a file present in the '${jsonBasePath}' directory.`
   );
-  process.exit();
+  process.exit(1);
 }
 
 const schemaName = myArgs[0];
@@ -30,14 +30,14 @@ if (!validSchemaNames.includes(schemaName)) {
       ', '
     )}`
   );
-  process.exit();
+  process.exit(1);
 }
 
 if (!fs.existsSync(path.join(jsonBasePath, jsonFileName))) {
   console.error(
     `Invalid json filename argument '${jsonFileName}', file does not exist in directory ${jsonBasePath}`
   );
-  process.exit();
+  process.exit(1);
 }
 
 const validatorInstance = new SchemaValidator(


### PR DESCRIPTION
## Summary

When validations failed the node script didn't properly return an exit code, hence CI wouldn't pick up the fact that it failed.
This is fixed in this PR

## Motivation

n/a

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a
