### PR TITLE
chore: change metric for infected locations

### DIFF
--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -317,7 +317,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                     />
                     <span>
                       <NursingHomeInfectedLocationsBarScale
-                        data={data?.total_newly_reported_locations}
+                        data={data?.total_reported_locations}
                         showAxis={true}
                       />
                     </span>

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -317,7 +317,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                     />
                     <span>
                       <NursingHomeInfectedLocationsBarScale
-                        data={data?.total_reported_locations}
+                        data={data?.total_newly_reported_locations}
                         showAxis={true}
                       />
                     </span>

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -21,7 +21,7 @@ const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;
 
 export function NursingHomeInfectedLocationsBarScale(props: {
-  data: TotalNewlyReportedLocations | undefined;
+  data: TotalReportedLocations | undefined;
   showAxis: boolean;
 }) {
   const { data, showAxis } = props;
@@ -33,9 +33,9 @@ export function NursingHomeInfectedLocationsBarScale(props: {
       min={0}
       max={30}
       screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.total_new_reported_locations}
+      value={data.last_value.total_reported_locations}
       id="besmette_locaties_verpleeghuis"
-      rangeKey="total_new_reported_locations"
+      rangeKey="total_reported_locations"
       gradient={[
         {
           color: '#3391CC',
@@ -74,8 +74,19 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
         <article className="metric-article column-item">
           <h3>{text.barscale_titel}</h3>
 
-          <NursingHomeInfectedLocationsBarScale
-            data={newLocations}
+          <BarScale
+            min={0}
+            max={30}
+            screenReaderText={text.barscale_screenreader_text}
+            value={newLocations?.last_value.total_new_reported_locations}
+            id="besmette_locaties_verpleeghuis"
+            rangeKey="total_new_reported_locations"
+            gradient={[
+              {
+                color: '#3391CC',
+                value: 0,
+              },
+            ]}
             showAxis={true}
           />
           <p>{text.barscale_toelichting}</p>
@@ -99,10 +110,10 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
       <article className="metric-article">
         <h3>{text.linechart_titel}</h3>
 
-        {newLocations && (
+        {totalLocations && (
           <LineChart
-            values={newLocations.values.map((value) => ({
-              value: value.total_new_reported_locations,
+            values={totalLocations.values.map((value) => ({
+              value: value.total_reported_locations,
               date: value.date_of_report_unix,
             }))}
           />

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -10,10 +10,7 @@ import formatNumber from 'utils/formatNumber';
 
 import siteText from 'locale';
 
-import {
-  TotalNewlyReportedLocations,
-  TotalReportedLocations,
-} from 'types/data.d';
+import { TotalReportedLocations } from 'types/data.d';
 
 import getNlData, { INationalData } from 'static-props/nl-data';
 
@@ -21,7 +18,7 @@ const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;
 
 export function NursingHomeInfectedLocationsBarScale(props: {
-  data: TotalNewlyReportedLocations | undefined;
+  data: TotalReportedLocations | undefined;
   showAxis: boolean;
 }) {
   const { data, showAxis } = props;
@@ -33,9 +30,9 @@ export function NursingHomeInfectedLocationsBarScale(props: {
       min={0}
       max={30}
       screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.total_new_reported_locations}
+      value={data.last_value.total_reported_locations}
       id="besmette_locaties_verpleeghuis"
-      rangeKey="total_new_reported_locations"
+      rangeKey="total_reported_locations"
       gradient={[
         {
           color: '#3391CC',
@@ -50,8 +47,6 @@ export function NursingHomeInfectedLocationsBarScale(props: {
 const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;
 
-  const newLocations: TotalNewlyReportedLocations | undefined =
-    state?.total_newly_reported_locations;
   const totalLocations: TotalReportedLocations | undefined =
     state?.total_reported_locations;
 
@@ -64,8 +59,8 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: newLocations?.last_value?.date_of_report_unix,
-          dateInsertedUnix: newLocations?.last_value?.date_of_insertion_unix,
+          dateUnix: totalLocations?.last_value?.date_of_report_unix,
+          dateInsertedUnix: totalLocations?.last_value?.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -75,7 +70,7 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
           <h3>{text.barscale_titel}</h3>
 
           <NursingHomeInfectedLocationsBarScale
-            data={newLocations}
+            data={totalLocations}
             showAxis={true}
           />
           <p>{text.barscale_toelichting}</p>
@@ -99,10 +94,10 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
       <article className="metric-article">
         <h3>{text.linechart_titel}</h3>
 
-        {newLocations && (
+        {totalLocations && (
           <LineChart
-            values={newLocations.values.map((value) => ({
-              value: value.total_new_reported_locations,
+            values={totalLocations.values.map((value) => ({
+              value: value.total_reported_locations,
               date: value.date_of_report_unix,
             }))}
           />

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -10,7 +10,10 @@ import formatNumber from 'utils/formatNumber';
 
 import siteText from 'locale';
 
-import { TotalReportedLocations } from 'types/data.d';
+import {
+  TotalNewlyReportedLocations,
+  TotalReportedLocations,
+} from 'types/data.d';
 
 import getNlData, { INationalData } from 'static-props/nl-data';
 
@@ -18,7 +21,7 @@ const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;
 
 export function NursingHomeInfectedLocationsBarScale(props: {
-  data: TotalReportedLocations | undefined;
+  data: TotalNewlyReportedLocations | undefined;
   showAxis: boolean;
 }) {
   const { data, showAxis } = props;
@@ -30,9 +33,9 @@ export function NursingHomeInfectedLocationsBarScale(props: {
       min={0}
       max={30}
       screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.total_reported_locations}
+      value={data.last_value.total_new_reported_locations}
       id="besmette_locaties_verpleeghuis"
-      rangeKey="total_reported_locations"
+      rangeKey="total_new_reported_locations"
       gradient={[
         {
           color: '#3391CC',
@@ -47,6 +50,8 @@ export function NursingHomeInfectedLocationsBarScale(props: {
 const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;
 
+  const newLocations: TotalNewlyReportedLocations | undefined =
+    state?.total_newly_reported_locations;
   const totalLocations: TotalReportedLocations | undefined =
     state?.total_reported_locations;
 
@@ -59,8 +64,8 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: totalLocations?.last_value?.date_of_report_unix,
-          dateInsertedUnix: totalLocations?.last_value?.date_of_insertion_unix,
+          dateUnix: newLocations?.last_value?.date_of_report_unix,
+          dateInsertedUnix: newLocations?.last_value?.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -70,7 +75,7 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
           <h3>{text.barscale_titel}</h3>
 
           <NursingHomeInfectedLocationsBarScale
-            data={totalLocations}
+            data={newLocations}
             showAxis={true}
           />
           <p>{text.barscale_toelichting}</p>
@@ -94,10 +99,10 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
       <article className="metric-article">
         <h3>{text.linechart_titel}</h3>
 
-        {totalLocations && (
+        {newLocations && (
           <LineChart
-            values={totalLocations.values.map((value) => ({
-              value: value.total_reported_locations,
+            values={newLocations.values.map((value) => ({
+              value: value.total_new_reported_locations,
               date: value.date_of_report_unix,
             }))}
           />


### PR DESCRIPTION
## Summary

This PR changes the metrics for `infected locations` (`verpleeghuis-besmette-locaties`). 
- The sidebar now uses `TotalReportedLocations` instead of `TotalNewlyReportedLocations`
- The barchart on the page still uses `TotalNewlyReportedLocations`
- The linechart uses `TotalReportedLocations` instead of `TotalNewlyReportedLocations`

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
