### PR TITLE
Fix: Escalation map mobile functionality

### DIFF
--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -12,19 +12,32 @@ import { localPoint } from '@vx/event';
 import Tooltip from './tooltips/tooltip';
 import useMediaQuery from 'utils/useMediaQuery';
 
-const tooltipStore = create((set) => ({
+export type TooltipState = {
+  tooltip: TooltipSettings | null;
+  updateTooltip: (tooltip: TooltipSettings) => void;
+  showTooltip: (settings: TooltipSettings) => void;
+  hideTooltip: () => void;
+};
+
+export type TooltipSettings = {
+  left: number;
+  top: number;
+  data: any;
+};
+
+const tooltipStore = create<TooltipState>((set) => ({
   tooltip: null,
-  updateTooltip: (tooltip: any) => {
+  updateTooltip: (tooltip: TooltipSettings) => {
     set({
       tooltip,
     });
   },
-  showTooltip: (hoveredElement: any) => {
+  showTooltip: (settings: TooltipSettings) => {
     return set({
       tooltip: {
-        left: hoveredElement.tooltipLeft,
-        top: hoveredElement.tooltipTop,
-        data: hoveredElement.tooltipData,
+        left: settings.left,
+        top: settings.top,
+        data: settings.data,
       },
     });
   },
@@ -190,8 +203,8 @@ const renderFeature = (callback: TRenderCallback) => {
 };
 
 const svgClick = (
-  onPathClick: any,
-  showTooltip: any,
+  onPathClick: (id: string) => void,
+  showTooltip: (settings: TooltipSettings) => void,
   isLargeScreen: boolean
 ) => {
   return (event: any) => {
@@ -210,16 +223,16 @@ const svgClick = (
 const positionTooltip = (
   event: any,
   element: any,
-  showTooltip: any,
+  showTooltip: (settings: TooltipSettings) => void,
   id: string
 ) => {
   const coords = localPoint(element.ownerSVGElement, event);
 
   if (coords) {
     showTooltip({
-      tooltipLeft: coords.x + 5,
-      tooltipTop: coords.y + 5,
-      tooltipData: id,
+      left: coords.x + 5,
+      top: coords.y + 5,
+      data: id,
     });
   }
 };

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -78,15 +78,15 @@ const escalationThresholds: RegionalThresholds = {
   svgClass: 'escalationMap',
   thresholds: [
     {
-      color: '#FFF7A3',
+      color: '#F291BC',
       threshold: 1,
     },
     {
-      color: '#FACB3E',
+      color: '#D95790',
       threshold: 2,
     },
     {
-      color: '#F5512D',
+      color: '#A11050',
       threshold: 3,
     },
   ],

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -20,7 +20,7 @@
 .chloroplethContainer.escalationMap {
   .svgMap {
     path {
-      stroke: #595959;
+      stroke: white;
     }
 
     path.overlay {

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -74,6 +74,6 @@
 
   path.hoverLayer:hover {
     stroke: #000000;
-    stroke-width: 1.5;
+    stroke-width: 2;
   }
 }

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -23,7 +23,6 @@ export const escalationTooltip = (router: NextRouter) => {
 
     const onSelectRegion = (event: any) => {
       event.stopPropagation();
-      event.stopImmediatePropagation();
       router.push(
         '/veiligheidsregio/[code]/positief-geteste-mensen',
         `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -1,0 +1,61 @@
+import { NextRouter } from 'next/router';
+import { ReactNode } from 'react';
+import formatDate from 'utils/formatDate';
+import replaceVariablesInText from 'utils/replaceVariablesInText';
+
+import text from 'locale';
+import styles from '../tooltip.module.scss';
+
+import ExclamationMark from 'assets/exclamation-mark-bubble.svg';
+import EmptyBubble from 'assets/empty-bubble.svg';
+
+import { thresholds } from 'components/chloropleth/SafetyRegionChloropleth';
+
+const escalationThresholds = thresholds.escalation_levels.thresholds;
+
+export const escalationTooltip = (router: NextRouter) => {
+  return (context: any): ReactNode => {
+    const type: number = context?.value;
+
+    const thresholdInfo = escalationThresholds.find(
+      (value) => value.threshold === type
+    );
+
+    const onSelectRegion = (event: any) => {
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      router.push(
+        '/veiligheidsregio/[code]/positief-geteste-mensen',
+        `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`
+      );
+    };
+
+    return (
+      type && (
+        <div className={styles.escalationTooltip} onClick={onSelectRegion}>
+          <div className={styles.escalationTooltipHeader}>
+            <h4>{context?.vrname}</h4>
+          </div>
+          {
+            <div className={styles.escalationInfo}>
+              <div className={styles.bubble}>
+                {type !== 1 && <ExclamationMark fill={thresholdInfo?.color} />}
+                {type === 1 && <EmptyBubble fill={thresholdInfo?.color} />}
+              </div>
+              <div>
+                <strong>
+                  {(text.escalatie_niveau.types as any)[type].titel}
+                </strong>
+                : {(text.escalatie_niveau.types as any)[type].toelichting}
+                <br />
+                {replaceVariablesInText(text.escalatie_niveau.valid_from, {
+                  validFrom: formatDate(context.valid_from_unix),
+                })}
+              </div>
+            </div>
+          }
+        </div>
+      )
+    );
+  };
+};

--- a/src/components/chloropleth/tooltips/tooltip.module.scss
+++ b/src/components/chloropleth/tooltips/tooltip.module.scss
@@ -35,6 +35,7 @@
   border-radius: 4px;
   margin: 0;
   padding: 0;
+  pointer-events: all;
   cursor: pointer;
 
   .escalationTooltipHeader {

--- a/src/components/chloropleth/tooltips/tooltip.module.scss
+++ b/src/components/chloropleth/tooltips/tooltip.module.scss
@@ -11,3 +11,73 @@
   pointer-events: none;
   line-height: 1em;
 }
+
+.legenda {
+  padding-left: 0;
+  margin-bottom: 1em;
+
+  @media (min-width: 1200px) {
+    margin-bottom: 0;
+  }
+
+  .escalationInfo {
+    margin-bottom: 1em;
+  }
+
+  h4 {
+    margin-bottom: 1em;
+  }
+}
+
+.escalationTooltip {
+  width: 265px;
+  background-color: white;
+  border-radius: 4px;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+
+  .escalationTooltipHeader {
+    border-bottom: 1px solid #c4c4c4;
+    padding-top: 0.1em;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    margin: 0;
+    font-size: 1.2em;
+    cursor: pointer;
+
+    &::after {
+      content: '';
+      background-image: url('/images/chevron-black.svg');
+      // match aspect ratio of chevron.svg
+      background-size: 0.6em 1em;
+      height: 1em;
+      width: 0.6em;
+      display: block;
+      position: absolute;
+      right: 1em;
+      top: 1em;
+    }
+  }
+
+  .escalationInfo {
+    padding: 1em;
+    cursor: pointer;
+  }
+}
+
+.escalationInfo {
+  display: flex;
+  flex-direction: row;
+
+  .bubble {
+    margin-right: 0.5em;
+    display: flex;
+    width: 3em;
+    height: 3em;
+    flex-grow: 0;
+    flex-shrink: 0;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/src/components/chloropleth/tooltips/tooltip.tsx
+++ b/src/components/chloropleth/tooltips/tooltip.tsx
@@ -1,16 +1,23 @@
-import { useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
+import { UseStore } from 'zustand';
+import { TooltipState } from '../Chloropleth';
 import styles from './tooltip.module.scss';
 
-export default function Tooltip(props: any) {
+export type TTooltipProps = {
+  tooltipStore: UseStore<TooltipState>;
+  getTooltipContent: (id: string) => ReactNode;
+};
+
+export default function Tooltip(props: TTooltipProps) {
   const { tooltipStore, getTooltipContent } = props;
   const ref = useRef<HTMLDivElement | undefined>();
-  const [tooltip, updateTooltip] = tooltipStore((state: any) => [
+  const [tooltip, updateTooltip] = tooltipStore((state: TooltipState) => [
     state.tooltip,
     state.updateTooltip,
   ]);
 
   useEffect(() => {
-    if (ref.current) {
+    if (ref.current && tooltip) {
       const viewPort = { width: window.innerWidth, height: window.innerHeight };
 
       const boundingRect = ref.current.getBoundingClientRect();

--- a/src/components/chloropleth/tooltips/tooltip.tsx
+++ b/src/components/chloropleth/tooltips/tooltip.tsx
@@ -11,12 +11,6 @@ export default function Tooltip(props: any) {
 
   useEffect(() => {
     if (ref.current) {
-      const { parentElement } = ref.current;
-
-      if (!parentElement) {
-        return;
-      }
-
       const viewPort = { width: window.innerWidth, height: window.innerHeight };
 
       const boundingRect = ref.current.getBoundingClientRect();

--- a/src/components/chloropleth/tooltips/tooltip.tsx
+++ b/src/components/chloropleth/tooltips/tooltip.tsx
@@ -1,14 +1,6 @@
 import { useEffect, useRef } from 'react';
 import styles from './tooltip.module.scss';
 
-function getOffsetInViewPort(el: HTMLElement) {
-  const rect = el.getBoundingClientRect(),
-    scrollLeft = window.pageXOffset || document.documentElement.scrollLeft,
-    scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-
-  return [{ top: rect.top + scrollTop, left: rect.left + scrollLeft }, rect];
-}
-
 export default function Tooltip(props: any) {
   const { tooltipStore, getTooltipContent } = props;
   const ref = useRef<HTMLDivElement | undefined>();
@@ -27,10 +19,10 @@ export default function Tooltip(props: any) {
 
       const viewPort = { width: window.innerWidth, height: window.innerHeight };
 
-      const [offset, rect] = getOffsetInViewPort(ref.current);
+      const boundingRect = ref.current.getBoundingClientRect();
 
-      const rightPos = offset.left + ref.current.clientWidth;
-      const bottomPos = rect.top + ref.current.clientHeight;
+      const rightPos = boundingRect.left + boundingRect.width;
+      const bottomPos = boundingRect.top + boundingRect.height;
 
       const left =
         rightPos > viewPort.width

--- a/src/components/chloropleth/tooltips/tooltip.tsx
+++ b/src/components/chloropleth/tooltips/tooltip.tsx
@@ -1,12 +1,56 @@
+import { useEffect, useRef } from 'react';
 import styles from './tooltip.module.scss';
+
+function getOffsetInViewPort(el: HTMLElement) {
+  const rect = el.getBoundingClientRect(),
+    scrollLeft = window.pageXOffset || document.documentElement.scrollLeft,
+    scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+  return [{ top: rect.top + scrollTop, left: rect.left + scrollLeft }, rect];
+}
 
 export default function Tooltip(props: any) {
   const { tooltipStore, getTooltipContent } = props;
+  const ref = useRef<HTMLDivElement | undefined>();
+  const [tooltip, updateTooltip] = tooltipStore((state: any) => [
+    state.tooltip,
+    state.updateTooltip,
+  ]);
 
-  const tooltip = tooltipStore((state: any) => state.tooltip);
+  useEffect(() => {
+    if (ref.current) {
+      const { parentElement } = ref.current;
+
+      if (!parentElement) {
+        return;
+      }
+
+      const viewPort = { width: window.innerWidth, height: window.innerHeight };
+
+      const [offset, rect] = getOffsetInViewPort(ref.current);
+
+      const rightPos = offset.left + ref.current.clientWidth;
+      const bottomPos = rect.top + ref.current.clientHeight;
+
+      const left =
+        rightPos > viewPort.width
+          ? tooltip.left - (rightPos - viewPort.width)
+          : tooltip.left;
+
+      const top =
+        bottomPos > viewPort.height
+          ? tooltip.top - (bottomPos - viewPort.height)
+          : tooltip.top;
+
+      if (left !== tooltip.left || top !== tooltip.top) {
+        updateTooltip({ ...tooltip, left, top });
+      }
+    }
+  }, [tooltip, updateTooltip]);
 
   return tooltip ? (
     <div
+      ref={ref as any}
       className={styles.tooltip}
       style={{
         left: tooltip.left,

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -11,6 +11,7 @@ import {
 import useThrottle from 'utils/useThrottle';
 
 import text from 'locale';
+import useMediaQuery from 'utils/useMediaQuery';
 
 type TOption = {
   displayName?: string;
@@ -46,6 +47,7 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const inputRef = useRef<HTMLInputElement>();
   const [term, setTerm] = useState<string>('');
   const results = useSearchedOptions<Option>(term, options);
+  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setTerm(event.target.value);
@@ -66,10 +68,10 @@ function ComboBox<Option extends TOption>(props: TProps<Option>) {
   }
 
   useEffect(() => {
-    if (!inputRef?.current?.value) {
+    if (!inputRef?.current?.value && isLargeScreen) {
       inputRef?.current?.focus();
     }
-  }, []);
+  }, [isLargeScreen]);
 
   return (
     <Combobox openOnFocus onSelect={onSelect}>

--- a/src/pages/veiligheidsregio/index.module.scss
+++ b/src/pages/veiligheidsregio/index.module.scss
@@ -21,6 +21,7 @@
   border-radius: 4px;
   margin: 0;
   padding: 0;
+  cursor: pointer;
 
   .escalationTooltipHeader {
     border-bottom: 1px solid #c4c4c4;
@@ -29,6 +30,7 @@
     padding-right: 0.5em;
     margin: 0;
     font-size: 1.2em;
+    cursor: pointer;
 
     &::after {
       content: '';
@@ -46,6 +48,7 @@
 
   .escalationInfo {
     padding: 1em;
+    cursor: pointer;
   }
 }
 

--- a/src/pages/veiligheidsregio/index.module.scss
+++ b/src/pages/veiligheidsregio/index.module.scss
@@ -30,7 +30,6 @@
     padding-right: 0.5em;
     margin: 0;
     font-size: 1.2em;
-    cursor: pointer;
 
     &::after {
       content: '';
@@ -48,7 +47,6 @@
 
   .escalationInfo {
     padding: 1em;
-    cursor: pointer;
   }
 }
 

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,71 +1,22 @@
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import { NextRouter, useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import ExclamationMark from 'assets/exclamation-mark-bubble.svg';
 import EmptyBubble from 'assets/empty-bubble.svg';
 import text from 'locale';
-import styles from './index.module.scss';
+import styles from 'components/chloropleth/tooltips/tooltip.module.scss';
 
 import getLastGeneratedData from 'static-props/last-generated-data';
 
-import { ReactNode } from 'react';
 import SafetyRegionChloropleth, {
   thresholds,
 } from 'components/chloropleth/SafetyRegionChloropleth';
-import formatDate from 'utils/formatDate';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
 import useMediaQuery from 'utils/useMediaQuery';
+import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 
-const escalationTooltipContent = (router: NextRouter) => {
-  return (context: any): ReactNode => {
-    const type: number = context?.value;
-
-    const thresholdInfo = escalationThresholds.find(
-      (value) => value.threshold === type
-    );
-
-    const onSelectRegion = (event: any) => {
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-      router.push(
-        '/veiligheidsregio/[code]/positief-geteste-mensen',
-        `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`
-      );
-    };
-
-    return (
-      type && (
-        <div className={styles.escalationTooltip} onClick={onSelectRegion}>
-          <div className={styles.escalationTooltipHeader}>
-            <h4>{context?.vrname}</h4>
-          </div>
-          {
-            <div className={styles.escalationInfo}>
-              <div className={styles.bubble}>
-                {type !== 1 && <ExclamationMark fill={thresholdInfo?.color} />}
-                {type === 1 && <EmptyBubble fill={thresholdInfo?.color} />}
-              </div>
-              <div>
-                <strong>
-                  {(text.escalatie_niveau.types as any)[type].titel}
-                </strong>
-                : {(text.escalatie_niveau.types as any)[type].toelichting}
-                <br />
-                {replaceVariablesInText(text.escalatie_niveau.valid_from, {
-                  validFrom: formatDate(context.valid_from_unix),
-                })}
-              </div>
-            </div>
-          }
-        </div>
-      )
-    );
-  };
-};
-
-const EscalationMapLegenda = () => {
+export const EscalationMapLegenda = () => {
   return (
     <div className={styles.legenda} aria-label="legend">
       <h4 className="text-max-width">{text.escalatie_niveau.legenda.titel}</h4>
@@ -134,7 +85,7 @@ const SafetyRegion: FCWithLayout<any> = () => {
             metricProperty="escalation_level"
             style={{ height: mapHeight }}
             onSelect={onSelectRegion}
-            tooltipContent={escalationTooltipContent(router)}
+            tooltipContent={escalationTooltip(router)}
           />
         </div>
         {!isLargeScreen && <EscalationMapLegenda />}

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,6 +1,6 @@
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import { useRouter } from 'next/router';
+import { NextRouter, useRouter } from 'next/router';
 import ExclamationMark from 'assets/exclamation-mark-bubble.svg';
 import EmptyBubble from 'assets/empty-bubble.svg';
 import text from 'locale';
@@ -14,40 +14,86 @@ import SafetyRegionChloropleth, {
 } from 'components/chloropleth/SafetyRegionChloropleth';
 import formatDate from 'utils/formatDate';
 import replaceVariablesInText from 'utils/replaceVariablesInText';
+import useMediaQuery from 'utils/useMediaQuery';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 
-const escalationTooltipContent = (context: any): ReactNode => {
-  const type: number = context?.value;
-  const thresholdInfo = escalationThresholds.find(
-    (value) => value.threshold === type
-  );
-  return (
-    type && (
-      <div className={styles.escalationTooltip}>
-        <div className={styles.escalationTooltipHeader}>
-          <h4>{context?.vrname}</h4>
-        </div>
-        {
-          <div className={styles.escalationInfo}>
-            <div className={styles.bubble}>
-              {type !== 1 && <ExclamationMark fill={thresholdInfo?.color} />}
-              {type === 1 && <EmptyBubble fill={thresholdInfo?.color} />}
-            </div>
-            <div>
-              <strong>
-                {(text.escalatie_niveau.types as any)[type].titel}
-              </strong>
-              : {(text.escalatie_niveau.types as any)[type].toelichting}
-              <br />
-              {replaceVariablesInText(text.escalatie_niveau.valid_from, {
-                validFrom: formatDate(context.valid_from_unix),
-              })}
-            </div>
+const escalationTooltipContent = (router: NextRouter) => {
+  return (context: any): ReactNode => {
+    const type: number = context?.value;
+
+    const thresholdInfo = escalationThresholds.find(
+      (value) => value.threshold === type
+    );
+
+    const onSelectRegion = (event: any) => {
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      router.push(
+        '/veiligheidsregio/[code]/positief-geteste-mensen',
+        `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`
+      );
+    };
+
+    return (
+      type && (
+        <div className={styles.escalationTooltip} onClick={onSelectRegion}>
+          <div className={styles.escalationTooltipHeader}>
+            <h4>{context?.vrname}</h4>
           </div>
-        }
-      </div>
-    )
+          {
+            <div className={styles.escalationInfo}>
+              <div className={styles.bubble}>
+                {type !== 1 && <ExclamationMark fill={thresholdInfo?.color} />}
+                {type === 1 && <EmptyBubble fill={thresholdInfo?.color} />}
+              </div>
+              <div>
+                <strong>
+                  {(text.escalatie_niveau.types as any)[type].titel}
+                </strong>
+                : {(text.escalatie_niveau.types as any)[type].toelichting}
+                <br />
+                {replaceVariablesInText(text.escalatie_niveau.valid_from, {
+                  validFrom: formatDate(context.valid_from_unix),
+                })}
+              </div>
+            </div>
+          }
+        </div>
+      )
+    );
+  };
+};
+
+const EscalationMapLegenda = () => {
+  return (
+    <div className={styles.legenda} aria-label="legend">
+      <h4 className="text-max-width">{text.escalatie_niveau.legenda.titel}</h4>
+      {escalationThresholds.map((info) => (
+        <div
+          className={styles.escalationInfo}
+          key={`legenda-item-${info?.threshold}`}
+        >
+          <div className={styles.bubble}>
+            {info.threshold !== 1 && <ExclamationMark fill={info?.color} />}
+            {info.threshold === 1 && <EmptyBubble fill={info?.color} />}
+          </div>
+          <div>
+            <strong>
+              {
+                (text.escalatie_niveau.types as any)[info.threshold.toString()]
+                  .titel
+              }
+            </strong>
+            :{' '}
+            {
+              (text.escalatie_niveau.types as any)[info.threshold.toString()]
+                .toelichting
+            }
+          </div>
+        </div>
+      ))}
+    </div>
   );
 };
 
@@ -59,6 +105,7 @@ const escalationTooltipContent = (context: any): ReactNode => {
 // lots of unnecessary null checks on those pages.
 const SafetyRegion: FCWithLayout<any> = () => {
   const router = useRouter();
+  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const onSelectRegion = (context: any) => {
     router.push(
@@ -66,6 +113,8 @@ const SafetyRegion: FCWithLayout<any> = () => {
       `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`
     );
   };
+
+  const mapHeight = isLargeScreen ? '500px' : '400px';
 
   return (
     <>
@@ -77,50 +126,18 @@ const SafetyRegion: FCWithLayout<any> = () => {
           <p className="text-max-width">
             {text.veiligheidsregio_index.selecteer_toelichting}
           </p>
-          <div className={styles.legenda} aria-label="legend">
-            <h4 className="text-max-width">
-              {text.escalatie_niveau.legenda.titel}
-            </h4>
-
-            {escalationThresholds.map((info) => (
-              <div
-                className={styles.escalationInfo}
-                key={`legenda-item-${info?.threshold}`}
-              >
-                <div className={styles.bubble}>
-                  {info.threshold !== 1 && (
-                    <ExclamationMark fill={info?.color} />
-                  )}
-                  {info.threshold === 1 && <EmptyBubble fill={info?.color} />}
-                </div>
-                <div>
-                  <strong>
-                    {
-                      (text.escalatie_niveau.types as any)[
-                        info.threshold.toString()
-                      ].titel
-                    }
-                  </strong>
-                  :{' '}
-                  {
-                    (text.escalatie_niveau.types as any)[
-                      info.threshold.toString()
-                    ].toelichting
-                  }
-                </div>
-              </div>
-            ))}
-          </div>
+          {isLargeScreen && <EscalationMapLegenda />}
         </div>
         <div className="column-item-no-margin column-item">
           <SafetyRegionChloropleth
             metricName="escalation_levels"
             metricProperty="escalation_level"
-            style={{ height: '500px' }}
+            style={{ height: mapHeight }}
             onSelect={onSelectRegion}
-            tooltipContent={escalationTooltipContent}
+            tooltipContent={escalationTooltipContent(router)}
           />
         </div>
+        {!isLargeScreen && <EscalationMapLegenda />}
       </article>
     </>
   );

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -182,7 +182,6 @@
 @media (max-width: 999px) {
   .small-screen-aside-tendency {
     .national-content,
-    .safety-region-content,
     .municipality-content {
       display: none;
     }
@@ -193,6 +192,12 @@
     .safety-region-aside,
     .municipality-aside {
       display: none;
+    }
+  }
+
+  .small-screen-aside-tendency {
+    .safety-region-aside {
+      min-height: 6em;
     }
   }
 }


### PR DESCRIPTION
## Summary

- The escalation map is now actually visible on mobile
- Clicking on the map on mobile will show the tooltip, clicking on the tooltip will trigger the route change
- Tooltip stays within viewport now
- Updated escalation colors to final versions

## Motivation

Feature request

## Detailed design

- The tooltip positioning all happens in the useEffect hook within the tooltip component.
- The escalation tool tip render has been augmented with an onclick handler that performs the route change

## Drawbacks

The switch between the click functionality on the map is now done based on screen size detection. Preferable this becomes some sort of feature detection where we can determine whether the current screen has touch capabilities or not.

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
