### PR TITLE
feat: Allow combobox to search for alternative spellings

### DIFF
--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -13,6 +13,7 @@ import useThrottle from 'utils/useThrottle';
 import text from 'locale';
 
 type TOption = {
+  displayName?: string;
   name: string;
 };
 
@@ -70,7 +71,10 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
         {results.length > 0 ? (
           <ComboboxList>
             {results.slice(0, 10).map((option) => (
-              <ComboboxOption key={option.name} value={option.name} />
+              <ComboboxOption
+                key={option.name}
+                value={option.displayName || option.name}
+              />
             ))}
           </ComboboxList>
         ) : (
@@ -92,7 +96,7 @@ function useSearchedOptions<Option extends TOption>(
     if (throttledTerm.trim() === '') return options.sort(sortByName);
 
     return matchSorter(options, throttledTerm, {
-      keys: [(item: Option) => item.name],
+      keys: [(item: Option) => item.name, 'searchTerms', 'displayName'],
     });
   }, [throttledTerm, options]);
 }

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -29,6 +29,7 @@ type TMuncipality = {
   displayName?: string;
   safetyRegion: string;
   gemcode: string;
+  searchTerms: string[];
 };
 
 export function getMunicipalityLayout() {

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -29,7 +29,7 @@ type TMuncipality = {
   displayName?: string;
   safetyRegion: string;
   gemcode: string;
-  searchTerms: string[];
+  searchTerms?: string[];
 };
 
 export function getMunicipalityLayout() {

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -24,14 +24,7 @@ import municipalities from 'data/gemeente_veiligheidsregio.json';
 
 export default MunicipalityLayout;
 
-type TMuncipality = {
-  name: string;
-  displayName?: string;
-  safetyRegion: string;
-  gemcode: string;
-  searchTerms?: string[];
-};
-
+export type TMunicipality = typeof municipalities;
 export function getMunicipalityLayout() {
   return function (page: React.ReactNode): React.ReactNode {
     return getSiteLayout(siteText.gemeente_metadata)(

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -8,6 +8,7 @@ import { getLayout as getSiteLayout } from 'components/layout';
 import { PostivelyTestedPeopleBarScale } from 'pages/gemeente/positief-geteste-mensen';
 import { IntakeHospitalBarScale } from 'pages/gemeente/ziekenhuis-opnames';
 import { SewerWaterBarScale } from 'pages/gemeente/rioolwater';
+import Combobox from 'components/comboBox';
 
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
@@ -19,7 +20,16 @@ import { WithChildren } from 'types';
 
 import useMediaQuery from 'utils/useMediaQuery';
 
+import municipalities from 'data/gemeente_veiligheidsregio.json';
+
 export default MunicipalityLayout;
+
+type TMuncipality = {
+  name: string;
+  displayName?: string;
+  safetyRegion: string;
+  gemcode: string;
+};
 
 export function getMunicipalityLayout() {
   return function (page: React.ReactNode): React.ReactNode {
@@ -80,6 +90,11 @@ function MunicipalityLayout(props: WithChildren) {
       <div className="municipality-layout">
         {showAside && (
           <aside className="municipality-aside">
+            <Combobox<TMuncipality>
+              handleSelect={() => false}
+              options={municipalities}
+            />
+
             <nav aria-label="metric navigation">
               <h2>{siteText.nationaal_layout.headings.medisch}</h2>
               <ul>

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -37,6 +37,7 @@ type TSafetyRegion = {
   displayName?: string;
   code: string;
   id: number;
+  searchTerms?: string[];
 };
 
 /*

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -34,6 +34,7 @@ export function getSafetyRegionLayout() {
 
 type TSafetyRegion = {
   name: string;
+  displayName?: string;
   code: string;
   id: number;
 };

--- a/src/data/gemeente_veiligheidsregio.json
+++ b/src/data/gemeente_veiligheidsregio.json
@@ -91,6 +91,7 @@
   },
   {
     "name": "s-Hertogenbosch",
+    "displayName": "'s Hertogenbosch",
     "safetyRegion": "VR21",
     "gemcode": "GM0796"
   },
@@ -666,6 +667,7 @@
   },
   {
     "name": "s-Gravenhage",
+    "displayName": "'s Gravenhage",
     "safetyRegion": "VR15",
     "gemcode": "GM0518"
   },

--- a/src/data/gemeente_veiligheidsregio.json
+++ b/src/data/gemeente_veiligheidsregio.json
@@ -329,7 +329,8 @@
   {
     "name": "De Fryske Marren",
     "safetyRegion": "VR02",
-    "gemcode": "GM1940"
+    "gemcode": "GM1940",
+    "searchTerms": ["De Friese Meeren"]
   },
   {
     "name": "Harlingen",
@@ -349,7 +350,8 @@
   {
     "name": "Noardeast-Fryslân",
     "safetyRegion": "VR02",
-    "gemcode": "GM1970"
+    "gemcode": "GM1970",
+    "searchTerms": ["Noordoost-Friesland"]
   },
   {
     "name": "Ooststellingwerf",
@@ -374,7 +376,8 @@
   {
     "name": "Súdwest-Fryslân",
     "safetyRegion": "VR02",
-    "gemcode": "GM1900"
+    "gemcode": "GM1900",
+    "searchTerms": ["Zuidwest-Friesland"]
   },
   {
     "name": "Terschelling",
@@ -384,7 +387,8 @@
   {
     "name": "Tytsjerksteradiel",
     "safetyRegion": "VR02",
-    "gemcode": "GM0737"
+    "gemcode": "GM0737",
+    "searchTerms": ["Tietjerksteradeel"]
   },
   {
     "name": "Vlieland",

--- a/src/data/gemeente_veiligheidsregio.json
+++ b/src/data/gemeente_veiligheidsregio.json
@@ -669,7 +669,8 @@
     "name": "s-Gravenhage",
     "displayName": "'s Gravenhage",
     "safetyRegion": "VR15",
-    "gemcode": "GM0518"
+    "gemcode": "GM0518",
+    "searchTerms": ["Den Haag"]
   },
   {
     "name": "Wassenaar",

--- a/src/data/gemeente_veiligheidsregio.json
+++ b/src/data/gemeente_veiligheidsregio.json
@@ -93,7 +93,8 @@
     "name": "s-Hertogenbosch",
     "displayName": "'s Hertogenbosch",
     "safetyRegion": "VR21",
-    "gemcode": "GM0796"
+    "gemcode": "GM0796",
+    "searchTerms": ["Den Bosch"]
   },
   {
     "name": "Sint Anthonis",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -12,7 +12,7 @@ const regioData = [
   { name: 'Noord-Holland Noord', code: 'VR10', id: 10 },
   { name: 'Zaanstreek-Waterland', code: 'VR11', id: 11 },
   { name: 'Kennemerland', code: 'VR12', id: 12 },
-  { name: 'Amsterdam-Amstelland', code: 'VR13', id: 13 },
+  { name: 'Amsterdam-Amstelland', code: 'VR13', id: 13, searchTerms: ['020'] },
   { name: 'Gooi en Vechtstreek', code: 'VR14', id: 14 },
   { name: 'Haaglanden', code: 'VR15', id: 15 },
   { name: 'Hollands Midden', code: 'VR16', id: 16 },

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -12,7 +12,7 @@ const regioData = [
   { name: 'Noord-Holland Noord', code: 'VR10', id: 10 },
   { name: 'Zaanstreek-Waterland', code: 'VR11', id: 11 },
   { name: 'Kennemerland', code: 'VR12', id: 12 },
-  { name: 'Amsterdam-Amstelland', code: 'VR13', id: 13, searchTerms: ['020'] },
+  { name: 'Amsterdam-Amstelland', code: 'VR13', id: 13 },
   { name: 'Gooi en Vechtstreek', code: 'VR14', id: 14 },
   { name: 'Haaglanden', code: 'VR15', id: 15 },
   { name: 'Hollands Midden', code: 'VR16', id: 16 },


### PR DESCRIPTION
## Summary

Currently, the combobox values have to be equal to municipality names in the GeoJSON files.
E.g. we can't match `'s Gravenhage`, the correct spelling of the municipality, to `s-gravenhage`, the format used in the GeoJSON.

![image](https://user-images.githubusercontent.com/66416946/92239364-28430f80-eebb-11ea-962e-35c6a145efc9.png)

In this PR I show how we can not only correct the display of the municipalities, but I also show how we can search for extra terms to match the correct municipality. E.g. you can now search for `Den Haag` as well.

![image](https://user-images.githubusercontent.com/66416946/92239347-1e211100-eebb-11ea-8076-03150f3fd684.png)


## Motivation
The search function will be easier to use by visitors.

## Detailed design

I've added support for an optional `displayName` key. For example, `option.displayName = "'s Gravenhage"` Whenever a search option provides this as a value, we use it in the UI. If it can't be found, we still use `option.name` as we did before. 

I've added a new array value as optional key to items, called `searchTerms`, which we use to match alternative spellings of search items.

E.g.
```json
  {
    "name": "s-Gravenhage",
    "displayName": "'s Gravenhage",
    "safetyRegion": "VR15",
    "gemcode": "GM0518",
    "searchTerms": ["Den Haag"]
  }
```

Both `displayName` and `searchTerms` are passed as extra keys to matchSorter, so they are taken into account while searching.

```ts
    return matchSorter(options, throttledTerm, {
      keys: [(item: Option) => item.name, 'searchTerms', 'displayName'],
    });
```



## Drawbacks

I can't see any drawbacks. Most of the heavy lifting is done by matchSorter. All we need to do is add alternative spellings to some regions and municipalities in the codebase.

Because handleSelect is a callback function (Inversion of control) it means how we show the options in the list has no impact on existing selection or redirection logic.

## Unresolved questions

~I'm not happy with the property name `searchTerms`, should we rename that to `alternativeSpellings` or similar?~ Solved by renaming to variations.