### PR TITLE
fix off by one error on index check

### DIFF
--- a/src/utils/getItemFromArray.ts
+++ b/src/utils/getItemFromArray.ts
@@ -3,7 +3,7 @@ import { assert } from '~/utils/assert';
 export function getItemFromArray<T>(arr: T[], index: number): T {
   const item = arr[index];
   assert(
-    index > 0 && index < arr.length && item !== undefined,
+    index >= 0 && index < arr.length && item !== undefined,
     `Index ${index} is out of range`
   );
   return item;

--- a/src/utils/getItemFromArray.ts
+++ b/src/utils/getItemFromArray.ts
@@ -2,9 +2,6 @@ import { assert } from '~/utils/assert';
 
 export function getItemFromArray<T>(arr: T[], index: number): T {
   const item = arr[index];
-  assert(
-    index >= 0 && index < arr.length && item !== undefined,
-    `Index ${index} is out of range`
-  );
+  assert(index >= 0 && index < arr.length, `Index ${index} is out of range`);
   return item;
 }


### PR DESCRIPTION
## Summary

The weekly view in the tooltip threw an error because of the check the `assert()` function.


