### PR TITLE
Feature/municipal chloropleth

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -27,6 +27,7 @@ import municipalities from 'data/gemeente_veiligheidsregio.json';
 export default MunicipalityLayout;
 
 export type TMunicipality = typeof municipalities;
+
 export function getMunicipalityLayout() {
   return function (page: React.ReactNode): React.ReactNode {
     return getSiteLayout(siteText.gemeente_metadata)(

--- a/src/components/mapChart/MunicipalityMap.tsx
+++ b/src/components/mapChart/MunicipalityMap.tsx
@@ -22,7 +22,7 @@ export interface MunicipalityProperties {
 }
 
 type TMunicipalityTooltipFormatterContextObject = TooltipFormatterContextObject & {
-  point: TMunicipalityPoint;
+  point: TMunicipalityPoint & { properties: MunicipalityProperties };
 };
 
 type TMunicipalityPoint = Highcharts.Point & MunicipalityProperties;
@@ -83,10 +83,20 @@ function MunicipalityMap(props: IProps) {
         data: municipalityData,
         // @ts-ignore
         joinBy: ['gemcode', 'gmcode'],
+        states: {
+          select: {
+            color: '#0000ff',
+            // @ts-ignore
+            dashStyle: 'dash',
+            borderColor: 'black',
+          },
+        },
+        borderWidth: 1,
+        borderColor: '#012090',
       },
     ];
 
-    // When there's no selected municipal code we render the outlines of the country:
+    // Only when there are no selected municipals do we render the outlines of the country:
     if (!municipalCodes?.length) {
       result.push({
         type: 'mapline',
@@ -99,6 +109,9 @@ function MunicipalityMap(props: IProps) {
 
   const mapOptions = useMemo<Highcharts.Options>(
     () => ({
+      credits: {
+        enabled: false,
+      },
       chart: {
         alignTicks: true,
         animation: true,
@@ -130,11 +143,12 @@ function MunicipalityMap(props: IProps) {
         borderColor: '#01689B',
         borderRadius: 0,
         // @ts-ignore
-        formatter: function (this: any): false | string {
+        formatter: function (
+          this: TMunicipalityTooltipFormatterContextObject
+        ): false | string {
           const { point } = this;
-
           if (point.properties?.gemnaam) {
-            const metricValue = point[metric];
+            const metricValue = (point as any)[metric];
             return `<strong>${point.properties.gemnaam}</strong><br/>${metricValue}`;
           }
           return false;
@@ -142,20 +156,6 @@ function MunicipalityMap(props: IProps) {
       },
       plotOptions: {
         panning: false,
-        map: {
-          states: {
-            hover: {
-              color: '#99C3D7',
-            },
-            select: {
-              brightness: 0,
-              borderColor: '#ffffff',
-              borderWidth: 4,
-            },
-          },
-          borderWidth: 1,
-          borderColor: '#012090',
-        },
         mapline: {
           borderColor: 'black',
           borderWidth: 2,
@@ -177,7 +177,7 @@ function MunicipalityMap(props: IProps) {
 
       point?.select(true, false);
     }
-  }, [ref, selected]);
+  }, [ref.current, selected]);
 
   return (
     <HighchartsReact

--- a/src/components/mapChart/MunicipalityMap.tsx
+++ b/src/components/mapChart/MunicipalityMap.tsx
@@ -79,7 +79,7 @@ function MunicipalityMap(props: IProps) {
         type: 'map',
         allAreas: false,
         mapData: municipalityLines,
-        allowPointSelect: false,
+        allowPointSelect: true,
         data: municipalityData,
         // @ts-ignore
         joinBy: ['gemcode', 'gmcode'],
@@ -108,7 +108,6 @@ function MunicipalityMap(props: IProps) {
         borderWidth: 0,
         className: 'undefined',
         colorCount: 10,
-        defaultSeriesType: 'line',
         displayErrors: true,
         margin: [],
         panning: { enabled: false },
@@ -149,7 +148,9 @@ function MunicipalityMap(props: IProps) {
               color: '#99C3D7',
             },
             select: {
-              color: '#ffffff',
+              brightness: 0,
+              borderColor: '#ffffff',
+              borderWidth: 4,
             },
           },
           borderWidth: 1,

--- a/src/components/mapChart/SafetyRegionMap.tsx
+++ b/src/components/mapChart/SafetyRegionMap.tsx
@@ -89,6 +89,9 @@ function SafetyRegionMap(props: IProps) {
 
   const mapOptions = useMemo<Highcharts.Options>(
     () => ({
+      credits: {
+        enabled: false,
+      },
       chart: {
         alignTicks: true,
         animation: true,

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -12,7 +12,7 @@ export type TLanguages = {
 export type TALLLanguages = TNLLocale | TENLocale;
 export type TLanguageKey = keyof TLanguages;
 
-const languages: TLanguages = { en, nl };
+const languages: TLanguages = { en, nl } as const;
 
 const targetLanguage: TLanguageKey =
   (process.env.NEXT_PUBLIC_LOCALE as TLanguageKey) || 'nl';

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -60,7 +60,8 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: data.name,
+          municipality:
+            data.positive_tested_people.last_value.municipality_name,
         })}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -14,8 +14,7 @@ import { PositiveTestedPeople, Municipal } from 'types/data';
 import useSWR from 'swr';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
-import municipalCodeToRegionCodeLookup from 'data/municipalCodeToRegionCodeLookup';
-import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import getSafetyRegionForMunicipal from 'utils/getSafetyRegionForMunicipal';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
@@ -50,12 +49,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
   const { code } = router.query;
   const { data } = useSWR<Municipal>(`/json/${code}.json`);
 
-  const municipalCode = typeof code === 'string' ? code : 'unknown';
-
-  const vrcode = municipalCodeToRegionCodeLookup[municipalCode];
-  const municipalCodes = vrcode
-    ? regionCodeToMunicipalCodeLookup[vrcode]
-    : undefined;
+  const [municipalCode, municipalCodes] = getSafetyRegionForMunicipal(code);
 
   const positivelyTestedPeople: PositiveTestedPeople | undefined =
     data?.positive_tested_people;

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -67,7 +67,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: data.name,
+          municipality: data.hospital_admissions.last_value.municipality_name,
         })}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -13,6 +13,8 @@ import siteText from 'locale';
 import { HospitalAdmissions, Municipal } from 'types/data';
 import { LineChart } from 'components/charts/index';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import getSafetyRegionForMunicipal from 'utils/getSafetyRegionForMunicipal';
+import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
@@ -55,6 +57,8 @@ const IntakeHospital: FCWithLayout = () => {
   const router = useRouter();
   const { code } = router.query;
   const { data } = useSWR<Municipal>(`/json/${code}.json`);
+
+  const [municipalCode, municipalCodes] = getSafetyRegionForMunicipal(code);
 
   const hospitalAdmissions: HospitalAdmissions | undefined =
     data?.hospital_admissions;
@@ -103,6 +107,24 @@ const IntakeHospital: FCWithLayout = () => {
             />
           </>
         )}
+      </article>
+
+      <article className="metric-article layout-two-column">
+        <div className="column-item column-item-extra-margin">
+          <h3>{text.map_titel}</h3>
+          <p>{text.map_toelichting}</p>
+        </div>
+
+        <div className="column-item column-item-extra-margin">
+          {municipalCodes && (
+            <MunicipalityMap
+              selected={municipalCode}
+              municipalCodes={municipalCodes}
+              metric="hospital_admissions"
+              gradient={['#69c253', '#f35065']}
+            />
+          )}
+        </div>
       </article>
     </>
   );

--- a/src/pages/gemeente/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/positief-geteste-mensen.tsx
@@ -12,6 +12,9 @@ import formatDecimal from 'utils/formatNumber';
 import { PositiveTestedPeople, Municipal } from 'types/data';
 import useSWR from 'swr';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import MunicipalityMap from 'components/mapChart/MunicipalityMap';
+import municipalCodeToRegionCodeLookup from 'data/municipalCodeToRegionCodeLookup';
+import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
@@ -42,6 +45,10 @@ export function PostivelyTestedPeopleBarScale(props: {
 }
 
 const PostivelyTestedPeople: FCWithLayout = () => {
+  const code = 'GM0014';
+  const vrcode = municipalCodeToRegionCodeLookup[code];
+  const municipalCodes = regionCodeToMunicipalCodeLookup[vrcode];
+
   const { data } = useSWR<Municipal>(`/json/GM0014.json`);
 
   const positivelyTestedPeople: PositiveTestedPeople | undefined =
@@ -101,6 +108,22 @@ const PostivelyTestedPeople: FCWithLayout = () => {
             }))}
           />
         )}
+      </article>
+
+      <article className="metric-article layout-two-column">
+        <div className="column-item column-item-extra-margin">
+          <h3>{text.map_titel}</h3>
+          <p>{text.map_toelichting}</p>
+        </div>
+
+        <div className="column-item column-item-extra-margin">
+          <MunicipalityMap
+            selected={code}
+            municipalCodes={municipalCodes}
+            metric="positive_tested_people"
+            gradient={['#9DDEFE', '#0290D6']}
+          />
+        </div>
       </article>
     </>
   );

--- a/src/utils/getSafetyRegionForMunicipal.ts
+++ b/src/utils/getSafetyRegionForMunicipal.ts
@@ -1,0 +1,15 @@
+import municipalCodeToRegionCodeLookup from 'data/municipalCodeToRegionCodeLookup';
+import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+
+export default function getSafetyRegionForMunicipal(
+  code: string | string[] | undefined
+): [string, string[] | undefined] {
+  const municipalCode = typeof code === 'string' ? code : 'unknown';
+
+  const vrcode = municipalCodeToRegionCodeLookup[municipalCode];
+  const municipalCodes = vrcode
+    ? regionCodeToMunicipalCodeLookup[vrcode]
+    : undefined;
+
+  return [municipalCode, municipalCodes];
+}


### PR DESCRIPTION
## Summary

Add municipal chlorpleth to the positive test and hospital pages of the municipal part of the site.

## Motivation

Feature request

## Detailed design

The selected municipal is determined by the code in the route path. Based on this the municipal that belong to the same safety region are gathered and the chloropleth is drawn.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

For the moment an 'ugly' way of displaying the selected municipal was implemented. This is temporary as we're investigating a new chloropleth solution based on a different library since Highcharts is starting to prove more of an impediment rather than a time saver. 

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
