### PR TITLE
Implement static props and paths instead of useSWR

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -1,7 +1,5 @@
 import Link from 'next/link';
 import Head from 'next/head';
-import { useState } from 'react';
-import useSWR from 'swr';
 import { useRouter } from 'next/router';
 
 import TitleWithIcon from 'components/titleWithIcon';
@@ -21,17 +19,21 @@ import siteText from 'locale';
 import { WithChildren } from 'types';
 
 import useMediaQuery from 'utils/useMediaQuery';
-import { Municipal } from 'types/data';
 
 import municipalities from 'data/gemeente_veiligheidsregio.json';
+import { IMunicipalityData } from 'static-props/municipality-data';
 
 export default MunicipalityLayout;
 
 export type TMunicipality = typeof municipalities;
+
 export function getMunicipalityLayout() {
-  return function (page: React.ReactNode): React.ReactNode {
+  return function (
+    page: React.ReactNode,
+    pageProps: IMunicipalityData
+  ): React.ReactNode {
     return getSiteLayout(siteText.gemeente_metadata)(
-      <MunicipalityLayout>{page}</MunicipalityLayout>
+      <MunicipalityLayout {...pageProps}>{page}</MunicipalityLayout>
     );
   };
 }
@@ -52,19 +54,16 @@ export function getMunicipalityLayout() {
  * More info on persistent layouts:
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function MunicipalityLayout(props: WithChildren) {
-  const { children } = props;
+function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
+  const { children, data } = props;
   const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Municipal>(`/json/${code}.json`);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)', true);
+
+  const { code } = router.query;
+
   const showAside = isLargeScreen || router.route === '/gemeente';
   const showContent = isLargeScreen || router.route !== '/gemeente';
   const showMetricLinks = router.route !== '/gemeente';
-
-  const [selectedMunicipality, setSelectedMunicipality] = useState<
-    TMunicipality[number]
-  >();
 
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
@@ -76,8 +75,6 @@ function MunicipalityLayout(props: WithChildren) {
   }
 
   function handleMunicipalitySelect(region: TMunicipality[number]) {
-    setSelectedMunicipality(region);
-
     if (isLargeScreen) {
       router.push(
         '/gemeente/[code]/positief-geteste-mensen',
@@ -112,14 +109,14 @@ function MunicipalityLayout(props: WithChildren) {
               options={municipalities}
             />
 
-            {showMetricLinks && selectedMunicipality && (
+            {showMetricLinks && (
               <nav aria-label="metric navigation">
                 <h2>{siteText.nationaal_layout.headings.medisch}</h2>
                 <ul>
                   <li>
                     <Link
                       href="/gemeente/[code]/positief-geteste-mensen"
-                      as={`/gemeente/${selectedMunicipality.gemcode}/positief-geteste-mensen`}
+                      as={`/gemeente/${code}/positief-geteste-mensen`}
                     >
                       <a
                         onClick={blur}
@@ -146,7 +143,7 @@ function MunicipalityLayout(props: WithChildren) {
                   <li>
                     <Link
                       href="/gemeente/[code]/ziekenhuis-opnames"
-                      as={`/gemeente/${selectedMunicipality.gemcode}/ziekenhuis-opnames`}
+                      as={`/gemeente/${code}/ziekenhuis-opnames`}
                     >
                       <a
                         onClick={blur}
@@ -176,7 +173,7 @@ function MunicipalityLayout(props: WithChildren) {
                   <li>
                     <Link
                       href="/gemeente/[code]/rioolwater"
-                      as={`/gemeente/${selectedMunicipality.gemcode}/rioolwater`}
+                      as={`/gemeente/${code}/rioolwater`}
                     >
                       <a
                         onClick={blur}

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -25,7 +25,11 @@ import { IMunicipalityData } from 'static-props/municipality-data';
 
 export default MunicipalityLayout;
 
-export type TMunicipality = typeof municipalities;
+interface IMunicipality {
+  name: string;
+  safetyRegion: string;
+  gemcode: string;
+}
 
 export function getMunicipalityLayout() {
   return function (
@@ -74,7 +78,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
       : 'metric-link';
   }
 
-  function handleMunicipalitySelect(region: TMunicipality[number]) {
+  function handleMunicipalitySelect(region: IMunicipality) {
     if (isLargeScreen) {
       router.push(
         '/gemeente/[code]/positief-geteste-mensen',
@@ -104,7 +108,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
       <div className="municipality-layout">
         {showAside && (
           <aside className="municipality-aside">
-            <Combobox<TMunicipality[number]>
+            <Combobox<IMunicipality>
               handleSelect={handleMunicipalitySelect}
               options={municipalities}
             />

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -1,8 +1,7 @@
 import Link from 'next/link';
 import Head from 'next/head';
-import useSWR from 'swr';
 import { useRouter } from 'next/router';
-import { useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 
 import TitleWithIcon from 'components/titleWithIcon';
 import { getLayout as getSiteLayout } from 'components/layout';
@@ -32,13 +31,17 @@ import siteText from 'locale';
 import { WithChildren } from 'types';
 
 import useMediaQuery from 'utils/useMediaQuery';
+import { INationalData } from 'static-props/nl-data';
 
 export default NationalLayout;
 
 export function getNationalLayout() {
-  return function (page: React.ReactNode): React.ReactNode {
+  return function (
+    page: React.ReactNode,
+    pageProps: INationalData
+  ): React.ReactNode {
     return getSiteLayout(siteText.nationaal_metadata)(
-      <NationalLayout>{page}</NationalLayout>
+      <NationalLayout {...pageProps}>{page}</NationalLayout>
     );
   };
 }
@@ -59,10 +62,9 @@ export function getNationalLayout() {
  * More info on persistent layouts:
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function NationalLayout(props: WithChildren) {
-  const { children } = props;
+function NationalLayout(props: WithChildren<INationalData>) {
+  const { children, data } = props;
   const router = useRouter();
-  const { data } = useSWR(`/json/NL.json`);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)', false);
   const showAside = isLargeScreen || router.route === '/landelijk';
   const showContent = isLargeScreen || router.route !== '/landelijk';
@@ -72,7 +74,7 @@ function NationalLayout(props: WithChildren) {
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isLargeScreen && router.route === '/landelijk') {
       router.push('/landelijk/positief-geteste-mensen');
     }

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -1,7 +1,5 @@
-import { useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
-import useSWR from 'swr';
 import { useRouter } from 'next/router';
 
 import TitleWithIcon from 'components/titleWithIcon';
@@ -22,14 +20,17 @@ import safetyRegions from 'data/index';
 import { WithChildren } from 'types';
 
 import useMediaQuery from 'utils/useMediaQuery';
-import { Regionaal } from 'types/data';
+import { ISafetyRegionData } from 'static-props/safetyregion-data';
 
 export default SafetyRegionLayout;
 
 export function getSafetyRegionLayout() {
-  return function (page: React.ReactNode): React.ReactNode {
+  return function (
+    page: React.ReactNode,
+    pageProps: ISafetyRegionData
+  ): React.ReactNode {
     return getSiteLayout(siteText.veiligheidsregio_metadata)(
-      <SafetyRegionLayout>{page}</SafetyRegionLayout>
+      <SafetyRegionLayout {...pageProps}>{page}</SafetyRegionLayout>
     );
   };
 }
@@ -58,16 +59,13 @@ type TSafetyRegion = {
  * More info on persistent layouts:
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function SafetyRegionLayout(props: WithChildren) {
-  const { children } = props;
+function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
+  const { children, data } = props;
 
   const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Regionaal>(`/json/${code}.json`);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)', true);
-  const [selectedSafetyRegion, setSelectedSafetyRegion] = useState<
-    TSafetyRegion
-  >();
+
+  const { code } = router.query;
 
   const showAside = isLargeScreen || router.route === '/veiligheidsregio';
   const showContent = isLargeScreen || router.route !== '/veiligheidsregio';
@@ -82,8 +80,6 @@ function SafetyRegionLayout(props: WithChildren) {
   }
 
   function handleSafeRegionSelect(region: TSafetyRegion) {
-    setSelectedSafetyRegion(region);
-
     if (isLargeScreen) {
       router.push(
         '/veiligheidsregio/[code]/positief-geteste-mensen',
@@ -121,7 +117,7 @@ function SafetyRegionLayout(props: WithChildren) {
               options={safetyRegions}
             />
 
-            {showMetricLinks && selectedSafetyRegion && (
+            {showMetricLinks && (
               <nav aria-label="metric navigation">
                 <h2>{siteText.veiligheidsregio_layout.headings.medisch}</h2>
 
@@ -129,7 +125,7 @@ function SafetyRegionLayout(props: WithChildren) {
                   <li>
                     <Link
                       href="/veiligheidsregio/[code]/positief-geteste-mensen"
-                      as={`/veiligheidsregio/${selectedSafetyRegion.code}/positief-geteste-mensen`}
+                      as={`/veiligheidsregio/${code}/positief-geteste-mensen`}
                     >
                       <a
                         onClick={blur}
@@ -156,7 +152,7 @@ function SafetyRegionLayout(props: WithChildren) {
                   <li>
                     <Link
                       href="/veiligheidsregio/[code]/ziekenhuis-opnames"
-                      as={`/veiligheidsregio/${selectedSafetyRegion.code}/ziekenhuis-opnames`}
+                      as={`/veiligheidsregio/${code}/ziekenhuis-opnames`}
                     >
                       <a
                         onClick={blur}
@@ -186,7 +182,7 @@ function SafetyRegionLayout(props: WithChildren) {
                   <li>
                     <Link
                       href="/veiligheidsregio/[code]/rioolwater"
-                      as={`/veiligheidsregio/${selectedSafetyRegion.code}/rioolwater`}
+                      as={`/veiligheidsregio/${code}/rioolwater`}
                     >
                       <a
                         onClick={blur}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -22,7 +22,7 @@ export interface LayoutProps {
 }
 
 export type FCWithLayout<Props = void> = React.FC<Props> & {
-  getLayout: (page: React.ReactNode) => React.ReactNode;
+  getLayout: (page: React.ReactNode, pageProps: Props) => React.ReactNode;
 };
 
 export function getLayout(layoutProps: LayoutProps) {

--- a/src/components/mapChart/MunicipalityMap.tsx
+++ b/src/components/mapChart/MunicipalityMap.tsx
@@ -1,7 +1,4 @@
-import Highcharts, {
-  TooltipFormatterContextObject,
-  SeriesOptionsType,
-} from 'highcharts';
+import Highcharts, { SeriesOptionsType } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
 import useSWR from 'swr';
@@ -20,12 +17,6 @@ export interface MunicipalityProperties {
   gemnaam: string;
   gemcode: string;
 }
-
-type TMunicipalityTooltipFormatterContextObject = TooltipFormatterContextObject & {
-  point: TMunicipalityPoint;
-};
-
-type TMunicipalityPoint = Highcharts.Point & MunicipalityProperties;
 
 interface IProps {
   selected?: string;
@@ -95,7 +86,7 @@ function MunicipalityMap(props: IProps) {
     }
 
     return result;
-  }, [countryLines, selected, municipalityData, municipalityLines]);
+  }, [countryLines, municipalityData, municipalityLines, municipalCodes]);
 
   const mapOptions = useMemo<Highcharts.Options>(
     () => ({

--- a/src/components/seoHead/index.tsx
+++ b/src/components/seoHead/index.tsx
@@ -84,14 +84,14 @@ function SEOHead(props: SEOHeadProps): any {
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Regular.woff2"
+        href="/webfonts/RO-SansWebText-Regular.woff2"
         as="font"
         type="font/woff2"
       />
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Regular.woff"
+        href="/webfonts/RO-SansWebText-Regular.woff"
         as="font"
         type="font/woff"
       />
@@ -99,14 +99,14 @@ function SEOHead(props: SEOHeadProps): any {
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Italic.woff2"
+        href="/webfonts/RO-SansWebText-Italic.woff2"
         as="font"
         type="font/woff2"
       />
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Italic.woff"
+        href="/webfonts/RO-SansWebText-Italic.woff"
         as="font"
         type="font/woff"
       />
@@ -114,14 +114,14 @@ function SEOHead(props: SEOHeadProps): any {
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Bold.woff2"
+        href="/webfonts/RO-SansWebText-Bold.woff2"
         as="font"
         type="font/woff2"
       />
       <link
         rel="preload"
         crossOrigin="anonymous"
-        href="webfonts/RO-SansWebText-Bold.woff"
+        href="/webfonts/RO-SansWebText-Bold.woff"
         as="font"
         type="font/woff"
       />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -30,7 +30,7 @@ export default MyApp;
 
 function MyApp(props: IProps): React.ReactElement {
   const { Component, pageProps } = props;
-  const page = (page: any) => page;
+  const page = (page: React.ReactNode) => page;
   const getLayout = Component.getLayout || page;
 
   useEffect(() => {
@@ -48,7 +48,7 @@ function MyApp(props: IProps): React.ReactElement {
         fetcher,
       }}
     >
-      {getLayout(<Component {...pageProps} />)}
+      {getLayout(<Component {...pageProps} />, pageProps)}
     </SWRConfig>
   );
 }

--- a/src/pages/gemeente/[code]/index.tsx
+++ b/src/pages/gemeente/[code]/index.tsx
@@ -1,10 +1,18 @@
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import {
+  getMunicipalityData,
+  getMunicipalityPaths,
+  IMunicipalityData,
+} from 'static-props/municipality-data';
 
-const Municipality: FCWithLayout = () => {
+const Municipality: FCWithLayout<IMunicipalityData> = () => {
   return null;
 };
 
 Municipality.getLayout = getMunicipalityLayout();
+
+export const getStaticProps = getMunicipalityData();
+export const getStaticPaths = getMunicipalityPaths();
 
 export default Municipality;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -56,7 +56,7 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: municipality?.name,
+          municipality: data.name,
         })}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
@@ -10,9 +9,13 @@ import { ContentHeader } from 'components/layout/Content';
 
 import Getest from 'assets/test.svg';
 import formatDecimal from 'utils/formatNumber';
-import { PositiveTestedPeople, Municipal } from 'types/data';
-import useSWR from 'swr';
+import { PositiveTestedPeople } from 'types/data';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import {
+  getMunicipalityData,
+  getMunicipalityPaths,
+  IMunicipalityData,
+} from 'static-props/municipality-data';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
@@ -42,10 +45,8 @@ export function PostivelyTestedPeopleBarScale(props: {
   );
 }
 
-const PostivelyTestedPeople: FCWithLayout = () => {
-  const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Municipal>(`/json/${code}.json`);
+const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
+  const { data } = props;
 
   const positivelyTestedPeople: PositiveTestedPeople | undefined =
     data?.positive_tested_people;
@@ -110,5 +111,8 @@ const PostivelyTestedPeople: FCWithLayout = () => {
 };
 
 PostivelyTestedPeople.getLayout = getMunicipalityLayout();
+
+export const getStaticProps = getMunicipalityData();
+export const getStaticPaths = getMunicipalityPaths();
 
 export default PostivelyTestedPeople;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -1,6 +1,3 @@
-import { useRouter } from 'next/router';
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
@@ -10,7 +7,6 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 
 import siteText from 'locale';
 
-import { Municipal } from 'types/data';
 import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import { useMemo } from 'react';
@@ -21,6 +17,11 @@ import {
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
 } from 'utils/sewer-water/municipality-sewer-water.util';
+import {
+  getMunicipalityData,
+  getMunicipalityPaths,
+  IMunicipalityData,
+} from 'static-props/municipality-data';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;
@@ -51,10 +52,8 @@ export function SewerWaterBarScale(props: {
   );
 }
 
-const SewerWater: FCWithLayout = () => {
-  const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Municipal>(`/json/${code}.json`);
+const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
+  const { data } = props;
 
   const { barScaleData, lineChartData, barChartData } = useMemo(() => {
     return {
@@ -127,5 +126,8 @@ const SewerWater: FCWithLayout = () => {
 };
 
 SewerWater.getLayout = getMunicipalityLayout();
+
+export const getStaticProps = getMunicipalityData();
+export const getStaticPaths = getMunicipalityPaths();
 
 export default SewerWater;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -68,7 +68,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
       <ContentHeader
         category="Overige indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: municipality?.name,
+          municipality: data.name,
         })}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}
@@ -111,7 +111,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
         <article className="metric-article">
           <h3>
             {replaceVariablesInText(text.bar_chart_title, {
-              municipality: municipality?.name,
+              municipality: data.name,
             })}
           </h3>
           <BarChart

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -64,7 +64,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          municipality: municipality?.name,
+          municipality: data.name,
         })}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,6 +1,3 @@
-import { useRouter } from 'next/router';
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
@@ -10,9 +7,14 @@ import Ziekenhuis from 'assets/ziekenhuis.svg';
 
 import siteText from 'locale';
 
-import { HospitalAdmissions, Municipal } from 'types/data';
+import { HospitalAdmissions } from 'types/data';
 import { LineChart } from 'components/charts/index';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import {
+  getMunicipalityData,
+  getMunicipalityPaths,
+  IMunicipalityData,
+} from 'static-props/municipality-data';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
@@ -51,10 +53,8 @@ export function IntakeHospitalBarScale(props: {
   );
 }
 
-const IntakeHospital: FCWithLayout = () => {
-  const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Municipal>(`/json/${code}.json`);
+const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
+  const { data } = props;
 
   const hospitalAdmissions: HospitalAdmissions | undefined =
     data?.hospital_admissions;
@@ -109,5 +109,8 @@ const IntakeHospital: FCWithLayout = () => {
 };
 
 IntakeHospital.getLayout = getMunicipalityLayout();
+
+export const getStaticProps = getMunicipalityData();
+export const getStaticPaths = getMunicipalityPaths();
 
 export default IntakeHospital;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,10 +1,18 @@
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import {
+  getMunicipalityData,
+  getMunicipalityPaths,
+  IMunicipalityData,
+} from 'static-props/municipality-data';
 
-const Municipality: FCWithLayout = () => {
+const Municipality: FCWithLayout<IMunicipalityData> = () => {
   return null;
 };
 
 Municipality.getLayout = getMunicipalityLayout();
+
+export const getStaticProps = getMunicipalityData();
+export const getStaticPaths = getMunicipalityPaths();
 
 export default Municipality;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,18 +1,16 @@
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
-import {
-  getMunicipalityData,
-  getMunicipalityPaths,
-  IMunicipalityData,
-} from 'static-props/municipality-data';
 
-const Municipality: FCWithLayout<IMunicipalityData> = () => {
+// Passing `any` to `FCWithLayout` because we
+// can't do `getStaticProps` on this page because we require
+// a code, but is is the screen we select a code (municipality).
+// All other pages which use `getMunicipalityLayout` can assume
+// the data is always there. Making the data optional would mean
+// lots of unnecessary null checks on those pages.
+const Municipality: FCWithLayout<any> = () => {
   return null;
 };
 
 Municipality.getLayout = getMunicipalityLayout();
-
-export const getStaticProps = getMunicipalityData();
-export const getStaticPaths = getMunicipalityPaths();
 
 export default Municipality;

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,4 +1,3 @@
-import useSWR from 'swr';
 import Link from 'next/link';
 
 import BarScale from 'components/barScale';
@@ -18,6 +17,7 @@ import {
   InfectiousPeopleCountNormalized,
 } from 'types/data';
 import { ContentHeader } from 'components/layout/Content';
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.besmettelijke_personen =
   siteText.besmettelijke_personen;
@@ -47,8 +47,8 @@ export function InfectiousPeopleBarScale(props: {
   );
 }
 
-const InfectiousPeople: FCWithLayout = () => {
-  const { data } = useSWR(`/json/NL.json`);
+const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
+  const { data } = props;
 
   const count: InfectiousPeopleCount | undefined =
     data?.infectious_people_count;
@@ -124,5 +124,7 @@ const InfectiousPeople: FCWithLayout = () => {
 };
 
 InfectiousPeople.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default InfectiousPeople;

--- a/src/pages/landelijk/index.tsx
+++ b/src/pages/landelijk/index.tsx
@@ -1,10 +1,14 @@
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 
-const National: FCWithLayout = () => {
+import getNlData, { INationalData } from 'static-props/nl-data';
+
+const National: FCWithLayout<INationalData> = () => {
   return null;
 };
 
 National.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default National;

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
@@ -11,6 +9,8 @@ import Arts from 'assets/arts.svg';
 import siteText from 'locale';
 
 import { IntakeIntensivecareMa } from 'types/data';
+
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
 
@@ -48,8 +48,8 @@ export function IntakeIntensiveCareBarscale(props: {
   );
 }
 
-const IntakeIntensiveCare: FCWithLayout = () => {
-  const { data: state } = useSWR(`/json/NL.json`);
+const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const data: IntakeIntensivecareMa | undefined =
     state?.intake_intensivecare_ma;
@@ -98,5 +98,7 @@ const IntakeIntensiveCare: FCWithLayout = () => {
 };
 
 IntakeIntensiveCare.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default IntakeIntensiveCare;

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,4 +1,4 @@
-import useSWR from 'swr';
+import { useState } from 'react';
 
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
@@ -6,6 +6,8 @@ import { getNationalLayout } from 'components/layout/NationalLayout';
 import { LineChart, BarChart } from 'components/charts/index';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import { ContentHeader } from 'components/layout/Content';
+import SafetyRegionMap from 'components/mapChart/SafetyRegionMap';
+import ChartRegionControls from 'components/chartRegionControls';
 
 import Getest from 'assets/test.svg';
 import formatDecimal from 'utils/formatNumber';
@@ -17,9 +19,8 @@ import {
   InfectedPeopleTotal,
   IntakeShareAgeGroups,
 } from 'types/data';
-import { useState } from 'react';
-import SafetyRegionMap from 'components/mapChart/SafetyRegionMap';
-import ChartRegionControls from 'components/chartRegionControls';
+
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;
@@ -58,8 +59,8 @@ export function PostivelyTestedPeopleBarScale(props: {
   );
 }
 
-const PostivelyTestedPeople: FCWithLayout = () => {
-  const { data } = useSWR(`/json/NL.json`);
+const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
+  const { data } = props;
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'municipal'
   );
@@ -177,5 +178,7 @@ const PostivelyTestedPeople: FCWithLayout = () => {
 };
 
 PostivelyTestedPeople.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default PostivelyTestedPeople;

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import Legenda from 'components/legenda';
 import { FCWithLayout } from 'components/layout';
@@ -12,6 +10,8 @@ import Repro from 'assets/reproductiegetal.svg';
 import siteText from 'locale';
 
 import { ReproductionIndex as ReproductionIndexData } from 'types/data';
+
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
 
@@ -54,8 +54,8 @@ export function ReproductionIndexBarScale(props: {
   );
 }
 
-const ReproductionIndex: FCWithLayout = () => {
-  const { data: state } = useSWR(`/json/NL.json`);
+const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const lastKnownValidData: ReproductionIndexData | undefined =
     state?.reproduction_index_last_known_average;
@@ -81,7 +81,7 @@ const ReproductionIndex: FCWithLayout = () => {
         <div className="column-item column-item-extra-margin">
           <h3>{text.barscale_titel}</h3>
           <ReproductionIndexBarScale
-            data={state}
+            data={data}
             lastKnown={lastKnownValidData}
           />
           <p>{text.barscale_toelichting}</p>
@@ -126,5 +126,7 @@ const ReproductionIndex: FCWithLayout = () => {
 };
 
 ReproductionIndex.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default ReproductionIndex;

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
@@ -11,6 +9,8 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 import siteText from 'locale';
 
 import { RioolwaterMetingen } from 'types/data';
+
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
 
@@ -39,8 +39,8 @@ export function SewerWaterBarScale(props: {
   );
 }
 
-const SewerWater: FCWithLayout = () => {
-  const { data: state } = useSWR(`/json/NL.json`);
+const SewerWater: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const data: RioolwaterMetingen | undefined = state?.rioolwater_metingen;
 
@@ -89,5 +89,7 @@ const SewerWater: FCWithLayout = () => {
 };
 
 SewerWater.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default SewerWater;

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
@@ -12,7 +10,8 @@ import formatNumber from 'utils/formatNumber';
 
 import siteText from 'locale';
 
-import { National, VerdenkingenHuisartsen } from 'types/data';
+import { VerdenkingenHuisartsen } from 'types/data';
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.verdenkingen_huisartsen =
   siteText.verdenkingen_huisartsen;
@@ -42,8 +41,8 @@ export function SuspectedPatientsBarScale(props: {
   );
 }
 
-const SuspectedPatients: FCWithLayout = () => {
-  const { data: state } = useSWR<National>(`/json/NL.json`);
+const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const data: VerdenkingenHuisartsen | undefined =
     state?.verdenkingen_huisartsen;
@@ -102,5 +101,7 @@ const SuspectedPatients: FCWithLayout = () => {
 };
 
 SuspectedPatients.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default SuspectedPatients;

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
@@ -13,10 +11,11 @@ import formatNumber from 'utils/formatNumber';
 import siteText from 'locale';
 
 import {
-  National,
   TotalNewlyReportedLocations,
   TotalReportedLocations,
 } from 'types/data';
+
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;
@@ -46,8 +45,8 @@ export function NursingHomeInfectedLocationsBarScale(props: {
   );
 }
 
-const NursingHomeInfectedLocations: FCWithLayout = () => {
-  const { data: state } = useSWR<National>(`/json/NL.json`);
+const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const newLocations: TotalNewlyReportedLocations | undefined =
     state?.total_newly_reported_locations;
@@ -109,5 +108,7 @@ const NursingHomeInfectedLocations: FCWithLayout = () => {
 };
 
 NursingHomeInfectedLocations.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default NursingHomeInfectedLocations;

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
@@ -10,7 +8,8 @@ import Getest from 'assets/test.svg';
 
 import siteText from 'locale';
 
-import { National, InfectedPeopleNurseryCountDaily } from 'types/data';
+import { InfectedPeopleNurseryCountDaily } from 'types/data';
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_positief_geteste_personen =
   siteText.verpleeghuis_positief_geteste_personen;
@@ -40,8 +39,8 @@ export function NursingHomeInfectedPeopleBarScale(props: {
   );
 }
 
-const NursingHomeInfectedPeople: FCWithLayout = () => {
-  const { data: state } = useSWR<National>(`/json/NL.json`);
+const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
 
   const data: InfectedPeopleNurseryCountDaily | undefined =
     state?.infected_people_nursery_count_daily;
@@ -90,5 +89,7 @@ const NursingHomeInfectedPeople: FCWithLayout = () => {
 };
 
 NursingHomeInfectedPeople.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default NursingHomeInfectedPeople;

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
@@ -15,6 +13,7 @@ import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import { useState } from 'react';
 import SafetyRegionMap from 'components/mapChart/SafetyRegionMap';
 import ChartRegionControls from 'components/chartRegionControls';
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_oversterfte =
   siteText.verpleeghuis_oversterfte;
@@ -44,8 +43,8 @@ export function NursingHomeDeathsBarScale(props: {
   );
 }
 
-const NursingHomeDeaths: FCWithLayout = () => {
-  const { data: state } = useSWR(`/json/NL.json`);
+const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'municipal'
   );
@@ -122,5 +121,7 @@ const NursingHomeDeaths: FCWithLayout = () => {
 };
 
 NursingHomeDeaths.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default NursingHomeDeaths;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,5 +1,3 @@
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
@@ -15,6 +13,7 @@ import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import { useState } from 'react';
 import SafetyRegionMap from 'components/mapChart/SafetyRegionMap';
 import ChartRegionControls from 'components/chartRegionControls';
+import getNlData, { INationalData } from 'static-props/nl-data';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;
@@ -53,8 +52,8 @@ export function IntakeHospitalBarScale(props: {
   );
 }
 
-const IntakeHospital: FCWithLayout = () => {
-  const { data: state } = useSWR(`/json/NL.json`);
+const IntakeHospital: FCWithLayout<INationalData> = (props) => {
+  const { data: state } = props;
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'municipal'
   );
@@ -132,5 +131,7 @@ const IntakeHospital: FCWithLayout = () => {
 };
 
 IntakeHospital.getLayout = getNationalLayout();
+
+export const getStaticProps = getNlData();
 
 export default IntakeHospital;

--- a/src/pages/veiligheidsregio/[code]/index.tsx
+++ b/src/pages/veiligheidsregio/[code]/index.tsx
@@ -1,10 +1,19 @@
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
 
-const SafetyRegion: FCWithLayout = () => {
+import {
+  getSafetyRegionData,
+  getSafetyRegionPaths,
+  ISafetyRegionData,
+} from 'static-props/safetyregion-data';
+
+const SafetyRegion: FCWithLayout<ISafetyRegionData> = () => {
   return null;
 };
 
 SafetyRegion.getLayout = getSafetyRegionLayout();
+
+export const getStaticProps = getSafetyRegionData();
+export const getStaticPaths = getSafetyRegionPaths();
 
 export default SafetyRegion;

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,5 +1,3 @@
-import { useRouter } from 'next/router';
-import useSWR from 'swr';
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
@@ -10,10 +8,16 @@ import siteText from 'locale';
 
 import Getest from 'assets/test.svg';
 import formatDecimal from 'utils/formatNumber';
-import { ResultsPerRegion, Regionaal } from 'types/data';
+import { ResultsPerRegion } from 'types/data';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import {
+  getSafetyRegionData,
+  getSafetyRegionPaths,
+  ISafetyRegionData,
+} from 'static-props/safetyregion-data';
+import { useRouter } from 'next/router';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;
@@ -52,10 +56,10 @@ export function PostivelyTestedPeopleBarScale(props: {
   );
 }
 
-const PostivelyTestedPeople: FCWithLayout = () => {
+const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
   const router = useRouter();
   const { code } = router.query;
-  const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+  const { data } = props;
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
@@ -139,5 +143,8 @@ const PostivelyTestedPeople: FCWithLayout = () => {
 };
 
 PostivelyTestedPeople.getLayout = getSafetyRegionLayout();
+
+export const getStaticProps = getSafetyRegionData();
+export const getStaticPaths = getSafetyRegionPaths();
 
 export default PostivelyTestedPeople;

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -74,7 +74,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: safetyRegion?.name,
+          safetyRegion: data.name,
         })}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -67,7 +67,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
       <ContentHeader
         category="Overige indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: safetyRegion?.name,
+          safetyRegion: data.name,
         })}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}
@@ -110,7 +110,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
         <article className="metric-article">
           <h3>
             {replaceVariablesInText(text.bar_chart_title, {
-              safetyRegion: safetyRegion?.name,
+              safetyRegion: data.name,
             })}
           </h3>
           <BarChart

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -1,6 +1,3 @@
-import { useRouter } from 'next/router';
-import useSWR from 'swr';
-
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
@@ -10,7 +7,6 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 
 import siteText from 'locale';
 
-import { Regionaal } from 'types/data';
 import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import { useMemo } from 'react';
@@ -21,6 +17,11 @@ import {
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
 } from 'utils/sewer-water/safety-region-sewer-water.util';
+import {
+  getSafetyRegionData,
+  getSafetyRegionPaths,
+  ISafetyRegionData,
+} from 'static-props/safetyregion-data';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;
@@ -50,10 +51,8 @@ export function SewerWaterBarScale(props: {
   );
 }
 
-const SewerWater: FCWithLayout = () => {
-  const router = useRouter();
-  const { code } = router.query;
-  const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
+  const { data } = props;
 
   const { barScaleData, lineChartData, barChartData } = useMemo(() => {
     return {
@@ -126,5 +125,8 @@ const SewerWater: FCWithLayout = () => {
 };
 
 SewerWater.getLayout = getSafetyRegionLayout();
+
+export const getStaticProps = getSafetyRegionData();
+export const getStaticPaths = getSafetyRegionPaths();
 
 export default SewerWater;

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -75,7 +75,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
       <ContentHeader
         category="Medische indicatoren"
         title={replaceVariablesInText(text.titel, {
-          safetyRegion: safetyRegion?.name,
+          safetyRegion: data.name,
         })}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import useSWR from 'swr';
 
 import BarScale from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
@@ -10,11 +9,16 @@ import Ziekenhuis from 'assets/ziekenhuis.svg';
 
 import siteText from 'locale';
 
-import { ResultsPerRegion, Regionaal } from 'types/data';
+import { ResultsPerRegion } from 'types/data';
 import { LineChart } from 'components/charts/index';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
 import MunicipalityMap from 'components/mapChart/MunicipalityMap';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import {
+  getSafetyRegionData,
+  getSafetyRegionPaths,
+  ISafetyRegionData,
+} from 'static-props/safetyregion-data';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
@@ -53,10 +57,10 @@ export function IntakeHospitalBarScale(props: {
   );
 }
 
-const IntakeHospital: FCWithLayout = () => {
+const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
   const router = useRouter();
   const { code } = router.query;
-  const { data } = useSWR<Regionaal>(`/json/${code}.json`);
+  const { data } = props;
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
@@ -128,5 +132,8 @@ const IntakeHospital: FCWithLayout = () => {
 };
 
 IntakeHospital.getLayout = getSafetyRegionLayout();
+
+export const getStaticProps = getSafetyRegionData();
+export const getStaticPaths = getSafetyRegionPaths();
 
 export default IntakeHospital;

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,10 +1,18 @@
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
+import {
+  getSafetyRegionData,
+  getSafetyRegionPaths,
+  ISafetyRegionData,
+} from 'static-props/safetyregion-data';
 
-const SafetyRegion: FCWithLayout = () => {
+const SafetyRegion: FCWithLayout<ISafetyRegionData> = () => {
   return null;
 };
 
 SafetyRegion.getLayout = getSafetyRegionLayout();
+
+export const getStaticProps = getSafetyRegionData();
+export const getStaticPaths = getSafetyRegionPaths();
 
 export default SafetyRegion;

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,18 +1,16 @@
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import {
-  getSafetyRegionData,
-  getSafetyRegionPaths,
-  ISafetyRegionData,
-} from 'static-props/safetyregion-data';
 
-const SafetyRegion: FCWithLayout<ISafetyRegionData> = () => {
+// Passing `any` to `FCWithLayout` because we
+// can't do `getStaticProps` on this page because we require
+// a code, but is is the screen we select a code (municipality).
+// All other pages which use `getSafetyRegionLayout` can assume
+// the data is always there. Making the data optional would mean
+// lots of unnecessary null checks on those pages.
+const SafetyRegion: FCWithLayout<any> = () => {
   return null;
 };
 
 SafetyRegion.getLayout = getSafetyRegionLayout();
-
-export const getStaticProps = getSafetyRegionData();
-export const getStaticPaths = getSafetyRegionPaths();
 
 export default SafetyRegion;

--- a/src/static-props/municipality-data.ts
+++ b/src/static-props/municipality-data.ts
@@ -1,0 +1,31 @@
+import { Municipal } from 'types/data';
+
+import municipalities from 'data/gemeente_veiligheidsregio.json';
+import { getSafetyRegionData } from './safetyregion-data';
+
+export interface IMunicipalityData {
+  data: Municipal;
+}
+
+interface IPaths {
+  paths: Array<{ params: { code: string } }>;
+  fallback: boolean;
+}
+
+export const getMunicipalityData = getSafetyRegionData;
+
+/*
+ * getMunicipalityPaths creates an array of all the allowed
+ * `/veiligheidsregio/[code]` routes. This should be used
+ * together with `getMunicipalityData`.
+ */
+export function getMunicipalityPaths(): () => IPaths {
+  return function () {
+    const paths = municipalities.map((municipality) => ({
+      params: { code: municipality.gemcode },
+    }));
+
+    // { fallback: false } means other routes should 404.
+    return { paths, fallback: false };
+  };
+}

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+
+import { National } from 'types/data';
+
+export interface INationalData {
+  data: National;
+}
+
+interface IProps {
+  props: INationalData;
+}
+
+/*
+ * getNlData loads the data for /landelijk pages.
+ * It needs to be used as the Next.js `getStaticProps` function.
+ *
+ * Example:
+ * ```ts
+ * PostivelyTestedPeople.getLayout = getNationalLayout();
+ *
+ * export const getStaticProps = getNlData();
+ *
+ * export default PostivelyTestedPeople;
+ * ```
+ *
+ * The `INationalData` should be used in conjuction with `FCWithLayout`
+ *
+ * Example:
+ * ```ts
+ * const PostivelyTestedPeople: FCWithLayout<INationalData> = props => {
+ *   // ...
+ * }
+ * ```
+ */
+export default function getNlData(): () => IProps {
+  return function () {
+    const filePath = path.join(process.cwd(), 'public', 'json', 'NL.json');
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+
+    return {
+      props: {
+        data: JSON.parse(fileContents),
+      },
+    };
+  };
+}

--- a/src/static-props/safetyregion-data.ts
+++ b/src/static-props/safetyregion-data.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Regionaal } from 'types/data';
+
+import safetyRegions from 'data';
+
+export interface ISafetyRegionData {
+  data: Regionaal;
+}
+
+interface IProps {
+  props: ISafetyRegionData;
+}
+
+interface IPaths {
+  paths: Array<{ params: { code: string } }>;
+  fallback: boolean;
+}
+
+interface IParams {
+  params: {
+    code: string;
+  };
+}
+
+/*
+ * getSafetyRegionData loads the data for /veiligheidsregio pages.
+ * It needs to be used as the Next.js `getStaticProps` function.
+ *
+ * Example:
+ * ```ts
+ * PostivelyTestedPeople.getLayout = getSafetyRegionLayout();
+ *
+ * export const getStaticProps = getSafetyRegionData();
+ *
+ * export default PostivelyTestedPeople;
+ * ```
+ *
+ * The `ISafetyRegionData` should be used in conjuction with `FCWithLayout`
+ *
+ * Example:
+ * ```ts
+ * const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = props => {
+ *   // ...
+ * }
+ * ```
+ */
+export function getSafetyRegionData() {
+  return function ({ params }: IParams): IProps {
+    const { code } = params;
+
+    const filePath = path.join(process.cwd(), 'public', 'json', `${code}.json`);
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const data = JSON.parse(fileContents);
+
+    return {
+      props: {
+        data: data,
+      },
+    };
+  };
+}
+
+/*
+ * getSafetyRegionPaths creates an array of all the allowed
+ * `/veiligheidsregio/[code]` routes. This should be used
+ * together with `getSafetyRegionData`.
+ */
+export function getSafetyRegionPaths(): () => IPaths {
+  return function () {
+    const filteredRegions = safetyRegions.filter(
+      (region) => region.code.indexOf('VR') === 0
+    );
+    const paths = filteredRegions.map((region) => ({
+      params: { code: region.code },
+    }));
+
+    // { fallback: false } means other routes should 404.
+    return { paths, fallback: false };
+  };
+}


### PR DESCRIPTION
## Summary

- Pass `pageProps` in `_app.tsx` to `getLayout`.
- Use passed props in layout components instead of `useSWR`
- Create `src/static-props/nl-data.ts` and implement on all `/landelijk` pages.
- Create `src/static-props/municipality-data.ts` and implement on all `/gemeente` pages.
- Create `src/static-props/safefyregion-data.ts` and implement on all `/veiligheidsregio` pages.

## Motivation

- Pre-build pages instead of fetching data on run-time.
- Only build valid pages and redirect to 404 for invalid codes.
- Remove the need for `useSWR`, resulting in a smaller bundle size.

## Detailed design

n\a

## Drawbacks

Not sure

## Alternatives

- Run time fetches
- `import` statements

## Unresolved questions

1. We should figure out a way to get rid of the remaining uses of `useSWR`:

![Screenshot 2020-09-07 at 16 42 05](https://user-images.githubusercontent.com/69849549/92399079-fc799100-f129-11ea-8e50-f0dfed084681.png)

2. We should try to inject the locale via `getStaticProps` otherwise we will never be able to only ship the needed locale (currently `en.json` and `nl.json` are always in the bundle). This is because the build step cannot determine whether only one import is needed because we export them conditionally.

