### PR TITLE
Fix searchbar margins on for mobile region and municipal pages.

### DIFF
--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -185,6 +185,19 @@
 }
 
 @media (max-width: 999px) {
+  .national-layout,
+  .safety-region-layout,
+  .municipality-layout {
+    > section {
+      padding-top: 0;
+      margin-top: 0.5em;
+    }
+
+    .index-article {
+      margin-top: 0;
+    }
+  }
+
   .small-screen-aside-tendency {
     .national-content {
       display: none;


### PR DESCRIPTION
## Summary

Fix margins underneath the search bar on mobile for region and municipal pages.

## Motivation

Bug report

## Detailed design

Just some CSS tweaks in a mediaquery to reduce the amount of white space underneath the searchbar on smaller viewports.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
