### PR TITLE
Fixed the layout and colors of the region and municipal selection maps

### DIFF
--- a/src/components/vx/MunicipalityChloropleth.tsx
+++ b/src/components/vx/MunicipalityChloropleth.tsx
@@ -90,11 +90,14 @@ export default function MunicipalityChloropleth(props: TProps) {
 
   const getFillColor = useCallback(
     (gmCode: string) => {
-      const data = municipalityData[gmCode];
-      const value = data?.value ?? 0;
-      return color(value);
+      if (hasData) {
+        const data = municipalityData[gmCode];
+        const value = data?.value ?? 0;
+        return color(value);
+      }
+      return 'white';
     },
-    [municipalityData, color]
+    [municipalityData, color, hasData]
   );
 
   const getData = useCallback(
@@ -105,7 +108,7 @@ export default function MunicipalityChloropleth(props: TProps) {
             (feat) => feat.properties.gemcode === gmCode
           )?.properties;
     },
-    [municipalityData, hasData]
+    [municipalityData, hasData, municipalGeo]
   );
 
   const [showTooltip, hideTooltip, tooltipInfo] = useMapTooltip<
@@ -172,14 +175,7 @@ export default function MunicipalityChloropleth(props: TProps) {
             }
           />
         </clipPath>
-        <rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          fill={'white'}
-          rx={14}
-        />
+        <rect x={0} y={0} width={width} height={height} fill={'none'} rx={14} />
         <g
           transform={`translate(${[marginLeft, marginTop].join(',')})`}
           clipPath={`url(#${clipPathId.current})`}
