### PR TITLE
Fix text size on about page, calculate highest legenda color correctly

### DIFF
--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -39,7 +39,7 @@ export default function useLegendaItems(
       const nextValue = calcValue(i + 1);
       const label = `${value} - ${nextValue}`;
       legendaItems.push({
-        color: color(value),
+        color: color(i === numberOfItems - 1 ? nextValue : value),
         label: label,
       });
     }

--- a/src/pages/over.module.scss
+++ b/src/pages/over.module.scss
@@ -1,5 +1,4 @@
 .faqList {
-  font-size: 1.125em;
   dt {
     font-weight: bold;
   }


### PR DESCRIPTION
## Summary

- This time CORRECTLY fix the text sizes on the about page.
- Correctly show the last color in the chloropleth legenda
- Add missing dependency to a callback

## Motivation

Bug fixes

## Detailed design

As per the summary

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
