### PR TITLE
IE layout and rendering fixes

### DIFF
--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -219,6 +219,14 @@ $language-switcher-offset: 55px;
   .text {
     display: flex;
     margin-left: 4rem;
+
+    p {
+      flex: 1 1 60%;
+    }
+
+    div {
+      flex: 0 1 40%;
+    }
   }
 }
 

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -79,14 +79,15 @@
   min-height: 30em;
 
   [data-reach-combobox] {
-    margin: 1em;
+    padding: 1em;
   }
 }
 
 .national-layout,
 .safety-region-layout,
 .municipality-layout {
-  display: flex;
+  /* will become display: flex at wider screens */
+  display: block;
   flex-direction: column;
 
   .back-button {
@@ -106,6 +107,7 @@
     }
 
     > svg {
+      height: 10px;
       width: 16px;
       transform: rotate(90deg);
       margin-right: 0.7em;
@@ -127,6 +129,7 @@
   .national-layout,
   .safety-region-layout,
   .municipality-layout {
+    display: flex;
     flex-direction: row;
 
     & > aside {
@@ -135,7 +138,7 @@
     }
 
     & > section {
-      max-width: 80em;
+      max-width: calc(100vw - 25em);
     }
   }
 }
@@ -150,6 +153,16 @@
   }
 }
 
+@media (min-width: 1600px) {
+  .national-layout,
+  .safety-region-layout,
+  .municipality-layout {
+    & > section {
+      max-width: 80em;
+    }
+  }
+}
+
 .national-aside,
 .safety-region-aside,
 .municipality-aside {
@@ -158,8 +171,8 @@
   z-index: 2;
 
   h2 {
-    margin: 1rem;
-    margin-top: 3rem;
+    padding: 1rem;
+    padding-top: 3rem;
   }
 
   ul {
@@ -197,9 +210,10 @@ a.metric-link {
   &::after {
     content: '';
     background-image: url('/images/chevron.svg');
-    background-size: 1.5em 1.5em;
-    height: 1.5em;
-    width: 1.5em;
+    // match aspect ratio of chevron.svg
+    background-size: 1.1em 1.8em;
+    height: 1.8em;
+    width: 1.1em;
     display: block;
     position: absolute;
     right: 1em;
@@ -217,20 +231,16 @@ a.active-metric-link {
   border-right: 5px solid $red;
 }
 
-.layout-two-column {
-  display: flex;
-  flex-direction: column;
-
-  .column-item {
-    flex: 1 1 50%;
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 @media (min-width: 1200px) {
   .layout-two-column {
+    display: flex;
     flex-direction: row;
+
+    .column-item {
+      flex: 1 1 50%;
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   .column-item {


### PR DESCRIPTION
## Summary & Motivation

Fixes several major IE11 layout glitches.

## Detailed design

* IE does not like the use of flexbox to render things horizontally. Adjusted it to use display:block, and when the need comes adjusted to flex using a media query.
* Sizing of certain SVGs made pages collapse / break / take up way to much space. Added deliberate sizing for a bunch of them.

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
