### PR TITLE
Add signaalwaarde as dashed line to areachart

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -6,6 +6,8 @@ import ChartTimeControls, {
   TimeframeOption,
 } from 'components/chartTimeControls';
 
+import text from 'locale';
+
 import formatNumber from 'utils/formatNumber';
 import formatDate from 'utils/formatDate';
 import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
@@ -157,6 +159,17 @@ function getOptions(props: IGetOptions): Highcharts.Options {
       value: signaalwaarde,
       width: 1,
       color: '#4f5458',
+      dashStyle: 'Dash',
+      zIndex: 1,
+      label: {
+        text: text.common.barScale.signaalwaarde,
+        align: 'right',
+        y: -8,
+        x: 0,
+        style: {
+          color: '#4f5458',
+        },
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

As the title suggests. The 'signaalwaarde' wasn't properly displayed on the areachart, this is fixed.

## Motivation

Bug report

## Detailed design

Changed the config for the signaalwaarde series to match that of the line chart so that the signaalwaardes are displayed the same way.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
