### PR TITLE
Fix: LineChart on positively tested people tile for municipality now uses correct key

### DIFF
--- a/src/components/tiles/municipality/PositivelyTestedPeople.tsx
+++ b/src/components/tiles/municipality/PositivelyTestedPeople.tsx
@@ -130,7 +130,7 @@ export const PostivelyTestedPeopleMunicipality: React.FC<IProps> = (props) => {
             <LineChart
               values={data.positive_tested_people.values.map(
                 (value: PositiveTestedPeople) => ({
-                  value: value.infected_daily_total,
+                  value: value.infected_daily_increase,
                   date: value.date_of_report_unix,
                 })
               )}


### PR DESCRIPTION
## Summary

As the title says

## Motivation

n/a

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
