### PR TITLE
Small tweaks for safety region and municipality pages

### DIFF
--- a/src/components/chartTimeControls/chartTimeControls.module.scss
+++ b/src/components/chartTimeControls/chartTimeControls.module.scss
@@ -4,11 +4,14 @@
   margin: 1em 0;
   justify-content: flex-end;
 
-  label {
-    padding: 0.2em 1.5em;
+  /* Extra specificity to overrule radio-group rules */
+  &.chart-radio-group {
+    label {
+      padding: 0.2em 1.5em;
 
-    @media screen and (min-width: 700px) {
-      flex: 0 1 auto;
+      @media screen and (min-width: 700px) {
+        flex: 0 1 auto;
+      }
     }
   }
 }

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -51,7 +51,7 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
   }
 
   function onSelect(name: string): void {
-    const option = options.find(option => option.name === name);
+    const option = options.find((option) => option.name === name);
 
     handleSelect(option as Option);
   }
@@ -70,7 +70,7 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
       <ComboboxPopover>
         {results.length > 0 ? (
           <ComboboxList>
-            {results.map(option => (
+            {results.map((option) => (
               <ComboboxOption key={option.name} value={option.name} />
             ))}
           </ComboboxList>

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -209,7 +209,7 @@ $language-switcher-offset: 55px;
 .category {
   font-size: 1.42383rem;
   font-weight: 600;
-  color: $text-color-grey;
+  color: #9d9d9d;
   margin: 0;
   margin-bottom: 0.3rem;
   margin-left: 4rem;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -13,6 +13,7 @@ import formatDecimal from 'utils/formatNumber';
 import { PositiveTestedPeople, Municipal } from 'types/data';
 import useSWR from 'swr';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import municipalities from 'data/gemeente_veiligheidsregio.json';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
@@ -46,6 +47,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Municipal>(`/json/${code}.json`);
+  const municipality = municipalities.find((m) => m.gemcode === code);
 
   const positivelyTestedPeople: PositiveTestedPeople | undefined =
     data?.positive_tested_people;
@@ -55,7 +57,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: 'Gemeentenaam',
+          municipality: municipality?.name,
         })}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -21,6 +21,7 @@ import {
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
 } from 'utils/sewer-water/municipality-sewer-water.util';
+import municipalities from 'data/gemeente_veiligheidsregio.json';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;
@@ -55,6 +56,7 @@ const SewerWater: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Municipal>(`/json/${code}.json`);
+  const municipality = municipalities.find((m) => m.gemcode === code);
 
   const { barScaleData, lineChartData, barChartData } = useMemo(() => {
     return {
@@ -69,7 +71,7 @@ const SewerWater: FCWithLayout = () => {
       <ContentHeader
         category="Overige indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: 'Gemeentenaam',
+          municipality: municipality?.name,
         })}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}
@@ -112,7 +114,7 @@ const SewerWater: FCWithLayout = () => {
         <article className="metric-article">
           <h3>
             {replaceVariablesInText(text.bar_chart_title, {
-              municipality: 'Gemeentenaam',
+              municipality: municipality?.name,
             })}
           </h3>
           <BarChart

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -13,6 +13,7 @@ import siteText from 'locale';
 import { HospitalAdmissions, Municipal } from 'types/data';
 import { LineChart } from 'components/charts/index';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import municipalities from 'data/gemeente_veiligheidsregio.json';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
@@ -55,6 +56,7 @@ const IntakeHospital: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Municipal>(`/json/${code}.json`);
+  const municipality = municipalities.find((m) => m.gemcode === code);
 
   const hospitalAdmissions: HospitalAdmissions | undefined =
     data?.hospital_admissions;
@@ -64,7 +66,7 @@ const IntakeHospital: FCWithLayout = () => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: 'Gemeentenaam',
+          municipality: municipality?.name,
         })}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -14,6 +14,7 @@ import { ResultsPerRegion, Regionaal } from 'types/data';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import safetyRegions from 'data/index';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;
@@ -56,6 +57,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+  const safetyRegion = safetyRegions.find((region) => region.code === code);
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
@@ -70,7 +72,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: 'Veiligheidsregionaam',
+          safetyRegion: safetyRegion?.name,
         })}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -21,6 +21,7 @@ import {
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
 } from 'utils/sewer-water/safety-region-sewer-water.util';
+import safetyRegions from 'data/index';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;
@@ -54,6 +55,7 @@ const SewerWater: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+  const safetyRegion = safetyRegions.find((region) => region.code === code);
 
   const { barScaleData, lineChartData, barChartData } = useMemo(() => {
     return {
@@ -68,7 +70,7 @@ const SewerWater: FCWithLayout = () => {
       <ContentHeader
         category="Overige indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: 'Veiligheidsregionaam',
+          safetyRegion: safetyRegion?.name,
         })}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}
@@ -111,7 +113,7 @@ const SewerWater: FCWithLayout = () => {
         <article className="metric-article">
           <h3>
             {replaceVariablesInText(text.bar_chart_title, {
-              safetyRegion: 'Veiligheidsregionaam',
+              safetyRegion: safetyRegion?.name,
             })}
           </h3>
           <BarChart

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -15,6 +15,7 @@ import { LineChart } from 'components/charts/index';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import safetyRegions from 'data/index';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
@@ -57,6 +58,7 @@ const IntakeHospital: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+  const safetyRegion = safetyRegions.find((region) => region.code === code);
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
@@ -71,7 +73,7 @@ const IntakeHospital: FCWithLayout = () => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: 'Veiligheidsregionaam',
+          safetyRegion: safetyRegion?.name,
         })}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}


### PR DESCRIPTION
## Summary & Motivation

Small adjustments to meet the design for Safety region and Municipality pages

## Detailed design

* Correct color in heading
* Region name in heading
* Locations of radio group (eg next to line charts) matching more like the design

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
