### PR TITLE
Chore/chloropleth fixes

### DIFF
--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -21,6 +21,9 @@ export type TProps<TFeatureProperties> = {
   // These are features that are used as an overlay, overlays have no interactions
   // they are simply there to beautify the map or emphasise certain parts.
   overlays: FeatureCollection<MultiPolygon>;
+  // These are features that are used as as the hover features, these are
+  // typically activated when the user mouse overs them.
+  hovers?: FeatureCollection<MultiPolygon, TFeatureProperties>;
   // The boundingbox is calculated based on these features, this can be used to
   // zoom in on a specific part of the map upon initialisation.
   boundingbox: FeatureCollection<MultiPolygon>;
@@ -37,6 +40,13 @@ export type TProps<TFeatureProperties> = {
   // This will usually return a <path/> element.
   overlayCallback: (
     feature: Feature<MultiPolygon>,
+    path: string,
+    index: number
+  ) => ReactNode;
+  // This callback is invoked for each of the features in the hovers property.
+  // This will usually return a <path/> element.
+  hoverCallback: (
+    feature: Feature<MultiPolygon, TFeatureProperties>,
     path: string,
     index: number
   ) => ReactNode;
@@ -61,10 +71,12 @@ export default function Chloropleth<T>(props: TProps<T>) {
   const {
     featureCollection,
     overlays,
+    hovers,
     boundingbox,
     dimensions,
     featureCallback,
     overlayCallback,
+    hoverCallback,
     onPathClick,
     getTooltipContent,
   } = props;
@@ -127,6 +139,11 @@ export default function Chloropleth<T>(props: TProps<T>) {
           <Mercator data={overlays.features} fitSize={sizeToFit}>
             {renderFeature(overlayCallback)}
           </Mercator>
+          {hovers && (
+            <Mercator data={hovers.features} fitSize={sizeToFit}>
+              {renderFeature(hoverCallback)}
+            </Mercator>
+          )}
         </g>
       </svg>
       {tooltipOpen && tooltipData && getTooltipContent && (

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { SafetyRegionProperties, TRegionMetricName } from './shared';
+import { Regions } from 'types/data';
 import { CSSProperties, ReactNode, useCallback } from 'react';
 import useChartDimensions from './hooks/useChartDimensions';
 import Chloropleth from './Chloropleth';
@@ -9,7 +10,6 @@ import styles from './chloropleth.module.scss';
 import useSafetyRegionBoundingbox from './hooks/useSafetyRegionBoundingbox';
 import useChloroplethColorScale from './hooks/useChloroplethColorScale';
 import useSafetyRegionData from './hooks/useSafetyRegionData';
-import { Regions } from 'types/data.d';
 
 export type TProps<
   T extends TRegionMetricName,
@@ -20,6 +20,7 @@ export type TProps<
   metricName?: T;
   metricProperty?: string;
   selected?: string;
+  highlightSelection?: boolean;
   style?: CSSProperties;
   onSelect?: (context: TContext) => void;
   tooltipContent?: (context: TContext) => ReactNode;
@@ -49,6 +50,7 @@ export default function SafetyRegionChloropleth<
 >(props: TProps<T, ItemType, ReturnType, TContext>) {
   const {
     selected,
+    highlightSelection = true,
     style,
     metricName,
     metricProperty,
@@ -77,11 +79,7 @@ export default function SafetyRegionChloropleth<
     ) => {
       const { vrcode } = feature.properties;
 
-      const isSelected = vrcode === selected;
-      const className = classNames(
-        isSelected ? styles.selectedPath : '',
-        !hasData ? styles.noData : undefined
-      );
+      const className = classNames(!hasData ? styles.noData : undefined);
 
       return (
         <path
@@ -94,7 +92,7 @@ export default function SafetyRegionChloropleth<
         />
       );
     },
-    [getFillColor, hasData, selected]
+    [getFillColor, hasData]
   );
 
   const overlayCallback = (
@@ -112,6 +110,27 @@ export default function SafetyRegionChloropleth<
       />
     );
   };
+
+  const hoverCallback = useCallback(
+    (feature: Feature<MultiPolygon, SafetyRegionProperties>, path: string) => {
+      const { vrcode } = feature.properties;
+      const isSelected = vrcode === selected && highlightSelection;
+      const className = classNames(
+        isSelected ? styles.selectedPath : styles.hoverLayer
+      );
+
+      return (
+        <path
+          className={className}
+          data-id={vrcode}
+          shapeRendering="optimizeQuality"
+          key={`safetyregion-map-hover-${vrcode}`}
+          d={path}
+        />
+      );
+    },
+    [selected, highlightSelection]
+  );
 
   const onClick = (id: string) => {
     if (onSelect) {
@@ -139,10 +158,12 @@ export default function SafetyRegionChloropleth<
       <Chloropleth
         featureCollection={regionGeo}
         overlays={countryGeo}
+        hovers={hasData ? regionGeo : undefined}
         boundingbox={boundingbox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}
         overlayCallback={overlayCallback}
+        hoverCallback={hoverCallback}
         onPathClick={onClick}
         getTooltipContent={getTooltipContent}
       />

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -2,7 +2,6 @@
 
 .defaultTooltip {
   background-color: white;
-  border: 1px solid lightgrey;
   padding: 0.5em;
 }
 
@@ -18,40 +17,45 @@
 
   path {
     pointer-events: all;
-    stroke: grey;
+    stroke: #01689b;
     stroke-width: 0.5;
   }
 
-  path:hover {
-    stroke-width: 2;
-    stroke: #fff;
-    z-index: 1000;
+  path.selectedPath {
+    stroke: #000000;
+    stroke-width: 1.5;
+    fill: none;
   }
 
-  path.selectedPath {
-    stroke: black;
-    stroke-width: 3;
+  path.noData {
+    pointer-events: all;
+    fill: #fff;
   }
 
   path.noData:hover {
-    stroke: black;
+    pointer-events: all;
+    fill: #62a0be;
   }
 
   path.faded {
-    fill-opacity: 0.2;
-    stroke-opacity: 0.2;
+    stroke: #c4c4c4;
   }
 
   path.overlay {
     pointer-events: none;
-    stroke: black;
-    stroke-width: 1;
+    stroke: #01689b;
+    stroke-width: 0.5;
     fill: transparent;
   }
 
-  path.overlay:hover {
-    stroke: black;
-    stroke-width: 1;
-    fill: transparent;
+  path.hoverLayer {
+    pointer-events: all;
+    fill: none;
+    stroke: transparent;
+  }
+
+  path.hoverLayer:hover {
+    stroke: #000000;
+    stroke-width: 1.5;
   }
 }

--- a/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
@@ -13,10 +13,10 @@ import { useMemo } from 'react';
 export default function useMunicipalityBoundingbox(
   regionGeo: FeatureCollection<MultiPolygon, SafetyRegionProperties>,
   selectedMunicipality?: string
-): FeatureCollection<MultiPolygon> | undefined {
+): [FeatureCollection<MultiPolygon>, string] | [undefined, undefined] {
   return useMemo(() => {
     if (!selectedMunicipality) {
-      return undefined;
+      return [undefined, undefined];
     }
 
     const vrcode = municipalCodeToRegionCodeLookup[selectedMunicipality];
@@ -26,14 +26,17 @@ export default function useMunicipalityBoundingbox(
         (feat) => feat.properties.vrcode === vrcode
       );
       if (!feature) {
-        return undefined;
+        return [undefined, undefined];
       }
-      return {
-        ...regionGeo,
-        features: [feature],
-      };
+      return [
+        {
+          ...regionGeo,
+          features: [feature],
+        },
+        vrcode,
+      ];
     }
 
-    return undefined;
+    return [undefined, undefined];
   }, [selectedMunicipality, regionGeo]);
 }

--- a/src/components/chloropleth/hooks/useMunicipalityData.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityData.ts
@@ -1,4 +1,4 @@
-import { Municipalities } from 'types/data.d';
+import { Municipalities } from 'types/data';
 import { MunicipalityProperties, TMunicipalityMetricName } from '../shared';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import useSWR from 'swr';

--- a/src/components/chloropleth/hooks/useSafetyRegionData.ts
+++ b/src/components/chloropleth/hooks/useSafetyRegionData.ts
@@ -1,7 +1,7 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { Regions } from 'types/data.d';
+import { Regions } from 'types/data';
 import useExtent from 'utils/useExtent';
 import { SafetyRegionProperties, TRegionMetricName } from '../shared';
 

--- a/src/components/chloropleth/legenda/MunicipalityLegenda.tsx
+++ b/src/components/chloropleth/legenda/MunicipalityLegenda.tsx
@@ -5,11 +5,11 @@ import useMunicipalLegendaData from './hooks/useMunicipalLegendaData';
 export type TProps = {
   metricName: TMunicipalityMetricName;
   title: string;
-  gradients: [minColor: string, maxColor: string];
+  gradients?: [minColor: string, maxColor: string];
 };
 
 export default function MunicipalityLegenda(props: TProps) {
-  const { metricName, title, gradients } = props;
+  const { metricName, title, gradients = ['#C0E8FC', '#0579B3'] } = props;
   const items = useMunicipalLegendaData(metricName, gradients);
 
   if (!items) {
@@ -18,7 +18,3 @@ export default function MunicipalityLegenda(props: TProps) {
 
   return items && <ChloroplethLegenda items={items} title={title} />;
 }
-
-MunicipalityLegenda.defaultProps = {
-  gradients: ['#C0E8FC', '#0579B3'],
-};

--- a/src/components/chloropleth/legenda/SafetyRegionLegenda.tsx
+++ b/src/components/chloropleth/legenda/SafetyRegionLegenda.tsx
@@ -5,11 +5,11 @@ import useSafetyRegionLegendaData from './hooks/useSafetyRegionLegendaData';
 export type TProps = {
   metricName: TRegionMetricName;
   title: string;
-  gradients: [minColor: string, maxColor: string];
+  gradients?: [minColor: string, maxColor: string];
 };
 
 export default function SafetyRegionLegenda(props: TProps) {
-  const { metricName, title, gradients } = props;
+  const { metricName, title, gradients = ['#C0E8FC', '#0579B3'] } = props;
   const items = useSafetyRegionLegendaData(metricName, gradients);
 
   if (!items) {
@@ -18,7 +18,3 @@ export default function SafetyRegionLegenda(props: TProps) {
 
   return items && <ChloroplethLegenda items={items} title={title} />;
 }
-
-SafetyRegionLegenda.defaultProps = {
-  gradients: ['#C0E8FC', '#0579B3'],
-};

--- a/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
+++ b/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
@@ -4,7 +4,7 @@
   list-style: none;
 
   li {
-    margin: 1em 0;
+    margin: 0.5em 0;
     position: relative;
   }
 
@@ -13,11 +13,11 @@
     flex-direction: row;
 
     .box {
-      width: 40px;
-      height: 34px;
+      width: 34px;
+      height: 20px;
       flex-grow: 0;
       flex-shrink: 0;
-      margin-right: 0.5em;
+      margin-right: 0.75em;
     }
   }
 }

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -22,6 +22,7 @@ export default function useLegendaItems(
     const steps = (max - min) / numberOfItems;
 
     const calcValue = (i: number) => {
+      if (i === numberOfItems) return max;
       return Math.floor(i > 0 ? i * steps : 0);
     };
 
@@ -35,7 +36,7 @@ export default function useLegendaItems(
 
     for (let i = 0; i < numberOfItems; i++) {
       const value = calcValue(i);
-      const nextValue = calcValue(i + 1) - (i === numberOfItems - 1 ? 0 : 1);
+      const nextValue = calcValue(i + 1);
       const label = `${value} - ${nextValue}`;
       legendaItems.push({
         color: color(value),

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -2,8 +2,6 @@ import { scaleLinear } from '@vx/scale';
 import { useMemo } from 'react';
 import { ILegendaItem } from '../ChloroplethLegenda';
 
-const NUMBER_OF_ITEMS = 5;
-
 import siteText from 'locale';
 
 export default function useLegendaItems(
@@ -20,7 +18,8 @@ export default function useLegendaItems(
       domain: domain,
       range: gradient,
     });
-    const steps = (max - min) / NUMBER_OF_ITEMS;
+    const numberOfItems = calculateDivisible(max - min);
+    const steps = (max - min) / numberOfItems;
 
     const calcValue = (i: number) => {
       return Math.floor(i > 0 ? i * steps : 0);
@@ -34,9 +33,9 @@ export default function useLegendaItems(
       },
     ];
 
-    for (let i = 0; i < NUMBER_OF_ITEMS; i++) {
+    for (let i = 0; i < numberOfItems; i++) {
       const value = calcValue(i);
-      const nextValue = calcValue(i + 1) - (i === NUMBER_OF_ITEMS - 1 ? 0 : 1);
+      const nextValue = calcValue(i + 1) - (i === numberOfItems - 1 ? 0 : 1);
       const label = `${value} - ${nextValue}`;
       legendaItems.push({
         color: color(value),
@@ -46,4 +45,15 @@ export default function useLegendaItems(
 
     return legendaItems;
   }, [domain, gradient]);
+}
+
+function calculateDivisible(input: number) {
+  let div = 5;
+  let quotient = Math.floor(input / div);
+
+  while (quotient === 0 && div > 0) {
+    quotient = Math.floor(input / --div);
+  }
+
+  return div;
 }

--- a/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
@@ -1,6 +1,6 @@
 import { TMunicipalityMetricName } from 'components/chloropleth/shared';
 import useSWR from 'swr';
-import { Municipalities } from 'types/data.d';
+import { Municipalities } from 'types/data';
 import useExtent from 'utils/useExtent';
 
 import useLegendaItems from './useLegendaItems';

--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -1,6 +1,6 @@
 import { TRegionMetricName } from '../../shared';
 import useSWR from 'swr';
-import { Regions } from 'types/data.d';
+import { Regions } from 'types/data';
 import useExtent from 'utils/useExtent';
 
 import useLegendaItems from './useLegendaItems';

--- a/src/components/chloropleth/shared.d.ts
+++ b/src/components/chloropleth/shared.d.ts
@@ -1,5 +1,5 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
-import { Municipalities, Regions } from 'types/data.d';
+import { Municipalities, Regions } from 'types/data';
 
 type TMetricHolder<T> = keyof Omit<
   T,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,8 @@ import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municip
 import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
 import { useState } from 'react';
 import Link from 'next/link';
+import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
 const Home: FCWithLayout<INationalData> = () => {
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
@@ -54,15 +56,27 @@ const Home: FCWithLayout<INationalData> = () => {
           />
 
           {selectedMap === 'municipal' && (
-            <Link href="/gemeente">
-              <a>{text.laatste_ontwikkelingen.regio_cta_gemeente}</a>
-            </Link>
+            <>
+              <MunicipalityLegenda
+                metricName="positive_tested_people"
+                title={text.positief_geteste_personen.chloropleth_legenda.titel}
+              />
+              <Link href="/gemeente">
+                <a>{text.laatste_ontwikkelingen.regio_cta_gemeente}</a>
+              </Link>
+            </>
           )}
 
           {selectedMap === 'region' && (
-            <Link href="/veiligheidsregio">
-              <a>{text.laatste_ontwikkelingen.regio_cta_veiligheidsregio}</a>
-            </Link>
+            <>
+              <SafetyRegionLegenda
+                metricName="positive_tested_people"
+                title={text.positief_geteste_personen.chloropleth_legenda.titel}
+              />
+              <Link href="/veiligheidsregio">
+                <a>{text.laatste_ontwikkelingen.regio_cta_veiligheidsregio}</a>
+              </Link>
+            </>
           )}
         </div>
 

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -23,6 +23,8 @@ import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropl
 import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
 import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
 import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;
@@ -126,6 +128,19 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           <ChartRegionControls
             onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
           />
+          {selectedMap === 'municipal' && (
+            <MunicipalityLegenda
+              metricName="positive_tested_people"
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
+
+          {selectedMap === 'region' && (
+            <SafetyRegionLegenda
+              metricName="positive_tested_people"
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
         </div>
 
         <div className="column-item column-item-extra-margin">

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -15,6 +15,8 @@ import getNlData, { INationalData } from 'static-props/nl-data';
 import ChartRegionControls from 'components/chartRegionControls';
 import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
 import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
+import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;
@@ -120,6 +122,19 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
           <ChartRegionControls
             onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
           />
+          {selectedMap === 'municipal' && (
+            <MunicipalityLegenda
+              metricName="hospital_admissions"
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
+
+          {selectedMap === 'region' && (
+            <SafetyRegionLegenda
+              metricName="hospital_admissions"
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
         </div>
 
         <div className="column-item column-item-extra-margin">

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -16,9 +16,10 @@ import {
   ISafetyRegionData,
 } from 'static-props/safetyregion-data';
 import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;
@@ -64,6 +65,9 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
+
+  const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
+  const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
 
   return (
     <>
@@ -125,15 +129,16 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           <h3>{getLocalTitleForRegion(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
 
-          <SafetyRegionLegenda
+          <MunicipalityLegenda
             metricName="positive_tested_people"
             title={siteText.positief_geteste_personen.chloropleth_legenda.titel}
           />
         </div>
 
         <div className="column-item column-item-extra-margin">
-          <SafetyRegionChloropleth
-            selected={data.code}
+          <MunicipalityChloropleth
+            selected={selectedMunicipalCode}
+            highlightSelection={false}
             metricName="positive_tested_people"
             tooltipContent={positiveTestedPeopleTooltip}
           />

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -16,9 +16,10 @@ import {
   ISafetyRegionData,
 } from 'static-props/safetyregion-data';
 import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/region/hospitalAdmissionsTooltip';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
@@ -64,6 +65,9 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
 
   const resultsPerRegion: ResultsPerRegion | undefined =
     data?.results_per_region;
+
+  const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
+  const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
 
   return (
     <>
@@ -111,15 +115,16 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           <h3>{getLocalTitleForRegion(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
 
-          <SafetyRegionLegenda
+          <MunicipalityLegenda
             metricName="hospital_admissions"
             title={siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel}
           />
         </div>
 
         <div className="column-item column-item-extra-margin">
-          <SafetyRegionChloropleth
-            selected={data.code}
+          <MunicipalityChloropleth
+            selected={selectedMunicipalCode}
+            highlightSelection={false}
             metricName="hospital_admissions"
             tooltipContent={hospitalAdmissionsTooltip}
           />


### PR DESCRIPTION
## Summary

Add 

- Correct stroke colors and widths on Chloropleths
- Fix hovered feature on Chloropleths
- Fix selected feature on Chloropleths
- Create number of legenda items according to what the data allows (max 5 items)
- Tweak legenda size
- Add legenda's to landelijk page

## Motivation

Design requests

## Detailed design

Mostly just CSS tweaks, the hover and selection states were solved by rendering another layer on top of the chloropleth that contains all of the features but each feature has an empty stroke and stroke-width, on hover the stroke and width are changed just by CSS.
The number of legenda items are now calculated by checking the maximum quotient, so the number of items shrinks when the given domain is small.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
