### PR TITLE
chore: always position zeroline on bottom of y-axis

### DIFF
--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -76,6 +76,7 @@ function getOptions(
     },
     yAxis: {
       min: 0,
+      max: values.length > 0 ? null : 1,
       allowDecimals: false,
       lineColor: '#C4C4C4',
       gridLineColor: '#C4C4C4',


### PR DESCRIPTION
## Summary

This PR adds a `max` value for the line chart based on a ternary that checks if data is available.

## Motivation

The default settings of the `highcharts` `linechart` places the line based on the middle of the y-axis, resulting in a floating zero-line when data is absent.

## Detailed design

When no data is available, its data (`filteredValues`) is an empty array (not `null`), the ternary checks if the length of `values` is more than 0.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