@@ -194,15 +190,19 @@ export default function MunicipalityChloropleth(props: TProps) {
                   if (!path) return null;
                   const { gemcode } = feature.properties;
                   if (gemcode) {
+                    const isSelected = gemcode === selection;
+                    let className = isSelected ? styles.selectedPath : '';
+                    if (!hasData) {
+                      className += ` ${styles.noData}`;
+                    }
                     return (
                       <path
+                        className={className}
                         shapeRendering="optimizeQuality"
                         id={gemcode}
                         key={`municipality-map-feature-${i}`}
                         d={path}
                         fill={getFillColor(gemcode)}
-                        stroke={gemcode === selection ? 'black' : 'grey'}
-                        strokeWidth={gemcode === selection ? 3 : 0.5}
                       />
                     );
                   } else {

--- a/src/components/vx/SafetyRegionChloropleth.tsx
+++ b/src/components/vx/SafetyRegionChloropleth.tsx
@@ -145,14 +145,7 @@ export default function SafetyRegionChloropleth(props: TProps) {
             }
           />
         </clipPath>
-        <rect
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          fill={'white'}
-          rx={14}
-        />
+        <rect x={0} y={0} width={width} height={height} fill={'none'} rx={14} />
         <g
           transform={`translate(${[marginLeft, marginTop].join(',')})`}
           clipPath={`url(#${clipPathId.current})`}
@@ -169,15 +162,19 @@ export default function SafetyRegionChloropleth(props: TProps) {
                   const { vrcode } = feature.properties;
 
                   if (vrcode) {
+                    const isSelected = vrcode === selection;
+                    let className = isSelected ? styles.selectedPath : '';
+                    if (!hasData) {
+                      className += ` ${styles.noData}`;
+                    }
                     return (
                       <path
+                        className={className}
                         shapeRendering="optimizeQuality"
                         id={vrcode}
                         key={`safetyregion-map-feature-${i}`}
                         d={path || ''}
                         fill={getFillColor(vrcode)}
-                        stroke={vrcode === selection ? 'black' : 'grey'}
-                        strokeWidth={vrcode === selection ? 2 : 0.5}
                       />
                     );
                   } else {

--- a/src/components/vx/chloropleth.module.scss
+++ b/src/components/vx/chloropleth.module.scss
@@ -21,6 +21,8 @@
 
   path {
     pointer-events: all;
+    stroke: grey;
+    stroke-width: 0.5;
   }
 
   path:hover {
@@ -29,14 +31,23 @@
     z-index: 1000;
   }
 
-  .overlay {
+  path.selectedPath {
+    stroke: black;
+    stroke-width: 3;
+  }
+
+  path.noData:hover {
+    stroke: black;
+  }
+
+  path.overlay {
     pointer-events: none;
     stroke: black;
     stroke-width: 1;
     fill: transparent;
   }
 
-  .overlay:hover {
+  path.overlay:hover {
     stroke: black;
     stroke-width: 1;
     fill: transparent;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -23,15 +23,23 @@ const Municipality: FCWithLayout<any> = () => {
 
   return (
     <>
-      <h2 className="text-max-width">{text.gemeente_index.selecteer_titel}</h2>
-      <p className="text-max-width">
-        {text.gemeente_index.selecteer_toelichting}
-      </p>
-      <MunicipalityMap
-        style={{ height: '500px' }}
-        onSelect={onSelectMunicpal}
-        gradient={['#ffff', '#ffff']}
-      />
+      <article className="map-article layout-two-column">
+        <div className="column-item-no-margin column-item-small">
+          <h2 className="text-max-width">
+            {text.gemeente_index.selecteer_titel}
+          </h2>
+          <p className="text-max-width">
+            {text.gemeente_index.selecteer_toelichting}
+          </p>
+        </div>
+        <div className="column-item-no-margin column-item">
+          <MunicipalityMap
+            style={{ height: '800px', backgroundColor: 'none' }}
+            onSelect={onSelectMunicpal}
+            gradient={['#ffff', '#ffff']}
+          />
+        </div>
+      </article>
     </>
   );
 };

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -23,17 +23,23 @@ const SafetyRegion: FCWithLayout<any> = () => {
 
   return (
     <>
-      <h2 className="text-max-width">
-        {text.veiligheidsregio_index.selecteer_titel}
-      </h2>
-      <p className="text-max-width">
-        {text.veiligheidsregio_index.selecteer_toelichting}
-      </p>
-      <SafetyRegionMap
-        style={{ height: '500px' }}
-        onSelect={onSelectRegion}
-        gradient={['#ffff', '#ffff']}
-      />
+      <article className="map-article layout-two-column">
+        <div className="column-item-no-margin column-item-small">
+          <h2 className="text-max-width">
+            {text.veiligheidsregio_index.selecteer_titel}
+          </h2>
+          <p className="text-max-width">
+            {text.veiligheidsregio_index.selecteer_toelichting}
+          </p>
+        </div>
+        <div className="column-item-no-margin column-item">
+          <SafetyRegionMap
+            style={{ height: '800px', backgroundColor: 'none' }}
+            onSelect={onSelectRegion}
+            gradient={['#ffff', '#ffff']}
+          />
+        </div>
+      </article>
     </>
   );
 };

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -60,6 +60,13 @@
   margin-bottom: $default-margin * 2;
 }
 
+.map-article {
+  background: transparent;
+  padding: 0 2em 2em 2em;
+  border-radius: 5px;
+  margin: 0 -2rem;
+}
+
 .metric-article {
   background: white;
   padding: 2em;
@@ -281,8 +288,18 @@ a.active-metric-link {
     display: flex;
     flex-direction: row;
 
+    .column-item-no-margin {
+      margin: 0;
+    }
+
     .column-item {
       flex: 1 1 50%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .column-item-small {
+      flex: 1 1 10%;
       display: flex;
       flex-direction: column;
     }
@@ -305,6 +322,16 @@ a.active-metric-link {
 
     &:nth-of-type(2) {
       margin-left: $default-margin * 3;
+    }
+  }
+
+  .column-item-no-margin {
+    &:first-of-type {
+      margin-right: 0;
+    }
+
+    &:nth-of-type(2) {
+      margin-left: 0;
     }
   }
 }


### PR DESCRIPTION
## Summary

As the title suggests

## Motivation

Things need to look as they should

## Detailed design

Tweaked the stroke colors and hovers for the maps when there's no data being displayed (like the municipal and region selection pages). Put all of the different states into css classes to keep things a little neater.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
