### PR TITLE
chore: apply darker grey tint for active metric

### DIFF
--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -330,6 +330,10 @@ a.metric-link {
 a.active-metric-link {
   background: $page-background-active;
   border-right: 5px solid $red;
+
+  &::after {
+    content: none;
+  }
 }
 
 @media (min-width: 1200px) {

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -275,9 +275,12 @@ a.metric-link {
   text-decoration: none;
   position: relative;
 
-  &:hover,
-  &:focus {
+  &:hover {
     background: $page-background;
+  }
+
+  &:focus {
+    background: $page-background-active;
   }
 
   h3 {
@@ -325,7 +328,7 @@ a.metric-link {
 }
 
 a.active-metric-link {
-  background: $page-background;
+  background: $page-background-active;
   border-right: 5px solid $red;
 }
 

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,6 +1,7 @@
 $base-font-stack: 'RO Sans', sans-serif;
 
 $page-background: #f3f3f3;
+$page-background-active: #ebebeb;
 $icon-color: #01689b;
 $button-color: $icon-color;
 


### PR DESCRIPTION
## Summary

This PR adds a grey-tint to the variables file and applies it to the `.active-metric-link` class. The purpose of this is to separate the `hover` from the `active` style on the sidebar metrics. It also removes the arrow from the active metric since the magenta box makes the arrow redundant.

## Unresolved Questions

- [ ] Is the contrast between `#f3f3f3` and `#ebebeb` significant enough that it passes WCAG?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
