### PR TITLE
Barrel files

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
     "validate-json": "node schema/validator/validate-json.js",
     "validate-single": "node schema/validator/validate-single.js",
     "generate-typescript": "node schema/validator/generate-typescript.js"
-  }
+  },
+  "sideEffects": [
+    "./src/some-side-effectful-file.js"
+  ]
 }

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -164,14 +164,23 @@ export function Chloropleth<T>(props: TProps<T>) {
           transform={`translate(${marginLeft},${marginTop})`}
           clipPath={`url(#${clipPathId.current})`}
         >
-          <Mercator data={featureCollection.features} fitSize={sizeToFit}>
+          <Mercator
+            data={featureCollection.features}
+            fitSize={sizeToFit as [[number, number], any]}
+          >
             {renderFeature(featureCallback)}
           </Mercator>
-          <Mercator data={overlays.features} fitSize={sizeToFit}>
+          <Mercator
+            data={overlays.features}
+            fitSize={sizeToFit as [[number, number], any]}
+          >
             {renderFeature(overlayCallback)}
           </Mercator>
           {hovers && (
-            <Mercator data={hovers.features} fitSize={sizeToFit}>
+            <Mercator
+              data={hovers.features}
+              fitSize={sizeToFit as [[number, number], any]}
+            >
               {renderFeature(hoverCallback)}
             </Mercator>
           )}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,15 @@
+export * from './areaChart';
+export * from './barChart';
+export * from './barScale';
+export * from './chartRegionControls';
+export * from './charts';
+export * from './chartTimeControls';
+// export * from './chloropleth';
+export * from './comboBox';
+// export * from './gemeente';
+// export * from './landelijk';
+export * from './layout';
+export * from './legenda';
+export * from './lineChart';
+
+export * from './maxWidth';

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,5 +1,5 @@
-import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
-import { MaxWidth } from '~/components/maxWidth';
+import { getLayoutWithMetadata, FCWithLayout } from '~/components';
+import { MaxWidth } from '~/components';
 
 import text from '~/locale/index';
 import styles from './over.module.scss';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "~/components/*": ["./src/components/*"],
-      "~/scss/*": ["./src/scss/*"],
-      "~/assets/*": ["./src/assets/*"],
-      "~/data/*": ["./src/data/*"],
-      "~/lib/*": ["./src/lib/*"],
-      "~/locale/*": ["./src/locale/*"],
-      "~/static-props/*": ["./src/static-props/*"],
-      "~/types/*": ["./src/types/*"],
-      "~/utils/*": ["./src/utils/*"]
+      "~/*": ["src/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Summary

A draft PR to verify the working of barrel files and their effect on bundle size / tree shaking. Webpack needs to know which files have side effects. For example, modules that inject a polyfill would be considered as having a side effect.

https://webpack.js.org/configuration/optimization/#optimizationsideeffects

In this PR a (partial) barrel file is created for ~/components and it is used for imports in the 404 page. So the size of the compiled 404 page is what you should look at here:

Before:

```
Page                                                           Size     First Load JS
┌ ● /                                                          2.57 kB         214 kB
├   └ css/b8f09c2cd1b1ac1dcb75.css                             2.82 kB
├   /_app                                                      0 B            63.4 kB
├ ○ /404                                                       452 B           101 kB
├ ● /500                                                       441 B           101 kB          
```

Without config:

```
Page                                                           Size     First Load JS
┌ ● /                                                          2.57 kB         214 kB
├   └ css/b8f09c2cd1b1ac1dcb75.css                             2.82 kB
├   /_app                                                      0 B            63.4 kB
├ ○ /404                                                       32.8 kB         248 kB
├   └ css/bef9b58462241312ebcb.css                             1.79 kB
├ ● /500                                                       441 B           101 kB
```


With config:

```
Page                                                           Size     First Load JS
┌ ● /                                                          2.57 kB         214 kB
├   └ css/a2852150e50fc414760f.css                             2.81 kB
├   /_app                                                      0 B            63.4 kB
├ ○ /404                                                       452 B           101 kB
├ ● /500                                                       441 B           101 kB
```
