### PR TITLE
Fix: Turn legenda back on 

### DIFF
--- a/schema/regions/regions.json
+++ b/schema/regions/regions.json
@@ -8,6 +8,7 @@
     "proto_name",
     "name",
     "code",
+    "escalation_levels",
     "hospital_admissions",
     "positive_tested_people"
   ],

--- a/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
+++ b/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
@@ -1,4 +1,4 @@
-//import styles from './chloroplethlegenda.module.scss';
+import styles from './chloroplethlegenda.module.scss';
 
 export interface ILegendaItem {
   color: string;
@@ -10,9 +10,9 @@ export type TProps = {
   items: ILegendaItem[];
 };
 
-export default function ChloroplethLegenda(_props: TProps) {
-  return null;
-  /*const { items, title } = props;
+export default function ChloroplethLegenda(props: TProps) {
+  const { items, title } = props;
+
   return (
     <>
       <h4>{title}</h4>
@@ -28,5 +28,5 @@ export default function ChloroplethLegenda(_props: TProps) {
         ))}
       </ul>
     </>
-  );*/
+  );
 }

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
 import { ILegendaItem } from '../ChloroplethLegenda';
 
-import siteText from 'locale';
-
 import { ChloroplethThresholdsValue } from 'components/chloropleth/shared';
 
 const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
@@ -23,21 +21,13 @@ export default function useLegendaItems(
       return;
     }
 
-    const legendaItems: ILegendaItem[] = [
-      {
-        color: '#C4C4C4',
-        label:
-          siteText.positief_geteste_personen.chloropleth_legenda.geen_meldingen,
-      },
-    ].concat(
-      thresholds.map<ILegendaItem>(
-        (threshold: ChloroplethThresholdsValue, index: number) => {
-          return {
-            color: threshold.color,
-            label: createLabel(thresholds, index),
-          };
-        }
-      )
+    const legendaItems: ILegendaItem[] = thresholds.map<ILegendaItem>(
+      (threshold: ChloroplethThresholdsValue, index: number) => {
+        return {
+          color: threshold.color,
+          label: createLabel(thresholds, index),
+        };
+      }
     );
 
     return legendaItems;


### PR DESCRIPTION
## Summary

- Legend was commented out, probably a merge error.
- Escalation_level is now required again
- Re-generated data.d.ts because of the schema change

## Motivation

n/a

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
