### PR TITLE
Fixed typo in indicator scale title

### DIFF
--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -106,7 +106,7 @@
     },
     "titel": "Positief geteste mensen",
     "pagina_toelichting": "Door het aantal positief geteste mensen bij te houden krijgen we een duidelijk beeld van hoe snel het virus zich verspreidt voordat het de intensive care bereikt. Hierdoor blijven we voorbereid.",
-    "barscale_titel": "Gemiddeld aantal positief geteste mensen per 100.00 inwoners",
+    "barscale_titel": "Gemiddeld aantal positief geteste mensen per 100.000 inwoners",
     "barscale_toelichting": "Dit getal laat zien van hoeveel mensen gisteren per 100.000 inwoners gemeld is dat ze positief getest zijn en COVID-19 hebben.",
     "barscale_screenreader_text": "{{value}} positief geteste mensen per dag.",
     "kpi_titel": "Aantal positief geteste mensen:",


### PR DESCRIPTION
## Summary

The text on the indicator for the average number of confirmed cases per day on the National tab was showing "100.00" as the divider the rate is based on, instead of "100.000".

## Motivation

Having accurate information on the dashboard.

## Detailed design

Locale text updated.

## Drawbacks

N/A

## Alternatives

N/A

## Unresolved questions

N/A

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
