### PR TITLE
Feature/municipal selection map

### DIFF
--- a/src/components/mapChart/MunicipalityMap.tsx
+++ b/src/components/mapChart/MunicipalityMap.tsx
@@ -1,4 +1,7 @@
-import Highcharts, { SeriesOptionsType } from 'highcharts';
+import Highcharts, {
+  SeriesOptionsType,
+  TooltipFormatterContextObject,
+} from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
 import useSWR from 'swr';

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -9,7 +9,7 @@ const Municipality: FCWithLayout = () => {
   const router = useRouter();
 
   const onSelectMunicpal = (context: TMunicipalityPoint) => {
-    router.push(`/gemeente/${context.gmcode}/positief-geteste-mensen`);
+    router.push(`/gemeente/${context.gemcode}/positief-geteste-mensen`);
   };
 
   return (

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,8 +1,23 @@
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import MunicipalityMap, {
+  TMunicipalityPoint,
+} from 'components/mapChart/MunicipalityMap';
+import { useRouter } from 'next/router';
 
 const Municipality: FCWithLayout = () => {
-  return null;
+  const router = useRouter();
+
+  const onSelectMunicpal = (context: TMunicipalityPoint) => {
+    router.push(`/gemeente/${context.gmcode}/positief-geteste-mensen`);
+  };
+
+  return (
+    <MunicipalityMap
+      onSelect={onSelectMunicpal}
+      gradient={['#9DDEFE', '#0290D6']}
+    />
+  );
 };
 
 Municipality.getLayout = getMunicipalityLayout();

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -9,7 +9,10 @@ const Municipality: FCWithLayout = () => {
   const router = useRouter();
 
   const onSelectMunicpal = (context: TMunicipalityPoint) => {
-    router.push(`/gemeente/${context.gemcode}/positief-geteste-mensen`);
+    router.push(
+      '/gemeente/[code]/positief-geteste-mensen',
+      `/gemeente/${context.gemcode}/positief-geteste-mensen`
+    );
   };
 
   return (

--- a/src/utils/useMunicipalityData.ts
+++ b/src/utils/useMunicipalityData.ts
@@ -30,10 +30,13 @@ function createMunicipalCodeFilter<T extends { gmcode: string }>(
 function useMunicipalityData<
   T extends TMunicipalityMetricName,
   K extends Municipalities[T]
->(metricName: T, municipalCodes?: string[]): (K[number] & { value: number })[] {
+>(
+  metricName?: T,
+  municipalCodes?: string[]
+): (K[number] & { value: number })[] {
   const { data } = useSWR<Municipalities>('/json/municipalities.json');
 
-  const metricItems = data?.[metricName];
+  const metricItems = metricName ? data?.[metricName] : [];
 
   return useMemo(() => {
     if (!metricItems) {

--- a/src/utils/useMunicipalityData.ts
+++ b/src/utils/useMunicipalityData.ts
@@ -36,7 +36,7 @@ function useMunicipalityData<
 ): (K[number] & { value: number })[] {
   const { data } = useSWR<Municipalities>('/json/municipalities.json');
 
-  const metricItems = metricName ? data?.[metricName] : [];
+  const metricItems = metricName ? data?.[metricName] : undefined;
 
   return useMemo(() => {
     if (!metricItems) {


### PR DESCRIPTION
## Summary

Add map with municipalities to Gemeente index where a municipality can be selected by clicking on the map.

## Motivation

Feature request

## Detailed design

Tweaked the MunicipalityMap a little so that it can render a map without chloropleth data. Added an optional onSelect prop that gets called when the user clicks on a feature.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
