### PR TITLE
Fix chloropleth map resizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "dependencies": {
-    "@juggle/resize-observer": "^3.2.0",
     "@reach/combobox": "^0.11.2",
     "@types/geojson": "^7946.0.7",
     "@vx/event": "^0.0.198",
@@ -34,6 +33,7 @@
     "topojson-client": "^3.1.0",
     "unfetch": "^4.1.0",
     "unified": "^9.2.0",
+    "use-resize-observer": "^6.1.0",
     "zustand": "^3.1.2"
   },
   "devDependencies": {

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -1,6 +1,6 @@
 import { Mercator } from '@vx/geo';
 import { Feature, FeatureCollection, MultiPolygon } from 'geojson';
-import { MutableRefObject, ReactNode, useMemo, useRef } from 'react';
+import { MutableRefObject, ReactNode, useRef } from 'react';
 
 import create, { UseStore } from 'zustand';
 
@@ -132,9 +132,7 @@ export default function Chloropleth<T>(props: TProps<T>) {
     boundedHeight,
   } = dimensions;
 
-  const sizeToFit: [[number, number], FeatureCollection] = useMemo(() => {
-    return [[boundedWidth, boundedHeight], boundingbox];
-  }, [boundedWidth, boundedHeight, boundingbox]);
+  const sizeToFit = [[boundedWidth, boundedHeight], boundingbox];
 
   const showTooltip = tooltipStore.current((state) => state.showTooltip);
   const hideTooltip = tooltipStore.current((state) => state.hideTooltip);

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -53,7 +53,7 @@ const useChartDimensions = (
    * The ref will be initialized from the outside by mutating the return value of this
    * hook. This is a bit funky.
    *
-   * @TODO pass ref as prop
+   * @REF https://trello.com/c/i25FG3jk/548-usechartdemensions-pass-ref-as-prop
    */
   const ref = useRef<HTMLElement | null>(null);
 

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -1,12 +1,12 @@
-import { ResizeObserver } from '@juggle/resize-observer';
-import { useRef, useState, useEffect, MutableRefObject } from 'react';
+import { useRef, MutableRefObject } from 'react';
+import useResizeObserver from 'use-resize-observer';
 
 /**
- * This custom hook has been taken from the wonderful blog of
- * Amelia Wattenberger. https://wattenberger.com/blog/react-and-d3
- * We tried using @vx/responsive but felt it lacking in documentation and
- * it didn't work on IE11. This way we have more control over how we resize
- * our charts. Plus, who doesn't love D3 margin conventions?
+ * This code was originally inspired by https://wattenberger.com/blog/react-and-d3
+ *
+ * However the ResizeObserver from the original wasn't working properly and the
+ * useResizeObserver hook allows us to cut out pretty much all of the complexity
+ * while making it more React-like.
  */
 const combineChartDimensions = (
   dimensions: TChartDimensions = {}
@@ -20,28 +20,15 @@ const combineChartDimensions = (
     marginLeft = 0,
   } = dimensions;
 
-  const parsedDimensions = {
+  return {
     width,
     height,
     marginTop,
     marginRight,
     marginBottom,
     marginLeft,
-  };
-  return {
-    ...parsedDimensions,
-    boundedHeight: Math.max(
-      parsedDimensions.height -
-        parsedDimensions.marginTop -
-        parsedDimensions.marginBottom,
-      0
-    ),
-    boundedWidth: Math.max(
-      parsedDimensions.width -
-        parsedDimensions.marginLeft -
-        parsedDimensions.marginRight,
-      0
-    ),
+    boundedHeight: Math.max(height - marginTop - marginBottom, 0),
+    boundedWidth: Math.max(width - marginLeft - marginRight, 0),
   };
 };
 
@@ -60,54 +47,33 @@ export type TCombinedChartDimensions = TChartDimensions & {
 };
 
 const useChartDimensions = (
-  passedSettings?: TChartDimensions
+  chartDimensions: TChartDimensions = {}
 ): [MutableRefObject<HTMLElement | null>, TCombinedChartDimensions] => {
+  /**
+   * The ref will be initialized from the outside by mutating the return value of this
+   * hook. This is a bit funky.
+   *
+   * @TODO pass ref as prop
+   */
   const ref = useRef<HTMLElement | null>(null);
-  const dimensions = combineChartDimensions(passedSettings);
 
-  const [width, setWidth] = useState(0);
-  const [height, setHeight] = useState(0);
+  const { width, height } = useResizeObserver({ ref });
 
-  if (dimensions.width && dimensions.height) {
-    setWidth(dimensions.width);
-    setHeight(dimensions.height);
-  }
+  /**
+   * The previous useChartDimensions implementation allowed the passed in width and height to overrule any
+   * observed sizes. This is not currently used in the app, so we could decide
+   * to take it out. This implementation follows that same behavior for now.
+   */
+  const shouldOverruleWidthAndHeight =
+    chartDimensions.width && chartDimensions.height;
 
-  useEffect(() => {
-    // If we provide an explicit width and height, we simply return the dimensions
-    // as they are, but run through combineChartDimensions. In other words,
-    // when both width and height are set we don't need to set up a ResizeObserver
-    if (width && height) {
-      return;
-    }
-
-    const element = ref.current;
-
-    if (!element) {
-      return;
-    }
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      if (!Array.isArray(entries)) return;
-      if (!entries.length) return;
-
-      const entry = entries[0];
-
-      if (width != entry.contentRect.width) setWidth(entry.contentRect.width);
-      if (height != entry.contentRect.height)
-        setHeight(entry.contentRect.height);
-    });
-    resizeObserver.observe(element);
-    return () => resizeObserver.unobserve(element);
-  }, [width, height]);
-
-  const newSettings = combineChartDimensions({
-    ...dimensions,
-    width: dimensions.width || width,
-    height: dimensions.height || height,
-  });
-
-  return [ref, newSettings];
+  return [
+    ref,
+    combineChartDimensions({
+      width: shouldOverruleWidthAndHeight ? chartDimensions.width : width,
+      height: shouldOverruleWidthAndHeight ? chartDimensions.height : height,
+    }),
+  ];
 };
 
 export default useChartDimensions;

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -1,5 +1,5 @@
 import { useRef, MutableRefObject } from 'react';
-import useResizeObserver from 'use-resize-observer';
+import useResizeObserver from 'use-resize-observer/polyfilled';
 
 /**
  * This code was originally inspired by https://wattenberger.com/blog/react-and-d3

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,11 +1461,6 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@juggle/resize-observer@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
-  integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -9455,6 +9450,11 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -11139,6 +11139,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-resize-observer@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-6.1.0.tgz#d4d267a940dbf9c326da6042f8a4bb8c89d29729"
+  integrity sha512-SiPcWHiIQ1CnHmb6PxbYtygqiZXR0U9dNkkbpX9VYnlstUwF8+QqpUTrzh13pjPwcjMVGR+QIC+nvF5ujfFNng==
+  dependencies:
+    resize-observer-polyfill "^1.5.1"
 
 use-subscription@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
## Summary

Fix and re-implement the useChartDimensions hook.

## Motivation

The map resizing wasn't working because the resize listener was not firing in the useChartDimensions hook. This problem has been solved by replacing the observer with a hook based approach, and in addition, the code could be greatly simplified.
