### PR TITLE
Feature: Add click-through navigation to positive tested people choropleths

### DIFF
--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -42,7 +42,7 @@ const Municipality: FCWithLayout<any> = () => {
   const router = useRouter();
   const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
-  const onSelectMunicpal = (context: MunicipalityProperties) => {
+  const onSelectMunicipal = (context: MunicipalityProperties) => {
     router.push(
       '/gemeente/[code]/positief-geteste-mensen',
       `/gemeente/${context.gemcode}/positief-geteste-mensen`
@@ -66,7 +66,7 @@ const Municipality: FCWithLayout<any> = () => {
           <MunicipalityChloropleth
             tooltipContent={tooltipContent(router)}
             style={{ height: mapHeight }}
-            onSelect={onSelectMunicpal}
+            onSelect={onSelectMunicipal}
           />
         </div>
       </article>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,6 +28,7 @@ import { useRouter } from 'next/router';
 import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
 import MDToHTMLString from 'utils/MDToHTMLString';
 import { National } from 'types/data';
+import { MunicipalityProperties } from 'components/chloropleth/shared';
 
 const Home: FCWithLayout<INationalData> = (props) => {
   const { text } = props;
@@ -42,6 +43,13 @@ const Home: FCWithLayout<INationalData> = (props) => {
     router.push(
       '/veiligheidsregio/[code]/positief-geteste-mensen',
       `/veiligheidsregio/${context.vrcode}/positief-geteste-mensen`
+    );
+  };
+
+  const onSelectMunicipal = (context: MunicipalityProperties) => {
+    router.push(
+      '/gemeente/[code]/positief-geteste-mensen',
+      `/gemeente/${context.gemcode}/positief-geteste-mensen`
     );
   };
 
@@ -134,12 +142,14 @@ const Home: FCWithLayout<INationalData> = (props) => {
             <MunicipalityChloropleth
               metricName="positive_tested_people"
               tooltipContent={positiveTestedPeopleTooltip}
+              onSelect={onSelectMunicipal}
             />
           )}
           {selectedMap === 'region' && (
             <SafetyRegionChloropleth
               metricName="positive_tested_people"
               tooltipContent={positiveTestedPeopleTooltipRegion}
+              onSelect={onSelectRegion}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

Add onSelect handlers to the municipal and region choropleths for positive tested people that navigate to their associated municipality or region page.

## Motivation

Feature request

## Detailed design

The Summary says it all basically.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
