### PR TITLE
chore: Refactor absolute imports to use aliases

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -4,11 +4,11 @@ import HighchartsReact from 'highcharts-react-official';
 
 import ChartTimeControls, {
   TimeframeOption,
-} from '@/components/chartTimeControls';
+} from '~/components/chartTimeControls';
 
-import formatNumber from '@/utils/formatNumber';
-import formatDate from '@/utils/formatDate';
-import { getFilteredValues } from '@/components/chartTimeControls/chartTimeControlUtils';
+import formatNumber from '~/utils/formatNumber';
+import formatDate from '~/utils/formatDate';
+import { getFilteredValues } from '~/components/chartTimeControls/chartTimeControlUtils';
 
 if (typeof Highcharts === 'object') {
   require('highcharts/highcharts-more')(Highcharts);

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -4,11 +4,11 @@ import HighchartsReact from 'highcharts-react-official';
 
 import ChartTimeControls, {
   TimeframeOption,
-} from 'components/chartTimeControls';
+} from '@/components/chartTimeControls';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
-import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
+import formatNumber from '@/utils/formatNumber';
+import formatDate from '@/utils/formatDate';
+import { getFilteredValues } from '@/components/chartTimeControls/chartTimeControlUtils';
 
 if (typeof Highcharts === 'object') {
   require('highcharts/highcharts-more')(Highcharts);

--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -1,12 +1,12 @@
 import styles from './styles.module.scss';
 import { useRef } from 'react';
-import formatNumber from '@/utils/formatNumber';
-import ScreenReaderOnly from '@/components/screenReaderOnly';
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import formatNumber from '~/utils/formatNumber';
+import ScreenReaderOnly from '~/components/screenReaderOnly';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
 import { scaleQuantile, scaleThreshold } from 'd3-scale';
 
-import useDynamicScale from '@/utils/useDynamicScale';
-import siteText from '@/locale/index';
+import useDynamicScale from '~/utils/useDynamicScale';
+import siteText from '~/locale/index';
 
 type GradientStop = {
   color: string;

--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -1,12 +1,12 @@
 import styles from './styles.module.scss';
 import { useRef } from 'react';
-import formatNumber from 'utils/formatNumber';
-import ScreenReaderOnly from 'components/screenReaderOnly';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import formatNumber from '@/utils/formatNumber';
+import ScreenReaderOnly from '@/components/screenReaderOnly';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
 import { scaleQuantile, scaleThreshold } from 'd3-scale';
 
-import useDynamicScale from 'utils/useDynamicScale';
-import siteText from 'locale';
+import useDynamicScale from '@/utils/useDynamicScale';
+import siteText from '@/locale/index';
 
 type GradientStop = {
   color: string;

--- a/src/components/barScale/styles.module.scss
+++ b/src/components/barScale/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .root {
   width: 100%;

--- a/src/components/barScale/styles.module.scss
+++ b/src/components/barScale/styles.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .root {
   width: 100%;

--- a/src/components/chartRegionControls/chartregioncontrols.module.scss
+++ b/src/components/chartRegionControls/chartregioncontrols.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .select-region-group {
   margin: 0 0 1rem;

--- a/src/components/chartRegionControls/chartregioncontrols.module.scss
+++ b/src/components/chartRegionControls/chartregioncontrols.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .select-region-group {
   margin: 0 0 1rem;

--- a/src/components/chartRegionControls/index.tsx
+++ b/src/components/chartRegionControls/index.tsx
@@ -1,7 +1,7 @@
 import styles from './chartregioncontrols.module.scss';
-import RadioGroup, { IRadioGroupItem } from 'components/radioGroup';
+import RadioGroup, { IRadioGroupItem } from '@/components/radioGroup';
 
-import text from 'locale';
+import text from '@/locale/index';
 
 export interface IProps {
   onChange: (value: any) => void;

--- a/src/components/chartRegionControls/index.tsx
+++ b/src/components/chartRegionControls/index.tsx
@@ -1,7 +1,7 @@
 import styles from './chartregioncontrols.module.scss';
-import RadioGroup, { IRadioGroupItem } from '@/components/radioGroup';
+import RadioGroup, { IRadioGroupItem } from '~/components/radioGroup';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 
 export interface IProps {
   onChange: (value: any) => void;

--- a/src/components/chartTimeControls/chartTimeControls.module.scss
+++ b/src/components/chartTimeControls/chartTimeControls.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .root {
   /*

--- a/src/components/chartTimeControls/chartTimeControls.module.scss
+++ b/src/components/chartTimeControls/chartTimeControls.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .root {
   /*

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -1,8 +1,8 @@
 import styles from './chartTimeControls.module.scss';
 
-import RadioGroup, { IRadioGroupItem } from '@/components/radioGroup';
+import RadioGroup, { IRadioGroupItem } from '~/components/radioGroup';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 
 export type TimeframeOption = 'all' | '5weeks' | 'week';
 

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -1,8 +1,8 @@
 import styles from './chartTimeControls.module.scss';
 
-import RadioGroup, { IRadioGroupItem } from 'components/radioGroup';
+import RadioGroup, { IRadioGroupItem } from '@/components/radioGroup';
 
-import text from 'locale';
+import text from '@/locale/index';
 
 export type TimeframeOption = 'all' | '5weeks' | 'week';
 

--- a/src/components/charts/index.tsx
+++ b/src/components/charts/index.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
 
-export const AreaChart = dynamic(() => import('components/areaChart'));
-export const BarChart = dynamic(() => import('components/barChart'));
-export const LineChart = dynamic(() => import('components/lineChart'));
+export const AreaChart = dynamic(() => import('@/components/areaChart'));
+export const BarChart = dynamic(() => import('@/components/barChart'));
+export const LineChart = dynamic(() => import('@/components/lineChart'));

--- a/src/components/charts/index.tsx
+++ b/src/components/charts/index.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
 
-export const AreaChart = dynamic(() => import('@/components/areaChart'));
-export const BarChart = dynamic(() => import('@/components/barChart'));
-export const LineChart = dynamic(() => import('@/components/lineChart'));
+export const AreaChart = dynamic(() => import('~/components/areaChart'));
+export const BarChart = dynamic(() => import('~/components/barChart'));
+export const LineChart = dynamic(() => import('~/components/lineChart'));

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -10,7 +10,7 @@ import styles from './chloropleth.module.scss';
 import { localPoint } from '@vx/event';
 
 import Tooltip from './tooltips/tooltip';
-import useMediaQuery from '@/utils/useMediaQuery';
+import useMediaQuery from '~/utils/useMediaQuery';
 
 export type TooltipState = {
   tooltip: TooltipSettings | null;

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -10,7 +10,7 @@ import styles from './chloropleth.module.scss';
 import { localPoint } from '@vx/event';
 
 import Tooltip from './tooltips/tooltip';
-import useMediaQuery from 'utils/useMediaQuery';
+import useMediaQuery from '@/utils/useMediaQuery';
 
 export type TooltipState = {
   tooltip: TooltipSettings | null;

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -11,7 +11,7 @@ import useChartDimensions from './hooks/useChartDimensions';
 
 import styles from './chloropleth.module.scss';
 import { CSSProperties, ReactNode, useCallback } from 'react';
-import { Municipalities } from 'types/data';
+import { Municipalities } from '@/types/data';
 import useMunicipalityData from './hooks/useMunicipalityData';
 import useChloroplethColorScale from './hooks/useChloroplethColorScale';
 import useMunicipalityBoundingbox from './hooks/useMunicipalityBoundingbox';

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -11,7 +11,7 @@ import useChartDimensions from './hooks/useChartDimensions';
 
 import styles from './chloropleth.module.scss';
 import { CSSProperties, ReactNode, useCallback } from 'react';
-import { Municipalities } from '@/types/data';
+import { Municipalities } from '~/types/data';
 import useMunicipalityData from './hooks/useMunicipalityData';
 import useChloroplethColorScale from './hooks/useChloroplethColorScale';
 import useMunicipalityBoundingbox from './hooks/useMunicipalityBoundingbox';

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -4,7 +4,7 @@ import {
   SafetyRegionProperties,
   TRegionMetricName,
 } from './shared';
-import { Regions } from 'types/data';
+import { Regions } from '@/types/data';
 import { CSSProperties, ReactNode, useCallback } from 'react';
 import useChartDimensions from './hooks/useChartDimensions';
 import Chloropleth from './Chloropleth';

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -4,7 +4,7 @@ import {
   SafetyRegionProperties,
   TRegionMetricName,
 } from './shared';
-import { Regions } from '@/types/data';
+import { Regions } from '~/types/data';
 import { CSSProperties, ReactNode, useCallback } from 'react';
 import useChartDimensions from './hooks/useChartDimensions';
 import Chloropleth from './Chloropleth';

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .tooltipBase {
   padding: 0;

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .tooltipBase {
   padding: 0;

--- a/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
@@ -1,5 +1,5 @@
 import { SafetyRegionProperties } from '../shared';
-import municipalCodeToRegionCodeLookup from '@/data/municipalCodeToRegionCodeLookup';
+import municipalCodeToRegionCodeLookup from '~/data/municipalCodeToRegionCodeLookup';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { useMemo } from 'react';
 

--- a/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
@@ -1,5 +1,5 @@
 import { SafetyRegionProperties } from '../shared';
-import municipalCodeToRegionCodeLookup from 'data/municipalCodeToRegionCodeLookup';
+import municipalCodeToRegionCodeLookup from '@/data/municipalCodeToRegionCodeLookup';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { useMemo } from 'react';
 

--- a/src/components/chloropleth/hooks/useMunicipalityData.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityData.ts
@@ -1,4 +1,4 @@
-import { Municipalities } from '@/types/data';
+import { Municipalities } from '~/types/data';
 import { MunicipalityProperties, TMunicipalityMetricName } from '../shared';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import useSWR from 'swr';

--- a/src/components/chloropleth/hooks/useMunicipalityData.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityData.ts
@@ -1,4 +1,4 @@
-import { Municipalities } from 'types/data';
+import { Municipalities } from '@/types/data';
 import { MunicipalityProperties, TMunicipalityMetricName } from '../shared';
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import useSWR from 'swr';

--- a/src/components/chloropleth/hooks/useRegionMunicipalities.ts
+++ b/src/components/chloropleth/hooks/useRegionMunicipalities.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import getSafetyRegionMunicipalsForMunicipalCode from '@/utils/getSafetyRegionMunicipalsForMunicipalCode';
+import getSafetyRegionMunicipalsForMunicipalCode from '~/utils/getSafetyRegionMunicipalsForMunicipalCode';
 
 /**
  * This hook returns all the municipal codes that belong to the same safety region

--- a/src/components/chloropleth/hooks/useRegionMunicipalities.ts
+++ b/src/components/chloropleth/hooks/useRegionMunicipalities.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import getSafetyRegionMunicipalsForMunicipalCode from 'utils/getSafetyRegionMunicipalsForMunicipalCode';
+import getSafetyRegionMunicipalsForMunicipalCode from '@/utils/getSafetyRegionMunicipalsForMunicipalCode';
 
 /**
  * This hook returns all the municipal codes that belong to the same safety region

--- a/src/components/chloropleth/hooks/useSafetyRegionData.ts
+++ b/src/components/chloropleth/hooks/useSafetyRegionData.ts
@@ -1,7 +1,7 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { Regions } from 'types/data';
+import { Regions } from '@/types/data';
 import { SafetyRegionProperties, TRegionMetricName } from '../shared';
 
 export type TGetRegionFunc<T> = (id: string) => T | SafetyRegionProperties;

--- a/src/components/chloropleth/hooks/useSafetyRegionData.ts
+++ b/src/components/chloropleth/hooks/useSafetyRegionData.ts
@@ -1,7 +1,7 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import { Regions } from '@/types/data';
+import { Regions } from '~/types/data';
 import { SafetyRegionProperties, TRegionMetricName } from '../shared';
 
 export type TGetRegionFunc<T> = (id: string) => T | SafetyRegionProperties;

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { ILegendaItem } from '../ChloroplethLegenda';
 
-import { ChloroplethThresholdsValue } from 'components/chloropleth/shared';
+import { ChloroplethThresholdsValue } from '@/components/chloropleth/shared';
 
 const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
   if (index === 0) {

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { ILegendaItem } from '../ChloroplethLegenda';
 
-import { ChloroplethThresholdsValue } from '@/components/chloropleth/shared';
+import { ChloroplethThresholdsValue } from '~/components/chloropleth/shared';
 
 const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
   if (index === 0) {

--- a/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
@@ -1,5 +1,5 @@
-import { thresholds } from '@/components/chloropleth/MunicipalityChloropleth';
-import { TMunicipalityMetricName } from '@/components/chloropleth/shared';
+import { thresholds } from '~/components/chloropleth/MunicipalityChloropleth';
+import { TMunicipalityMetricName } from '~/components/chloropleth/shared';
 
 import useLegendaItems from './useLegendaItems';
 

--- a/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
@@ -1,5 +1,5 @@
-import { thresholds } from 'components/chloropleth/MunicipalityChloropleth';
-import { TMunicipalityMetricName } from 'components/chloropleth/shared';
+import { thresholds } from '@/components/chloropleth/MunicipalityChloropleth';
+import { TMunicipalityMetricName } from '@/components/chloropleth/shared';
 
 import useLegendaItems from './useLegendaItems';
 

--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -1,7 +1,7 @@
 import { TRegionMetricName } from '../../shared';
 
 import useLegendaItems from './useLegendaItems';
-import { thresholds } from 'components/chloropleth/SafetyRegionChloropleth';
+import { thresholds } from '@/components/chloropleth/SafetyRegionChloropleth';
 
 export default function useSafetyRegionLegendaData(metric: TRegionMetricName) {
   const ths = thresholds[metric];

--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -1,7 +1,7 @@
 import { TRegionMetricName } from '../../shared';
 
 import useLegendaItems from './useLegendaItems';
-import { thresholds } from '@/components/chloropleth/SafetyRegionChloropleth';
+import { thresholds } from '~/components/chloropleth/SafetyRegionChloropleth';
 
 export default function useSafetyRegionLegendaData(metric: TRegionMetricName) {
   const ths = thresholds[metric];

--- a/src/components/chloropleth/shared.d.ts
+++ b/src/components/chloropleth/shared.d.ts
@@ -1,5 +1,5 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
-import { Municipalities, Regions } from '@/types/data';
+import { Municipalities, Regions } from '~/types/data';
 
 type TMetricHolder<T> = keyof Omit<
   T,

--- a/src/components/chloropleth/shared.d.ts
+++ b/src/components/chloropleth/shared.d.ts
@@ -1,5 +1,5 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
-import { Municipalities, Regions } from 'types/data';
+import { Municipalities, Regions } from '@/types/data';
 
 type TMetricHolder<T> = keyof Omit<
   T,

--- a/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
-import styles from 'components/chloropleth/chloropleth.module.scss';
-import { MunicipalityProperties } from 'components/chloropleth/shared';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
+import { MunicipalityProperties } from '@/components/chloropleth/shared';
 
 export default function hospitalAdmissionsTooltip(
   context: MunicipalityProperties & { value: number }

--- a/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
-import { MunicipalityProperties } from '@/components/chloropleth/shared';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
+import { MunicipalityProperties } from '~/components/chloropleth/shared';
 
 export default function hospitalAdmissionsTooltip(
   context: MunicipalityProperties & { value: number }

--- a/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { MunicipalityProperties } from '../../shared';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
 
 export default function positiveTestedPeopleTooltip(
   context: MunicipalityProperties & { value: number }

--- a/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { MunicipalityProperties } from '../../shared';
-import styles from 'components/chloropleth/chloropleth.module.scss';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
 
 export default function positiveTestedPeopleTooltip(
   context: MunicipalityProperties & { value: number }

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -1,16 +1,16 @@
 import { NextRouter } from 'next/router';
 import { ReactNode } from 'react';
-import formatDate from '@/utils/formatDate';
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import formatDate from '~/utils/formatDate';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 import styles from '../tooltip.module.scss';
 
-import EscalationLevel1 from '@/assets/niveau-1.svg';
-import EscalationLevel2 from '@/assets/niveau-2.svg';
-import EscalationLevel3 from '@/assets/niveau-3.svg';
+import EscalationLevel1 from '~/assets/niveau-1.svg';
+import EscalationLevel2 from '~/assets/niveau-2.svg';
+import EscalationLevel3 from '~/assets/niveau-3.svg';
 
-import { thresholds } from '@/components/chloropleth/SafetyRegionChloropleth';
+import { thresholds } from '~/components/chloropleth/SafetyRegionChloropleth';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -1,16 +1,16 @@
 import { NextRouter } from 'next/router';
 import { ReactNode } from 'react';
-import formatDate from 'utils/formatDate';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import formatDate from '@/utils/formatDate';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
 
-import text from 'locale';
+import text from '@/locale/index';
 import styles from '../tooltip.module.scss';
 
-import EscalationLevel1 from 'assets/niveau-1.svg';
-import EscalationLevel2 from 'assets/niveau-2.svg';
-import EscalationLevel3 from 'assets/niveau-3.svg';
+import EscalationLevel1 from '@/assets/niveau-1.svg';
+import EscalationLevel2 from '@/assets/niveau-2.svg';
+import EscalationLevel3 from '@/assets/niveau-3.svg';
 
-import { thresholds } from 'components/chloropleth/SafetyRegionChloropleth';
+import { thresholds } from '@/components/chloropleth/SafetyRegionChloropleth';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 

--- a/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
-import { SafetyRegionProperties } from '@/components/chloropleth/shared';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
+import { SafetyRegionProperties } from '~/components/chloropleth/shared';
 
 export default function hospitalAdmissionsTooltip(
   context: SafetyRegionProperties & { value: number }

--- a/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
-import styles from 'components/chloropleth/chloropleth.module.scss';
-import { SafetyRegionProperties } from 'components/chloropleth/shared';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
+import { SafetyRegionProperties } from '@/components/chloropleth/shared';
 
 export default function hospitalAdmissionsTooltip(
   context: SafetyRegionProperties & { value: number }

--- a/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { SafetyRegionProperties } from '../../shared';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
 
 export default function positiveTestedPeopleTooltip(
   context: SafetyRegionProperties & { value: number }

--- a/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { SafetyRegionProperties } from '../../shared';
-import styles from 'components/chloropleth/chloropleth.module.scss';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
 
 export default function positiveTestedPeopleTooltip(
   context: SafetyRegionProperties & { value: number }

--- a/src/components/chloropleth/tooltips/tooltip.module.scss
+++ b/src/components/chloropleth/tooltips/tooltip.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .tooltip {
   background: white;

--- a/src/components/chloropleth/tooltips/tooltip.module.scss
+++ b/src/components/chloropleth/tooltips/tooltip.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .tooltip {
   background: white;

--- a/src/components/comboBox/comboBox.scss
+++ b/src/components/comboBox/comboBox.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 [data-reach-combobox] {
   position: relative;

--- a/src/components/comboBox/comboBox.scss
+++ b/src/components/comboBox/comboBox.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 [data-reach-combobox] {
   position: relative;

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -8,10 +8,10 @@ import {
   ComboboxOption,
 } from '@reach/combobox';
 
-import useThrottle from 'utils/useThrottle';
+import useThrottle from '@/utils/useThrottle';
 
-import text from 'locale';
-import useMediaQuery from 'utils/useMediaQuery';
+import text from '@/locale/index';
+import useMediaQuery from '@/utils/useMediaQuery';
 
 type TOption = {
   displayName?: string;

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -8,10 +8,10 @@ import {
   ComboboxOption,
 } from '@reach/combobox';
 
-import useThrottle from '@/utils/useThrottle';
+import useThrottle from '~/utils/useThrottle';
 
-import text from '@/locale/index';
-import useMediaQuery from '@/utils/useMediaQuery';
+import text from '~/locale/index';
+import useMediaQuery from '~/utils/useMediaQuery';
 
 type TOption = {
   displayName?: string;

--- a/src/components/gemeente/intake-hospital-barscale.tsx
+++ b/src/components/gemeente/intake-hospital-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { HospitalAdmissions } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
+  siteText.gemeente_ziekenhuisopnames_per_dag;
+
+export function IntakeHospitalBarScale(props: {
+  data: HospitalAdmissions | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.screen_reader_graph_content}
+      value={data.last_value.moving_average_hospital}
+      id="opnames"
+      rangeKey="moving_average_hospital"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/gemeente/intake-hospital-barscale.tsx
+++ b/src/components/gemeente/intake-hospital-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { HospitalAdmissions } from '~/types/data.d';
 
 import siteText from '~/locale/index';

--- a/src/components/gemeente/intake-hospital-barscale.tsx
+++ b/src/components/gemeente/intake-hospital-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
-import { HospitalAdmissions } from '@/types/data.d';
+import BarScale from '~/components/barScale';
+import { HospitalAdmissions } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
 

--- a/src/components/gemeente/positively-tested-people-barscale.tsx
+++ b/src/components/gemeente/positively-tested-people-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { PositiveTestedPeople } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+const text: typeof siteText.gemeente_positief_geteste_personen =
+  siteText.gemeente_positief_geteste_personen;
+
+export function PositivelyTestedPeopleBarScale(props: {
+  data: PositiveTestedPeople | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={10}
+      screenReaderText={text.screen_reader_graph_content}
+      value={data.last_value.infected_daily_increase}
+      id="positief"
+      rangeKey="infected_daily_increase"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/gemeente/positively-tested-people-barscale.tsx
+++ b/src/components/gemeente/positively-tested-people-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { PositiveTestedPeople } from '~/types/data.d';
 
 import siteText from '~/locale/index';

--- a/src/components/gemeente/positively-tested-people-barscale.tsx
+++ b/src/components/gemeente/positively-tested-people-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
-import { PositiveTestedPeople } from '@/types/data.d';
+import BarScale from '~/components/barScale';
+import { PositiveTestedPeople } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
 

--- a/src/components/gemeente/sewer-water-barscale.tsx
+++ b/src/components/gemeente/sewer-water-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { SewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
-import siteText from '@/locale/index';
+import { SewerWaterBarScaleData } from '~/utils/sewer-water/municipality-sewer-water.util';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;

--- a/src/components/gemeente/sewer-water-barscale.tsx
+++ b/src/components/gemeente/sewer-water-barscale.tsx
@@ -1,0 +1,35 @@
+import BarScale from '@/components/barScale';
+
+import { SewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
+import siteText from '@/locale/index';
+
+const text: typeof siteText.gemeente_rioolwater_metingen =
+  siteText.gemeente_rioolwater_metingen;
+
+export function SewerWaterBarScale(props: {
+  data: SewerWaterBarScaleData | null;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (data === null)
+    return <p>{siteText.no_data_for_this_municipality.text}</p>;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.screen_reader_graph_content}
+      value={Number(data.value)}
+      id="rioolwater_metingen"
+      rangeKey="average"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/gemeente/sewer-water-barscale.tsx
+++ b/src/components/gemeente/sewer-water-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { SewerWaterBarScaleData } from '~/utils/sewer-water/municipality-sewer-water.util';
 import siteText from '~/locale/index';

--- a/src/components/landelijk/infectious-people-barscale.tsx
+++ b/src/components/landelijk/infectious-people-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
-import { InfectiousPeopleCountNormalized } from '@/types/data.d';
+import BarScale from '~/components/barScale';
+import { InfectiousPeopleCountNormalized } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.besmettelijke_personen =
   siteText.besmettelijke_personen;

--- a/src/components/landelijk/infectious-people-barscale.tsx
+++ b/src/components/landelijk/infectious-people-barscale.tsx
@@ -1,0 +1,34 @@
+import BarScale from '@/components/barScale';
+import { InfectiousPeopleCountNormalized } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+
+const text: typeof siteText.besmettelijke_personen =
+  siteText.besmettelijke_personen;
+
+export function InfectiousPeopleBarScale(props: {
+  data: InfectiousPeopleCountNormalized | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={80}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.infectious_avg_normalized}
+      id="besmettelijk"
+      rangeKey="infectious_normalized_high"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/infectious-people-barscale.tsx
+++ b/src/components/landelijk/infectious-people-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { InfectiousPeopleCountNormalized } from '~/types/data.d';
 
 import siteText from '~/locale/index';

--- a/src/components/landelijk/intake-hospital-barscale.tsx
+++ b/src/components/landelijk/intake-hospital-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { IntakeHospitalMa } from '~/types/data.d';
 import siteText from '~/locale/index';

--- a/src/components/landelijk/intake-hospital-barscale.tsx
+++ b/src/components/landelijk/intake-hospital-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { IntakeHospitalMa } from '@/types/data.d';
-import siteText from '@/locale/index';
+import { IntakeHospitalMa } from '~/types/data.d';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;

--- a/src/components/landelijk/intake-hospital-barscale.tsx
+++ b/src/components/landelijk/intake-hospital-barscale.tsx
@@ -1,0 +1,43 @@
+import BarScale from '@/components/barScale';
+
+import { IntakeHospitalMa } from '@/types/data.d';
+import siteText from '@/locale/index';
+
+const text: typeof siteText.ziekenhuisopnames_per_dag =
+  siteText.ziekenhuisopnames_per_dag;
+
+export function IntakeHospitalBarScale(props: {
+  data: IntakeHospitalMa | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      signaalwaarde={40}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.moving_average_hospital}
+      id="opnames"
+      rangeKey="moving_average_hospital"
+      gradient={[
+        {
+          color: '#69c253',
+          value: 0,
+        },
+        {
+          color: '#D3A500',
+          value: 40,
+        },
+        {
+          color: '#f35065',
+          value: 90,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/intake-intensive-care-barscale.tsx
+++ b/src/components/landelijk/intake-intensive-care-barscale.tsx
@@ -1,0 +1,42 @@
+import BarScale from '@/components/barScale';
+
+import { IntakeIntensivecareMa } from '@/types/data.d';
+import siteText from '@/locale/index';
+
+const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
+
+export function IntakeIntensiveCareBarscale(props: {
+  data: IntakeIntensivecareMa | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={30}
+      gradient={[
+        {
+          color: '#69c253',
+          value: 0,
+        },
+        {
+          color: '#D3A500',
+          value: 10,
+        },
+        {
+          color: '#f35065',
+          value: 20,
+        },
+      ]}
+      rangeKey="moving_average_ic"
+      screenReaderText={text.barscale_screenreader_text}
+      signaalwaarde={10}
+      value={data.last_value.moving_average_ic}
+      id="ic"
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/intake-intensive-care-barscale.tsx
+++ b/src/components/landelijk/intake-intensive-care-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { IntakeIntensivecareMa } from '~/types/data.d';
 import siteText from '~/locale/index';

--- a/src/components/landelijk/intake-intensive-care-barscale.tsx
+++ b/src/components/landelijk/intake-intensive-care-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { IntakeIntensivecareMa } from '@/types/data.d';
-import siteText from '@/locale/index';
+import { IntakeIntensivecareMa } from '~/types/data.d';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
 

--- a/src/components/landelijk/nursing-home-deaths-barscale.tsx
+++ b/src/components/landelijk/nursing-home-deaths-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import siteText from '~/locale/index';
 import { DeceasedPeopleNurseryCountDaily } from '~/types/data.d';
 

--- a/src/components/landelijk/nursing-home-deaths-barscale.tsx
+++ b/src/components/landelijk/nursing-home-deaths-barscale.tsx
@@ -1,6 +1,6 @@
-import BarScale from '@/components/barScale';
-import siteText from '@/locale/index';
-import { DeceasedPeopleNurseryCountDaily } from '@/types/data.d';
+import BarScale from '~/components/barScale';
+import siteText from '~/locale/index';
+import { DeceasedPeopleNurseryCountDaily } from '~/types/data.d';
 
 const text: typeof siteText.verpleeghuis_oversterfte =
   siteText.verpleeghuis_oversterfte;

--- a/src/components/landelijk/nursing-home-deaths-barscale.tsx
+++ b/src/components/landelijk/nursing-home-deaths-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import siteText from '@/locale/index';
+import { DeceasedPeopleNurseryCountDaily } from '@/types/data.d';
+
+const text: typeof siteText.verpleeghuis_oversterfte =
+  siteText.verpleeghuis_oversterfte;
+
+export function NursingHomeDeathsBarScale(props: {
+  data: DeceasedPeopleNurseryCountDaily | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={50}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.deceased_nursery_daily}
+      id="over"
+      rangeKey="deceased_nursery_daily"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { TotalReportedLocations } from '@/types/data.d';
+import { TotalReportedLocations } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;

--- a/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
@@ -1,0 +1,35 @@
+import BarScale from '@/components/barScale';
+
+import { TotalReportedLocations } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+
+const text: typeof siteText.verpleeghuis_besmette_locaties =
+  siteText.verpleeghuis_besmette_locaties;
+
+export function NursingHomeInfectedLocationsBarScale(props: {
+  data: TotalReportedLocations | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={30}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.total_reported_locations}
+      id="besmette_locaties_verpleeghuis"
+      rangeKey="total_reported_locations"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { TotalReportedLocations } from '~/types/data.d';
 

--- a/src/components/landelijk/nursing-home-infected-people-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-people-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { InfectedPeopleNurseryCountDaily } from '@/types/data.d';
+import siteText from '@/locale/index';
+
+const text: typeof siteText.verpleeghuis_positief_geteste_personen =
+  siteText.verpleeghuis_positief_geteste_personen;
+
+export function NursingHomeInfectedPeopleBarScale(props: {
+  data: InfectedPeopleNurseryCountDaily | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.infected_nursery_daily}
+      id="positief_verpleeghuis"
+      rangeKey="infected_nursery_daily"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/nursing-home-infected-people-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-people-barscale.tsx
@@ -1,6 +1,6 @@
-import BarScale from '@/components/barScale';
-import { InfectedPeopleNurseryCountDaily } from '@/types/data.d';
-import siteText from '@/locale/index';
+import BarScale from '~/components/barScale';
+import { InfectedPeopleNurseryCountDaily } from '~/types/data.d';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.verpleeghuis_positief_geteste_personen =
   siteText.verpleeghuis_positief_geteste_personen;

--- a/src/components/landelijk/nursing-home-infected-people-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-people-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { InfectedPeopleNurseryCountDaily } from '~/types/data.d';
 import siteText from '~/locale/index';
 

--- a/src/components/landelijk/positive-tested-people-barscale.tsx
+++ b/src/components/landelijk/positive-tested-people-barscale.tsx
@@ -1,0 +1,44 @@
+import BarScale from '@/components/barScale';
+
+import { InfectedPeopleDeltaNormalized } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+
+export function PositiveTestedPeopleBarScale(props: {
+  data: InfectedPeopleDeltaNormalized | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  const text: typeof siteText.positief_geteste_personen =
+    siteText.positief_geteste_personen;
+
+  return (
+    <BarScale
+      min={0}
+      max={10}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.infected_daily_increase}
+      id="positief"
+      rangeKey="infected_daily_increase"
+      gradient={[
+        {
+          color: '#69c253',
+          value: 0,
+        },
+        {
+          color: '#D3A500',
+          value: 7,
+        },
+        {
+          color: '#f35065',
+          value: 10,
+        },
+      ]}
+      signaalwaarde={7}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/positive-tested-people-barscale.tsx
+++ b/src/components/landelijk/positive-tested-people-barscale.tsx
@@ -3,6 +3,8 @@ import BarScale from '~/components/barScale';
 import { InfectedPeopleDeltaNormalized } from '~/types/data.d';
 
 import siteText from '~/locale/index';
+const text: typeof siteText.positief_geteste_personen =
+  siteText.positief_geteste_personen;
 
 export function PositiveTestedPeopleBarScale(props: {
   data: InfectedPeopleDeltaNormalized | undefined;
@@ -11,9 +13,6 @@ export function PositiveTestedPeopleBarScale(props: {
   const { data, showAxis } = props;
 
   if (!data) return null;
-
-  const text: typeof siteText.positief_geteste_personen =
-    siteText.positief_geteste_personen;
 
   return (
     <BarScale

--- a/src/components/landelijk/positive-tested-people-barscale.tsx
+++ b/src/components/landelijk/positive-tested-people-barscale.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { InfectedPeopleDeltaNormalized } from '@/types/data.d';
+import { InfectedPeopleDeltaNormalized } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 export function PositiveTestedPeopleBarScale(props: {
   data: InfectedPeopleDeltaNormalized | undefined;

--- a/src/components/landelijk/positive-tested-people-barscale.tsx
+++ b/src/components/landelijk/positive-tested-people-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { InfectedPeopleDeltaNormalized } from '~/types/data.d';
 

--- a/src/components/landelijk/reproduction-index-barscale.tsx
+++ b/src/components/landelijk/reproduction-index-barscale.tsx
@@ -1,0 +1,48 @@
+import BarScale from '@/components/barScale';
+
+import { ReproductionIndex as ReproductionIndexData } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+
+export function ReproductionIndexBarScale(props: {
+  data: ReproductionIndexData | undefined;
+  lastKnown: ReproductionIndexData | undefined;
+  showAxis: boolean;
+}) {
+  const { data, lastKnown, showAxis } = props;
+
+  if (!data) return null;
+
+  const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
+
+  return (
+    <BarScale
+      min={0}
+      max={2}
+      screenReaderText={text.barscale_screenreader_text}
+      signaalwaarde={1}
+      value={lastKnown?.last_value?.reproduction_index_avg}
+      id="repro"
+      rangeKey="reproduction_index_avg"
+      gradient={[
+        {
+          color: '#69c253',
+          value: 0,
+        },
+        {
+          color: '#69c253',
+          value: 1,
+        },
+        {
+          color: '#D3A500',
+          value: 1.0104,
+        },
+        {
+          color: '#f35065',
+          value: 1.125,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/reproduction-index-barscale.tsx
+++ b/src/components/landelijk/reproduction-index-barscale.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { ReproductionIndex as ReproductionIndexData } from '@/types/data.d';
+import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 export function ReproductionIndexBarScale(props: {
   data: ReproductionIndexData | undefined;

--- a/src/components/landelijk/reproduction-index-barscale.tsx
+++ b/src/components/landelijk/reproduction-index-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 

--- a/src/components/landelijk/reproduction-index-barscale.tsx
+++ b/src/components/landelijk/reproduction-index-barscale.tsx
@@ -3,6 +3,7 @@ import BarScale from '~/components/barScale';
 import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 
 import siteText from '~/locale/index';
+const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
 
 export function ReproductionIndexBarScale(props: {
   data: ReproductionIndexData | undefined;
@@ -12,8 +13,6 @@ export function ReproductionIndexBarScale(props: {
   const { data, lastKnown, showAxis } = props;
 
   if (!data) return null;
-
-  const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
 
   return (
     <BarScale

--- a/src/components/landelijk/sewer-water-barscale.tsx
+++ b/src/components/landelijk/sewer-water-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 
 import { RioolwaterMetingen } from '~/types/data.d';
 

--- a/src/components/landelijk/sewer-water-barscale.tsx
+++ b/src/components/landelijk/sewer-water-barscale.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
+import BarScale from '~/components/barScale';
 
-import { RioolwaterMetingen } from '@/types/data.d';
+import { RioolwaterMetingen } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
 
 export function SewerWaterBarScale(props: {

--- a/src/components/landelijk/sewer-water-barscale.tsx
+++ b/src/components/landelijk/sewer-water-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+
+import { RioolwaterMetingen } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
+
+export function SewerWaterBarScale(props: {
+  data: RioolwaterMetingen | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.barscale_screenreader_text}
+      value={Number(data.last_value.average)}
+      id="rioolwater_metingen"
+      rangeKey="average"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/suspected-patients-barscale.tsx
+++ b/src/components/landelijk/suspected-patients-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { VerdenkingenHuisartsen } from '@/types/data.d';
+
+import siteText from '@/locale/index';
+const text: typeof siteText.verdenkingen_huisartsen =
+  siteText.verdenkingen_huisartsen;
+
+export function SuspectedPatientsBarScale(props: {
+  data: VerdenkingenHuisartsen | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  return (
+    <BarScale
+      min={0}
+      max={140}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.incidentie as number | null}
+      id="verdenkingen_huisartsen"
+      rangeKey="incidentie"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/landelijk/suspected-patients-barscale.tsx
+++ b/src/components/landelijk/suspected-patients-barscale.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
-import { VerdenkingenHuisartsen } from '@/types/data.d';
+import BarScale from '~/components/barScale';
+import { VerdenkingenHuisartsen } from '~/types/data.d';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 const text: typeof siteText.verdenkingen_huisartsen =
   siteText.verdenkingen_huisartsen;
 

--- a/src/components/landelijk/suspected-patients-barscale.tsx
+++ b/src/components/landelijk/suspected-patients-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { VerdenkingenHuisartsen } from '~/types/data.d';
 
 import siteText from '~/locale/index';

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -1,5 +1,5 @@
-import Metadata from 'components/metadata';
-import TitleWithIcon from 'components/titleWithIcon';
+import Metadata from '@/components/metadata';
+import TitleWithIcon from '@/components/titleWithIcon';
 import styles from './layout.module.scss';
 
 export { ContentHeader };

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -1,5 +1,5 @@
-import Metadata from '@/components/metadata';
-import TitleWithIcon from '@/components/titleWithIcon';
+import Metadata from '~/components/metadata';
+import TitleWithIcon from '~/components/titleWithIcon';
 import styles from './layout.module.scss';
 
 export { ContentHeader };

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -2,28 +2,28 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import siteText from '@/locale/index';
-import { WithChildren } from '@/types/index';
-import municipalities from '@/data/gemeente_veiligheidsregio.json';
-import { IMunicipalityData } from '@/static-props/municipality-data';
+import siteText from '~/locale/index';
+import { WithChildren } from '~/types/index';
+import municipalities from '~/data/gemeente_veiligheidsregio.json';
+import { IMunicipalityData } from '~/static-props/municipality-data';
 
-import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
-import getSafetyRegionForMunicipalityCode from '@/utils/getSafetyRegionForMunicipalityCode';
-import { getSewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
-import useMediaQuery from '@/utils/useMediaQuery';
+import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
+import getSafetyRegionForMunicipalityCode from '~/utils/getSafetyRegionForMunicipalityCode';
+import { getSewerWaterBarScaleData } from '~/utils/sewer-water/municipality-sewer-water.util';
+import useMediaQuery from '~/utils/useMediaQuery';
 
-import { PositivelyTestedPeopleBarScale } from '@/components/gemeente/positively-tested-people-barscale';
-import { IntakeHospitalBarScale } from '@/components/gemeente/intake-hospital-barscale';
-import { SewerWaterBarScale } from '@/components/gemeente/sewer-water-barscale';
+import { PositivelyTestedPeopleBarScale } from '~/components/gemeente/positively-tested-people-barscale';
+import { IntakeHospitalBarScale } from '~/components/gemeente/intake-hospital-barscale';
+import { SewerWaterBarScale } from '~/components/gemeente/sewer-water-barscale';
 
-import TitleWithIcon from '@/components/titleWithIcon';
-import { getLayout as getSiteLayout } from '@/components/layout';
-import Combobox from '@/components/comboBox';
+import TitleWithIcon from '~/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '~/components/layout';
+import Combobox from '~/components/comboBox';
 
-import GetestIcon from '@/assets/test.svg';
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
-import Arrow from '@/assets/arrow.svg';
+import GetestIcon from '~/assets/test.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
+import Arrow from '~/assets/arrow.svg';
 
 export default MunicipalityLayout;
 

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -2,28 +2,28 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 import { WithChildren } from 'types';
-import municipalities from 'data/gemeente_veiligheidsregio.json';
-import { IMunicipalityData } from 'static-props/municipality-data';
+import municipalities from '@/data/gemeente_veiligheidsregio.json';
+import { IMunicipalityData } from '@/static-props/municipality-data';
 
-import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
-import getSafetyRegionForMunicipalityCode from 'utils/getSafetyRegionForMunicipalityCode';
-import { getSewerWaterBarScaleData } from 'utils/sewer-water/municipality-sewer-water.util';
-import useMediaQuery from 'utils/useMediaQuery';
+import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
+import getSafetyRegionForMunicipalityCode from '@/utils/getSafetyRegionForMunicipalityCode';
+import { getSewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
+import useMediaQuery from '@/utils/useMediaQuery';
 
-import { PostivelyTestedPeopleBarScale } from 'pages/gemeente/[code]/positief-geteste-mensen';
-import { IntakeHospitalBarScale } from 'pages/gemeente/[code]/ziekenhuis-opnames';
-import { SewerWaterBarScale } from 'pages/gemeente/[code]/rioolwater';
+import { PostivelyTestedPeopleBarScale } from '@/pages/gemeente/[code]/positief-geteste-mensen';
+import { IntakeHospitalBarScale } from '@/pages/gemeente/[code]/ziekenhuis-opnames';
+import { SewerWaterBarScale } from '@/pages/gemeente/[code]/rioolwater';
 
-import TitleWithIcon from 'components/titleWithIcon';
-import { getLayout as getSiteLayout } from 'components/layout';
-import Combobox from 'components/comboBox';
+import TitleWithIcon from '@/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '@/components/layout';
+import Combobox from '@/components/comboBox';
 
-import GetestIcon from 'assets/test.svg';
-import Ziekenhuis from 'assets/ziekenhuis.svg';
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
-import Arrow from 'assets/arrow.svg';
+import GetestIcon from '@/assets/test.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import Arrow from '@/assets/arrow.svg';
 
 export default MunicipalityLayout;
 

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 import siteText from '@/locale/index';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 import municipalities from '@/data/gemeente_veiligheidsregio.json';
 import { IMunicipalityData } from '@/static-props/municipality-data';
 

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -12,9 +12,9 @@ import getSafetyRegionForMunicipalityCode from '@/utils/getSafetyRegionForMunici
 import { getSewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
 import useMediaQuery from '@/utils/useMediaQuery';
 
-import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
-import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
-import { SewerWaterBarScale } from '@/components/veiligheidsregio/sewer-water-barscale';
+import { PositivelyTestedPeopleBarScale } from '@/components/gemeente/positively-tested-people-barscale';
+import { IntakeHospitalBarScale } from '@/components/gemeente/intake-hospital-barscale';
+import { SewerWaterBarScale } from '@/components/gemeente/sewer-water-barscale';
 
 import TitleWithIcon from '@/components/titleWithIcon';
 import { getLayout as getSiteLayout } from '@/components/layout';

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -12,9 +12,9 @@ import getSafetyRegionForMunicipalityCode from '@/utils/getSafetyRegionForMunici
 import { getSewerWaterBarScaleData } from '@/utils/sewer-water/municipality-sewer-water.util';
 import useMediaQuery from '@/utils/useMediaQuery';
 
-import { PostivelyTestedPeopleBarScale } from '@/pages/gemeente/[code]/positief-geteste-mensen';
-import { IntakeHospitalBarScale } from '@/pages/gemeente/[code]/ziekenhuis-opnames';
-import { SewerWaterBarScale } from '@/pages/gemeente/[code]/rioolwater';
+import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
+import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
+import { SewerWaterBarScale } from '@/components/veiligheidsregio/sewer-water-barscale';
 
 import TitleWithIcon from '@/components/titleWithIcon';
 import { getLayout as getSiteLayout } from '@/components/layout';
@@ -176,7 +176,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
                         }
                       />
                       <span>
-                        <PostivelyTestedPeopleBarScale
+                        <PositivelyTestedPeopleBarScale
                           data={data?.positive_tested_people}
                           showAxis={true}
                         />

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -28,7 +28,7 @@ import Notification from '@/assets/notification.svg';
 
 import siteText from '@/locale/index';
 
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 import { INationalData } from '@/static-props/nl-data';
 

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -2,37 +2,37 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import TitleWithIcon from '@/components/titleWithIcon';
-import { getLayout as getSiteLayout } from '@/components/layout';
+import TitleWithIcon from '~/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '~/components/layout';
 
-import { ReproductionIndexBarScale } from '@/components/landelijk/reproduction-index-barscale';
-import { PositiveTestedPeopleBarScale } from '@/components/landelijk/positive-tested-people-barscale';
-import { InfectiousPeopleBarScale } from '@/components/landelijk/infectious-people-barscale';
-import { IntakeHospitalBarScale } from '@/components/landelijk/intake-hospital-barscale';
+import { ReproductionIndexBarScale } from '~/components/landelijk/reproduction-index-barscale';
+import { PositiveTestedPeopleBarScale } from '~/components/landelijk/positive-tested-people-barscale';
+import { InfectiousPeopleBarScale } from '~/components/landelijk/infectious-people-barscale';
+import { IntakeHospitalBarScale } from '~/components/landelijk/intake-hospital-barscale';
 
-import { IntakeIntensiveCareBarscale } from '@/components/landelijk/intake-intensive-care-barscale';
-import { SuspectedPatientsBarScale } from '@/components/landelijk/suspected-patients-barscale';
-import { SewerWaterBarScale } from '@/components/landelijk/sewer-water-barscale';
-import { NursingHomeInfectedPeopleBarScale } from '@/components/landelijk/nursing-home-infected-people-barscale';
-import { NursingHomeInfectedLocationsBarScale } from '@/components/landelijk/nursing-home-infected-locations-barscale';
-import { NursingHomeDeathsBarScale } from '@/components/landelijk/nursing-home-deaths-barscale';
+import { IntakeIntensiveCareBarscale } from '~/components/landelijk/intake-intensive-care-barscale';
+import { SuspectedPatientsBarScale } from '~/components/landelijk/suspected-patients-barscale';
+import { SewerWaterBarScale } from '~/components/landelijk/sewer-water-barscale';
+import { NursingHomeInfectedPeopleBarScale } from '~/components/landelijk/nursing-home-infected-people-barscale';
+import { NursingHomeInfectedLocationsBarScale } from '~/components/landelijk/nursing-home-infected-locations-barscale';
+import { NursingHomeDeathsBarScale } from '~/components/landelijk/nursing-home-deaths-barscale';
 
-import GetestIcon from '@/assets/test.svg';
-import ReproIcon from '@/assets/reproductiegetal.svg';
-import Ziektegolf from '@/assets/ziektegolf.svg';
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
-import Arts from '@/assets/arts.svg';
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
-import Locatie from '@/assets/locaties.svg';
-import CoronaVirus from '@/assets/coronavirus.svg';
-import Arrow from '@/assets/arrow.svg';
-import Notification from '@/assets/notification.svg';
+import GetestIcon from '~/assets/test.svg';
+import ReproIcon from '~/assets/reproductiegetal.svg';
+import Ziektegolf from '~/assets/ziektegolf.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
+import Arts from '~/assets/arts.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
+import Locatie from '~/assets/locaties.svg';
+import CoronaVirus from '~/assets/coronavirus.svg';
+import Arrow from '~/assets/arrow.svg';
+import Notification from '~/assets/notification.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
-import { INationalData } from '@/static-props/nl-data';
+import { INationalData } from '~/static-props/nl-data';
 
 export default NationalLayout;
 

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -2,35 +2,35 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import TitleWithIcon from 'components/titleWithIcon';
-import { getLayout as getSiteLayout } from 'components/layout';
-import { ReproductionIndexBarScale } from 'pages/landelijk/reproductiegetal';
-import { PostivelyTestedPeopleBarScale } from 'pages/landelijk/positief-geteste-mensen';
-import { InfectiousPeopleBarScale } from 'pages/landelijk/besmettelijke-mensen';
-import { IntakeHospitalBarScale } from 'pages/landelijk/ziekenhuis-opnames';
-import { IntakeIntensiveCareBarscale } from 'pages/landelijk/intensive-care-opnames';
-import { SuspectedPatientsBarScale } from 'pages/landelijk/verdenkingen-huisartsen';
-import { SewerWaterBarScale } from 'pages/landelijk/rioolwater';
-import { NursingHomeInfectedPeopleBarScale } from 'pages/landelijk/verpleeghuis-positief-geteste-personen';
-import { NursingHomeInfectedLocationsBarScale } from 'pages/landelijk/verpleeghuis-besmette-locaties';
-import { NursingHomeDeathsBarScale } from 'pages/landelijk/verpleeghuis-sterfte';
+import TitleWithIcon from '@/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '@/components/layout';
+import { ReproductionIndexBarScale } from '@/pages/landelijk/reproductiegetal';
+import { PostivelyTestedPeopleBarScale } from '@/pages/landelijk/positief-geteste-mensen';
+import { InfectiousPeopleBarScale } from '@/pages/landelijk/besmettelijke-mensen';
+import { IntakeHospitalBarScale } from '@/pages/landelijk/ziekenhuis-opnames';
+import { IntakeIntensiveCareBarscale } from '@/pages/landelijk/intensive-care-opnames';
+import { SuspectedPatientsBarScale } from '@/pages/landelijk/verdenkingen-huisartsen';
+import { SewerWaterBarScale } from '@/pages/landelijk/rioolwater';
+import { NursingHomeInfectedPeopleBarScale } from '@/pages/landelijk/verpleeghuis-positief-geteste-personen';
+import { NursingHomeInfectedLocationsBarScale } from '@/pages/landelijk/verpleeghuis-besmette-locaties';
+import { NursingHomeDeathsBarScale } from '@/pages/landelijk/verpleeghuis-sterfte';
 
-import GetestIcon from 'assets/test.svg';
-import ReproIcon from 'assets/reproductiegetal.svg';
-import Ziektegolf from 'assets/ziektegolf.svg';
-import Ziekenhuis from 'assets/ziekenhuis.svg';
-import Arts from 'assets/arts.svg';
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
-import Locatie from 'assets/locaties.svg';
-import CoronaVirus from 'assets/coronavirus.svg';
-import Arrow from 'assets/arrow.svg';
-import Notification from 'assets/notification.svg';
+import GetestIcon from '@/assets/test.svg';
+import ReproIcon from '@/assets/reproductiegetal.svg';
+import Ziektegolf from '@/assets/ziektegolf.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import Arts from '@/assets/arts.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import Locatie from '@/assets/locaties.svg';
+import CoronaVirus from '@/assets/coronavirus.svg';
+import Arrow from '@/assets/arrow.svg';
+import Notification from '@/assets/notification.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 import { WithChildren } from 'types';
 
-import { INationalData } from 'static-props/nl-data';
+import { INationalData } from '@/static-props/nl-data';
 
 export default NationalLayout;
 

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -4,16 +4,18 @@ import { useRouter } from 'next/router';
 
 import TitleWithIcon from '@/components/titleWithIcon';
 import { getLayout as getSiteLayout } from '@/components/layout';
-import { ReproductionIndexBarScale } from '@/pages/landelijk/reproductiegetal';
-import { PostivelyTestedPeopleBarScale } from '@/pages/landelijk/positief-geteste-mensen';
-import { InfectiousPeopleBarScale } from '@/pages/landelijk/besmettelijke-mensen';
-import { IntakeHospitalBarScale } from '@/pages/landelijk/ziekenhuis-opnames';
-import { IntakeIntensiveCareBarscale } from '@/pages/landelijk/intensive-care-opnames';
-import { SuspectedPatientsBarScale } from '@/pages/landelijk/verdenkingen-huisartsen';
-import { SewerWaterBarScale } from '@/pages/landelijk/rioolwater';
-import { NursingHomeInfectedPeopleBarScale } from '@/pages/landelijk/verpleeghuis-positief-geteste-personen';
-import { NursingHomeInfectedLocationsBarScale } from '@/pages/landelijk/verpleeghuis-besmette-locaties';
-import { NursingHomeDeathsBarScale } from '@/pages/landelijk/verpleeghuis-sterfte';
+
+import { ReproductionIndexBarScale } from '@/components/landelijk/reproduction-index-barscale';
+import { PositiveTestedPeopleBarScale } from '@/components/landelijk/positive-tested-people-barscale';
+import { InfectiousPeopleBarScale } from '@/components/landelijk/infectious-people-barscale';
+import { IntakeHospitalBarScale } from '@/components/landelijk/intake-hospital-barscale';
+
+import { IntakeIntensiveCareBarscale } from '@/components/landelijk/intake-intensive-care-barscale';
+import { SuspectedPatientsBarScale } from '@/components/landelijk/suspected-patients-barscale';
+import { SewerWaterBarScale } from '@/components/landelijk/sewer-water-barscale';
+import { NursingHomeInfectedPeopleBarScale } from '@/components/landelijk/nursing-home-infected-people-barscale';
+import { NursingHomeInfectedLocationsBarScale } from '@/components/landelijk/nursing-home-infected-locations-barscale';
+import { NursingHomeDeathsBarScale } from '@/components/landelijk/nursing-home-deaths-barscale';
 
 import GetestIcon from '@/assets/test.svg';
 import ReproIcon from '@/assets/reproductiegetal.svg';
@@ -139,7 +141,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                       title={siteText.positief_geteste_personen.titel_sidebar}
                     />
                     <span>
-                      <PostivelyTestedPeopleBarScale
+                      <PositiveTestedPeopleBarScale
                         data={data?.infected_people_delta_normalized}
                         showAxis={true}
                       />

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -4,15 +4,15 @@ import { useRouter } from 'next/router';
 
 import siteText from '@/locale/index';
 import safetyRegions from '@/data/index';
-import { WithChildren } from '@types/index';
+import { WithChildren } from '@/types/index';
 import { ISafetyRegionData } from '@/static-props/safetyregion-data';
 
 import useMediaQuery from '@/utils/useMediaQuery';
 import { getSewerWaterBarScaleData } from '@/utils/sewer-water/safety-region-sewer-water.util';
 
-import { PostivelyTestedPeopleBarScale } from '@/pages/veiligheidsregio/[code]/positief-geteste-mensen';
-import { IntakeHospitalBarScale } from '@/pages/veiligheidsregio/[code]/ziekenhuis-opnames';
-import { SewerWaterBarScale } from '@/pages/veiligheidsregio/[code]/rioolwater';
+import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
+import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
+import { SewerWaterBarScale } from '@/components/veiligheidsregio/sewer-water-barscale';
 
 import TitleWithIcon from '@/components/titleWithIcon';
 import { getLayout as getSiteLayout } from '@/components/layout';
@@ -159,7 +159,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                         }
                       />
                       <span>
-                        <PostivelyTestedPeopleBarScale
+                        <PositivelyTestedPeopleBarScale
                           data={data?.results_per_region}
                           showAxis={true}
                         />

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 
 import siteText from '@/locale/index';
 import safetyRegions from '@/data/index';
-import { WithChildren } from 'types';
+import { WithChildren } from '@types/index';
 import { ISafetyRegionData } from '@/static-props/safetyregion-data';
 
 import useMediaQuery from '@/utils/useMediaQuery';

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -2,26 +2,26 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import siteText from 'locale';
-import safetyRegions from 'data/index';
+import siteText from '@/locale/index';
+import safetyRegions from '@/data/index';
 import { WithChildren } from 'types';
-import { ISafetyRegionData } from 'static-props/safetyregion-data';
+import { ISafetyRegionData } from '@/static-props/safetyregion-data';
 
-import useMediaQuery from 'utils/useMediaQuery';
-import { getSewerWaterBarScaleData } from 'utils/sewer-water/safety-region-sewer-water.util';
+import useMediaQuery from '@/utils/useMediaQuery';
+import { getSewerWaterBarScaleData } from '@/utils/sewer-water/safety-region-sewer-water.util';
 
-import { PostivelyTestedPeopleBarScale } from 'pages/veiligheidsregio/[code]/positief-geteste-mensen';
-import { IntakeHospitalBarScale } from 'pages/veiligheidsregio/[code]/ziekenhuis-opnames';
-import { SewerWaterBarScale } from 'pages/veiligheidsregio/[code]/rioolwater';
+import { PostivelyTestedPeopleBarScale } from '@/pages/veiligheidsregio/[code]/positief-geteste-mensen';
+import { IntakeHospitalBarScale } from '@/pages/veiligheidsregio/[code]/ziekenhuis-opnames';
+import { SewerWaterBarScale } from '@/pages/veiligheidsregio/[code]/rioolwater';
 
-import TitleWithIcon from 'components/titleWithIcon';
-import { getLayout as getSiteLayout } from 'components/layout';
-import Combobox from 'components/comboBox';
+import TitleWithIcon from '@/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '@/components/layout';
+import Combobox from '@/components/comboBox';
 
-import GetestIcon from 'assets/test.svg';
-import Ziekenhuis from 'assets/ziekenhuis.svg';
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
-import Arrow from 'assets/arrow.svg';
+import GetestIcon from '@/assets/test.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import Arrow from '@/assets/arrow.svg';
 
 export default SafetyRegionLayout;
 

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -2,26 +2,26 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import siteText from '@/locale/index';
-import safetyRegions from '@/data/index';
-import { WithChildren } from '@/types/index';
-import { ISafetyRegionData } from '@/static-props/safetyregion-data';
+import siteText from '~/locale/index';
+import safetyRegions from '~/data/index';
+import { WithChildren } from '~/types/index';
+import { ISafetyRegionData } from '~/static-props/safetyregion-data';
 
-import useMediaQuery from '@/utils/useMediaQuery';
-import { getSewerWaterBarScaleData } from '@/utils/sewer-water/safety-region-sewer-water.util';
+import useMediaQuery from '~/utils/useMediaQuery';
+import { getSewerWaterBarScaleData } from '~/utils/sewer-water/safety-region-sewer-water.util';
 
-import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
-import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
-import { SewerWaterBarScale } from '@/components/veiligheidsregio/sewer-water-barscale';
+import { PositivelyTestedPeopleBarScale } from '~/components/veiligheidsregio/positive-tested-people-barscale';
+import { IntakeHospitalBarScale } from '~/components/veiligheidsregio/intake-hospital-barscale';
+import { SewerWaterBarScale } from '~/components/veiligheidsregio/sewer-water-barscale';
 
-import TitleWithIcon from '@/components/titleWithIcon';
-import { getLayout as getSiteLayout } from '@/components/layout';
-import Combobox from '@/components/comboBox';
+import TitleWithIcon from '~/components/titleWithIcon';
+import { getLayout as getSiteLayout } from '~/components/layout';
+import Combobox from '~/components/comboBox';
 
-import GetestIcon from '@/assets/test.svg';
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
-import Arrow from '@/assets/arrow.svg';
+import GetestIcon from '~/assets/test.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
+import Arrow from '~/assets/arrow.svg';
 
 export default SafetyRegionLayout;
 

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { WithChildren } from '@/types/index';
-import text from '@/locale/index';
-import { ILastGeneratedData } from '@/static-props/last-generated-data';
+import { WithChildren } from '~/types/index';
+import text from '~/locale/index';
+import { ILastGeneratedData } from '~/static-props/last-generated-data';
 import styles from './layout.module.scss';
 
-import useMediaQuery from '@/utils/useMediaQuery';
-import formatDate from '@/utils/formatDate';
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
-import getLocale from '@/utils/getLocale';
+import useMediaQuery from '~/utils/useMediaQuery';
+import formatDate from '~/utils/formatDate';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
+import getLocale from '~/utils/getLocale';
 
-import SEOHead from '@/components/seoHead';
-import MaxWidth from '@/components/maxWidth';
+import SEOHead from '~/components/seoHead';
+import MaxWidth from '~/components/maxWidth';
 
 export interface LayoutProps {
   url?: string;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 import text from '@/locale/index';
 import { ILastGeneratedData } from '@/static-props/last-generated-data';
 import styles from './layout.module.scss';

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -3,17 +3,17 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { WithChildren } from 'types';
-import text from 'locale';
-import { ILastGeneratedData } from 'static-props/last-generated-data';
+import text from '@/locale/index';
+import { ILastGeneratedData } from '@/static-props/last-generated-data';
 import styles from './layout.module.scss';
 
-import useMediaQuery from 'utils/useMediaQuery';
-import formatDate from 'utils/formatDate';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import getLocale from 'utils/getLocale';
+import useMediaQuery from '@/utils/useMediaQuery';
+import formatDate from '@/utils/formatDate';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import getLocale from '@/utils/getLocale';
 
-import SEOHead from 'components/seoHead';
-import MaxWidth from 'components/maxWidth';
+import SEOHead from '@/components/seoHead';
+import MaxWidth from '@/components/maxWidth';
 
 export interface LayoutProps {
   url?: string;

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 $language-switcher-offset: 55px;
 

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 $language-switcher-offset: 55px;
 

--- a/src/components/legenda/index.tsx
+++ b/src/components/legenda/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 export default Legenda;
 

--- a/src/components/legenda/index.tsx
+++ b/src/components/legenda/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 export default Legenda;
 

--- a/src/components/legenda/legenda.scss
+++ b/src/components/legenda/legenda.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .legenda {
   list-style: none;

--- a/src/components/legenda/legenda.scss
+++ b/src/components/legenda/legenda.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .legenda {
   list-style: none;
@@ -20,11 +20,11 @@
   }
 
   li.blue::after {
-    background: #3391CC;
+    background: #3391cc;
   }
 
   li.gray::after {
-    background: #C4C4C4;
+    background: #c4c4c4;
   }
 
   li.square::after {

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -2,15 +2,15 @@ import React, { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import styles from './lineChart.module.scss';
-import text from 'locale';
+import text from '@/locale/index';
 
 import ChartTimeControls, {
   TimeframeOption,
-} from 'components/chartTimeControls';
+} from '@/components/chartTimeControls';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
-import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
+import formatNumber from '@/utils/formatNumber';
+import formatDate from '@/utils/formatDate';
+import { getFilteredValues } from '@/components/chartTimeControls/chartTimeControlUtils';
 
 type Value = {
   date: number;

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -2,15 +2,15 @@ import React, { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import styles from './lineChart.module.scss';
-import text from '@/locale/index';
+import text from '~/locale/index';
 
 import ChartTimeControls, {
   TimeframeOption,
-} from '@/components/chartTimeControls';
+} from '~/components/chartTimeControls';
 
-import formatNumber from '@/utils/formatNumber';
-import formatDate from '@/utils/formatDate';
-import { getFilteredValues } from '@/components/chartTimeControls/chartTimeControlUtils';
+import formatNumber from '~/utils/formatNumber';
+import formatDate from '~/utils/formatDate';
+import { getFilteredValues } from '~/components/chartTimeControls/chartTimeControlUtils';
 
 type Value = {
   date: number;

--- a/src/components/lineChart/lineChart.module.scss
+++ b/src/components/lineChart/lineChart.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 $breakpoint: 1200px;
 

--- a/src/components/lineChart/lineChart.module.scss
+++ b/src/components/lineChart/lineChart.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 $breakpoint: 1200px;
 

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import Highcharts, { SeriesLineOptions } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
+import formatNumber from '@/utils/formatNumber';
+import formatDate from '@/utils/formatDate';
 
 type TranslationStrings = Record<string, string>;
 

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import Highcharts, { SeriesLineOptions } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import formatNumber from '@/utils/formatNumber';
-import formatDate from '@/utils/formatDate';
+import formatNumber from '~/utils/formatNumber';
+import formatDate from '~/utils/formatDate';
 
 type TranslationStrings = Record<string, string>;
 

--- a/src/components/loadingPlaceholder/index.tsx
+++ b/src/components/loadingPlaceholder/index.tsx
@@ -1,5 +1,5 @@
 import styles from './loadingPlaceholder.module.scss';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 export default LoadingPlaceholder;
 

--- a/src/components/loadingPlaceholder/index.tsx
+++ b/src/components/loadingPlaceholder/index.tsx
@@ -1,5 +1,5 @@
 import styles from './loadingPlaceholder.module.scss';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 export default LoadingPlaceholder;
 

--- a/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
+++ b/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .loadingPlaceholder {
   opacity: 0.05;

--- a/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
+++ b/src/components/loadingPlaceholder/loadingPlaceholder.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .loadingPlaceholder {
   opacity: 0.05;

--- a/src/components/mapChart/municipality.module.scss
+++ b/src/components/mapChart/municipality.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .container {
   padding: 0 $default-padding;

--- a/src/components/mapChart/municipality.module.scss
+++ b/src/components/mapChart/municipality.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .container {
   padding: 0 $default-padding;

--- a/src/components/mapChart/svgmap.module.scss
+++ b/src/components/mapChart/svgmap.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .scalingContainer {
   position: relative;

--- a/src/components/mapChart/svgmap.module.scss
+++ b/src/components/mapChart/svgmap.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .scalingContainer {
   position: relative;

--- a/src/components/maxWidth/index.tsx
+++ b/src/components/maxWidth/index.tsx
@@ -1,5 +1,5 @@
 import styles from './maxWidth.module.scss';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 export default MaxWidth;
 

--- a/src/components/maxWidth/index.tsx
+++ b/src/components/maxWidth/index.tsx
@@ -1,5 +1,5 @@
 import styles from './maxWidth.module.scss';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 export default MaxWidth;
 

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -1,12 +1,12 @@
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 import styles from './metadata.module.scss';
 
-import ClockIcon from '@/assets/clock.svg';
-import DatabaseIcon from '@/assets/database.svg';
+import ClockIcon from '~/assets/clock.svg';
+import DatabaseIcon from '~/assets/database.svg';
 
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
-import formatDate from '@/utils/formatDate';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
+import formatDate from '~/utils/formatDate';
 
 interface IProps {
   dataSource: {

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -1,12 +1,12 @@
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 import styles from './metadata.module.scss';
 
-import ClockIcon from 'assets/clock.svg';
-import DatabaseIcon from 'assets/database.svg';
+import ClockIcon from '@/assets/clock.svg';
+import DatabaseIcon from '@/assets/database.svg';
 
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import formatDate from 'utils/formatDate';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import formatDate from '@/utils/formatDate';
 
 interface IProps {
   dataSource: {

--- a/src/components/metadata/metadata.module.scss
+++ b/src/components/metadata/metadata.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .item {
   display: flex;

--- a/src/components/metadata/metadata.module.scss
+++ b/src/components/metadata/metadata.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .item {
   display: flex;

--- a/src/components/radioGroup/radiogroup.module.scss
+++ b/src/components/radioGroup/radiogroup.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .select-radio-group {
   background: white;

--- a/src/components/radioGroup/radiogroup.module.scss
+++ b/src/components/radioGroup/radiogroup.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .select-radio-group {
   background: white;

--- a/src/components/scalingSVG/index.tsx
+++ b/src/components/scalingSVG/index.tsx
@@ -1,6 +1,6 @@
 import styles from './scalingSVG.module.scss';
 import CSS from 'csstype';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 interface IProps {
   width: number;

--- a/src/components/scalingSVG/index.tsx
+++ b/src/components/scalingSVG/index.tsx
@@ -1,6 +1,6 @@
 import styles from './scalingSVG.module.scss';
 import CSS from 'csstype';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 interface IProps {
   width: number;

--- a/src/components/scalingSVG/scalingSVG.module.scss
+++ b/src/components/scalingSVG/scalingSVG.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .scalingSvgContainer {
   position: relative;

--- a/src/components/scalingSVG/scalingSVG.module.scss
+++ b/src/components/scalingSVG/scalingSVG.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .scalingSvgContainer {
   position: relative;

--- a/src/components/screenReaderOnly/index.tsx
+++ b/src/components/screenReaderOnly/index.tsx
@@ -1,5 +1,5 @@
 import styles from './screenReaderOnly.module.scss';
-import { WithChildren } from 'types';
+import { WithChildren } from '@types/index';
 
 export default ScreenReaderOnly;
 

--- a/src/components/screenReaderOnly/index.tsx
+++ b/src/components/screenReaderOnly/index.tsx
@@ -1,5 +1,5 @@
 import styles from './screenReaderOnly.module.scss';
-import { WithChildren } from '@types/index';
+import { WithChildren } from '@/types/index';
 
 export default ScreenReaderOnly;
 

--- a/src/components/screenReaderOnly/index.tsx
+++ b/src/components/screenReaderOnly/index.tsx
@@ -1,5 +1,5 @@
 import styles from './screenReaderOnly.module.scss';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 export default ScreenReaderOnly;
 

--- a/src/components/seoHead/index.tsx
+++ b/src/components/seoHead/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 export default SEOHead;
 

--- a/src/components/seoHead/index.tsx
+++ b/src/components/seoHead/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 export default SEOHead;
 

--- a/src/components/titleBlock/index.tsx
+++ b/src/components/titleBlock/index.tsx
@@ -1,5 +1,5 @@
 import styles from './titleBlock.module.scss';
-import { WithChildren } from 'types';
+import { WithChildren } from '@/types/index';
 
 interface IProps {
   Icon: any;

--- a/src/components/titleBlock/index.tsx
+++ b/src/components/titleBlock/index.tsx
@@ -1,5 +1,5 @@
 import styles from './titleBlock.module.scss';
-import { WithChildren } from '@/types/index';
+import { WithChildren } from '~/types/index';
 
 interface IProps {
   Icon: any;

--- a/src/components/titleBlock/titleBlock.module.scss
+++ b/src/components/titleBlock/titleBlock.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .titleRow {
   display: flex;

--- a/src/components/titleBlock/titleBlock.module.scss
+++ b/src/components/titleBlock/titleBlock.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .titleRow {
   display: flex;

--- a/src/components/titleWithIcon/titleWithIcon.module.scss
+++ b/src/components/titleWithIcon/titleWithIcon.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .titleWithIcon {
   display: flex;

--- a/src/components/titleWithIcon/titleWithIcon.module.scss
+++ b/src/components/titleWithIcon/titleWithIcon.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .titleWithIcon {
   display: flex;

--- a/src/components/veiligheidsregio/intake-hospital-barscale.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-barscale.tsx
@@ -1,6 +1,6 @@
-import BarScale from '@/components/barScale';
-import { ResultsPerRegion } from '@/types/data.d';
-import siteText from '@/locale/index';
+import BarScale from '~/components/barScale';
+import { ResultsPerRegion } from '~/types/data.d';
+import siteText from '~/locale/index';
 
 export function IntakeHospitalBarScale(props: {
   data: ResultsPerRegion | undefined;

--- a/src/components/veiligheidsregio/intake-hospital-barscale.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { ResultsPerRegion } from '~/types/data.d';
 import siteText from '~/locale/index';
 

--- a/src/components/veiligheidsregio/intake-hospital-barscale.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { ResultsPerRegion } from '@/types/data.d';
+import siteText from '@/locale/index';
+
+export function IntakeHospitalBarScale(props: {
+  data: ResultsPerRegion | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
+    siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.hospital_moving_avg_per_region}
+      id="opnames"
+      rangeKey="hospital_moving_avg_per_region"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
@@ -1,6 +1,6 @@
-import BarScale from '@/components/barScale';
-import { ResultsPerRegion } from '@/types/data.d';
-import siteText from '@/locale/index';
+import BarScale from '~/components/barScale';
+import { ResultsPerRegion } from '~/types/data.d';
+import siteText from '~/locale/index';
 
 export function PositivelyTestedPeopleBarScale(props: {
   data: ResultsPerRegion | undefined;

--- a/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
@@ -1,4 +1,4 @@
-import BarScale from '~/components/barScale';
+import { BarScale } from '~/components/barScale';
 import { ResultsPerRegion } from '~/types/data.d';
 import siteText from '~/locale/index';
 

--- a/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
@@ -1,0 +1,42 @@
+import BarScale from '@/components/barScale';
+import { ResultsPerRegion } from '@/types/data.d';
+import siteText from '@/locale/index';
+
+export function PositivelyTestedPeopleBarScale(props: {
+  data: ResultsPerRegion | undefined;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
+    siteText.veiligheidsregio_positief_geteste_personen;
+
+  return (
+    <BarScale
+      min={0}
+      max={10}
+      screenReaderText={text.barscale_screenreader_text}
+      value={data.last_value.infected_increase_per_region}
+      id="positief"
+      rangeKey="infected_daily_increase"
+      gradient={[
+        {
+          color: '#69c253',
+          value: 0,
+        },
+        {
+          color: '#D3A500',
+          value: 7,
+        },
+        {
+          color: '#f35065',
+          value: 10,
+        },
+      ]}
+      signaalwaarde={7}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/veiligheidsregio/sewer-water-barscale.tsx
+++ b/src/components/veiligheidsregio/sewer-water-barscale.tsx
@@ -1,0 +1,33 @@
+import BarScale from '@/components/barScale';
+import { SewerWaterBarScaleData } from '@/utils/sewer-water/safety-region-sewer-water.util';
+import siteText from '@/locale/index';
+
+export function SewerWaterBarScale(props: {
+  data: SewerWaterBarScaleData | null;
+  showAxis: boolean;
+}) {
+  const { data, showAxis } = props;
+
+  if (!data) return null;
+
+  const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
+    siteText.veiligheidsregio_rioolwater_metingen;
+
+  return (
+    <BarScale
+      min={0}
+      max={100}
+      screenReaderText={text.screen_reader_graph_content}
+      value={Number(data.value)}
+      id="rioolwater_metingen"
+      rangeKey="average"
+      gradient={[
+        {
+          color: '#3391CC',
+          value: 0,
+        },
+      ]}
+      showAxis={showAxis}
+    />
+  );
+}

--- a/src/components/veiligheidsregio/sewer-water-barscale.tsx
+++ b/src/components/veiligheidsregio/sewer-water-barscale.tsx
@@ -1,6 +1,6 @@
-import BarScale from '@/components/barScale';
-import { SewerWaterBarScaleData } from '@/utils/sewer-water/safety-region-sewer-water.util';
-import siteText from '@/locale/index';
+import BarScale from '~/components/barScale';
+import { SewerWaterBarScaleData } from '~/utils/sewer-water/safety-region-sewer-water.util';
+import siteText from '~/locale/index';
 
 export function SewerWaterBarScale(props: {
   data: SewerWaterBarScaleData | null;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,10 @@
-import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
+import MaxWidth from '@/components/maxWidth';
 
-import text from 'locale';
+import text from '@/locale/index';
 import styles from './over.module.scss';
 
-import getLastGeneratedData from 'static-props/last-generated-data';
+import getLastGeneratedData from '@/static-props/last-generated-data';
 
 const NotFound: FCWithLayout = () => {
   return (

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,10 @@
-import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
-import MaxWidth from '@/components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
+import MaxWidth from '~/components/maxWidth';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 import styles from './over.module.scss';
 
-import getLastGeneratedData from '@/static-props/last-generated-data';
+import getLastGeneratedData from '~/static-props/last-generated-data';
 
 const NotFound: FCWithLayout = () => {
   return (

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,9 +1,9 @@
-import { FCWithLayout, getLayoutWithMetadata } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { FCWithLayout, getLayoutWithMetadata } from '@/components/layout';
+import MaxWidth from '@/components/maxWidth';
 
-import getLastGeneratedData from 'static-props/last-generated-data';
+import getLastGeneratedData from '@/static-props/last-generated-data';
 
-import text from 'locale';
+import text from '@/locale/index';
 import styles from './error.module.scss';
 
 const ErrorPage: FCWithLayout = () => {

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,9 +1,9 @@
-import { FCWithLayout, getLayoutWithMetadata } from '@/components/layout';
-import MaxWidth from '@/components/maxWidth';
+import { FCWithLayout, getLayoutWithMetadata } from '~/components/layout';
+import MaxWidth from '~/components/maxWidth';
 
-import getLastGeneratedData from '@/static-props/last-generated-data';
+import getLastGeneratedData from '~/static-props/last-generated-data';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 import styles from './error.module.scss';
 
 const ErrorPage: FCWithLayout = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,9 @@
 import '@reach/combobox/styles.css';
 import './index.css';
-import '@/scss/style.scss';
+import '~/scss/style.scss';
 
-import '@/components/legenda/legenda.scss';
-import '@/components/comboBox/comboBox.scss';
+import '~/components/legenda/legenda.scss';
+import '~/components/comboBox/comboBox.scss';
 
 // Import Preact DevTools in development
 // if (process.env.NODE_ENV === 'development') {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,9 @@
 import '@reach/combobox/styles.css';
 import './index.css';
-import 'scss/style.scss';
+import '@/scss/style.scss';
 
-import 'components/legenda/legenda.scss';
-import 'components/comboBox/comboBox.scss';
+import '@/components/legenda/legenda.scss';
+import '@/components/comboBox/comboBox.scss';
 
 // Import Preact DevTools in development
 // if (process.env.NODE_ENV === 'development') {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,7 @@ import Document, {
   NextScript,
   DocumentContext,
 } from 'next/document';
-import getLocale from '@/utils/getLocale';
+import getLocale from '~/utils/getLocale';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<any> {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,7 @@ import Document, {
   NextScript,
   DocumentContext,
 } from 'next/document';
-import getLocale from 'utils/getLocale';
+import getLocale from '@/utils/getLocale';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<any> {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,9 +1,9 @@
-import { FCWithLayout, getLayoutWithMetadata } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { FCWithLayout, getLayoutWithMetadata } from '@/components/layout';
+import MaxWidth from '@/components/maxWidth';
 
-import getLastGeneratedData from 'static-props/last-generated-data';
+import getLastGeneratedData from '@/static-props/last-generated-data';
 
-import text from 'locale';
+import text from '@/locale/index';
 import styles from './error.module.scss';
 
 const ErrorPage: FCWithLayout = () => {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,9 +1,9 @@
-import { FCWithLayout, getLayoutWithMetadata } from '@/components/layout';
-import MaxWidth from '@/components/maxWidth';
+import { FCWithLayout, getLayoutWithMetadata } from '~/components/layout';
+import MaxWidth from '~/components/maxWidth';
 
-import getLastGeneratedData from '@/static-props/last-generated-data';
+import getLastGeneratedData from '~/static-props/last-generated-data';
 
-import text from '@/locale/index';
+import text from '~/locale/index';
 import styles from './error.module.scss';
 
 const ErrorPage: FCWithLayout = () => {

--- a/src/pages/gemeente/[code]/index.tsx
+++ b/src/pages/gemeente/[code]/index.tsx
@@ -1,10 +1,10 @@
-import { FCWithLayout } from '@/components/layout';
-import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from '@/static-props/municipality-data';
+} from '~/static-props/municipality-data';
 
 const Municipality: FCWithLayout<IMunicipalityData> = () => {
   return null;

--- a/src/pages/gemeente/[code]/index.tsx
+++ b/src/pages/gemeente/[code]/index.tsx
@@ -1,10 +1,10 @@
-import { FCWithLayout } from 'components/layout';
-import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import { FCWithLayout } from '@/components/layout';
+import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from 'static-props/municipality-data';
+} from '@/static-props/municipality-data';
 
 const Municipality: FCWithLayout<IMunicipalityData> = () => {
   return null;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,25 +1,25 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { LineChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
-import { PositiveTestedPeople } from 'types/data.d';
+import Getest from '@/assets/test.svg';
+import formatDecimal from '@/utils/formatNumber';
+import { PositiveTestedPeople } from '@/types/data.d';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from 'static-props/municipality-data';
-import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
+} from '@/static-props/municipality-data';
+import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
 
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,4 +1,3 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 
@@ -6,6 +5,8 @@ import siteText from '@/locale/index';
 
 import { LineChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+
+import { PositivelyTestedPeopleBarScale } from '@/components/gemeente/positively-tested-people-barscale';
 
 import Getest from '@/assets/test.svg';
 import formatDecimal from '@/utils/formatNumber';
@@ -23,33 +24,6 @@ import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLe
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
-
-export function PostivelyTestedPeopleBarScale(props: {
-  data: PositiveTestedPeople | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={10}
-      screenReaderText={text.screen_reader_graph_content}
-      value={data.last_value.infected_daily_increase}
-      id="positief"
-      rangeKey="infected_daily_increase"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
   const { data } = props;
@@ -78,7 +52,7 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
           <h3>{text.barscale_titel}</h3>
 
           {positivelyTestedPeople && (
-            <PostivelyTestedPeopleBarScale
+            <PositivelyTestedPeopleBarScale
               data={positivelyTestedPeople}
               showAxis={true}
             />

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,26 +1,26 @@
-import { FCWithLayout } from '@/components/layout';
-import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { LineChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
+import { LineChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
 
-import { PositivelyTestedPeopleBarScale } from '@/components/gemeente/positively-tested-people-barscale';
+import { PositivelyTestedPeopleBarScale } from '~/components/gemeente/positively-tested-people-barscale';
 
-import Getest from '@/assets/test.svg';
-import formatDecimal from '@/utils/formatNumber';
-import { PositiveTestedPeople } from '@/types/data.d';
+import Getest from '~/assets/test.svg';
+import formatDecimal from '~/utils/formatNumber';
+import { PositiveTestedPeople } from '~/types/data.d';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from '@/static-props/municipality-data';
-import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
+} from '~/static-props/municipality-data';
+import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
 
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import positiveTestedPeopleTooltip from '~/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -1,27 +1,27 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
+import { ContentHeader } from '@/components/layout/Content';
 
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
+import RegionalSewerWaterLineChart from '@/components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from 'components/barChart';
+import BarChart from '@/components/barChart';
 import {
   SewerWaterBarScaleData,
   getSewerWaterBarScaleData,
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
-} from 'utils/sewer-water/municipality-sewer-water.util';
+} from '@/utils/sewer-water/municipality-sewer-water.util';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from 'static-props/municipality-data';
-import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
+} from '@/static-props/municipality-data';
+import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -1,7 +1,8 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 import { ContentHeader } from '@/components/layout/Content';
+
+import { SewerWaterBarScale } from '@/components/gemeente/sewer-water-barscale';
 
 import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
 
@@ -11,7 +12,6 @@ import RegionalSewerWaterLineChart from '@/components/lineChart/regionalSewerWat
 import { useMemo } from 'react';
 import BarChart from '@/components/barChart';
 import {
-  SewerWaterBarScaleData,
   getSewerWaterBarScaleData,
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
@@ -25,34 +25,6 @@ import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;
-
-export function SewerWaterBarScale(props: {
-  data: SewerWaterBarScaleData | null;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (data === null)
-    return <p>{siteText.no_data_for_this_municipality.text}</p>;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      screenReaderText={text.screen_reader_graph_content}
-      value={Number(data.value)}
-      id="rioolwater_metingen"
-      rangeKey="average"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
   const { data } = props;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -1,27 +1,27 @@
-import { FCWithLayout } from '@/components/layout';
-import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
-import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
+import { ContentHeader } from '~/components/layout/Content';
 
-import { SewerWaterBarScale } from '@/components/gemeente/sewer-water-barscale';
+import { SewerWaterBarScale } from '~/components/gemeente/sewer-water-barscale';
 
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import RegionalSewerWaterLineChart from '@/components/lineChart/regionalSewerWaterLineChart';
+import RegionalSewerWaterLineChart from '~/components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from '@/components/barChart';
+import BarChart from '~/components/barChart';
 import {
   getSewerWaterBarScaleData,
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
-} from '@/utils/sewer-water/municipality-sewer-water.util';
+} from '~/utils/sewer-water/municipality-sewer-water.util';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from '@/static-props/municipality-data';
-import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
+} from '~/static-props/municipality-data';
+import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,28 +1,28 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Ziekenhuis from 'assets/ziekenhuis.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { HospitalAdmissions } from 'types/data.d';
-import { LineChart } from 'components/charts/index';
+import { HospitalAdmissions } from '@/types/data.d';
+import { LineChart } from '@/components/charts/index';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from 'static-props/municipality-data';
+} from '@/static-props/municipality-data';
 
-import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
+import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
 
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import hospitalAdmissionsTooltip from '@/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
 
 export function IntakeHospitalBarScale(props: {
   data: HospitalAdmissions | undefined;

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,7 +1,7 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 import { ContentHeader } from '@/components/layout/Content';
+import { IntakeHospitalBarScale } from '@/components/gemeente/intake-hospital-barscale';
 
 import Ziekenhuis from '@/assets/ziekenhuis.svg';
 
@@ -23,33 +23,6 @@ const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
 import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
 import hospitalAdmissionsTooltip from '@/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
 import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-
-export function IntakeHospitalBarScale(props: {
-  data: HospitalAdmissions | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      screenReaderText={text.screen_reader_graph_content}
-      value={data.last_value.moving_average_hospital}
-      id="opnames"
-      rangeKey="moving_average_hospital"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
   const { data } = props;

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,28 +1,28 @@
-import { FCWithLayout } from '@/components/layout';
-import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
-import { ContentHeader } from '@/components/layout/Content';
-import { IntakeHospitalBarScale } from '@/components/gemeente/intake-hospital-barscale';
+import { FCWithLayout } from '~/components/layout';
+import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
+import { ContentHeader } from '~/components/layout/Content';
+import { IntakeHospitalBarScale } from '~/components/gemeente/intake-hospital-barscale';
 
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { HospitalAdmissions } from '@/types/data.d';
-import { LineChart } from '@/components/charts/index';
+import { HospitalAdmissions } from '~/types/data.d';
+import { LineChart } from '~/components/charts/index';
 import {
   getMunicipalityData,
   getMunicipalityPaths,
   IMunicipalityData,
-} from '@/static-props/municipality-data';
+} from '~/static-props/municipality-data';
 
-import { getLocalTitleForMuncipality } from '@/utils/getLocalTitleForCode';
+import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
 
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import hospitalAdmissionsTooltip from '@/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import hospitalAdmissionsTooltip from '~/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
 
 const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
   const { data } = props;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,16 +1,16 @@
-import { FCWithLayout } from 'components/layout';
-import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
+import { FCWithLayout } from '@/components/layout';
+import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
 import { NextRouter, useRouter } from 'next/router';
 
-import getLastGeneratedData from 'static-props/last-generated-data';
+import getLastGeneratedData from '@/static-props/last-generated-data';
 
-import text from 'locale';
-import styles from 'components/chloropleth/chloropleth.module.scss';
+import text from '@/locale/index';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
 
 import { ReactNode } from 'react';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import { MunicipalityProperties } from 'components/chloropleth/shared';
-import useMediaQuery from 'utils/useMediaQuery';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import { MunicipalityProperties } from '@/components/chloropleth/shared';
+import useMediaQuery from '@/utils/useMediaQuery';
 
 const tooltipContent = (router: NextRouter) => {
   return (context: MunicipalityProperties): ReactNode => {

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,16 +1,16 @@
-import { FCWithLayout } from '@/components/layout';
-import { getMunicipalityLayout } from '@/components/layout/MunicipalityLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
 import { NextRouter, useRouter } from 'next/router';
 
-import getLastGeneratedData from '@/static-props/last-generated-data';
+import getLastGeneratedData from '~/static-props/last-generated-data';
 
-import text from '@/locale/index';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
+import text from '~/locale/index';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
 
 import { ReactNode } from 'react';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import { MunicipalityProperties } from '@/components/chloropleth/shared';
-import useMediaQuery from '@/utils/useMediaQuery';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import { MunicipalityProperties } from '~/components/chloropleth/shared';
+import useMediaQuery from '~/utils/useMediaQuery';
 
 const tooltipContent = (router: NextRouter) => {
   return (context: MunicipalityProperties): ReactNode => {

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -1,4 +1,4 @@
-@import 'scss/variables.scss';
+@import '@/scss/variables.scss';
 
 .notification {
   background: white;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -1,4 +1,4 @@
-@import '@/scss/variables.scss';
+@import '~/scss/variables.scss';
 
 .notification {
   background: white;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,34 +1,34 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import Notification from '@/assets/notification.svg';
-import ExternalLink from '@/assets/external-link.svg';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import Notification from '~/assets/notification.svg';
+import ExternalLink from '~/assets/external-link.svg';
 
 import path from 'path';
 import fs from 'fs';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { INationalData } from '@/static-props/nl-data';
+import { INationalData } from '~/static-props/nl-data';
 
 import styles from './index.module.scss';
 
-import TitleWithIcon from '@/components/titleWithIcon';
-import ChartRegionControls from '@/components/chartRegionControls';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from '@/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import TitleWithIcon from '~/components/titleWithIcon';
+import ChartRegionControls from '~/components/chartRegionControls';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '~/components/chloropleth/SafetyRegionChloropleth';
+import positiveTestedPeopleTooltip from '~/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import positiveTestedPeopleTooltipRegion from '~/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
 import { useState } from 'react';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '~/components/chloropleth/legenda/SafetyRegionLegenda';
 import Link from 'next/link';
 import { EscalationMapLegenda } from './veiligheidsregio';
-import useMediaQuery from '@/utils/useMediaQuery';
+import useMediaQuery from '~/utils/useMediaQuery';
 import { useRouter } from 'next/router';
-import { escalationTooltip } from '@/components/chloropleth/tooltips/region/escalationTooltip';
-import MDToHTMLString from '@/utils/MDToHTMLString';
-import { National } from '@/types/data';
-import { MunicipalityProperties } from '@/components/chloropleth/shared';
+import { escalationTooltip } from '~/components/chloropleth/tooltips/region/escalationTooltip';
+import MDToHTMLString from '~/utils/MDToHTMLString';
+import { National } from '~/types/data';
+import { MunicipalityProperties } from '~/components/chloropleth/shared';
 
 const Home: FCWithLayout<INationalData> = (props) => {
   const { text } = props;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,34 +1,34 @@
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import Notification from 'assets/notification.svg';
-import ExternalLink from 'assets/external-link.svg';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import Notification from '@/assets/notification.svg';
+import ExternalLink from '@/assets/external-link.svg';
 
 import path from 'path';
 import fs from 'fs';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { INationalData } from 'static-props/nl-data';
+import { INationalData } from '@/static-props/nl-data';
 
 import styles from './index.module.scss';
 
-import TitleWithIcon from 'components/titleWithIcon';
-import ChartRegionControls from 'components/chartRegionControls';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import TitleWithIcon from '@/components/titleWithIcon';
+import ChartRegionControls from '@/components/chartRegionControls';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
+import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import positiveTestedPeopleTooltipRegion from '@/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
 import { useState } from 'react';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
 import Link from 'next/link';
 import { EscalationMapLegenda } from './veiligheidsregio';
-import useMediaQuery from 'utils/useMediaQuery';
+import useMediaQuery from '@/utils/useMediaQuery';
 import { useRouter } from 'next/router';
-import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
-import MDToHTMLString from 'utils/MDToHTMLString';
-import { National } from 'types/data';
-import { MunicipalityProperties } from 'components/chloropleth/shared';
+import { escalationTooltip } from '@/components/chloropleth/tooltips/region/escalationTooltip';
+import MDToHTMLString from '@/utils/MDToHTMLString';
+import { National } from '@/types/data';
+import { MunicipalityProperties } from '@/components/chloropleth/shared';
 
 const Home: FCWithLayout<INationalData> = (props) => {
   const { text } = props;

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,10 +1,11 @@
 import Link from 'next/link';
 
-import BarScale from '@/components/barScale';
 import Legenda from '@/components/legenda';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { AreaChart } from '@/components/charts/index';
+
+import { InfectiousPeopleBarScale } from '@/components/landelijk/infectious-people-barscale';
 
 import Ziektegolf from '@/assets/ziektegolf.svg';
 
@@ -21,33 +22,6 @@ import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.besmettelijke_personen =
   siteText.besmettelijke_personen;
-
-export function InfectiousPeopleBarScale(props: {
-  data: InfectiousPeopleCountNormalized | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={80}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.infectious_avg_normalized}
-      id="besmettelijk"
-      rangeKey="infectious_normalized_high"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
   const { data } = props;

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,23 +1,23 @@
 import Link from 'next/link';
 
-import BarScale from 'components/barScale';
-import Legenda from 'components/legenda';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { AreaChart } from 'components/charts/index';
+import BarScale from '@/components/barScale';
+import Legenda from '@/components/legenda';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { AreaChart } from '@/components/charts/index';
 
-import Ziektegolf from 'assets/ziektegolf.svg';
+import Ziektegolf from '@/assets/ziektegolf.svg';
 
-import formatNumber from 'utils/formatNumber';
+import formatNumber from '@/utils/formatNumber';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 import {
   InfectiousPeopleCount,
   InfectiousPeopleCountNormalized,
-} from 'types/data.d';
-import { ContentHeader } from 'components/layout/Content';
-import getNlData, { INationalData } from 'static-props/nl-data';
+} from '@/types/data.d';
+import { ContentHeader } from '@/components/layout/Content';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.besmettelijke_personen =
   siteText.besmettelijke_personen;

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,24 +1,24 @@
 import Link from 'next/link';
 
-import Legenda from '@/components/legenda';
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { AreaChart } from '@/components/charts/index';
+import Legenda from '~/components/legenda';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { AreaChart } from '~/components/charts/index';
 
-import { InfectiousPeopleBarScale } from '@/components/landelijk/infectious-people-barscale';
+import { InfectiousPeopleBarScale } from '~/components/landelijk/infectious-people-barscale';
 
-import Ziektegolf from '@/assets/ziektegolf.svg';
+import Ziektegolf from '~/assets/ziektegolf.svg';
 
-import formatNumber from '@/utils/formatNumber';
+import formatNumber from '~/utils/formatNumber';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 import {
   InfectiousPeopleCount,
   InfectiousPeopleCountNormalized,
-} from '@/types/data.d';
-import { ContentHeader } from '@/components/layout/Content';
-import getNlData, { INationalData } from '@/static-props/nl-data';
+} from '~/types/data.d';
+import { ContentHeader } from '~/components/layout/Content';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.besmettelijke_personen =
   siteText.besmettelijke_personen;

--- a/src/pages/landelijk/index.tsx
+++ b/src/pages/landelijk/index.tsx
@@ -1,7 +1,7 @@
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const National: FCWithLayout<INationalData> = () => {
   return null;

--- a/src/pages/landelijk/index.tsx
+++ b/src/pages/landelijk/index.tsx
@@ -1,7 +1,7 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const National: FCWithLayout<INationalData> = () => {
   return null;

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,16 +1,16 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Arts from 'assets/arts.svg';
+import Arts from '@/assets/arts.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { IntakeIntensivecareMa } from 'types/data.d';
+import { IntakeIntensivecareMa } from '@/types/data.d';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
 

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,16 +1,16 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
-import { IntakeIntensiveCareBarscale } from '@/components/landelijk/intake-intensive-care-barscale';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import { IntakeIntensiveCareBarscale } from '~/components/landelijk/intake-intensive-care-barscale';
 
-import Arts from '@/assets/arts.svg';
+import Arts from '~/assets/arts.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { IntakeIntensivecareMa } from '@/types/data.d';
+import { IntakeIntensivecareMa } from '~/types/data.d';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
 

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+import { IntakeIntensiveCareBarscale } from '@/components/landelijk/intake-intensive-care-barscale';
 
 import Arts from '@/assets/arts.svg';
 
@@ -13,42 +13,6 @@ import { IntakeIntensivecareMa } from '@/types/data.d';
 import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
-
-export function IntakeIntensiveCareBarscale(props: {
-  data: IntakeIntensivecareMa | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={30}
-      gradient={[
-        {
-          color: '#69c253',
-          value: 0,
-        },
-        {
-          color: '#D3A500',
-          value: 10,
-        },
-        {
-          color: '#f35065',
-          value: 20,
-        },
-      ]}
-      rangeKey="moving_average_ic"
-      screenReaderText={text.barscale_screenreader_text}
-      signaalwaarde={10}
-      value={data.last_value.moving_average_ic}
-      id="ic"
-      showAxis={showAxis}
-    />
-  );
-}
 
 const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart, BarChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
 import ChartRegionControls from '@/components/chartRegionControls';
+
+import { PositiveTestedPeopleBarScale } from '@/components/landelijk/positive-tested-people-barscale';
 
 import Getest from '@/assets/test.svg';
 import formatDecimal from '@/utils/formatNumber';
@@ -28,42 +29,6 @@ import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLe
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;
-
-export function PostivelyTestedPeopleBarScale(props: {
-  data: InfectedPeopleDeltaNormalized | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={10}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.infected_daily_increase}
-      id="positief"
-      rangeKey="infected_daily_increase"
-      gradient={[
-        {
-          color: '#69c253',
-          value: 0,
-        },
-        {
-          color: '#D3A500',
-          value: 7,
-        },
-        {
-          color: '#f35065',
-          value: 10,
-        },
-      ]}
-      signaalwaarde={7}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
   const { data } = props;
@@ -103,7 +68,7 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           <h3>{text.barscale_titel}</h3>
 
           {delta && (
-            <PostivelyTestedPeopleBarScale data={delta} showAxis={true} />
+            <PositiveTestedPeopleBarScale data={delta} showAxis={true} />
           )}
           <p>{text.barscale_toelichting}</p>
         </article>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,31 +1,31 @@
 import { useState } from 'react';
 
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart, BarChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
-import ChartRegionControls from '@/components/chartRegionControls';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart, BarChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import ChartRegionControls from '~/components/chartRegionControls';
 
-import { PositiveTestedPeopleBarScale } from '@/components/landelijk/positive-tested-people-barscale';
+import { PositiveTestedPeopleBarScale } from '~/components/landelijk/positive-tested-people-barscale';
 
-import Getest from '@/assets/test.svg';
-import formatDecimal from '@/utils/formatNumber';
+import Getest from '~/assets/test.svg';
+import formatDecimal from '~/utils/formatNumber';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 import {
   InfectedPeopleDeltaNormalized,
   InfectedPeopleTotal,
   IntakeShareAgeGroups,
-} from '@/types/data.d';
+} from '~/types/data.d';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from '@/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
+import getNlData, { INationalData } from '~/static-props/nl-data';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '~/components/chloropleth/SafetyRegionChloropleth';
+import positiveTestedPeopleTooltip from '~/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import positiveTestedPeopleTooltipRegion from '~/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '~/components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,30 +1,30 @@
 import { useState } from 'react';
 
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart, BarChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
-import ChartRegionControls from 'components/chartRegionControls';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart, BarChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
+import ChartRegionControls from '@/components/chartRegionControls';
 
-import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
+import Getest from '@/assets/test.svg';
+import formatDecimal from '@/utils/formatNumber';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 import {
   InfectedPeopleDeltaNormalized,
   InfectedPeopleTotal,
   IntakeShareAgeGroups,
-} from 'types/data.d';
+} from '@/types/data.d';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import getNlData, { INationalData } from '@/static-props/nl-data';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
+import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import positiveTestedPeopleTooltipRegion from '@/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -1,17 +1,17 @@
-import BarScale from 'components/barScale';
-import Legenda from 'components/legenda';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { AreaChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import Legenda from '@/components/legenda';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { AreaChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Repro from 'assets/reproductiegetal.svg';
+import Repro from '@/assets/reproductiegetal.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { ReproductionIndex as ReproductionIndexData } from 'types/data.d';
+import { ReproductionIndex as ReproductionIndexData } from '@/types/data.d';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
 

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -1,17 +1,17 @@
-import Legenda from '@/components/legenda';
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { AreaChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
-import { ReproductionIndexBarScale } from '@/components/landelijk/reproduction-index-barscale';
+import Legenda from '~/components/legenda';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { AreaChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import { ReproductionIndexBarScale } from '~/components/landelijk/reproduction-index-barscale';
 
-import Repro from '@/assets/reproductiegetal.svg';
+import Repro from '~/assets/reproductiegetal.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { ReproductionIndex as ReproductionIndexData } from '@/types/data.d';
+import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
 

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -1,9 +1,9 @@
-import BarScale from '@/components/barScale';
 import Legenda from '@/components/legenda';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { AreaChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+import { ReproductionIndexBarScale } from '@/components/landelijk/reproduction-index-barscale';
 
 import Repro from '@/assets/reproductiegetal.svg';
 
@@ -14,47 +14,6 @@ import { ReproductionIndex as ReproductionIndexData } from '@/types/data.d';
 import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
-
-export function ReproductionIndexBarScale(props: {
-  data: ReproductionIndexData | undefined;
-  lastKnown: ReproductionIndexData | undefined;
-  showAxis: boolean;
-}) {
-  const { data, lastKnown, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={2}
-      screenReaderText={text.barscale_screenreader_text}
-      signaalwaarde={1}
-      value={lastKnown?.last_value?.reproduction_index_avg}
-      id="repro"
-      rangeKey="reproduction_index_avg"
-      gradient={[
-        {
-          color: '#69c253',
-          value: 0,
-        },
-        {
-          color: '#69c253',
-          value: 1,
-        },
-        {
-          color: '#D3A500',
-          value: 1.0104,
-        },
-        {
-          color: '#f35065',
-          value: 1.125,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,16 +1,16 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { RioolwaterMetingen } from 'types/data.d';
+import { RioolwaterMetingen } from '@/types/data.d';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
 

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,17 +1,17 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
 
-import { SewerWaterBarScale } from '@/components/landelijk/sewer-water-barscale';
+import { SewerWaterBarScale } from '~/components/landelijk/sewer-water-barscale';
 
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { RioolwaterMetingen } from '@/types/data.d';
+import { RioolwaterMetingen } from '~/types/data.d';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
 

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,8 +1,9 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+
+import { SewerWaterBarScale } from '@/components/landelijk/sewer-water-barscale';
 
 import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
 
@@ -13,33 +14,6 @@ import { RioolwaterMetingen } from '@/types/data.d';
 import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
-
-export function SewerWaterBarScale(props: {
-  data: RioolwaterMetingen | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      screenReaderText={text.barscale_screenreader_text}
-      value={Number(data.last_value.average)}
-      id="rioolwater_metingen"
-      rangeKey="average"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const SewerWater: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,18 +1,18 @@
-import { ContentHeader } from '@/components/layout/Content';
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
 
-import { SuspectedPatientsBarScale } from '@/components/landelijk/suspected-patients-barscale';
+import { SuspectedPatientsBarScale } from '~/components/landelijk/suspected-patients-barscale';
 
-import Arts from '@/assets/arts.svg';
+import Arts from '~/assets/arts.svg';
 
-import formatNumber from '@/utils/formatNumber';
+import formatNumber from '~/utils/formatNumber';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { VerdenkingenHuisartsen } from '@/types/data.d';
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import { VerdenkingenHuisartsen } from '~/types/data.d';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.verdenkingen_huisartsen =
   siteText.verdenkingen_huisartsen;

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,17 +1,17 @@
-import BarScale from 'components/barScale';
-import { ContentHeader } from 'components/layout/Content';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
+import BarScale from '@/components/barScale';
+import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
 
-import Arts from 'assets/arts.svg';
+import Arts from '@/assets/arts.svg';
 
-import formatNumber from 'utils/formatNumber';
+import formatNumber from '@/utils/formatNumber';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { VerdenkingenHuisartsen } from 'types/data.d';
-import getNlData, { INationalData } from 'static-props/nl-data';
+import { VerdenkingenHuisartsen } from '@/types/data.d';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verdenkingen_huisartsen =
   siteText.verdenkingen_huisartsen;

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,8 +1,9 @@
-import BarScale from '@/components/barScale';
 import { ContentHeader } from '@/components/layout/Content';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart } from '@/components/charts/index';
+
+import { SuspectedPatientsBarScale } from '@/components/landelijk/suspected-patients-barscale';
 
 import Arts from '@/assets/arts.svg';
 
@@ -15,33 +16,6 @@ import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verdenkingen_huisartsen =
   siteText.verdenkingen_huisartsen;
-
-export function SuspectedPatientsBarScale(props: {
-  data: VerdenkingenHuisartsen | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={140}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.incidentie as number | null}
-      id="verdenkingen_huisartsen"
-      rangeKey="incidentie"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -1,21 +1,21 @@
-import BarScale from 'components/barScale';
-import { ContentHeader } from 'components/layout/Content';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
+import BarScale from '@/components/barScale';
+import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
 
-import Locatie from 'assets/locaties.svg';
+import Locatie from '@/assets/locaties.svg';
 
-import formatNumber from 'utils/formatNumber';
+import formatNumber from '@/utils/formatNumber';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 import {
   TotalNewlyReportedLocations,
   TotalReportedLocations,
-} from 'types/data.d';
+} from '@/types/data.d';
 
-import getNlData, { INationalData } from 'static-props/nl-data';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -1,21 +1,21 @@
-import BarScale from '@/components/barScale';
-import { ContentHeader } from '@/components/layout/Content';
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
+import BarScale from '~/components/barScale';
+import { ContentHeader } from '~/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
 
-import Locatie from '@/assets/locaties.svg';
+import Locatie from '~/assets/locaties.svg';
 
-import formatNumber from '@/utils/formatNumber';
+import formatNumber from '~/utils/formatNumber';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 import {
   TotalNewlyReportedLocations,
   TotalReportedLocations,
-} from '@/types/data.d';
+} from '~/types/data.d';
 
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -20,33 +20,6 @@ import getNlData, { INationalData } from '@/static-props/nl-data';
 const text: typeof siteText.verpleeghuis_besmette_locaties =
   siteText.verpleeghuis_besmette_locaties;
 
-export function NursingHomeInfectedLocationsBarScale(props: {
-  data: TotalReportedLocations | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={30}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.total_reported_locations}
-      id="besmette_locaties_verpleeghuis"
-      rangeKey="total_reported_locations"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
-
 const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;
 

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -1,15 +1,15 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { ContentHeader } from 'components/layout/Content';
-import { LineChart } from 'components/charts/index';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { ContentHeader } from '@/components/layout/Content';
+import { LineChart } from '@/components/charts/index';
 
-import Getest from 'assets/test.svg';
+import Getest from '@/assets/test.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { InfectedPeopleNurseryCountDaily } from 'types/data.d';
-import getNlData, { INationalData } from 'static-props/nl-data';
+import { InfectedPeopleNurseryCountDaily } from '@/types/data.d';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_positief_geteste_personen =
   siteText.verpleeghuis_positief_geteste_personen;

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -1,16 +1,16 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { ContentHeader } from '@/components/layout/Content';
-import { LineChart } from '@/components/charts/index';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { ContentHeader } from '~/components/layout/Content';
+import { LineChart } from '~/components/charts/index';
 
-import { NursingHomeInfectedPeopleBarScale } from '@/components/landelijk/nursing-home-infected-people-barscale';
+import { NursingHomeInfectedPeopleBarScale } from '~/components/landelijk/nursing-home-infected-people-barscale';
 
-import Getest from '@/assets/test.svg';
+import Getest from '~/assets/test.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { InfectedPeopleNurseryCountDaily } from '@/types/data.d';
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import { InfectedPeopleNurseryCountDaily } from '~/types/data.d';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_positief_geteste_personen =
   siteText.verpleeghuis_positief_geteste_personen;

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -1,8 +1,9 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { ContentHeader } from '@/components/layout/Content';
 import { LineChart } from '@/components/charts/index';
+
+import { NursingHomeInfectedPeopleBarScale } from '@/components/landelijk/nursing-home-infected-people-barscale';
 
 import Getest from '@/assets/test.svg';
 
@@ -13,33 +14,6 @@ import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_positief_geteste_personen =
   siteText.verpleeghuis_positief_geteste_personen;
-
-export function NursingHomeInfectedPeopleBarScale(props: {
-  data: InfectedPeopleNurseryCountDaily | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.infected_nursery_daily}
-      id="positief_verpleeghuis"
-      rangeKey="infected_nursery_daily"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -1,16 +1,16 @@
-import { ContentHeader } from '@/components/layout/Content';
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
 
-import { NursingHomeDeathsBarScale } from '@/components/landelijk/nursing-home-deaths-barscale';
+import { NursingHomeDeathsBarScale } from '~/components/landelijk/nursing-home-deaths-barscale';
 
-import CoronaVirus from '@/assets/coronavirus.svg';
+import CoronaVirus from '~/assets/coronavirus.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { DeceasedPeopleNurseryCountDaily } from '@/types/data.d';
-import getNlData, { INationalData } from '@/static-props/nl-data';
+import { DeceasedPeopleNurseryCountDaily } from '~/types/data.d';
+import getNlData, { INationalData } from '~/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_oversterfte =
   siteText.verpleeghuis_oversterfte;

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -1,15 +1,15 @@
-import BarScale from 'components/barScale';
-import { ContentHeader } from 'components/layout/Content';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
+import BarScale from '@/components/barScale';
+import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
 
-import CoronaVirus from 'assets/coronavirus.svg';
+import CoronaVirus from '@/assets/coronavirus.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { DeceasedPeopleNurseryCountDaily } from 'types/data.d';
-import getNlData, { INationalData } from 'static-props/nl-data';
+import { DeceasedPeopleNurseryCountDaily } from '@/types/data.d';
+import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_oversterfte =
   siteText.verpleeghuis_oversterfte;

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -1,8 +1,9 @@
-import BarScale from '@/components/barScale';
 import { ContentHeader } from '@/components/layout/Content';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart } from '@/components/charts/index';
+
+import { NursingHomeDeathsBarScale } from '@/components/landelijk/nursing-home-deaths-barscale';
 
 import CoronaVirus from '@/assets/coronavirus.svg';
 
@@ -13,33 +14,6 @@ import getNlData, { INationalData } from '@/static-props/nl-data';
 
 const text: typeof siteText.verpleeghuis_oversterfte =
   siteText.verpleeghuis_oversterfte;
-
-export function NursingHomeDeathsBarScale(props: {
-  data: DeceasedPeopleNurseryCountDaily | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={50}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.deceased_nursery_daily}
-      id="over"
-      rangeKey="deceased_nursery_daily"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,8 +1,9 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getNationalLayout } from '@/components/layout/NationalLayout';
 import { LineChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+
+import { IntakeHospitalBarScale } from '@/components/landelijk/intake-hospital-barscale';
 
 import Ziekenhuis from '@/assets/ziekenhuis.svg';
 
@@ -44,42 +45,6 @@ const tooltipRegionContent = (context: any): ReactNode => {
     )
   );
 };
-
-export function IntakeHospitalBarScale(props: {
-  data: IntakeHospitalMa | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      signaalwaarde={40}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.moving_average_hospital}
-      id="opnames"
-      rangeKey="moving_average_hospital"
-      gradient={[
-        {
-          color: '#69c253',
-          value: 0,
-        },
-        {
-          color: '#D3A500',
-          value: 40,
-        },
-        {
-          color: '#f35065',
-          value: 90,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const IntakeHospital: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,23 +1,23 @@
-import { FCWithLayout } from '@/components/layout';
-import { getNationalLayout } from '@/components/layout/NationalLayout';
-import { LineChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { LineChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
 
-import { IntakeHospitalBarScale } from '@/components/landelijk/intake-hospital-barscale';
+import { IntakeHospitalBarScale } from '~/components/landelijk/intake-hospital-barscale';
 
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
 
-import siteText from '@/locale/index';
-import styles from '@/components/chloropleth/chloropleth.module.scss';
+import siteText from '~/locale/index';
+import styles from '~/components/chloropleth/chloropleth.module.scss';
 
-import { IntakeHospitalMa } from '@/types/data.d';
+import { IntakeHospitalMa } from '~/types/data.d';
 import { ReactNode, useState } from 'react';
-import getNlData, { INationalData } from '@/static-props/nl-data';
-import ChartRegionControls from '@/components/chartRegionControls';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
+import getNlData, { INationalData } from '~/static-props/nl-data';
+import ChartRegionControls from '~/components/chartRegionControls';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '~/components/chloropleth/SafetyRegionChloropleth';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '~/components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,22 +1,22 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getNationalLayout } from 'components/layout/NationalLayout';
-import { LineChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getNationalLayout } from '@/components/layout/NationalLayout';
+import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Ziekenhuis from 'assets/ziekenhuis.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
 
-import siteText from 'locale';
-import styles from 'components/chloropleth/chloropleth.module.scss';
+import siteText from '@/locale/index';
+import styles from '@/components/chloropleth/chloropleth.module.scss';
 
-import { IntakeHospitalMa } from 'types/data.d';
+import { IntakeHospitalMa } from '@/types/data.d';
 import { ReactNode, useState } from 'react';
-import getNlData, { INationalData } from 'static-props/nl-data';
-import ChartRegionControls from 'components/chartRegionControls';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import getNlData, { INationalData } from '@/static-props/nl-data';
+import ChartRegionControls from '@/components/chartRegionControls';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import SafetyRegionChloropleth from '@/components/chloropleth/SafetyRegionChloropleth';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import SafetyRegionLegenda from '@/components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -4,13 +4,13 @@ import fs from 'fs';
 import { Fragment } from 'react';
 import Head from 'next/head';
 
-import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
-import MaxWidth from '@/components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
+import MaxWidth from '~/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import MDToHTMLString from '@/utils/MDToHTMLString';
+import MDToHTMLString from '~/utils/MDToHTMLString';
 
 interface IVraagEnAntwoord {
   vraag: string;

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -4,13 +4,13 @@ import fs from 'fs';
 import { Fragment } from 'react';
 import Head from 'next/head';
 
-import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
+import MaxWidth from '@/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import MDToHTMLString from 'utils/MDToHTMLString';
+import MDToHTMLString from '@/utils/MDToHTMLString';
 
 interface IVraagEnAntwoord {
   vraag: string;

--- a/src/pages/veiligheidsregio/[code]/index.tsx
+++ b/src/pages/veiligheidsregio/[code]/index.tsx
@@ -1,11 +1,11 @@
-import { FCWithLayout } from '@/components/layout';
-import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from '@/static-props/safetyregion-data';
+} from '~/static-props/safetyregion-data';
 
 const SafetyRegion: FCWithLayout<ISafetyRegionData> = () => {
   return null;

--- a/src/pages/veiligheidsregio/[code]/index.tsx
+++ b/src/pages/veiligheidsregio/[code]/index.tsx
@@ -1,11 +1,11 @@
-import { FCWithLayout } from 'components/layout';
-import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
+import { FCWithLayout } from '@/components/layout';
+import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from 'static-props/safetyregion-data';
+} from '@/static-props/safetyregion-data';
 
 const SafetyRegion: FCWithLayout<ISafetyRegionData> = () => {
   return null;

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,25 +1,25 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import { LineChart } from 'components/charts/index';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
+import { LineChart } from '@/components/charts/index';
+import { ContentHeader } from '@/components/layout/Content';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
-import { ResultsPerRegion } from 'types/data.d';
+import Getest from '@/assets/test.svg';
+import formatDecimal from '@/utils/formatNumber';
+import { ResultsPerRegion } from '@/types/data.d';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from 'static-props/safetyregion-data';
-import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+} from '@/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
+import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,25 +1,25 @@
-import { FCWithLayout } from '@/components/layout';
-import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
-import { LineChart } from '@/components/charts/index';
-import { ContentHeader } from '@/components/layout/Content';
-import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
+import { FCWithLayout } from '~/components/layout';
+import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
+import { LineChart } from '~/components/charts/index';
+import { ContentHeader } from '~/components/layout/Content';
+import { PositivelyTestedPeopleBarScale } from '~/components/veiligheidsregio/positive-tested-people-barscale';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import Getest from '@/assets/test.svg';
-import formatDecimal from '@/utils/formatNumber';
-import { ResultsPerRegion } from '@/types/data.d';
+import Getest from '~/assets/test.svg';
+import formatDecimal from '~/utils/formatNumber';
+import { ResultsPerRegion } from '~/types/data.d';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from '@/static-props/safetyregion-data';
-import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
-import positiveTestedPeopleTooltip from '@/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
+} from '~/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '~/utils/getLocalTitleForCode';
+import positiveTestedPeopleTooltip from '~/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,8 +1,8 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
 import { LineChart } from '@/components/charts/index';
 import { ContentHeader } from '@/components/layout/Content';
+import { PositivelyTestedPeopleBarScale } from '@/components/veiligheidsregio/positive-tested-people-barscale';
 
 import siteText from '@/locale/index';
 
@@ -23,42 +23,6 @@ import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLoo
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
   siteText.veiligheidsregio_positief_geteste_personen;
-
-export function PostivelyTestedPeopleBarScale(props: {
-  data: ResultsPerRegion | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={10}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.infected_increase_per_region}
-      id="positief"
-      rangeKey="infected_daily_increase"
-      gradient={[
-        {
-          color: '#69c253',
-          value: 0,
-        },
-        {
-          color: '#D3A500',
-          value: 7,
-        },
-        {
-          color: '#f35065',
-          value: 10,
-        },
-      ]}
-      signaalwaarde={7}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data } = props;
@@ -89,7 +53,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           <h3>{text.barscale_titel}</h3>
 
           {resultsPerRegion && (
-            <PostivelyTestedPeopleBarScale
+            <PositivelyTestedPeopleBarScale
               data={resultsPerRegion}
               showAxis={true}
             />

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -1,27 +1,27 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
+import { ContentHeader } from '@/components/layout/Content';
 
-import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
+import RegionalSewerWaterLineChart from '@/components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from 'components/barChart';
+import BarChart from '@/components/barChart';
 import {
   SewerWaterBarScaleData,
   getSewerWaterBarScaleData,
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
-} from 'utils/sewer-water/safety-region-sewer-water.util';
+} from '@/utils/sewer-water/safety-region-sewer-water.util';
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from 'static-props/safetyregion-data';
-import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
+} from '@/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -1,27 +1,27 @@
-import BarScale from '@/components/barScale';
-import { FCWithLayout } from '@/components/layout';
-import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
-import { ContentHeader } from '@/components/layout/Content';
+import BarScale from '~/components/barScale';
+import { FCWithLayout } from '~/components/layout';
+import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
+import { ContentHeader } from '~/components/layout/Content';
 
-import RioolwaterMonitoring from '@/assets/rioolwater-monitoring.svg';
+import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import RegionalSewerWaterLineChart from '@/components/lineChart/regionalSewerWaterLineChart';
+import RegionalSewerWaterLineChart from '~/components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from '@/components/barChart';
+import BarChart from '~/components/barChart';
 import {
   SewerWaterBarScaleData,
   getSewerWaterBarScaleData,
   getSewerWaterLineChartData,
   getSewerWaterBarChartData,
-} from '@/utils/sewer-water/safety-region-sewer-water.util';
+} from '~/utils/sewer-water/safety-region-sewer-water.util';
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from '@/static-props/safetyregion-data';
-import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
+} from '~/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '~/utils/getLocalTitleForCode';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,25 +1,25 @@
-import { FCWithLayout } from '@/components/layout';
-import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
-import { ContentHeader } from '@/components/layout/Content';
+import { FCWithLayout } from '~/components/layout';
+import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
+import { ContentHeader } from '~/components/layout/Content';
 
-import Ziekenhuis from '@/assets/ziekenhuis.svg';
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import { ResultsPerRegion } from '@/types/data.d';
-import { LineChart } from '@/components/charts/index';
-import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
+import { ResultsPerRegion } from '~/types/data.d';
+import { LineChart } from '~/components/charts/index';
+import { IntakeHospitalBarScale } from '~/components/veiligheidsregio/intake-hospital-barscale';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from '@/static-props/safetyregion-data';
-import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
-import hospitalAdmissionsTooltip from '@/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
-import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
+} from '~/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '~/utils/getLocalTitleForCode';
+import hospitalAdmissionsTooltip from '~/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import MunicipalityLegenda from '~/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '~/components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,4 +1,3 @@
-import BarScale from '@/components/barScale';
 import { FCWithLayout } from '@/components/layout';
 import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
 import { ContentHeader } from '@/components/layout/Content';
@@ -9,6 +8,7 @@ import siteText from '@/locale/index';
 
 import { ResultsPerRegion } from '@/types/data.d';
 import { LineChart } from '@/components/charts/index';
+import { IntakeHospitalBarScale } from '@/components/veiligheidsregio/intake-hospital-barscale';
 
 import {
   getSafetyRegionData,
@@ -23,33 +23,6 @@ import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLoo
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
-
-export function IntakeHospitalBarScale(props: {
-  data: ResultsPerRegion | undefined;
-  showAxis: boolean;
-}) {
-  const { data, showAxis } = props;
-
-  if (!data) return null;
-
-  return (
-    <BarScale
-      min={0}
-      max={100}
-      screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.hospital_moving_avg_per_region}
-      id="opnames"
-      rangeKey="hospital_moving_avg_per_region"
-      gradient={[
-        {
-          color: '#3391CC',
-          value: 0,
-        },
-      ]}
-      showAxis={showAxis}
-    />
-  );
-}
 
 const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data } = props;

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,25 +1,25 @@
-import BarScale from 'components/barScale';
-import { FCWithLayout } from 'components/layout';
-import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
-import { ContentHeader } from 'components/layout/Content';
+import BarScale from '@/components/barScale';
+import { FCWithLayout } from '@/components/layout';
+import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
+import { ContentHeader } from '@/components/layout/Content';
 
-import Ziekenhuis from 'assets/ziekenhuis.svg';
+import Ziekenhuis from '@/assets/ziekenhuis.svg';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import { ResultsPerRegion } from 'types/data.d';
-import { LineChart } from 'components/charts/index';
+import { ResultsPerRegion } from '@/types/data.d';
+import { LineChart } from '@/components/charts/index';
 
 import {
   getSafetyRegionData,
   getSafetyRegionPaths,
   ISafetyRegionData,
-} from 'static-props/safetyregion-data';
-import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+} from '@/static-props/safetyregion-data';
+import { getLocalTitleForRegion } from '@/utils/getLocalTitleForCode';
+import hospitalAdmissionsTooltip from '@/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import MunicipalityLegenda from '@/components/chloropleth/legenda/MunicipalityLegenda';
+import MunicipalityChloropleth from '@/components/chloropleth/MunicipalityChloropleth';
+import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
   siteText.veiligheidsregio_ziekenhuisopnames_per_dag;

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,22 +1,22 @@
 import path from 'path';
 import fs from 'fs';
 
-import { FCWithLayout } from '@/components/layout';
-import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
+import { FCWithLayout } from '~/components/layout';
+import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
 import { useRouter } from 'next/router';
-import EscalationLevel1 from '@/assets/niveau-1.svg';
-import EscalationLevel2 from '@/assets/niveau-2.svg';
-import EscalationLevel3 from '@/assets/niveau-3.svg';
-import styles from '@/components/chloropleth/tooltips/tooltip.module.scss';
+import EscalationLevel1 from '~/assets/niveau-1.svg';
+import EscalationLevel2 from '~/assets/niveau-2.svg';
+import EscalationLevel3 from '~/assets/niveau-3.svg';
+import styles from '~/components/chloropleth/tooltips/tooltip.module.scss';
 
-import siteText from '@/locale/index';
-import MDToHTMLString from '@/utils/MDToHTMLString';
+import siteText from '~/locale/index';
+import MDToHTMLString from '~/utils/MDToHTMLString';
 
 import SafetyRegionChloropleth, {
   thresholds,
-} from '@/components/chloropleth/SafetyRegionChloropleth';
-import useMediaQuery from '@/utils/useMediaQuery';
-import { escalationTooltip } from '@/components/chloropleth/tooltips/region/escalationTooltip';
+} from '~/components/chloropleth/SafetyRegionChloropleth';
+import useMediaQuery from '~/utils/useMediaQuery';
+import { escalationTooltip } from '~/components/chloropleth/tooltips/region/escalationTooltip';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -1,22 +1,22 @@
 import path from 'path';
 import fs from 'fs';
 
-import { FCWithLayout } from 'components/layout';
-import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
+import { FCWithLayout } from '@/components/layout';
+import { getSafetyRegionLayout } from '@/components/layout/SafetyRegionLayout';
 import { useRouter } from 'next/router';
-import EscalationLevel1 from 'assets/niveau-1.svg';
-import EscalationLevel2 from 'assets/niveau-2.svg';
-import EscalationLevel3 from 'assets/niveau-3.svg';
-import styles from 'components/chloropleth/tooltips/tooltip.module.scss';
+import EscalationLevel1 from '@/assets/niveau-1.svg';
+import EscalationLevel2 from '@/assets/niveau-2.svg';
+import EscalationLevel3 from '@/assets/niveau-3.svg';
+import styles from '@/components/chloropleth/tooltips/tooltip.module.scss';
 
-import siteText from 'locale';
-import MDToHTMLString from 'utils/MDToHTMLString';
+import siteText from '@/locale/index';
+import MDToHTMLString from '@/utils/MDToHTMLString';
 
 import SafetyRegionChloropleth, {
   thresholds,
-} from 'components/chloropleth/SafetyRegionChloropleth';
-import useMediaQuery from 'utils/useMediaQuery';
-import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
+} from '@/components/chloropleth/SafetyRegionChloropleth';
+import useMediaQuery from '@/utils/useMediaQuery';
+import { escalationTooltip } from '@/components/chloropleth/tooltips/region/escalationTooltip';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;
 

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -4,13 +4,13 @@ import fs from 'fs';
 import { Fragment } from 'react';
 import Head from 'next/head';
 
-import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
-import MaxWidth from '@/components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
+import MaxWidth from '~/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
-import MDToHTMLString from '@/utils/MDToHTMLString';
+import MDToHTMLString from '~/utils/MDToHTMLString';
 
 interface ICijfer {
   cijfer: string;

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -4,13 +4,13 @@ import fs from 'fs';
 import { Fragment } from 'react';
 import Head from 'next/head';
 
-import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '@/components/layout';
+import MaxWidth from '@/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
-import MDToHTMLString from 'utils/MDToHTMLString';
+import MDToHTMLString from '@/utils/MDToHTMLString';
 
 interface ICijfer {
   cijfer: string;

--- a/src/static-props/municipality-data.ts
+++ b/src/static-props/municipality-data.ts
@@ -1,6 +1,6 @@
-import { Municipal } from 'types/data.d';
+import { Municipal } from '@/types/data.d';
 
-import municipalities from 'data/gemeente_veiligheidsregio.json';
+import municipalities from '@/data/gemeente_veiligheidsregio.json';
 import { getSafetyRegionData } from './safetyregion-data';
 
 export interface IMunicipalityData {

--- a/src/static-props/municipality-data.ts
+++ b/src/static-props/municipality-data.ts
@@ -1,6 +1,6 @@
-import { Municipal } from '@/types/data.d';
+import { Municipal } from '~/types/data.d';
 
-import municipalities from '@/data/gemeente_veiligheidsregio.json';
+import municipalities from '~/data/gemeente_veiligheidsregio.json';
 import { getSafetyRegionData } from './safetyregion-data';
 
 export interface IMunicipalityData {

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { National } from 'types/data.d';
+import { National } from '@/types/data.d';
 
 export interface INationalData {
   data: National;

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { National } from '@/types/data.d';
+import { National } from '~/types/data.d';
 
 export interface INationalData {
   data: National;

--- a/src/static-props/safetyregion-data.ts
+++ b/src/static-props/safetyregion-data.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Regionaal } from 'types/data.d';
+import { Regionaal } from '@/types/data.d';
 
-import safetyRegions from 'data';
+import safetyRegions from '@/data/index';
 
 export interface ISafetyRegionData {
   data: Regionaal;

--- a/src/static-props/safetyregion-data.ts
+++ b/src/static-props/safetyregion-data.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Regionaal } from '@/types/data.d';
+import { Regionaal } from '~/types/data.d';
 
-import safetyRegions from '@/data/index';
+import safetyRegions from '~/data/index';
 
 export interface ISafetyRegionData {
   data: Regionaal;

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,7 +1,7 @@
 import { isToday, isYesterday } from 'date-fns';
 
-import siteText from 'locale';
-import getLocale from 'utils/getLocale';
+import siteText from '@/locale/index';
+import getLocale from '@/utils/getLocale';
 
 const locale = getLocale();
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,7 +1,7 @@
 import { isToday, isYesterday } from 'date-fns';
 
-import siteText from '@/locale/index';
-import getLocale from '@/utils/getLocale';
+import siteText from '~/locale/index';
+import getLocale from '~/utils/getLocale';
 
 const locale = getLocale();
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,4 +1,4 @@
-import getLocale from '@/utils/getLocale';
+import getLocale from '~/utils/getLocale';
 
 const locale = getLocale();
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,4 +1,4 @@
-import getLocale from 'utils/getLocale';
+import getLocale from '@/utils/getLocale';
 
 const locale = getLocale();
 

--- a/src/utils/getLocalTitleForCode.ts
+++ b/src/utils/getLocalTitleForCode.ts
@@ -1,7 +1,7 @@
 import replaceVariablesInText from './replaceVariablesInText';
 
-import regios from '@/data/index';
-import municipalities from '@/data/gemeente_veiligheidsregio.json';
+import regios from '~/data/index';
+import municipalities from '~/data/gemeente_veiligheidsregio.json';
 
 export { getLocalTitleForRegion, getLocalTitleForMuncipality };
 

--- a/src/utils/getLocalTitleForCode.ts
+++ b/src/utils/getLocalTitleForCode.ts
@@ -1,7 +1,7 @@
 import replaceVariablesInText from './replaceVariablesInText';
 
-import regios from 'data';
-import municipalities from 'data/gemeente_veiligheidsregio.json';
+import regios from '@/data/index';
+import municipalities from '@/data/gemeente_veiligheidsregio.json';
 
 export { getLocalTitleForRegion, getLocalTitleForMuncipality };
 

--- a/src/utils/getSafetyRegionForMunicipalityCode.ts
+++ b/src/utils/getSafetyRegionForMunicipalityCode.ts
@@ -1,5 +1,5 @@
-import municipalities from '@/data/gemeente_veiligheidsregio.json';
-import regios from '@/data/index';
+import municipalities from '~/data/gemeente_veiligheidsregio.json';
+import regios from '~/data/index';
 
 /**
  * This function returns the safety region information for the given

--- a/src/utils/getSafetyRegionForMunicipalityCode.ts
+++ b/src/utils/getSafetyRegionForMunicipalityCode.ts
@@ -1,5 +1,5 @@
-import municipalities from 'data/gemeente_veiligheidsregio.json';
-import regios from 'data';
+import municipalities from '@/data/gemeente_veiligheidsregio.json';
+import regios from '@/data/index';
 
 /**
  * This function returns the safety region information for the given

--- a/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
+++ b/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
@@ -1,5 +1,5 @@
-import municipalCodeToRegionCodeLookup from '@/data/municipalCodeToRegionCodeLookup';
-import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
+import municipalCodeToRegionCodeLookup from '~/data/municipalCodeToRegionCodeLookup';
+import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
 
 /**
  * This method looks up all the municipal codes that belong to the same safety region

--- a/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
+++ b/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
@@ -1,5 +1,5 @@
-import municipalCodeToRegionCodeLookup from 'data/municipalCodeToRegionCodeLookup';
-import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
+import municipalCodeToRegionCodeLookup from '@/data/municipalCodeToRegionCodeLookup';
+import regionCodeToMunicipalCodeLookup from '@/data/regionCodeToMunicipalCodeLookup';
 
 /**
  * This method looks up all the municipal codes that belong to the same safety region

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -3,13 +3,13 @@ import {
   ResultsPerSewerInstallationPerMunicipalityItem,
   SewerMeasurementsLastValue,
   ResultsPerSewerInstallationPerMunicipalityLastValue,
-} from 'types/data.d';
-import formatDate from 'utils/formatDate';
-import formatNumber from 'utils/formatNumber';
+} from '@/types/data.d';
+import formatDate from '@/utils/formatDate';
+import formatNumber from '@/utils/formatNumber';
 import { XrangePointOptionsObject } from 'highcharts';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
 
-import siteText from 'locale';
+import siteText from '@/locale/index';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -3,13 +3,13 @@ import {
   ResultsPerSewerInstallationPerMunicipalityItem,
   SewerMeasurementsLastValue,
   ResultsPerSewerInstallationPerMunicipalityLastValue,
-} from '@/types/data.d';
-import formatDate from '@/utils/formatDate';
-import formatNumber from '@/utils/formatNumber';
+} from '~/types/data.d';
+import formatDate from '~/utils/formatDate';
+import formatNumber from '~/utils/formatNumber';
 import { XrangePointOptionsObject } from 'highcharts';
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
 
-import siteText from '@/locale/index';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.gemeente_rioolwater_metingen =
   siteText.gemeente_rioolwater_metingen;

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -4,11 +4,11 @@ import {
   SewerValue,
   AverageSewerInstallationPerRegionItem,
   SewerValueElement,
-} from 'types/data.d';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import formatDate from 'utils/formatDate';
-import formatNumber from 'utils/formatNumber';
-import siteText from 'locale';
+} from '@/types/data.d';
+import replaceVariablesInText from '@/utils/replaceVariablesInText';
+import formatDate from '@/utils/formatDate';
+import formatNumber from '@/utils/formatNumber';
+import siteText from '@/locale/index';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -4,11 +4,11 @@ import {
   SewerValue,
   AverageSewerInstallationPerRegionItem,
   SewerValueElement,
-} from '@/types/data.d';
-import replaceVariablesInText from '@/utils/replaceVariablesInText';
-import formatDate from '@/utils/formatDate';
-import formatNumber from '@/utils/formatNumber';
-import siteText from '@/locale/index';
+} from '~/types/data.d';
+import replaceVariablesInText from '~/utils/replaceVariablesInText';
+import formatDate from '~/utils/formatDate';
+import formatNumber from '~/utils/formatNumber';
+import siteText from '~/locale/index';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
   siteText.veiligheidsregio_rioolwater_metingen;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,15 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["./src/components/*"],
-      "@/scss/*": ["./src/scss/*"],
-      "@/assets/*": ["./src/assets/*"],
-      "@/data/*": ["./src/data/*"],
-      "@/lib/*": ["./src/lib/*"],
-      "@/locale/*": ["./src/locale/*"],
-      "@/static-props/*": ["./src/static-props/*"],
-      "@/types/*": ["./src/types/*"],
-      "@/utils/*": ["./src/utils/*"]
+      "~/components/*": ["./src/components/*"],
+      "~/scss/*": ["./src/scss/*"],
+      "~/assets/*": ["./src/assets/*"],
+      "~/data/*": ["./src/data/*"],
+      "~/lib/*": ["./src/lib/*"],
+      "~/locale/*": ["./src/locale/*"],
+      "~/static-props/*": ["./src/static-props/*"],
+      "~/types/*": ["./src/types/*"],
+      "~/utils/*": ["./src/utils/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,18 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./src/components/*"],
+      "@/scss/*": ["./src/scss/*"],
+      "@/assets/*": ["./src/assets/*"],
+      "@/data/*": ["./src/data/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/locale/*": ["./src/locale/*"],
+      "@/static-props/*": ["./src/static-props/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/pages/*": ["./src/pages/*"]
+    },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
       "@/locale/*": ["./src/locale/*"],
       "@/static-props/*": ["./src/static-props/*"],
       "@/types/*": ["./src/types/*"],
-      "@/utils/*": ["./src/utils/*"],
-      "@/pages/*": ["./src/pages/*"]
+      "@/utils/*": ["./src/utils/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Summary

Configure Typescript path alias for src with prefix "~". The current module resolve is not clear and can cause name collision with node modules. https://nextjs.org/docs/advanced-features/module-path-aliases

## Motivation

Cleaner code.
Easier to read.
Hopefully easier to solve absolute imports in Jest as well!