### PR TITLE
chore: change copy last edited in footer

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -2,19 +2,18 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import SEOHead from 'components/seoHead';
-import MaxWidth from 'components/maxWidth';
-
+import { WithChildren } from 'types';
 import text from 'locale';
-import useMediaQuery from 'utils/useMediaQuery';
-import formatDate from 'utils/formatDate';
-
+import { ILastGeneratedData } from 'static-props/last-generated-data';
 import styles from './layout.module.scss';
 
-import { WithChildren } from 'types';
+import useMediaQuery from 'utils/useMediaQuery';
+import formatDate from 'utils/formatDate';
+import replaceVariablesInText from 'utils/replaceVariablesInText';
 import getLocale from 'utils/getLocale';
 
-import { ILastGeneratedData } from 'static-props/last-generated-data';
+import SEOHead from 'components/seoHead';
+import MaxWidth from 'components/maxWidth';
 
 export interface LayoutProps {
   url?: string;
@@ -251,8 +250,17 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
                 </nav>
               </div>
               <div className={styles.footerColumn}>
-                <h3>{text.laatst_bijgewerkt.message}</h3>
-                <time dateTime={dateTime}>{dateOfInsertion}</time>
+                <h3>{text.laatst_bijgewerkt.title}</h3>
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: replaceVariablesInText(
+                      text.laatst_bijgewerkt.message,
+                      {
+                        dateOfInstertion: `<time dateTime=${dateTime}>${dateOfInsertion}</time>`,
+                      }
+                    ),
+                  }}
+                />
               </div>
             </div>
           </MaxWidth>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -256,7 +256,7 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
                     __html: replaceVariablesInText(
                       text.laatst_bijgewerkt.message,
                       {
-                        dateOfInstertion: `<time dateTime=${dateTime}>${dateOfInsertion}</time>`,
+                        dateOfInsertion: `<time dateTime=${dateTime}>${dateOfInsertion}</time>`,
                       }
                     ),
                   }}

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -150,8 +150,9 @@ $language-switcher-offset: 55px;
   display: flex;
   flex-direction: column;
 
-  time {
+  p {
     font-size: 1.125em;
+    max-width: 25em;
   }
 
   @media (min-width: 768px) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -5,7 +5,8 @@
     "message": "Data that could give insight in the spread of the virus."
   },
   "laatst_bijgewerkt": {
-    "message": "Last updated"
+    "title": "Last updated",
+    "message": "Het dashboard is op {{dateOfInstertion}} voor het laatst voorzien van nieuwe data."
   },
   "notificatie": {
     "titel": "More new COVID-19 infections",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -6,7 +6,7 @@
   },
   "laatst_bijgewerkt": {
     "title": "Laatst bijgewerkt",
-    "message": "Het dashboard is op {{dateOfInstertion}} voor het laatst voorzien van nieuwe data."
+    "message": "Het dashboard is op {{dateOfInsertion}} voor het laatst voorzien van nieuwe data."
   },
   "notificatie": {
     "titel": "Besmettingen COVID-19 verder toegenomen",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -5,7 +5,8 @@
     "message": "Cijfers die iets kunnen zeggen over de verspreiding van het virus."
   },
   "laatst_bijgewerkt": {
-    "message": "Laatst bijgewerkt"
+    "title": "Laatst bijgewerkt",
+    "message": "Het dashboard is op {{dateOfInstertion}} voor het laatst voorzien van nieuwe data."
   },
   "notificatie": {
     "titel": "Besmettingen COVID-19 verder toegenomen",


### PR DESCRIPTION
## Summary

This PR adds a `<p>` element to the footer that holds a full sentence describing the last time the dashboard's data was updated. It injects a `<time>` element stating the `dateOfInsertion` using `dangerouslySetInnerHTML` in a `<p>` element.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
