### PR TITLE
fix: situatiekaart layout

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -61,8 +61,8 @@
 .legenda {
   padding-left: 0;
   vertical-align: bottom;
-  position: absolute;
-  bottom: 0;
+  // position: absolute;
+  // bottom: 0;
 
   .escalationInfo {
     margin-bottom: 1em;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -60,9 +60,11 @@
 
 .legenda {
   padding-left: 0;
-  vertical-align: bottom;
-  // position: absolute;
-  // bottom: 0;
+  margin-bottom: 1em;
+
+  @media (min-width: 1200px) {
+    margin-bottom: 0;
+  }
 
   .escalationInfo {
     margin-bottom: 1em;

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -102,6 +102,9 @@
   @media (min-width: 700px) {
     margin: 0;
     margin-top: 2rem;
+  }
+
+  @media (min-width: 1200px) {
     flex-direction: row;
   }
 

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -92,6 +92,8 @@
   margin: 0 -2rem;
   margin-top: 2rem;
   box-shadow: $box-shadow;
+  display: flex;
+  flex-direction: column;
 
   .article-text {
     max-width: 30rem;
@@ -100,6 +102,7 @@
   @media (min-width: 700px) {
     margin: 0;
     margin-top: 2rem;
+    flex-direction: row;
   }
 
   .column-item-no-margin {


### PR DESCRIPTION
## Summary

Fixes the layout issue for the Escalatiekaart by removing a `position: absolute` attribute and applying `flexbox` in media-queries so that it breaks in a more responsive fashion.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
