### PR TITLE
Adjust showing / hiding of sidebar or content to be done via CSS mostly

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -111,14 +111,8 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
         className={`municipality-layout  small-screen-${displayTendency}-tendency`}
       >
         {!isMainRoute && (
-          <Link
-            href={code ? '/gemeente/[code]' : '/gemeente'}
-            as={code ? `/gemeente/${code}` : '/gemeente'}
-          >
-            <a
-              className="back-button"
-              href={code ? `/gemeente/${code}` : '/gemeente'}
-            >
+          <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>
+            <a className="back-button" href={`/gemeente/${code}`}>
               <Arrow />
               {siteText.nav.terug_naar_alle_cijfers}
             </a>

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -13,6 +13,7 @@ import { getSewerWaterBarScaleData } from 'utils/sewer-water/municipality-sewer-
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import Arrow from 'assets/arrow.svg';
 
 import siteText from 'locale';
 
@@ -65,9 +66,11 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
 
   const { code } = router.query;
 
-  const showAside = isLargeScreen || router.route === '/gemeente';
-  const showContent = isLargeScreen || router.route !== '/gemeente';
   const showMetricLinks = router.route !== '/gemeente';
+
+  const isMainRoute =
+    router.route === '/gemeente' || router.route === `/gemeente/[code]`;
+  const displayTendency = isMainRoute ? 'aside' : 'content';
 
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
@@ -104,108 +107,121 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
           title="Nederland"
         />
       </Head>
-
-      <div className="municipality-layout">
-        {showAside && (
-          <aside className="municipality-aside">
-            <Combobox<IMunicipality>
-              handleSelect={handleMunicipalitySelect}
-              options={municipalities}
-            />
-
-            {showMetricLinks && (
-              <nav aria-label="metric navigation">
-                <h2>{siteText.nationaal_layout.headings.medisch}</h2>
-                <ul>
-                  <li>
-                    <Link
-                      href="/gemeente/[code]/positief-geteste-mensen"
-                      as={`/gemeente/${code}/positief-geteste-mensen`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/positief-geteste-mensen`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={GetestIcon}
-                          title={
-                            siteText.gemeente_positief_geteste_personen
-                              .titel_sidebar
-                          }
-                        />
-                        <span>
-                          <PostivelyTestedPeopleBarScale
-                            data={data?.positive_tested_people}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-
-                  <li>
-                    <Link
-                      href="/gemeente/[code]/ziekenhuis-opnames"
-                      as={`/gemeente/${code}/ziekenhuis-opnames`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/ziekenhuis-opnames`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={Ziekenhuis}
-                          title={
-                            siteText.gemeente_ziekenhuisopnames_per_dag
-                              .titel_sidebar
-                          }
-                        />
-                        <span>
-                          <IntakeHospitalBarScale
-                            data={data?.hospital_admissions}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-                </ul>
-
-                <h2>{siteText.nationaal_layout.headings.overig}</h2>
-                <ul>
-                  <li>
-                    <Link
-                      href="/gemeente/[code]/rioolwater"
-                      as={`/gemeente/${code}/rioolwater`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/rioolwater`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={RioolwaterMonitoring}
-                          title={
-                            siteText.gemeente_rioolwater_metingen.titel_sidebar
-                          }
-                        />
-                        <span>
-                          <SewerWaterBarScale
-                            data={getSewerWaterBarScaleData(data)}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-                </ul>
-              </nav>
-            )}
-          </aside>
+      <div
+        className={`municipality-layout  small-screen-${displayTendency}-tendency`}
+      >
+        {!isMainRoute && (
+          <Link
+            href={code ? '/gemeente/[code]' : '/gemeente'}
+            as={code ? `/gemeente/${code}` : '/gemeente'}
+          >
+            <a
+              className="back-button"
+              href={code ? `/gemeente/${code}` : '/gemeente'}
+            >
+              <Arrow />
+              {siteText.nav.terug_naar_alle_cijfers}
+            </a>
+          </Link>
         )}
+        <aside className="municipality-aside">
+          <Combobox<IMunicipality>
+            handleSelect={handleMunicipalitySelect}
+            options={municipalities}
+          />
 
-        {showContent && <section>{children}</section>}
+          {showMetricLinks && (
+            <nav aria-label="metric navigation">
+              <h2>{siteText.nationaal_layout.headings.medisch}</h2>
+              <ul>
+                <li>
+                  <Link
+                    href="/gemeente/[code]/positief-geteste-mensen"
+                    as={`/gemeente/${code}/positief-geteste-mensen`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/positief-geteste-mensen`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={GetestIcon}
+                        title={
+                          siteText.gemeente_positief_geteste_personen
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <PostivelyTestedPeopleBarScale
+                          data={data?.positive_tested_people}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+
+                <li>
+                  <Link
+                    href="/gemeente/[code]/ziekenhuis-opnames"
+                    as={`/gemeente/${code}/ziekenhuis-opnames`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/ziekenhuis-opnames`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={Ziekenhuis}
+                        title={
+                          siteText.gemeente_ziekenhuisopnames_per_dag
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <IntakeHospitalBarScale
+                          data={data?.hospital_admissions}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+
+              <h2>{siteText.nationaal_layout.headings.overig}</h2>
+              <ul>
+                <li>
+                  <Link
+                    href="/gemeente/[code]/rioolwater"
+                    as={`/gemeente/${code}/rioolwater`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/rioolwater`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={RioolwaterMonitoring}
+                        title={
+                          siteText.gemeente_rioolwater_metingen.titel_sidebar
+                        }
+                      />
+                      <span>
+                        <SewerWaterBarScale
+                          data={getSewerWaterBarScaleData(data)}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+          )}
+        </aside>
+
+        <section className="municipality-content">{children}</section>
       </div>
     </>
   );

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -112,7 +112,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
       >
         {!isMainRoute && (
           <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>
-            <a className="back-button" href={`/gemeente/${code}`}>
+            <a className="back-button">
               <Arrow />
               {siteText.nav.terug_naar_alle_cijfers}
             </a>

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -66,11 +66,9 @@ function NationalLayout(props: WithChildren<INationalData>) {
   const { children, data } = props;
   const router = useRouter();
   const isLargeScreen = useMediaQuery('(min-width: 1000px)', false);
-  const showAside = isLargeScreen || router.route === '/landelijk';
-  const showContent = isLargeScreen || router.route !== '/landelijk';
-  const showBackButton =
-    useMediaQuery('(max-width: 1000px)', false) &&
-    router.route !== '/landelijk';
+  const isMainRoute = router.route === '/landelijk';
+  const displayTendency = isMainRoute ? 'aside' : 'content';
+
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
 
@@ -102,8 +100,10 @@ function NationalLayout(props: WithChildren<INationalData>) {
         />
       </Head>
 
-      <div className="national-layout">
-        {showBackButton && (
+      <div
+        className={`national-layout small-screen-${displayTendency}-tendency`}
+      >
+        {!isMainRoute && (
           <Link href="/landelijk">
             <a className="back-button" href="/landelijk">
               <Arrow />
@@ -111,229 +111,219 @@ function NationalLayout(props: WithChildren<INationalData>) {
             </a>
           </Link>
         )}
-        {showAside && (
-          <aside className="national-aside">
-            <nav aria-label="metric navigation">
-              <h2>{siteText.nationaal_layout.headings.medisch}</h2>
-              <ul>
-                <li>
-                  <Link href="/landelijk/positief-geteste-mensen">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/positief-geteste-mensen'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={GetestIcon}
-                        title={siteText.positief_geteste_personen.titel}
+        <aside className="national-aside">
+          <nav aria-label="metric navigation">
+            <h2>{siteText.nationaal_layout.headings.medisch}</h2>
+            <ul>
+              <li>
+                <Link href="/landelijk/positief-geteste-mensen">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/positief-geteste-mensen'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={GetestIcon}
+                      title={siteText.positief_geteste_personen.titel}
+                    />
+                    <span>
+                      <PostivelyTestedPeopleBarScale
+                        data={data?.infected_people_delta_normalized}
                       />
-                      <span>
-                        <PostivelyTestedPeopleBarScale
-                          data={data?.infected_people_delta_normalized}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-                <li>
-                  <Link href="/landelijk/reproductiegetal">
-                    <a
-                      onClick={blur}
-                      className={getClassName('/landelijk/reproductiegetal')}
-                    >
-                      <TitleWithIcon
-                        Icon={ReproIcon}
-                        title={siteText.reproductiegetal.titel}
+              <li>
+                <Link href="/landelijk/reproductiegetal">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/reproductiegetal')}
+                  >
+                    <TitleWithIcon
+                      Icon={ReproIcon}
+                      title={siteText.reproductiegetal.titel}
+                    />
+                    <span>
+                      <ReproductionIndexBarScale
+                        data={data?.reproduction_index}
+                        lastKnown={data?.reproduction_index_last_known_average}
                       />
-                      <span>
-                        <ReproductionIndexBarScale
-                          data={data?.reproduction_index}
-                          lastKnown={
-                            data?.reproduction_index_last_known_average
-                          }
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-                <li>
-                  <Link href="/landelijk/besmettelijke-mensen">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/besmettelijke-mensen'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={Ziektegolf}
-                        title={siteText.besmettelijke_personen.title}
+              <li>
+                <Link href="/landelijk/besmettelijke-mensen">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/besmettelijke-mensen')}
+                  >
+                    <TitleWithIcon
+                      Icon={Ziektegolf}
+                      title={siteText.besmettelijke_personen.title}
+                    />
+                    <span>
+                      <InfectiousPeopleBarScale
+                        data={data?.infectious_people_count_normalized}
                       />
-                      <span>
-                        <InfectiousPeopleBarScale
-                          data={data?.infectious_people_count_normalized}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-                <li>
-                  <Link href="/landelijk/ziekenhuis-opnames">
-                    <a
-                      onClick={blur}
-                      className={getClassName('/landelijk/ziekenhuis-opnames')}
-                    >
-                      <TitleWithIcon
-                        Icon={Ziekenhuis}
-                        title={siteText.ziekenhuisopnames_per_dag.titel}
+              <li>
+                <Link href="/landelijk/ziekenhuis-opnames">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/ziekenhuis-opnames')}
+                  >
+                    <TitleWithIcon
+                      Icon={Ziekenhuis}
+                      title={siteText.ziekenhuisopnames_per_dag.titel}
+                    />
+                    <span>
+                      <IntakeHospitalBarScale data={data?.intake_hospital_ma} />
+                    </span>
+                  </a>
+                </Link>
+              </li>
+
+              <li>
+                <Link href="/landelijk/intensive-care-opnames">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/intensive-care-opnames'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={Arts}
+                      title={siteText.ic_opnames_per_dag.titel}
+                    />
+                    <span>
+                      <IntakeIntensiveCareBarscale
+                        data={data?.intake_intensivecare_ma}
                       />
-                      <span>
-                        <IntakeHospitalBarScale
-                          data={data?.intake_hospital_ma}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
+            </ul>
 
-                <li>
-                  <Link href="/landelijk/intensive-care-opnames">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/intensive-care-opnames'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={Arts}
-                        title={siteText.ic_opnames_per_dag.titel}
+            <h2>{siteText.nationaal_layout.headings.overig}</h2>
+            <ul>
+              <li>
+                <Link href="/landelijk/verdenkingen-huisartsen">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/verdenkingen-huisartsen'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={Arts}
+                      title={siteText.verdenkingen_huisartsen.titel}
+                    />
+                    <span>
+                      <SuspectedPatientsBarScale
+                        data={data?.verdenkingen_huisartsen}
                       />
-                      <span>
-                        <IntakeIntensiveCareBarscale
-                          data={data?.intake_intensivecare_ma}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-              <h2>{siteText.nationaal_layout.headings.overig}</h2>
-              <ul>
-                <li>
-                  <Link href="/landelijk/verdenkingen-huisartsen">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/verdenkingen-huisartsen'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={Arts}
-                        title={siteText.verdenkingen_huisartsen.titel}
+              <li>
+                <Link href="/landelijk/rioolwater">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/rioolwater')}
+                  >
+                    <TitleWithIcon
+                      Icon={RioolwaterMonitoring}
+                      title={siteText.rioolwater_metingen.titel}
+                    />
+                    <span>
+                      <SewerWaterBarScale data={data?.rioolwater_metingen} />
+                    </span>
+                  </a>
+                </Link>
+              </li>
+            </ul>
+
+            <h2>{siteText.nationaal_layout.headings.verpleeghuis}</h2>
+            <ul>
+              <li>
+                <Link href="/landelijk/verpleeghuis-positief-geteste-personen">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/verpleeghuis-positief-geteste-personen'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={GetestIcon}
+                      title={
+                        siteText.verpleeghuis_positief_geteste_personen.titel
+                      }
+                    />
+                    <span>
+                      <NursingHomeInfectedPeopleBarScale
+                        data={data?.infected_people_nursery_count_daily}
                       />
-                      <span>
-                        <SuspectedPatientsBarScale
-                          data={data?.verdenkingen_huisartsen}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-                <li>
-                  <Link href="/landelijk/rioolwater">
-                    <a
-                      onClick={blur}
-                      className={getClassName('/landelijk/rioolwater')}
-                    >
-                      <TitleWithIcon
-                        Icon={RioolwaterMonitoring}
-                        title={siteText.rioolwater_metingen.titel}
+              <li>
+                <Link href="/landelijk/verpleeghuis-besmette-locaties">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/verpleeghuis-besmette-locaties'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={Locatie}
+                      title={siteText.verpleeghuis_besmette_locaties.titel}
+                    />
+                    <span>
+                      <NursingHomeInfectedLocationsBarScale
+                        data={data?.total_newly_reported_locations}
                       />
-                      <span>
-                        <SewerWaterBarScale data={data?.rioolwater_metingen} />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
+                    </span>
+                  </a>
+                </Link>
+              </li>
 
-              <h2>{siteText.nationaal_layout.headings.verpleeghuis}</h2>
-              <ul>
-                <li>
-                  <Link href="/landelijk/verpleeghuis-positief-geteste-personen">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/verpleeghuis-positief-geteste-personen'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={GetestIcon}
-                        title={
-                          siteText.verpleeghuis_positief_geteste_personen.titel
-                        }
+              <li>
+                <Link href="/landelijk/verpleeghuis-sterfte">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/verpleeghuis-sterfte')}
+                  >
+                    <TitleWithIcon
+                      Icon={CoronaVirus}
+                      title={siteText.verpleeghuis_oversterfte.titel}
+                    />
+                    <span>
+                      <NursingHomeDeathsBarScale
+                        data={data?.deceased_people_nursery_count_daily}
                       />
-                      <span>
-                        <NursingHomeInfectedPeopleBarScale
-                          data={data?.infected_people_nursery_count_daily}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
+                    </span>
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </aside>
 
-                <li>
-                  <Link href="/landelijk/verpleeghuis-besmette-locaties">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/verpleeghuis-besmette-locaties'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={Locatie}
-                        title={siteText.verpleeghuis_besmette_locaties.titel}
-                      />
-                      <span>
-                        <NursingHomeInfectedLocationsBarScale
-                          data={data?.total_newly_reported_locations}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
-
-                <li>
-                  <Link href="/landelijk/verpleeghuis-sterfte">
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        '/landelijk/verpleeghuis-sterfte'
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={CoronaVirus}
-                        title={siteText.verpleeghuis_oversterfte.titel}
-                      />
-                      <span>
-                        <NursingHomeDeathsBarScale
-                          data={data?.deceased_people_nursery_count_daily}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
-            </nav>
-          </aside>
-        )}
-
-        {showContent && <section>{children}</section>}
+        <section className="national-content">{children}</section>
       </div>
     </>
   );

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -118,13 +118,10 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
       >
         {!isMainRoute && (
           <Link
-            href={code ? '/veiligheidsregio/[code]' : '/veiligheidsregio'}
-            as={code ? `/veiligheidsregio/${code}` : '/veiligheidsregio'}
+            href="/veiligheidsregio/[code]"
+            as={`/veiligheidsregio/${code}`}
           >
-            <a
-              className="back-button"
-              href={code ? `/veiligheidsregio/${code}` : '/veiligheidsregio'}
-            >
+            <a className="back-button" href={`/veiligheidsregio/${code}`}>
               <Arrow />
               {siteText.nav.terug_naar_alle_cijfers}
             </a>

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -13,6 +13,7 @@ import Combobox from 'components/comboBox';
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import Arrow from 'assets/arrow.svg';
 
 import siteText from 'locale';
 import safetyRegions from 'data/index';
@@ -67,8 +68,11 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
 
   const { code } = router.query;
 
-  const showAside = isLargeScreen || router.route === '/veiligheidsregio';
-  const showContent = isLargeScreen || router.route !== '/veiligheidsregio';
+  const isMainRoute =
+    router.route === '/veiligheidsregio' ||
+    router.route === `/veiligheidsregio/[code]`;
+  const displayTendency = isMainRoute ? 'aside' : 'content';
+
   const showMetricLinks = router.route !== '/veiligheidsregio';
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
@@ -109,109 +113,124 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
         />
       </Head>
 
-      <div className="safety-region-layout">
-        {showAside && (
-          <aside className="safety-region-aside">
-            <Combobox<TSafetyRegion>
-              handleSelect={handleSafeRegionSelect}
-              options={safetyRegions}
-            />
-
-            {showMetricLinks && (
-              <nav aria-label="metric navigation">
-                <h2>{siteText.veiligheidsregio_layout.headings.medisch}</h2>
-
-                <ul>
-                  <li>
-                    <Link
-                      href="/veiligheidsregio/[code]/positief-geteste-mensen"
-                      as={`/veiligheidsregio/${code}/positief-geteste-mensen`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/positief-geteste-mensen`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={GetestIcon}
-                          title={
-                            siteText.veiligheidsregio_positief_geteste_personen
-                              .titel_sidebar
-                          }
-                        />
-                        <span>
-                          <PostivelyTestedPeopleBarScale
-                            data={data?.results_per_region}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-
-                  <li>
-                    <Link
-                      href="/veiligheidsregio/[code]/ziekenhuis-opnames"
-                      as={`/veiligheidsregio/${code}/ziekenhuis-opnames`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/ziekenhuis-opnames`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={Ziekenhuis}
-                          title={
-                            siteText.veiligheidsregio_ziekenhuisopnames_per_dag
-                              .titel_sidebar
-                          }
-                        />
-                        <span>
-                          <IntakeHospitalBarScale
-                            data={data?.results_per_region}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-                </ul>
-
-                <h2>{siteText.veiligheidsregio_layout.headings.overig}</h2>
-                <ul>
-                  <li>
-                    <Link
-                      href="/veiligheidsregio/[code]/rioolwater"
-                      as={`/veiligheidsregio/${code}/rioolwater`}
-                    >
-                      <a
-                        onClick={blur}
-                        className={getClassName(
-                          `/veiligheidsregio/[code]/rioolwater`
-                        )}
-                      >
-                        <TitleWithIcon
-                          Icon={RioolwaterMonitoring}
-                          title={
-                            siteText.veiligheidsregio_rioolwater_metingen
-                              .titel_sidebar
-                          }
-                        />
-                        <span>
-                          <SewerWaterBarScale
-                            data={getSewerWaterBarScaleData(data)}
-                          />
-                        </span>
-                      </a>
-                    </Link>
-                  </li>
-                </ul>
-              </nav>
-            )}
-          </aside>
+      <div
+        className={`safety-region-layout  small-screen-${displayTendency}-tendency`}
+      >
+        {!isMainRoute && (
+          <Link
+            href={code ? '/veiligheidsregio/[code]' : '/veiligheidsregio'}
+            as={code ? `/veiligheidsregio/${code}` : '/veiligheidsregio'}
+          >
+            <a
+              className="back-button"
+              href={code ? `/veiligheidsregio/${code}` : '/veiligheidsregio'}
+            >
+              <Arrow />
+              {siteText.nav.terug_naar_alle_cijfers}
+            </a>
+          </Link>
         )}
 
-        {showContent && <section>{children}</section>}
+        <aside className="safety-region-aside">
+          <Combobox<TSafetyRegion>
+            handleSelect={handleSafeRegionSelect}
+            options={safetyRegions}
+          />
+
+          {showMetricLinks && (
+            <nav aria-label="metric navigation">
+              <h2>{siteText.veiligheidsregio_layout.headings.medisch}</h2>
+
+              <ul>
+                <li>
+                  <Link
+                    href="/veiligheidsregio/[code]/positief-geteste-mensen"
+                    as={`/veiligheidsregio/${code}/positief-geteste-mensen`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/positief-geteste-mensen`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={GetestIcon}
+                        title={
+                          siteText.veiligheidsregio_positief_geteste_personen
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <PostivelyTestedPeopleBarScale
+                          data={data?.results_per_region}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+
+                <li>
+                  <Link
+                    href="/veiligheidsregio/[code]/ziekenhuis-opnames"
+                    as={`/veiligheidsregio/${code}/ziekenhuis-opnames`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/ziekenhuis-opnames`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={Ziekenhuis}
+                        title={
+                          siteText.veiligheidsregio_ziekenhuisopnames_per_dag
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <IntakeHospitalBarScale
+                          data={data?.results_per_region}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+
+              <h2>{siteText.veiligheidsregio_layout.headings.overig}</h2>
+              <ul>
+                <li>
+                  <Link
+                    href="/veiligheidsregio/[code]/rioolwater"
+                    as={`/veiligheidsregio/${code}/rioolwater`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/rioolwater`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={RioolwaterMonitoring}
+                        title={
+                          siteText.veiligheidsregio_rioolwater_metingen
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <SewerWaterBarScale
+                          data={getSewerWaterBarScaleData(data)}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+          )}
+        </aside>
+
+        <section className="safety-region-content">{children}</section>
       </div>
     </>
   );

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -97,10 +97,7 @@
     box-shadow: $box-shadow;
     text-decoration: none;
 
-    &:hover {
-      text-decoration: underline;
-    }
-
+    &:hover,
     &:focus {
       text-decoration: underline;
     }
@@ -123,6 +120,24 @@
   }
 }
 
+@media (max-width: 1000px) {
+  .small-screen-aside-tendency {
+    .national-content,
+    .safety-region-content,
+    .municipality-content {
+      display: none;
+    }
+  }
+
+  .small-screen-content-tendency {
+    .national-aside,
+    .safety-region-aside,
+    .municipality-aside {
+      display: none;
+    }
+  }
+}
+
 @media (min-width: 1000px) {
   .national-layout,
   .safety-region-layout,
@@ -136,6 +151,10 @@
 
     & > section {
       max-width: 80em;
+    }
+
+    .back-button {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
## Summary

Adjustment of rendering of sidebar / content on small screens: now mostly via CSS.

## Motivation

The previous implementation was not able to statically render.

## Detailed design

* Add a classname on the main layout wrapper, with the tendency for the small screen: aside or content.
* Use actual media queries in CSS to show and hide the sidebar or content.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

Separate question for statically rendering: the redirect on `/landelijk` on initial page load.

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
