### PR TITLE
Fix municipality tooltip values

### DIFF
--- a/src/components/chloropleth/municipalities.topo.json
+++ b/src/components/chloropleth/municipalities.topo.json
@@ -8959,7 +8959,7 @@
           "arcs": [[8, 9, 10, 11, 12, 13]],
           "type": "Polygon",
           "properties": {
-            "gemnaam": "Groningen (gemeente)",
+            "gemnaam": "Groningen",
             "gemcode": "GM0014"
           }
         },
@@ -9446,7 +9446,7 @@
         {
           "arcs": [[-330, 366, -337, -343, 367, -355, 368, 369]],
           "type": "Polygon",
-          "properties": { "gemnaam": "Utrecht (gemeente)", "gemcode": "GM0344" }
+          "properties": { "gemnaam": "Utrecht", "gemcode": "GM0344" }
         },
         {
           "arcs": [[-360, -229, -365, 370]],
@@ -9738,7 +9738,7 @@
           "arcs": [[557, 558, 559, 560, 561]],
           "type": "Polygon",
           "properties": {
-            "gemnaam": "'s-Gravenhage (gemeente)",
+            "gemnaam": "'s-Gravenhage",
             "gemcode": "GM0518"
           }
         },


### PR DESCRIPTION
## Summary

Remove ' (gemeente)' suffix from municipal geodata

## Motivation

Bug report

## Detailed design

The word 'gemeente' was hardcoded in the topojson dataset, and therefore also shown in the English part of the site. Since the map itself already makes clear whether you're looking at a region or a municipality, it was decided to just remove the suffix instead of coming up with contrived solutions to translate it.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
