### PR TITLE
Show plotline y-axis value

### DIFF
--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import styles from './lineChart.module.scss';
+import text from 'locale';
 
 import ChartTimeControls, {
   TimeframeOption,
@@ -101,7 +102,7 @@ function getChartOptions(values: Value[], signaalwaarde?: number | undefined) {
               color: '#4f5458',
               zIndex: 1,
               label: {
-                text: 'Signaalwaarde',
+                text: text.common.barScale.signaalwaarde,
                 align: 'right',
                 y: -8,
                 x: 0,

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -110,6 +110,23 @@ function getChartOptions(values: Value[], signaalwaarde?: number | undefined) {
                 },
               },
             },
+            /**
+             * In order to show the value of the signaalwaarde, we plot a second
+             * transparent line, and only use its label positioned at the y-axis.
+             */
+            {
+              value: signaalwaarde,
+              color: 'transparent',
+              label: {
+                text: signaalwaarde,
+                align: 'left',
+                y: -8,
+                x: 0,
+                style: {
+                  color: '#4f5458',
+                },
+              },
+            },
           ]
         : undefined,
     },


### PR DESCRIPTION
## Summary

- Display the value of the "signaalwaarde" close to the y-axis

<img width="499" alt="Screenshot 2020-09-18 at 09 06 22" src="https://user-images.githubusercontent.com/71320230/93568819-048ac980-f991-11ea-909e-424d148f816b.png">
<img width="969" alt="Screenshot 2020-09-18 at 08 58 25" src="https://user-images.githubusercontent.com/71320230/93568822-06548d00-f991-11ea-9aba-1e69ec5f7e27.png">
