### PR TITLE
Add schema for positively tested people percentage

### DIFF
--- a/schema/national/infected_people_percentage.json
+++ b/schema/national/infected_people_percentage.json
@@ -1,0 +1,50 @@
+{
+  "definitions": {
+    "item": {
+      "title": "infected_people_percentage_last_value",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "infected_ggd",
+        "percentage_infected_ggd",
+        "total_tested_ggd",
+        "date_of_report_unix",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "infected_ggd": {
+          "type": "number"
+        },
+        "percentage_infected_ggd": {
+          "type": "number"
+        },
+        "total_tested_ggd": {
+          "type": "number"
+        },
+        "date_of_report_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "infected_people_perentage.json",
+  "title": "infected_people_percentage",
+  "type": "object",
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/item"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/item"
+    }
+  }
+}

--- a/schema/national/national.json
+++ b/schema/national/national.json
@@ -65,6 +65,9 @@
     "infected_people_clusters": {
       "$ref": "infected_people_clusters.json"
     },
+    "infected_people_percentage": {
+      "$ref": "infected_people_percentage.json"
+    },
     "total_reported_locations": {
       "$ref": "total_reported_locations.json"
     },


### PR DESCRIPTION
## Summary

Initial setup for percentage of positively tested people

## Unresolved questions

* Comments on the keys welcome
* ~I guess we do not strictly need a calculated percentage; but it's in the name of the structure...~

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
