### PR TITLE
chore: visual tweaks to charts

### DIFF
--- a/src/components/chartTimeControls/chartTimeControls.module.scss
+++ b/src/components/chartTimeControls/chartTimeControls.module.scss
@@ -2,7 +2,7 @@
 
 .chart-radio-group {
   margin: 1em 0;
-  justify-content: flex-end;
+  justify-content: center;
 
   /* Extra specificity to overrule radio-group rules */
   &.chart-radio-group {

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -98,16 +98,32 @@ function getOptions(
     },
     series: [
       {
-        type: 'line',
+        type: 'area',
         data: values.map((value) => value.value as number),
         name: '',
         showInLegend: false,
         color: '#3391CC',
+        // hex to rgb converted, added opacity
+        fillColor: 'rgba(51, 145, 204, 0.2)',
         marker: {
           enabled: false,
         },
       },
     ],
+    plotOptions: {
+      area: {
+        marker: {
+          enabled: false,
+          symbol: 'circle',
+          radius: 2,
+          states: {
+            hover: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    },
   };
 
   if (signaalwaarde) {
@@ -142,12 +158,12 @@ function LineChart({
 
   return (
     <>
+      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
       <ChartTimeControls
         timeframe={timeframe}
         timeframeOptions={timeframeOptions}
         onChange={(value) => setTimeframe(value as TimeframeOption)}
       />
-      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
     </>
   );
 }

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -76,7 +76,7 @@ function getOptions(
     },
     yAxis: {
       min: 0,
-      max: values.length > 0 ? null : 1,
+      max: signaalwaarde ? signaalwaarde + 1 : values.length > 0 ? null : 1,
       allowDecimals: false,
       lineColor: '#C4C4C4',
       gridLineColor: '#C4C4C4',

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -139,8 +139,11 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
       </article>
 
       <article className="metric-article">
-        <h3>{text.linechart_titel}</h3>
-        <p>{text.linechart_toelichting}</p>
+        <div className="article-text">
+          <h3>{text.linechart_titel}</h3>
+          <p>{text.linechart_toelichting}</p>
+        </div>
+
         {delta && (
           <LineChart
             values={delta.values.map((value) => ({

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -152,9 +152,11 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         )}
       </article>
 
-      <article className="metric-article">
-        <h3>{text.barscale_titel}</h3>
-        <p>{text.barchart_toelichting}</p>
+      <article className="metric-article layout-two-column">
+        <div className="column-item column-item-extra-margin">
+          <h3>{text.barscale_titel}</h3>
+          <p>{text.barchart_toelichting}</p>
+        </div>
         {age && (
           <>
             <BarChart

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -68,9 +68,9 @@
   margin-top: 2rem;
   box-shadow: $box-shadow;
 
-  h3,
-  p {
+  .article-text {
     max-width: 30rem;
+    // color: blue;
   }
 }
 

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -67,6 +67,11 @@
   margin: 0;
   margin-top: 2rem;
   box-shadow: $box-shadow;
+
+  h3,
+  p {
+    max-width: 30rem;
+  }
 }
 
 /* Remove outline from programatically focussed elements. */


### PR DESCRIPTION
## Summary

- adds an area fill to the linecharts with subtle fill-color
- restyles the barchart tile to have a two-column layout
- repositions the controls for the linechart to be centered under the chart
- sets the max value of the line-chart to always show the signaalwaarde value (when available)

## Motivation

design tweaks

## Detailed design


## Drawbacks


## Alternatives


## Unresolved questions


### Governance

