### PR TITLE
Only use blue color scale for maps

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,5 +1,4 @@
 const regioData = [
-  { name: 'Nederland', code: 'NL', id: 0 },
   { name: 'Groningen', code: 'VR01', id: 1 },
   { name: 'Friesland', code: 'VR02', id: 2 },
   { name: 'Drenthe', code: 'VR03', id: 3 },

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -120,7 +120,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
               selected={data.code}
               municipalCodes={municipalCodes}
               metric="hospital_admissions"
-              gradient={['#69c253', '#f35065']}
+              gradient={['#9DDEFE', '#0290D6']}
             />
           )}
         </div>

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -99,13 +99,13 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
           {selectedMap === 'municipal' && (
             <MunicipalityMap
               metric="hospital_admissions"
-              gradient={['#69c253', '#f35065']}
+              gradient={['#9DDEFE', '#0290D6']}
             />
           )}
           {selectedMap === 'region' && (
             <SafetyRegionMap
               metric="hospital_admissions"
-              gradient={['#69c253', '#f35065']}
+              gradient={['#9DDEFE', '#0290D6']}
             />
           )}
         </div>

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -137,7 +137,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           />
         </div>
       </article>
-      );
     </>
   );
 };

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -123,7 +123,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           <MunicipalityMap
             municipalCodes={municipalCodes}
             metric="hospital_admissions"
-            gradient={['#69c253', '#f35065']}
+            gradient={['#9DDEFE', '#0290D6']}
           />
         </div>
       </article>


### PR DESCRIPTION
## Summary

- Only use blue color scales for maps
- Remove `NL` from `regioData`.
- Remove invalid character loaded in the DOM.