### PR TITLE
Don't calculate extent for an empty array

### DIFF
--- a/src/utils/useExtent.ts
+++ b/src/utils/useExtent.ts
@@ -12,7 +12,7 @@ export default function useExtent(
   predicate?: (item: any) => number
 ): [number, number] | undefined {
   return useMemo(() => {
-    if (!collection) {
+    if (!collection?.length) {
       return undefined;
     }
     const numberCollection = predicate


### PR DESCRIPTION
## Summary

Extent shouldnt calculate a min and max value for an empty array, instead it should return undefined

## Motivation

Bug fix

## Detailed design

As per the summary

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
