### PR TITLE
Add “Terug naar alle cijfers” button to all pages & style changes

### DIFF
--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -19,6 +19,7 @@ type TOption = {
 
 type TProps<Option extends TOption> = {
   options: Option[];
+  placeholder: string;
   handleSelect: (option: Option) => void;
 };
 
@@ -40,7 +41,7 @@ export default ComboBox;
  * ```
  */
 function ComboBox<Option extends TOption>(props: TProps<Option>) {
-  const { options, handleSelect } = props;
+  const { options, placeholder, handleSelect } = props;
 
   const inputRef = useRef<HTMLInputElement>();
   const [term, setTerm] = useState<string>('');
@@ -65,7 +66,7 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
       <ComboboxInput
         ref={inputRef}
         onChange={handleChange}
-        placeholder={text.common.zoekveld_placeholder}
+        placeholder={placeholder}
       />
       <ComboboxPopover>
         {results.length > 0 ? (

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -13,6 +13,7 @@ import { getSewerWaterBarScaleData } from 'utils/sewer-water/municipality-sewer-
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import Arrow from 'assets/arrow.svg';
 
 import siteText from 'locale';
 
@@ -61,13 +62,17 @@ export function getMunicipalityLayout() {
 function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
   const { children, data } = props;
   const router = useRouter();
-  const isLargeScreen = useMediaQuery('(min-width: 1000px)', true);
+  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const { code } = router.query;
 
   const showAside = isLargeScreen || router.route === '/gemeente';
   const showContent = isLargeScreen || router.route !== '/gemeente';
   const showMetricLinks = router.route !== '/gemeente';
+  const showBackButton =
+    useMediaQuery('(max-width: 1000px)', false) &&
+    router.route !== '/gemeente' &&
+    router.route !== '/gemeente/[code]';
 
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
@@ -106,9 +111,18 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
       </Head>
 
       <div className="municipality-layout">
+        {showBackButton && (
+          <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>
+            <a className="back-button">
+              <Arrow />
+              {siteText.nav.terug_naar_alle_cijfers}
+            </a>
+          </Link>
+        )}
         {showAside && (
           <aside className="municipality-aside">
             <Combobox<IMunicipality>
+              placeholder={siteText.common.zoekveld_placeholder_gemeente}
               handleSelect={handleMunicipalitySelect}
               options={municipalities}
             />

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -65,12 +65,11 @@ export function getNationalLayout() {
 function NationalLayout(props: WithChildren<INationalData>) {
   const { children, data } = props;
   const router = useRouter();
-  const isLargeScreen = useMediaQuery('(min-width: 1000px)', false);
+  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
   const showAside = isLargeScreen || router.route === '/landelijk';
   const showContent = isLargeScreen || router.route !== '/landelijk';
   const showBackButton =
-    useMediaQuery('(max-width: 1000px)', false) &&
-    router.route !== '/landelijk';
+    useMediaQuery('(max-width: 1000px)') && router.route !== '/landelijk';
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
 
@@ -105,7 +104,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
       <div className="national-layout">
         {showBackButton && (
           <Link href="/landelijk">
-            <a className="back-button" href="/landelijk">
+            <a className="back-button">
               <Arrow />
               {siteText.nav.terug_naar_alle_cijfers}
             </a>

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -13,6 +13,7 @@ import Combobox from 'components/comboBox';
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import Arrow from 'assets/arrow.svg';
 
 import siteText from 'locale';
 import safetyRegions from 'data/index';
@@ -70,6 +71,10 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
   const showAside = isLargeScreen || router.route === '/veiligheidsregio';
   const showContent = isLargeScreen || router.route !== '/veiligheidsregio';
   const showMetricLinks = router.route !== '/veiligheidsregio';
+  const showBackButton =
+    useMediaQuery('(max-width: 1000px)', false) &&
+    router.route !== '/veiligheidsregio' &&
+    router.route !== '/veiligheidsregio/[code]';
   // remove focus after navigation
   const blur = (evt: any) => evt.target.blur();
 
@@ -110,9 +115,21 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
       </Head>
 
       <div className="safety-region-layout">
+        {showBackButton && (
+          <Link
+            href="/veiligheidsregio/[code]"
+            as={`/veiligheidsregio/${code}`}
+          >
+            <a className="back-button">
+              <Arrow />
+              {siteText.nav.terug_naar_alle_cijfers}
+            </a>
+          </Link>
+        )}
         {showAside && (
           <aside className="safety-region-aside">
             <Combobox<TSafetyRegion>
+              placeholder={siteText.common.zoekveld_placeholder_regio}
               handleSelect={handleSafeRegionSelect}
               options={safetyRegions}
             />

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -82,6 +82,11 @@ $language-switcher-offset: 55px;
   padding: 0;
   margin: 0;
   display: flex;
+  overflow-x: auto;
+
+  li {
+    white-space: nowrap;
+  }
 
   > li:last-child {
     display: none;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -617,7 +617,8 @@
     "barScale": {
       "signaalwaarde": "Signaalwaarde"
     },
-    "zoekveld_placeholder": "Zoek op gemeente of veiligheidsregio ",
+    "zoekveld_placeholder_regio": "Zoek op veiligheidsregio ",
+    "zoekveld_placeholder_gemeente": "Zoek op gemeente ",
     "zoekveld_geen_resultaten": "Geen resultaten"
   },
   "seoHead": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -616,7 +616,8 @@
     "barScale": {
       "signaalwaarde": "Signaalwaarde"
     },
-    "zoekveld_placeholder": "Zoek op gemeente of veiligheidsregio ",
+    "zoekveld_placeholder_regio": "Zoek op veiligheidsregio ",
+    "zoekveld_placeholder_gemeente": "Zoek op gemeente ",
     "zoekveld_geen_resultaten": "Geen resultaten"
   },
   "seoHead": {

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -96,6 +96,7 @@
     padding: 1em;
     box-shadow: $box-shadow;
     text-decoration: none;
+    z-index: 3;
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
## Summary

- Add “Terug naar alle cijfers” button to /veiligheidsregio and /gemeente & fix box-shadow
- Fix links styling in main layout on mobile.
- Update placeholder of `combobox`.

## Motivation

QA feedback.
