### PR TITLE
Fix whitespace underneath 'All numbers' button

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -59,7 +59,7 @@
 }
 
 .all-numbers {
-  padding: 3em 2em 2em;
+  padding: 3em 2em 1em;
   margin: 0 -2rem;
   text-align: center;
 


### PR DESCRIPTION
## Summary

Small visual tweak to the bottom margin of the 'Show all numbers link'.

## Motivation

Bug report

## Detailed design

Its a CSS tweak, nuff said.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
