### PR TITLE
Chore/named exports

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import ChartTimeControls, {
+import {
+  ChartTimeControls,
   TimeframeOption,
 } from 'components/chartTimeControls';
 
@@ -34,8 +35,6 @@ type IGetOptions = Omit<AreaChartProps, 'data'> & {
   rangeData: TRange[];
   lineData: TLine[];
 };
-
-export default AreaChart;
 
 function getOptions(props: IGetOptions): Highcharts.Options {
   const {
@@ -163,7 +162,7 @@ function getOptions(props: IGetOptions): Highcharts.Options {
   return options;
 }
 
-function AreaChart(props: AreaChartProps) {
+export default function AreaChart(props: AreaChartProps) {
   const {
     rangeLegendLabel,
     lineLegendLabel,

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -6,8 +6,8 @@ import ChartTimeControls, {
   TimeframeOption,
 } from 'components/chartTimeControls';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
+import { formatNumber } from 'utils/formatNumber';
+import { formatDate } from 'utils/formatDate';
 import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
 
 if (typeof Highcharts === 'object') {

--- a/src/components/barChart/index.tsx
+++ b/src/components/barChart/index.tsx
@@ -8,9 +8,7 @@ interface IProps {
   axisTitle: string;
 }
 
-export default BarChart;
-
-function BarChart(props: IProps) {
+export default function BarChart(props: IProps) {
   const { data, keys, axisTitle } = props;
 
   const options = useMemo<HighCharts.Options>(() => {

--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -1,11 +1,11 @@
 import styles from './styles.module.scss';
 import { useRef } from 'react';
-import formatNumber from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 import ScreenReaderOnly from 'components/screenReaderOnly';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
 import { scaleQuantile, scaleThreshold } from 'd3-scale';
 
-import useDynamicScale from 'utils/useDynamicScale';
+import { useDynamicScale } from 'utils/useDynamicScale';
 import siteText from 'locale';
 
 type GradientStop = {

--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -1,7 +1,7 @@
 import styles from './styles.module.scss';
 import { useRef } from 'react';
 import { formatNumber } from 'utils/formatNumber';
-import ScreenReaderOnly from 'components/screenReaderOnly';
+import { ScreenReaderOnly } from 'components/screenReaderOnly';
 import { replaceVariablesInText } from 'utils/replaceVariablesInText';
 import { scaleQuantile, scaleThreshold } from 'd3-scale';
 
@@ -25,9 +25,7 @@ type BarscaleProps = {
   showAxis?: boolean;
 };
 
-export default BarScale;
-
-function BarScale({
+export function BarScale({
   min,
   max,
   value,

--- a/src/components/chartRegionControls/index.tsx
+++ b/src/components/chartRegionControls/index.tsx
@@ -1,5 +1,5 @@
 import styles from './chartregioncontrols.module.scss';
-import RadioGroup, { IRadioGroupItem } from 'components/radioGroup';
+import { RadioGroup, IRadioGroupItem } from 'components/radioGroup';
 
 import text from 'locale';
 
@@ -7,7 +7,7 @@ export interface IProps {
   onChange: (value: any) => void;
 }
 
-export default function ChartRegionControls(props: IProps) {
+export function ChartRegionControls(props: IProps) {
   const { onChange } = props;
 
   const values: IRadioGroupItem[] = [

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -1,6 +1,6 @@
 import styles from './chartTimeControls.module.scss';
 
-import RadioGroup, { IRadioGroupItem } from 'components/radioGroup';
+import { RadioGroup, IRadioGroupItem } from 'components/radioGroup';
 
 import text from 'locale';
 
@@ -12,9 +12,7 @@ interface IProps {
   timeframeOptions: TimeframeOption[];
 }
 
-export default ChartTimeControls;
-
-function ChartTimeControls(props: IProps) {
+export function ChartTimeControls(props: IProps) {
   const { timeframe, onChange, timeframeOptions } = props;
 
   const values = timeframeOptions.map<IRadioGroupItem>((key) => ({

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -9,7 +9,7 @@ import { TCombinedChartDimensions } from './hooks/useChartDimensions';
 import styles from './chloropleth.module.scss';
 import { localPoint } from '@vx/event';
 
-import Tooltip from './tooltips/tooltip';
+import { Tooltip } from './tooltips/tooltip';
 import { useMediaQuery } from 'utils/useMediaQuery';
 
 export type TooltipState = {
@@ -84,7 +84,7 @@ export type TProps<TFeatureProperties> = {
  *
  * @param props
  */
-export default function Chloropleth<T>(props: TProps<T>) {
+export function Chloropleth<T>(props: TProps<T>) {
   const {
     featureCollection,
     overlays,

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -10,7 +10,7 @@ import styles from './chloropleth.module.scss';
 import { localPoint } from '@vx/event';
 
 import Tooltip from './tooltips/tooltip';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 
 export type TooltipState = {
   tooltip: TooltipSettings | null;

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -5,18 +5,18 @@ import {
   TMunicipalityMetricName,
 } from './shared';
 
-import Chloropleth from './Chloropleth';
+import { Chloropleth } from './Chloropleth';
 import { Feature, GeoJsonProperties, MultiPolygon } from 'geojson';
-import useChartDimensions from './hooks/useChartDimensions';
+import { useChartDimensions } from './hooks/useChartDimensions';
 
 import styles from './chloropleth.module.scss';
 import { CSSProperties, ReactNode, useCallback } from 'react';
 import { Municipalities } from 'types/data';
-import useMunicipalityData from './hooks/useMunicipalityData';
-import useChloroplethColorScale from './hooks/useChloroplethColorScale';
-import useMunicipalityBoundingbox from './hooks/useMunicipalityBoundingbox';
+import { useMunicipalityData } from './hooks/useMunicipalityData';
+import { useChloroplethColorScale } from './hooks/useChloroplethColorScale';
+import { useMunicipalityBoundingbox } from './hooks/useMunicipalityBoundingbox';
 import { MunicipalityProperties } from './shared';
-import useRegionMunicipalities from './hooks/useRegionMunicipalities';
+import { useRegionMunicipalities } from './hooks/useRegionMunicipalities';
 import { countryGeo, municipalGeo, regionGeo } from './topology';
 
 type MunicipalThresholds = ChloroplethThresholds<TMunicipalityMetricName>;
@@ -113,7 +113,7 @@ export type TProps<
  *
  * @param props
  */
-export default function MunicipalityChloropleth<
+export function MunicipalityChloropleth<
   T extends TMunicipalityMetricName,
   ItemType extends Municipalities[T][number],
   ReturnType extends ItemType & { value: number },

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -6,14 +6,14 @@ import {
 } from './shared';
 import { Regions } from 'types/data';
 import { CSSProperties, ReactNode, useCallback } from 'react';
-import useChartDimensions from './hooks/useChartDimensions';
-import Chloropleth from './Chloropleth';
+import { useChartDimensions } from './hooks/useChartDimensions';
+import { Chloropleth } from './Chloropleth';
 import { countryGeo, regionGeo } from './topology';
 import { Feature, MultiPolygon } from 'geojson';
 import styles from './chloropleth.module.scss';
-import useSafetyRegionBoundingbox from './hooks/useSafetyRegionBoundingbox';
-import useChloroplethColorScale from './hooks/useChloroplethColorScale';
-import useSafetyRegionData from './hooks/useSafetyRegionData';
+import { useSafetyRegionBoundingbox } from './hooks/useSafetyRegionBoundingbox';
+import { useChloroplethColorScale } from './hooks/useChloroplethColorScale';
+import { useSafetyRegionData } from './hooks/useSafetyRegionData';
 
 type RegionalThresholds = ChloroplethThresholds<TRegionMetricName>;
 
@@ -128,7 +128,7 @@ export type TProps<
  *
  * @param props
  */
-export default function SafetyRegionChloropleth<
+export function SafetyRegionChloropleth<
   T extends TRegionMetricName,
   ItemType extends Regions[T][number],
   ReturnType extends ItemType & { value: number },

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -59,7 +59,7 @@ export type TCombinedChartDimensions = TChartDimensions & {
   boundedHeight: number;
 };
 
-const useChartDimensions = (
+export const useChartDimensions = (
   passedSettings?: TChartDimensions
 ): [MutableRefObject<HTMLElement | null>, TCombinedChartDimensions] => {
   const ref = useRef<HTMLElement | null>(null);
@@ -109,5 +109,3 @@ const useChartDimensions = (
 
   return [ref, newSettings];
 };
-
-export default useChartDimensions;

--- a/src/components/chloropleth/hooks/useChloroplethColorScale.ts
+++ b/src/components/chloropleth/hooks/useChloroplethColorScale.ts
@@ -18,7 +18,7 @@ export type TGetFillColor = (id: string) => string;
  * @param gradient
  * @param defaultColor
  */
-export default function useChloroplethColorScale(
+export function useChloroplethColorScale(
   getData: (id: string) => any,
   thresholds?: ChloroplethThresholdsValue[],
   defaultColor = 'white'

--- a/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityBoundingbox.ts
@@ -10,7 +10,7 @@ import { useMemo } from 'react';
  * @param regionGeo
  * @param selectedMunicipality
  */
-export default function useMunicipalityBoundingbox(
+export function useMunicipalityBoundingbox(
   regionGeo: FeatureCollection<MultiPolygon, SafetyRegionProperties>,
   selectedMunicipality?: string
 ): [FeatureCollection<MultiPolygon>, string] | [undefined, undefined] {

--- a/src/components/chloropleth/hooks/useMunicipalityData.ts
+++ b/src/components/chloropleth/hooks/useMunicipalityData.ts
@@ -24,7 +24,7 @@ export type TMunicipalityDataInfo<T> = [TGetMunicipalityFunc<T>, boolean];
  * @param metricName
  * @param featureCollection
  */
-export default function useMunicipalityData<
+export function useMunicipalityData<
   T extends TMunicipalityMetricName,
   ItemType extends Municipalities[T][number],
   ReturnType extends ItemType & MunicipalityProperties & { value: number }

--- a/src/components/chloropleth/hooks/useRegionMunicipalities.ts
+++ b/src/components/chloropleth/hooks/useRegionMunicipalities.ts
@@ -7,7 +7,7 @@ import { getSafetyRegionMunicipalsForMunicipalCode } from 'utils/getSafetyRegion
  *
  * @param municipalCode
  */
-export default function useRegionMunicipalities(
+export function useRegionMunicipalities(
   municipalCode?: string
 ): string[] | undefined {
   return useMemo(() => {

--- a/src/components/chloropleth/hooks/useRegionMunicipalities.ts
+++ b/src/components/chloropleth/hooks/useRegionMunicipalities.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import getSafetyRegionMunicipalsForMunicipalCode from 'utils/getSafetyRegionMunicipalsForMunicipalCode';
+import { getSafetyRegionMunicipalsForMunicipalCode } from 'utils/getSafetyRegionMunicipalsForMunicipalCode';
 
 /**
  * This hook returns all the municipal codes that belong to the same safety region

--- a/src/components/chloropleth/hooks/useSafetyRegionBoundingbox.ts
+++ b/src/components/chloropleth/hooks/useSafetyRegionBoundingbox.ts
@@ -8,7 +8,7 @@ import { useMemo } from 'react';
  *
  * @param selectedRegion
  */
-export default function useSafetyRegionBoundingbox(
+export function useSafetyRegionBoundingbox(
   regionGeo: FeatureCollection<MultiPolygon, SafetyRegionProperties>,
   selectedRegion?: string
 ) {

--- a/src/components/chloropleth/hooks/useSafetyRegionData.ts
+++ b/src/components/chloropleth/hooks/useSafetyRegionData.ts
@@ -23,7 +23,7 @@ export type TSafetyRegionDataInfo<T> = [TGetRegionFunc<T>, boolean];
  * @param featureCollection
  * @param metricProperty
  */
-export default function useRegionData<
+export function useSafetyRegionData<
   T extends TRegionMetricName,
   K extends Regions[T],
   ReturnType extends K[number] & { value: number } & SafetyRegionProperties

--- a/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
+++ b/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
@@ -10,7 +10,7 @@ export type TProps = {
   items: ILegendaItem[];
 };
 
-export default function ChloroplethLegenda(props: TProps) {
+export function ChloroplethLegenda(props: TProps) {
   const { items, title } = props;
 
   return (

--- a/src/components/chloropleth/legenda/MunicipalityLegenda.tsx
+++ b/src/components/chloropleth/legenda/MunicipalityLegenda.tsx
@@ -1,13 +1,13 @@
 import { TMunicipalityMetricName } from '../shared';
-import ChloroplethLegenda from './ChloroplethLegenda';
-import useMunicipalLegendaData from './hooks/useMunicipalLegendaData';
+import { ChloroplethLegenda } from './ChloroplethLegenda';
+import { useMunicipalLegendaData } from './hooks/useMunicipalLegendaData';
 
 export type TProps = {
   metricName: TMunicipalityMetricName;
   title: string;
 };
 
-export default function MunicipalityLegenda(props: TProps) {
+export function MunicipalityLegenda(props: TProps) {
   const { metricName, title } = props;
   const items = useMunicipalLegendaData(metricName);
 

--- a/src/components/chloropleth/legenda/SafetyRegionLegenda.tsx
+++ b/src/components/chloropleth/legenda/SafetyRegionLegenda.tsx
@@ -1,13 +1,13 @@
 import { TRegionMetricName } from '../shared';
-import ChloroplethLegenda from './ChloroplethLegenda';
-import useSafetyRegionLegendaData from './hooks/useSafetyRegionLegendaData';
+import { ChloroplethLegenda } from './ChloroplethLegenda';
+import { useSafetyRegionLegendaData } from './hooks/useSafetyRegionLegendaData';
 
 export type TProps = {
   metricName: TRegionMetricName;
   title: string;
 };
 
-export default function SafetyRegionLegenda(props: TProps) {
+export function SafetyRegionLegenda(props: TProps) {
   const { metricName, title } = props;
   const items = useSafetyRegionLegendaData(metricName);
 

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -13,9 +13,7 @@ const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
   return `${list[index].threshold} - ${list[index + 1].threshold}`;
 };
 
-export default function useLegendaItems(
-  thresholds?: ChloroplethThresholdsValue[]
-) {
+export function useLegendaItems(thresholds?: ChloroplethThresholdsValue[]) {
   return useMemo(() => {
     if (!thresholds) {
       return;

--- a/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
@@ -1,11 +1,9 @@
 import { thresholds } from 'components/chloropleth/MunicipalityChloropleth';
 import { TMunicipalityMetricName } from 'components/chloropleth/shared';
 
-import useLegendaItems from './useLegendaItems';
+import { useLegendaItems } from './useLegendaItems';
 
-export default function useMunicipalLegendaData(
-  metric: TMunicipalityMetricName
-) {
+export function useMunicipalLegendaData(metric: TMunicipalityMetricName) {
   const ths = thresholds[metric];
 
   return useLegendaItems(ths.thresholds);

--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -1,9 +1,9 @@
 import { TRegionMetricName } from '../../shared';
 
-import useLegendaItems from './useLegendaItems';
+import { useLegendaItems } from './useLegendaItems';
 import { thresholds } from 'components/chloropleth/SafetyRegionChloropleth';
 
-export default function useSafetyRegionLegendaData(metric: TRegionMetricName) {
+export function useSafetyRegionLegendaData(metric: TRegionMetricName) {
   const ths = thresholds[metric];
 
   return useLegendaItems(ths.thresholds);

--- a/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 import { MunicipalityProperties } from 'components/chloropleth/shared';
 
-export default function hospitalAdmissionsTooltip(
+export function hospitalAdmissionsTooltip(
   context: MunicipalityProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { MunicipalityProperties } from '../../shared';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 
-export default function positiveTestedPeopleTooltip(
+export function positiveTestedPeopleTooltip(
   context: MunicipalityProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { MunicipalityProperties } from '../../shared';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 
-export function positiveTestedPeopleTooltip(
+export function positiveTestedPeopleMunicipalTooltip(
   context: MunicipalityProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -1,7 +1,7 @@
 import { NextRouter } from 'next/router';
 import { ReactNode } from 'react';
-import formatDate from 'utils/formatDate';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import { formatDate } from 'utils/formatDate';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
 
 import text from 'locale';
 import styles from '../tooltip.module.scss';

--- a/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/hospitalAdmissionsTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 import { SafetyRegionProperties } from 'components/chloropleth/shared';
 
-export default function hospitalAdmissionsTooltip(
+export function hospitalAdmissionsTooltip(
   context: SafetyRegionProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { SafetyRegionProperties } from '../../shared';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 
-export function positiveTestedPeopleTooltip(
+export function positiveTestedPeopleRegionTooltip(
   context: SafetyRegionProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/positiveTestedPeopleTooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { SafetyRegionProperties } from '../../shared';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 
-export default function positiveTestedPeopleTooltip(
+export function positiveTestedPeopleTooltip(
   context: SafetyRegionProperties & { value: number }
 ): ReactNode {
   return (

--- a/src/components/chloropleth/tooltips/tooltip.tsx
+++ b/src/components/chloropleth/tooltips/tooltip.tsx
@@ -8,7 +8,7 @@ export type TTooltipProps = {
   getTooltipContent: (id: string) => ReactNode;
 };
 
-export default function Tooltip(props: TTooltipProps) {
+export function Tooltip(props: TTooltipProps) {
   const { tooltipStore, getTooltipContent } = props;
   const ref = useRef<HTMLDivElement | undefined>();
   const [tooltip, updateTooltip] = tooltipStore((state: TooltipState) => [

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -24,8 +24,6 @@ type TProps<Option extends TOption> = {
   handleSelect: (option: Option) => void;
 };
 
-export default ComboBox;
-
 /*
  * Combox is an accessible dropdown with search.
  *
@@ -41,7 +39,7 @@ export default ComboBox;
  * />
  * ```
  */
-function ComboBox<Option extends TOption>(props: TProps<Option>) {
+export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const { options, placeholder, handleSelect } = props;
 
   const inputRef = useRef<HTMLInputElement>();

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -8,10 +8,10 @@ import {
   ComboboxOption,
 } from '@reach/combobox';
 
-import useThrottle from 'utils/useThrottle';
+import { useThrottle } from 'utils/useThrottle';
 
 import text from 'locale';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 
 type TOption = {
   displayName?: string;

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -1,5 +1,5 @@
-import Metadata from 'components/metadata';
-import TitleWithIcon from 'components/titleWithIcon';
+import { Metadata } from 'components/metadata';
+import { TitleWithIcon } from 'components/titleWithIcon';
 import styles from './layout.module.scss';
 
 export { ContentHeader };

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -2,9 +2,7 @@ import { Metadata } from 'components/metadata';
 import { TitleWithIcon } from 'components/titleWithIcon';
 import styles from './layout.module.scss';
 
-export { ContentHeader };
-
-function ContentHeader(props: IContentHeaderProps) {
+export function ContentHeader(props: IContentHeaderProps) {
   const { category, Icon, title, subtitle, metadata } = props;
 
   return (

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -16,9 +16,9 @@ import { PostivelyTestedPeopleBarScale } from 'pages/gemeente/[code]/positief-ge
 import { IntakeHospitalBarScale } from 'pages/gemeente/[code]/ziekenhuis-opnames';
 import { SewerWaterBarScale } from 'pages/gemeente/[code]/rioolwater';
 
-import TitleWithIcon from 'components/titleWithIcon';
+import { TitleWithIcon } from 'components/titleWithIcon';
 import { getLayout as getSiteLayout } from 'components/layout';
-import Combobox from 'components/comboBox';
+import { ComboBox } from 'components/comboBox';
 
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
@@ -128,7 +128,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
           </Link>
         )}
         <aside className="municipality-aside">
-          <Combobox<IMunicipality>
+          <ComboBox<IMunicipality>
             placeholder={siteText.common.zoekveld_placeholder_gemeente}
             handleSelect={handleMunicipalitySelect}
             options={municipalities}

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -8,9 +8,9 @@ import municipalities from 'data/gemeente_veiligheidsregio.json';
 import { IMunicipalityData } from 'static-props/municipality-data';
 
 import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
-import getSafetyRegionForMunicipalityCode from 'utils/getSafetyRegionForMunicipalityCode';
+import { getSafetyRegionForMunicipalityCode } from 'utils/getSafetyRegionForMunicipalityCode';
 import { getSewerWaterBarScaleData } from 'utils/sewer-water/municipality-sewer-water.util';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 
 import { PostivelyTestedPeopleBarScale } from 'pages/gemeente/[code]/positief-geteste-mensen';
 import { IntakeHospitalBarScale } from 'pages/gemeente/[code]/ziekenhuis-opnames';

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -25,8 +25,6 @@ import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 import Arrow from 'assets/arrow.svg';
 
-export default MunicipalityLayout;
-
 interface IMunicipality {
   name: string;
   safetyRegion: string;

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
-import TitleWithIcon from 'components/titleWithIcon';
+import { TitleWithIcon } from 'components/titleWithIcon';
 import { getLayout as getSiteLayout } from 'components/layout';
 import { ReproductionIndexBarScale } from 'pages/landelijk/reproductiegetal';
 import { PostivelyTestedPeopleBarScale } from 'pages/landelijk/positief-geteste-mensen';

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -32,8 +32,6 @@ import { WithChildren } from 'types';
 
 import { INationalData } from 'static-props/nl-data';
 
-export default NationalLayout;
-
 export function getNationalLayout() {
   return function (
     page: React.ReactNode,

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -7,7 +7,7 @@ import safetyRegions from 'data/index';
 import { WithChildren } from 'types';
 import { ISafetyRegionData } from 'static-props/safetyregion-data';
 
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 import { getSewerWaterBarScaleData } from 'utils/sewer-water/safety-region-sewer-water.util';
 
 import { PostivelyTestedPeopleBarScale } from 'pages/veiligheidsregio/[code]/positief-geteste-mensen';

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -23,8 +23,6 @@ import Ziekenhuis from 'assets/ziekenhuis.svg';
 import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 import Arrow from 'assets/arrow.svg';
 
-export default SafetyRegionLayout;
-
 export function getSafetyRegionLayout() {
   return function (
     page: React.ReactNode,

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -14,9 +14,9 @@ import { PostivelyTestedPeopleBarScale } from 'pages/veiligheidsregio/[code]/pos
 import { IntakeHospitalBarScale } from 'pages/veiligheidsregio/[code]/ziekenhuis-opnames';
 import { SewerWaterBarScale } from 'pages/veiligheidsregio/[code]/rioolwater';
 
-import TitleWithIcon from 'components/titleWithIcon';
+import { TitleWithIcon } from 'components/titleWithIcon';
 import { getLayout as getSiteLayout } from 'components/layout';
-import Combobox from 'components/comboBox';
+import { ComboBox } from 'components/comboBox';
 
 import GetestIcon from 'assets/test.svg';
 import Ziekenhuis from 'assets/ziekenhuis.svg';
@@ -129,7 +129,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
           </Link>
         )}
         <aside className="safety-region-aside">
-          <Combobox<TSafetyRegion>
+          <ComboBox<TSafetyRegion>
             placeholder={siteText.common.zoekveld_placeholder_regio}
             handleSelect={handleSafeRegionSelect}
             options={safetyRegions}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -12,8 +12,8 @@ import { formatDate } from 'utils/formatDate';
 import { replaceVariablesInText } from 'utils/replaceVariablesInText';
 import { getLocale } from 'utils/getLocale';
 
-import SEOHead from 'components/seoHead';
-import MaxWidth from 'components/maxWidth';
+import { SEOHead } from 'components/seoHead';
+import { MaxWidth } from 'components/maxWidth';
 
 export interface LayoutProps {
   url?: string;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -7,10 +7,10 @@ import text from 'locale';
 import { ILastGeneratedData } from 'static-props/last-generated-data';
 import styles from './layout.module.scss';
 
-import useMediaQuery from 'utils/useMediaQuery';
-import formatDate from 'utils/formatDate';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import getLocale from 'utils/getLocale';
+import { useMediaQuery } from 'utils/useMediaQuery';
+import { formatDate } from 'utils/formatDate';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
+import { getLocale } from 'utils/getLocale';
 
 import SEOHead from 'components/seoHead';
 import MaxWidth from 'components/maxWidth';

--- a/src/components/legenda/index.tsx
+++ b/src/components/legenda/index.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { WithChildren } from 'types';
 
-export default Legenda;
-
 /*
  * Takes `li` elements as children.
  * Use `.blue` and `.gray` to add list marker colors to a list item.
  */
-function Legenda({ children }: WithChildren) {
+export function Legenda({ children }: WithChildren) {
   return <ul className="legenda">{children}</ul>;
 }

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -4,7 +4,8 @@ import HighchartsReact from 'highcharts-react-official';
 import styles from './lineChart.module.scss';
 import text from 'locale';
 
-import ChartTimeControls, {
+import {
+  ChartTimeControls,
   TimeframeOption,
 } from 'components/chartTimeControls';
 
@@ -24,8 +25,6 @@ interface LineChartProps {
   signaalwaarde?: number;
   timeframeOptions?: TimeframeOption[];
 }
-
-export default LineChart;
 
 function getChartOptions(values: Value[], signaalwaarde?: number | undefined) {
   const options: Highcharts.Options = {
@@ -167,7 +166,7 @@ function getChartOptions(values: Value[], signaalwaarde?: number | undefined) {
   return options;
 }
 
-function LineChart({
+export default function LineChart({
   title,
   description,
   values,

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -8,8 +8,8 @@ import ChartTimeControls, {
   TimeframeOption,
 } from 'components/chartTimeControls';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
+import { formatNumber } from 'utils/formatNumber';
+import { formatDate } from 'utils/formatDate';
 import { getFilteredValues } from 'components/chartTimeControls/chartTimeControlUtils';
 
 type Value = {

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -17,8 +17,6 @@ type RegionalSewerWaterLineChartProps = {
   text: TranslationStrings;
 };
 
-export default RegionalSewerWaterLineChart;
-
 function getOptions(
   averageValues: Value[],
   text: TranslationStrings
@@ -139,7 +137,7 @@ function getOptions(
   return options;
 }
 
-function RegionalSewerWaterLineChart({
+export function RegionalSewerWaterLineChart({
   averageValues,
   text,
 }: RegionalSewerWaterLineChartProps) {

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import Highcharts, { SeriesLineOptions } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-import formatNumber from 'utils/formatNumber';
-import formatDate from 'utils/formatDate';
+import { formatNumber } from 'utils/formatNumber';
+import { formatDate } from 'utils/formatDate';
 
 type TranslationStrings = Record<string, string>;
 

--- a/src/components/loadingPlaceholder/index.tsx
+++ b/src/components/loadingPlaceholder/index.tsx
@@ -1,9 +1,7 @@
 import styles from './loadingPlaceholder.module.scss';
 import { WithChildren } from 'types';
 
-export default LoadingPlaceholder;
-
-function LoadingPlaceholder({ children }: WithChildren) {
+export function LoadingPlaceholder({ children }: WithChildren) {
   return (
     <span className={styles.loadingPlaceholder} aria-hidden="true">
       {children ? children : null}

--- a/src/components/maxWidth/index.tsx
+++ b/src/components/maxWidth/index.tsx
@@ -1,8 +1,6 @@
 import styles from './maxWidth.module.scss';
 import { WithChildren } from 'types';
 
-export default MaxWidth;
-
-function MaxWidth({ children }: WithChildren) {
+export function MaxWidth({ children }: WithChildren) {
   return <div className={styles.maxWidth}>{children}</div>;
 }

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -5,8 +5,8 @@ import styles from './metadata.module.scss';
 import ClockIcon from 'assets/clock.svg';
 import DatabaseIcon from 'assets/database.svg';
 
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import formatDate from 'utils/formatDate';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
+import { formatDate } from 'utils/formatDate';
 
 interface IProps {
   dataSource: {

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -20,9 +20,7 @@ interface IProps {
 
 const text: typeof siteText.common.metadata = siteText.common.metadata;
 
-export default Metadata;
-
-function Metadata(props: IProps) {
+export function Metadata(props: IProps) {
   const { dataSource, datumsText, dateUnix, dateInsertedUnix } = props;
 
   if (!dateUnix) return null;

--- a/src/components/radioGroup/index.tsx
+++ b/src/components/radioGroup/index.tsx
@@ -19,7 +19,7 @@ export interface IProps {
  *
  * @param props
  */
-export default function RadioGroup(props: IProps) {
+export function RadioGroup(props: IProps) {
   const { onChange, values, className, value } = props;
   const [selected, setSelected] = useState<string>(value ?? values?.[0].value);
 

--- a/src/components/scalingSVG/index.tsx
+++ b/src/components/scalingSVG/index.tsx
@@ -8,9 +8,7 @@ interface IProps {
   children: WithChildren;
 }
 
-export default ScalingSVG;
-
-function ScalingSVG(props: WithChildren<IProps>) {
+export function ScalingSVG(props: WithChildren<IProps>) {
   const { children, width, height } = props;
 
   const style: CSS.Properties = { paddingBottom: `${100 * (height / width)}%` };

--- a/src/components/screenReaderOnly/index.tsx
+++ b/src/components/screenReaderOnly/index.tsx
@@ -1,13 +1,11 @@
 import styles from './screenReaderOnly.module.scss';
 import { WithChildren } from 'types';
 
-export default ScreenReaderOnly;
-
 /**
  * A small utility component that renders text which is only
  * present for visually impaired users, alias it will be read out
  * loud by screenreaders without being visible on the screen.
  */
-function ScreenReaderOnly({ children }: WithChildren) {
+export function ScreenReaderOnly({ children }: WithChildren) {
   return <span className={styles.screenReaderOnly}>{children}</span>;
 }

--- a/src/components/seoHead/index.tsx
+++ b/src/components/seoHead/index.tsx
@@ -2,8 +2,6 @@ import Head from 'next/head';
 
 import siteText from 'locale';
 
-export default SEOHead;
-
 export type SEOHeadProps = {
   title?: string;
   description?: string;
@@ -20,7 +18,7 @@ SEOHead.defaultProps = {
   url: siteText.seoHead.default_url,
 };
 
-function SEOHead(props: SEOHeadProps): any {
+export function SEOHead(props: SEOHeadProps): any {
   const { description, openGraphImage, title, twitterImage, url } = props;
 
   return (

--- a/src/components/titleBlock/index.tsx
+++ b/src/components/titleBlock/index.tsx
@@ -7,9 +7,7 @@ interface IProps {
   children: WithChildren;
 }
 
-export default TitleBlock;
-
-function TitleBlock(props: WithChildren<IProps>) {
+export function TitleBlock(props: WithChildren<IProps>) {
   const { Icon, title, children } = props;
 
   return (

--- a/src/components/titleWithIcon/index.tsx
+++ b/src/components/titleWithIcon/index.tsx
@@ -10,9 +10,7 @@ interface IProps {
   as?: 'h2' | 'h3';
 }
 
-export default TitleWithIcon;
-
-function TitleWithIcon(props: IProps) {
+export function TitleWithIcon(props: IProps) {
   const { Icon, title, regio, headingRef, as = 'h3' } = props;
 
   return (

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { MaxWidth } from 'components/maxWidth';
 
 import text from 'locale';
 import styles from './over.module.scss';

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,5 +1,5 @@
 import { FCWithLayout, getLayoutWithMetadata } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { MaxWidth } from 'components/maxWidth';
 
 import getLastGeneratedData from 'static-props/last-generated-data';
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,7 @@ import Document, {
   NextScript,
   DocumentContext,
 } from 'next/document';
-import getLocale from 'utils/getLocale';
+import { getLocale } from 'utils/getLocale';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<any> {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,5 +1,5 @@
 import { FCWithLayout, getLayoutWithMetadata } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { MaxWidth } from 'components/maxWidth';
 
 import getLastGeneratedData from 'static-props/last-generated-data';
 

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
 
@@ -17,9 +17,9 @@ import {
 } from 'static-props/municipality-data';
 import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
 
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
+import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -18,7 +18,7 @@ import {
 import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
 
 import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
-import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleMunicipalTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
 import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 
 const text: typeof siteText.gemeente_positief_geteste_personen =
@@ -129,7 +129,7 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
           <MunicipalityChloropleth
             selected={data.code}
             metricName="positive_tested_people"
-            tooltipContent={positiveTestedPeopleTooltip}
+            tooltipContent={positiveTestedPeopleMunicipalTooltip}
           />
         </div>
       </article>

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -8,7 +8,7 @@ import { LineChart } from 'components/charts/index';
 import { ContentHeader } from 'components/layout/Content';
 
 import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 import { PositiveTestedPeople } from 'types/data.d';
 import {
   getMunicipalityData,
@@ -91,7 +91,7 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
             <h3>
               {text.kpi_titel}{' '}
               <span className="text-blue kpi">
-                {formatDecimal(
+                {formatNumber(
                   positivelyTestedPeople.last_value.infected_daily_total
                 )}
               </span>

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
 import { ContentHeader } from 'components/layout/Content';
@@ -7,9 +7,9 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 
 import siteText from 'locale';
 
-import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
+import { RegionalSewerWaterLineChart } from 'components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from 'components/barChart';
+import { BarChart } from 'components/charts';
 import {
   SewerWaterBarScaleData,
   getSewerWaterBarScaleData,

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getMunicipalityLayout } from 'components/layout/MunicipalityLayout';
 import { ContentHeader } from 'components/layout/Content';
@@ -20,9 +20,9 @@ import { getLocalTitleForMuncipality } from 'utils/getLocalTitleForCode';
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
 
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
+import { hospitalAdmissionsTooltip } from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 
 export function IntakeHospitalBarScale(props: {
   data: HospitalAdmissions | undefined;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -8,7 +8,7 @@ import text from 'locale';
 import styles from 'components/chloropleth/chloropleth.module.scss';
 
 import { ReactNode } from 'react';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import { MunicipalityProperties } from 'components/chloropleth/shared';
 import { useMediaQuery } from 'utils/useMediaQuery';
 

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -10,7 +10,7 @@ import styles from 'components/chloropleth/chloropleth.module.scss';
 import { ReactNode } from 'react';
 import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
 import { MunicipalityProperties } from 'components/chloropleth/shared';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 
 const tooltipContent = (router: NextRouter) => {
   return (context: MunicipalityProperties): ReactNode => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,15 +12,14 @@ import { INationalData } from 'static-props/nl-data';
 
 import styles from './index.module.scss';
 
-import TitleWithIcon from 'components/titleWithIcon';
-import ChartRegionControls from 'components/chartRegionControls';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
+import { TitleWithIcon } from 'components/titleWithIcon';
+import { ChartRegionControls } from 'components/chartRegionControls';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
+import { SafetyRegionChloropleth } from 'components/chloropleth/SafetyRegionChloropleth';
+import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
 import { useState } from 'react';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { SafetyRegionLegenda } from 'components/chloropleth/legenda/SafetyRegionLegenda';
 import Link from 'next/link';
 import { EscalationMapLegenda } from './veiligheidsregio';
 import { useMediaQuery } from 'utils/useMediaQuery';
@@ -148,7 +147,7 @@ const Home: FCWithLayout<INationalData> = (props) => {
           {selectedMap === 'region' && (
             <SafetyRegionChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltipRegion}
+              tooltipContent={positiveTestedPeopleTooltip}
               onSelect={onSelectRegion}
             />
           )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,8 @@ import { TitleWithIcon } from 'components/titleWithIcon';
 import { ChartRegionControls } from 'components/chartRegionControls';
 import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import { SafetyRegionChloropleth } from 'components/chloropleth/SafetyRegionChloropleth';
-import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleMunicipalTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleRegionTooltip } from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
 import { useState } from 'react';
 import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 import { SafetyRegionLegenda } from 'components/chloropleth/legenda/SafetyRegionLegenda';
@@ -140,14 +141,14 @@ const Home: FCWithLayout<INationalData> = (props) => {
           {selectedMap === 'municipal' && (
             <MunicipalityChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltip}
+              tooltipContent={positiveTestedPeopleMunicipalTooltip}
               onSelect={onSelectMunicipal}
             />
           )}
           {selectedMap === 'region' && (
             <SafetyRegionChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltip}
+              tooltipContent={positiveTestedPeopleRegionTooltip}
               onSelect={onSelectRegion}
             />
           )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,10 +23,10 @@ import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLege
 import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
 import Link from 'next/link';
 import { EscalationMapLegenda } from './veiligheidsregio';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 import { useRouter } from 'next/router';
 import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
-import MDToHTMLString from 'utils/MDToHTMLString';
+import { MDToHTMLString } from 'utils/MDToHTMLString';
 import { National } from 'types/data';
 import { MunicipalityProperties } from 'components/chloropleth/shared';
 

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -8,7 +8,7 @@ import { AreaChart } from 'components/charts/index';
 
 import Ziektegolf from 'assets/ziektegolf.svg';
 
-import formatNumber from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 
 import siteText from 'locale';
 

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
-import BarScale from 'components/barScale';
-import Legenda from 'components/legenda';
+import { BarScale } from 'components/barScale';
+import { Legenda } from 'components/legenda';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { AreaChart } from 'components/charts/index';

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { LineChart } from 'components/charts/index';

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -21,7 +21,8 @@ import {
 import getNlData, { INationalData } from 'static-props/nl-data';
 import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import { SafetyRegionChloropleth } from 'components/chloropleth/SafetyRegionChloropleth';
-import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleMunicipalTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleRegionTooltip } from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
 import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 import { SafetyRegionLegenda } from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
@@ -146,13 +147,13 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           {selectedMap === 'municipal' && (
             <MunicipalityChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltip}
+              tooltipContent={positiveTestedPeopleMunicipalTooltip}
             />
           )}
           {selectedMap === 'region' && (
             <SafetyRegionChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltip}
+              tooltipContent={positiveTestedPeopleRegionTooltip}
             />
           )}
         </div>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -8,7 +8,7 @@ import { ContentHeader } from 'components/layout/Content';
 import ChartRegionControls from 'components/chartRegionControls';
 
 import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 
 import siteText from 'locale';
 
@@ -113,7 +113,7 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
             <h3>
               {text.kpi_titel}{' '}
               <span className="text-blue kpi">
-                {formatDecimal(total.last_value.infected_daily_total)}
+                {formatNumber(total.last_value.infected_daily_total)}
               </span>
             </h3>
           )}

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { LineChart, BarChart } from 'components/charts/index';
 import { ContentHeader } from 'components/layout/Content';
-import ChartRegionControls from 'components/chartRegionControls';
+import { ChartRegionControls } from 'components/chartRegionControls';
 
 import Getest from 'assets/test.svg';
 import { formatNumber } from 'utils/formatNumber';
@@ -19,12 +19,11 @@ import {
 } from 'types/data.d';
 
 import getNlData, { INationalData } from 'static-props/nl-data';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import positiveTestedPeopleTooltipRegion from 'components/chloropleth/tooltips/region/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
+import { SafetyRegionChloropleth } from 'components/chloropleth/SafetyRegionChloropleth';
+import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { SafetyRegionLegenda } from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;
@@ -153,7 +152,7 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           {selectedMap === 'region' && (
             <SafetyRegionChloropleth
               metricName="positive_tested_people"
-              tooltipContent={positiveTestedPeopleTooltipRegion}
+              tooltipContent={positiveTestedPeopleTooltip}
             />
           )}
         </div>

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -1,5 +1,5 @@
-import BarScale from 'components/barScale';
-import Legenda from 'components/legenda';
+import { BarScale } from 'components/barScale';
+import { Legenda } from 'components/legenda';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { AreaChart } from 'components/charts/index';

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { LineChart } from 'components/charts/index';

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -6,7 +6,7 @@ import { LineChart } from 'components/charts/index';
 
 import Arts from 'assets/arts.svg';
 
-import formatNumber from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 
 import siteText from 'locale';
 

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -6,7 +6,7 @@ import { LineChart } from 'components/charts/index';
 
 import Locatie from 'assets/locaties.svg';
 
-import formatNumber from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 
 import siteText from 'locale';
 

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { ContentHeader } from 'components/layout/Content';

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { ContentHeader } from 'components/layout/Content';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getNationalLayout } from 'components/layout/NationalLayout';
 import { LineChart } from 'components/charts/index';
@@ -12,11 +12,11 @@ import styles from 'components/chloropleth/chloropleth.module.scss';
 import { IntakeHospitalMa } from 'types/data.d';
 import { ReactNode, useState } from 'react';
 import getNlData, { INationalData } from 'static-props/nl-data';
-import ChartRegionControls from 'components/chartRegionControls';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
-import SafetyRegionChloropleth from 'components/chloropleth/SafetyRegionChloropleth';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import SafetyRegionLegenda from 'components/chloropleth/legenda/SafetyRegionLegenda';
+import { ChartRegionControls } from 'components/chartRegionControls';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
+import { SafetyRegionChloropleth } from 'components/chloropleth/SafetyRegionChloropleth';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { SafetyRegionLegenda } from 'components/chloropleth/legenda/SafetyRegionLegenda';
 
 const text: typeof siteText.ziekenhuisopnames_per_dag =
   siteText.ziekenhuisopnames_per_dag;

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -10,7 +10,7 @@ import MaxWidth from 'components/maxWidth';
 import styles from './over.module.scss';
 import siteText from 'locale';
 
-import MDToHTMLString from 'utils/MDToHTMLString';
+import { MDToHTMLString } from 'utils/MDToHTMLString';
 
 interface IVraagEnAntwoord {
   vraag: string;

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react';
 import Head from 'next/head';
 
 import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { MaxWidth } from 'components/maxWidth';
 
 import styles from './over.module.scss';
 import siteText from 'locale';

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -16,7 +16,7 @@ import {
   ISafetyRegionData,
 } from 'static-props/safetyregion-data';
 import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { positiveTestedPeopleMunicipalTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
 import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
 import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
@@ -143,7 +143,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
             selected={selectedMunicipalCode}
             highlightSelection={false}
             metricName="positive_tested_people"
-            tooltipContent={positiveTestedPeopleTooltip}
+            tooltipContent={positiveTestedPeopleMunicipalTooltip}
           />
         </div>
       </article>

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
 import { LineChart } from 'components/charts/index';
@@ -16,9 +16,9 @@ import {
   ISafetyRegionData,
 } from 'static-props/safetyregion-data';
 import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import positiveTestedPeopleTooltip from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
+import { positiveTestedPeopleTooltip } from 'components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_positief_geteste_personen =

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -7,7 +7,7 @@ import { ContentHeader } from 'components/layout/Content';
 import siteText from 'locale';
 
 import Getest from 'assets/test.svg';
-import formatDecimal from 'utils/formatNumber';
+import { formatNumber } from 'utils/formatNumber';
 import { ResultsPerRegion } from 'types/data.d';
 
 import {
@@ -102,7 +102,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
             <h3>
               {text.kpi_titel}{' '}
               <span className="text-blue kpi">
-                {formatDecimal(
+                {formatNumber(
                   Math.round(
                     resultsPerRegion.last_value
                       .total_reported_increase_per_region

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
 import { ContentHeader } from 'components/layout/Content';
@@ -7,9 +7,9 @@ import RioolwaterMonitoring from 'assets/rioolwater-monitoring.svg';
 
 import siteText from 'locale';
 
-import RegionalSewerWaterLineChart from 'components/lineChart/regionalSewerWaterLineChart';
+import { RegionalSewerWaterLineChart } from 'components/lineChart/regionalSewerWaterLineChart';
 import { useMemo } from 'react';
-import BarChart from 'components/barChart';
+import { BarChart } from 'components/charts';
 import {
   SewerWaterBarScaleData,
   getSewerWaterBarScaleData,

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,4 +1,4 @@
-import BarScale from 'components/barScale';
+import { BarScale } from 'components/barScale';
 import { FCWithLayout } from 'components/layout';
 import { getSafetyRegionLayout } from 'components/layout/SafetyRegionLayout';
 import { ContentHeader } from 'components/layout/Content';
@@ -16,9 +16,9 @@ import {
   ISafetyRegionData,
 } from 'static-props/safetyregion-data';
 import { getLocalTitleForRegion } from 'utils/getLocalTitleForCode';
-import hospitalAdmissionsTooltip from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
-import MunicipalityLegenda from 'components/chloropleth/legenda/MunicipalityLegenda';
-import MunicipalityChloropleth from 'components/chloropleth/MunicipalityChloropleth';
+import { hospitalAdmissionsTooltip } from 'components/chloropleth/tooltips/municipal/hospitalAdmissionsTooltip';
+import { MunicipalityLegenda } from 'components/chloropleth/legenda/MunicipalityLegenda';
+import { MunicipalityChloropleth } from 'components/chloropleth/MunicipalityChloropleth';
 import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLookup';
 
 const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -12,7 +12,8 @@ import styles from 'components/chloropleth/tooltips/tooltip.module.scss';
 import siteText from 'locale';
 import { MDToHTMLString } from 'utils/MDToHTMLString';
 
-import SafetyRegionChloropleth, {
+import {
+  SafetyRegionChloropleth,
   thresholds,
 } from 'components/chloropleth/SafetyRegionChloropleth';
 import { useMediaQuery } from 'utils/useMediaQuery';

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -10,12 +10,12 @@ import EscalationLevel3 from 'assets/niveau-3.svg';
 import styles from 'components/chloropleth/tooltips/tooltip.module.scss';
 
 import siteText from 'locale';
-import MDToHTMLString from 'utils/MDToHTMLString';
+import { MDToHTMLString } from 'utils/MDToHTMLString';
 
 import SafetyRegionChloropleth, {
   thresholds,
 } from 'components/chloropleth/SafetyRegionChloropleth';
-import useMediaQuery from 'utils/useMediaQuery';
+import { useMediaQuery } from 'utils/useMediaQuery';
 import { escalationTooltip } from 'components/chloropleth/tooltips/region/escalationTooltip';
 
 const escalationThresholds = thresholds.escalation_levels.thresholds;

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -10,7 +10,7 @@ import MaxWidth from 'components/maxWidth';
 import styles from './over.module.scss';
 import siteText from 'locale';
 
-import MDToHTMLString from 'utils/MDToHTMLString';
+import { MDToHTMLString } from 'utils/MDToHTMLString';
 
 interface ICijfer {
   cijfer: string;

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -5,7 +5,7 @@ import { Fragment } from 'react';
 import Head from 'next/head';
 
 import { getLayoutWithMetadata, FCWithLayout } from 'components/layout';
-import MaxWidth from 'components/maxWidth';
+import { MaxWidth } from 'components/maxWidth';
 
 import styles from './over.module.scss';
 import siteText from 'locale';

--- a/src/utils/MDToHTMLString.ts
+++ b/src/utils/MDToHTMLString.ts
@@ -17,6 +17,6 @@ const processor = unified()
   .use(remark2rehype)
   .use(html);
 
-export default function MDToHTMLString(str: string): string {
+export function MDToHTMLString(str: string): string {
   return processor.processSync(str).toString();
 }

--- a/src/utils/__tests__/replaceVariablesInText.spec.ts
+++ b/src/utils/__tests__/replaceVariablesInText.spec.ts
@@ -1,4 +1,4 @@
-import replaceVariablesInText from '../replaceVariablesInText';
+import { replaceVariablesInText } from '../replaceVariablesInText';
 
 describe('Util: replaceVariablesInText', () => {
   it('Should return the translation string if no variables are present', () => {

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,11 +1,9 @@
 import { isToday, isYesterday } from 'date-fns';
 
 import siteText from 'locale';
-import getLocale from 'utils/getLocale';
+import { getLocale } from 'utils/getLocale';
 
 const locale = getLocale();
-
-export default formatDate;
 
 // TypeScript is missing some types for `Intl.DateTimeFormat`.
 // https://github.com/microsoft/TypeScript/issues/35865
@@ -42,7 +40,7 @@ const Day = new Intl.DateTimeFormat(locale, {
   day: 'numeric',
 });
 
-function formatDate(
+export function formatDate(
   value: number | Date,
   style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
 ): string {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,12 +1,12 @@
-import getLocale from 'utils/getLocale';
+import { getLocale } from 'utils/getLocale';
 
 const locale = getLocale();
 
 const NumberFormat = new Intl.NumberFormat(locale);
 
-export default formatNumber;
-
-function formatNumber(value: number | string | undefined | null): string {
+export function formatNumber(
+  value: number | string | undefined | null
+): string {
   if (typeof value === 'undefined' || value === null) return '-';
 
   return NumberFormat.format(Number(value));

--- a/src/utils/getLocalTitleForCode.ts
+++ b/src/utils/getLocalTitleForCode.ts
@@ -1,4 +1,4 @@
-import replaceVariablesInText from './replaceVariablesInText';
+import { replaceVariablesInText } from './replaceVariablesInText';
 
 import regios from 'data';
 import municipalities from 'data/gemeente_veiligheidsregio.json';

--- a/src/utils/getLocale.ts
+++ b/src/utils/getLocale.ts
@@ -1,4 +1,4 @@
-export default function getLocale(): string {
+export function getLocale(): string {
   const locale = process.env.NEXT_PUBLIC_LOCALE;
   const defaultLocale = 'nl';
   if (!locale) return defaultLocale;

--- a/src/utils/getSafetyRegionForMunicipalityCode.ts
+++ b/src/utils/getSafetyRegionForMunicipalityCode.ts
@@ -7,7 +7,7 @@ import regios from 'data';
  *
  * @param code
  */
-export default function getSafetyRegionForMunicipalityCode(
+export function getSafetyRegionForMunicipalityCode(
   code: string
 ): { name: string; code: string; id: number } | undefined {
   const municipality = municipalities.find((mun) => mun.gemcode === code);

--- a/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
+++ b/src/utils/getSafetyRegionMunicipalsForMunicipalCode.ts
@@ -7,7 +7,7 @@ import regionCodeToMunicipalCodeLookup from 'data/regionCodeToMunicipalCodeLooku
  *
  * @param code
  */
-export default function getSafetyRegionMunicipalsForMunicipalCode(
+export function getSafetyRegionMunicipalsForMunicipalCode(
   code: string
 ): string[] | undefined {
   const vrcode = municipalCodeToRegionCodeLookup[code];

--- a/src/utils/replaceVariablesInText.ts
+++ b/src/utils/replaceVariablesInText.ts
@@ -16,10 +16,10 @@ const curlyBracketRegex = /\{\{(.+?)\}\}/g;
  * @param variables - An object with keys representing any variable available for replacement.
  */
 
-const replaceVariablesInText = (
+export function replaceVariablesInText(
   translation?: string | undefined | null,
   variables?: { [key: string]: string | undefined }
-): string => {
+): string {
   if (!translation) return '';
 
   return translation.replace(curlyBracketRegex, (_string, variableName) => {
@@ -27,6 +27,4 @@ const replaceVariablesInText = (
 
     return variables[variableName.trim()] ?? '';
   });
-};
-
-export default replaceVariablesInText;
+}

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -4,10 +4,10 @@ import {
   SewerMeasurementsLastValue,
   ResultsPerSewerInstallationPerMunicipalityLastValue,
 } from 'types/data.d';
-import formatDate from 'utils/formatDate';
-import formatNumber from 'utils/formatNumber';
+import { formatDate } from 'utils/formatDate';
+import { formatNumber } from 'utils/formatNumber';
 import { XrangePointOptionsObject } from 'highcharts';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
 
 import siteText from 'locale';
 

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -5,9 +5,9 @@ import {
   AverageSewerInstallationPerRegionItem,
   SewerValueElement,
 } from 'types/data.d';
-import replaceVariablesInText from 'utils/replaceVariablesInText';
-import formatDate from 'utils/formatDate';
-import formatNumber from 'utils/formatNumber';
+import { replaceVariablesInText } from 'utils/replaceVariablesInText';
+import { formatDate } from 'utils/formatDate';
+import { formatNumber } from 'utils/formatNumber';
 import siteText from 'locale';
 
 const text: typeof siteText.veiligheidsregio_rioolwater_metingen =

--- a/src/utils/useDynamicScale.ts
+++ b/src/utils/useDynamicScale.ts
@@ -17,7 +17,7 @@ interface IDynamicScale {
  * if suddenly the value is higher than your desired min/max extent.
  */
 
-function useDynamicScale(
+export function useDynamicScale(
   min: number,
   max: number,
   dataKey: string,
@@ -64,5 +64,3 @@ function useDynamicScale(
   }
   return { scale, isValidating };
 }
-
-export default useDynamicScale;

--- a/src/utils/useExtent.ts
+++ b/src/utils/useExtent.ts
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
  * @param collection the given array
  * @param predicate the optional predicate
  */
-export default function useExtent(
+export function useExtent(
   collection?: any[],
   predicate?: (item: any) => number
 ): [number, number] | undefined {

--- a/src/utils/useMediaQuery.ts
+++ b/src/utils/useMediaQuery.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-export default function useMediaQuery(
+export function useMediaQuery(
   breakpoint: string,
   initialMatches = false
 ): boolean {

--- a/src/utils/useThrottle.ts
+++ b/src/utils/useThrottle.ts
@@ -1,14 +1,12 @@
 import { useState, useEffect, useRef } from 'react';
 
-export default useThrottle;
-
 // This hook uses a generic type to match the input with the output.
 //
 // Example:
 // ```
 // const throttledTerm = useThrottle<string>(term, 100);
 // ```
-function useThrottle<Value>(value: Value, limit: number): Value {
+export function useThrottle<Value>(value: Value, limit: number): Value {
   const [throttledValue, setThrottledValue] = useState<Value>(value);
   const lastRan = useRef(Date.now());
 


### PR DESCRIPTION
## Summary & Motivation

Remove most default exports, use named exports instead.

Notable exceptions: pages, as they require to be default exports; our locale; charts.

## Unresolved questions

The way to make Next's dynamic exports behave with named exports does not work. The provided example in their documentation gives various type errors. We could fix it in a separate PR, perhaps?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
