### PR TITLE
Add unit tests for Choropleth base component

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/out/*
 **/.next/*
+**/*.spec.*

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 **/out/*
 **/.next/*
 **/*.spec.*
+**/testhelpers/*

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -43,7 +43,7 @@ export type TProps<TFeatureProperties> = {
   hovers?: FeatureCollection<MultiPolygon, TFeatureProperties>;
   // The boundingbox is calculated based on these features, this can be used to
   // zoom in on a specific part of the map upon initialisation.
-  boundingbox: FeatureCollection<MultiPolygon>;
+  boundingBox: FeatureCollection<MultiPolygon>;
   // Height, width, etc
   dimensions: TCombinedChartDimensions;
   // This callback is invoked for each of the features in the featureCollection property.
@@ -89,7 +89,7 @@ export function Chloropleth<T>(props: TProps<T>) {
     featureCollection,
     overlays,
     hovers,
-    boundingbox,
+    boundingBox,
     dimensions,
     featureCallback,
     overlayCallback,
@@ -120,7 +120,7 @@ export function Chloropleth<T>(props: TProps<T>) {
   );
 
   const clipPathId = useRef(`_${Math.random().toString(36).substring(2, 15)}`);
-  const timout = useRef<any>(-1);
+  const timeout = useRef<any>(-1);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const {
@@ -134,11 +134,13 @@ export function Chloropleth<T>(props: TProps<T>) {
 
   const sizeToFit: [[number, number], any] = [
     [boundedWidth, boundedHeight],
-    boundingbox,
+    boundingBox,
   ];
 
-  const showTooltip = tooltipStore.current((state) => state.showTooltip);
-  const hideTooltip = tooltipStore.current((state) => state.hideTooltip);
+  const [showTooltip, hideTooltip] = tooltipStore.current((state) => [
+    state.showTooltip,
+    state.hideTooltip,
+  ]);
 
   return (
     <>
@@ -146,8 +148,8 @@ export function Chloropleth<T>(props: TProps<T>) {
         width={width}
         height={height}
         className={styles.svgMap}
-        onMouseOver={createSvgMouseOverHandler(timout, showTooltip)}
-        onMouseOut={createSvgMouseOutHandler(timout, hideTooltip)}
+        onMouseOver={createSvgMouseOverHandler(timeout, showTooltip)}
+        onMouseOut={createSvgMouseOutHandler(timeout, hideTooltip)}
         onClick={createSvgClickHandler(onPathClick, showTooltip, isLargeScreen)}
       >
         <clipPath id={clipPathId.current}>

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -146,9 +146,9 @@ export function Chloropleth<T>(props: TProps<T>) {
         width={width}
         height={height}
         className={styles.svgMap}
-        onMouseOver={svgMouseOver(timout, showTooltip)}
-        onMouseOut={svgMouseOut(timout, hideTooltip)}
-        onClick={svgClick(onPathClick, showTooltip, isLargeScreen)}
+        onMouseOver={createSvgMouseOverHandler(timout, showTooltip)}
+        onMouseOut={createSvgMouseOutHandler(timout, hideTooltip)}
+        onClick={createSvgClickHandler(onPathClick, showTooltip, isLargeScreen)}
       >
         <clipPath id={clipPathId.current}>
           <rect
@@ -205,7 +205,7 @@ const renderFeature = (callback: TRenderCallback) => {
   );
 };
 
-const svgClick = (
+const createSvgClickHandler = (
   onPathClick: (id: string) => void,
   showTooltip: (settings: TooltipSettings) => void,
   isLargeScreen: boolean
@@ -240,7 +240,10 @@ const positionTooltip = (
   }
 };
 
-const svgMouseOver = (timeout: MutableRefObject<any>, showTooltip: any) => {
+const createSvgMouseOverHandler = (
+  timeout: MutableRefObject<any>,
+  showTooltip: any
+) => {
   return (event: any) => {
     const elm = event.target;
 
@@ -256,7 +259,10 @@ const svgMouseOver = (timeout: MutableRefObject<any>, showTooltip: any) => {
   };
 };
 
-const svgMouseOut = (timeout: MutableRefObject<any>, hideTooltip: any) => {
+const createSvgMouseOutHandler = (
+  timeout: MutableRefObject<any>,
+  hideTooltip: any
+) => {
   return () => {
     if (timeout.current < 0) {
       timeout.current = setTimeout(() => {

--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -240,14 +240,14 @@ const positionTooltip = (
   }
 };
 
-const svgMouseOver = (timout: MutableRefObject<any>, showTooltip: any) => {
+const svgMouseOver = (timeout: MutableRefObject<any>, showTooltip: any) => {
   return (event: any) => {
     const elm = event.target;
 
     if (elm.attributes['data-id']) {
-      if (timout.current > -1) {
-        clearTimeout(timout.current);
-        timout.current = -1;
+      if (timeout.current > -1) {
+        clearTimeout(timeout.current);
+        timeout.current = -1;
       }
 
       const id = elm.attributes['data-id'].value;
@@ -256,10 +256,10 @@ const svgMouseOver = (timout: MutableRefObject<any>, showTooltip: any) => {
   };
 };
 
-const svgMouseOut = (timout: MutableRefObject<any>, hideTooltip: any) => {
+const svgMouseOut = (timeout: MutableRefObject<any>, hideTooltip: any) => {
   return () => {
-    if (timout.current < 0) {
-      timout.current = setTimeout(() => {
+    if (timeout.current < 0) {
+      timeout.current = setTimeout(() => {
         hideTooltip();
       }, 500);
     }

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -256,7 +256,7 @@ export function MunicipalityChloropleth<
         featureCollection={municipalGeo}
         overlays={overlays}
         hovers={hasData ? municipalGeo : undefined}
-        boundingbox={boundingbox || countryGeo}
+        boundingBox={boundingbox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}
         overlayCallback={overlayCallback}

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -103,7 +103,7 @@ export type TProps<
  * This component renders a map of the Netherlands with the outlines of all the municipalities which
  * receive a fill color based on the specified Municipality metric data.
  *
- * The metricName specifies which exact metric is visualised. The color scale is calculated using
+ * The metricName specifies which exact metric is visualized. The color scale is calculated using
  * the specified metric and the given gradient.
  *
  * When a selected municipal code is specified, the map will zoom in on the safety region to which
@@ -182,7 +182,7 @@ export function MunicipalityChloropleth<
         SafetyRegionProperties | GeoJsonProperties
       >,
       path: string,
-      index: number
+      _index: number
     ) => {
       const { vrcode } = feature.properties as SafetyRegionProperties;
       const className = classNames(
@@ -193,7 +193,7 @@ export function MunicipalityChloropleth<
         <path
           className={className}
           shapeRendering="optimizeQuality"
-          key={`municipality-map-overlay-${index}`}
+          key={`municipality-map-overlay-${vrcode}`}
           d={path}
           fill={'none'}
         />

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -253,7 +253,7 @@ export function SafetyRegionChloropleth<
         featureCollection={regionGeo}
         overlays={countryGeo}
         hovers={hasData ? regionGeo : undefined}
-        boundingbox={boundingbox || countryGeo}
+        boundingBox={boundingbox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}
         overlayCallback={overlayCallback}

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -4,16 +4,9 @@ import { Chloropleth, TProps } from '~/components/chloropleth/Chloropleth';
 import { MunicipalityProperties } from '../shared';
 import { Feature, MultiPolygon } from 'geojson';
 import { countryGeo, municipalGeo } from '../topology';
+import { mockMatchMedia } from '~/utils/testhelpers/mockMatchMedia';
 
 describe('Component: Choropleth', () => {
-  function mockMatchMedia(shouldMatchMedia: boolean) {
-    global.window.matchMedia = jest.fn().mockReturnValue({
-      matches: shouldMatchMedia,
-      addListener: () => {},
-      removeListener: () => {},
-    });
-  }
-
   const featureCollection = municipalGeo;
   const overlays = countryGeo;
   const hovers = municipalGeo;

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -157,7 +157,7 @@ describe('Component: Choropleth', () => {
     expect(pathReceiveClick).toBeTruthy();
   });
 
-  it('Should call the tooltip content handler when paths are clicked on on a small screen', () => {
+  it('Should show the tooltip content handler when paths are clicked on on a small screen', () => {
     // Arrange
     const testMunicipalCode = 'GM0003';
 
@@ -183,11 +183,8 @@ describe('Component: Choropleth', () => {
       expect(id).toEqual(testMunicipalCode);
     };
 
-    let tooltipRequested = false;
     const getTooltipContent = (id: string) => {
-      tooltipRequested = true;
-      expect(id).toEqual(testMunicipalCode);
-      return <div />;
+      return <div>Tooltip:{id}</div>;
     };
 
     const props: TProps<MunicipalityProperties> = {
@@ -213,7 +210,8 @@ describe('Component: Choropleth', () => {
 
     // Assert
     expect(pathReceiveClick).toBeFalsy();
-    expect(tooltipRequested).toBeTruthy();
+    const tooltips = renderResult.getAllByText(`Tooltip:${testMunicipalCode}`);
+    expect(tooltips.length).toEqual(1);
   });
 
   it('Should call the tooltip content handler when paths are mouse-overed', () => {
@@ -236,11 +234,8 @@ describe('Component: Choropleth', () => {
       );
     };
 
-    let tooltipRequested = false;
     const getTooltipContent = (id: string) => {
-      tooltipRequested = true;
-      expect(id).toEqual(testMunicipalCode);
-      return <div />;
+      return <div>Tooltip:{id}</div>;
     };
 
     const props: TProps<MunicipalityProperties> = {
@@ -265,6 +260,7 @@ describe('Component: Choropleth', () => {
     fireEvent.mouseOver(gemeente);
 
     // Assert
-    expect(tooltipRequested).toBeTruthy();
+    const tooltips = renderResult.getAllByText(`Tooltip:${testMunicipalCode}`);
+    expect(tooltips.length).toEqual(1);
   });
 });

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -9,7 +9,6 @@ describe('Component: Choropleth', () => {
   function mockMatchMedia(shouldMatchMedia: boolean) {
     global.window.matchMedia = jest.fn().mockReturnValue({
       matches: shouldMatchMedia,
-      mock: true,
       addListener: () => {},
       removeListener: () => {},
     });
@@ -85,7 +84,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingbox,
+      boundingBox: boundingbox,
       dimensions,
       featureCallback,
       overlayCallback,
@@ -110,6 +109,7 @@ describe('Component: Choropleth', () => {
     expect(featureCallbackWasCalled).toBeTruthy();
     expect(overlayCallbackWasCalled).toBeTruthy();
     expect(hoverCallbackWasCalled).toBeTruthy();
+    // Check if there are exactly 4 <g> elements. One container, and one for each feature collection
     expect(groups?.length).toEqual(4);
   });
 
@@ -143,7 +143,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingbox,
+      boundingBox: boundingbox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,
@@ -201,7 +201,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingbox,
+      boundingBox: boundingbox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,
@@ -254,7 +254,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingbox,
+      boundingBox: boundingbox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -10,7 +10,7 @@ describe('Component: Choropleth', () => {
   const featureCollection = municipalGeo;
   const overlays = countryGeo;
   const hovers = municipalGeo;
-  const boundingbox = municipalGeo;
+  const boundingBox = municipalGeo;
   const dimensions = {
     boundedWidth: 500,
     boundedHeight: 500,
@@ -39,27 +39,20 @@ describe('Component: Choropleth', () => {
 
   it('Should call the correct callbacks for the given feature collections', () => {
     // Arrange
-    let featureCallbackWasCalled = false;
-    let overlayCallbackWasCalled = false;
-    let hoverCallbackWasCalled = false;
 
     const featureCallback = (
       feature: Feature<MultiPolygon, MunicipalityProperties>,
       _path: string,
       _index: number
     ) => {
-      featureCallbackWasCalled = true;
-      expect(featureCollection.features.indexOf(feature)).toBeGreaterThan(-1);
       return <path key={`feature-${feature.properties.gemcode}`} />;
     };
 
     const overlayCallback = (
-      feature: Feature<MultiPolygon>,
+      _feature: Feature<MultiPolygon>,
       _path: string,
       index: number
     ) => {
-      overlayCallbackWasCalled = true;
-      expect(overlays.features.indexOf(feature)).toBeGreaterThan(-1);
       return <path key={`overlay-${index}`} />;
     };
 
@@ -68,8 +61,6 @@ describe('Component: Choropleth', () => {
       _path: string,
       _index: number
     ) => {
-      hoverCallbackWasCalled = true;
-      expect(featureCollection.features.indexOf(feature)).toBeGreaterThan(-1);
       return <path key={`hover-${feature.properties.gemcode}`} />;
     };
 
@@ -77,7 +68,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingBox: boundingbox,
+      boundingBox,
       dimensions,
       featureCallback,
       overlayCallback,
@@ -99,10 +90,11 @@ describe('Component: Choropleth', () => {
     } catch (e) {}
 
     // Assert
-    expect(featureCallbackWasCalled).toBeTruthy();
-    expect(overlayCallbackWasCalled).toBeTruthy();
-    expect(hoverCallbackWasCalled).toBeTruthy();
     // Check if there are exactly 4 <g> elements. One container, and one for each feature collection
+    expect(groups?.[0].children.length).toEqual(3);
+    expect(groups?.[1].children.length).toEqual(355); // municipal features
+    expect(groups?.[2].children.length).toEqual(1); // country outline
+    expect(groups?.[3].children.length).toEqual(355); // hover outlines
     expect(groups?.length).toEqual(4);
   });
 
@@ -136,7 +128,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingBox: boundingbox,
+      boundingBox: boundingBox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,
@@ -191,7 +183,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingBox: boundingbox,
+      boundingBox: boundingBox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,
@@ -242,7 +234,7 @@ describe('Component: Choropleth', () => {
       featureCollection,
       overlays,
       hovers,
-      boundingBox: boundingbox,
+      boundingBox: boundingBox,
       dimensions,
       featureCallback,
       overlayCallback: defaultOverlayCallback,

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -30,9 +30,7 @@ describe('Component: Choropleth', () => {
   };
 
   const defaultHoverCallback = (
-    feature: Feature<MultiPolygon, MunicipalityProperties>,
-    _path: string,
-    _index: number
+    feature: Feature<MultiPolygon, MunicipalityProperties>
   ) => {
     return <path key={`hover-${feature.properties.gemcode}`} />;
   };
@@ -41,9 +39,7 @@ describe('Component: Choropleth', () => {
     // Arrange
 
     const featureCallback = (
-      feature: Feature<MultiPolygon, MunicipalityProperties>,
-      _path: string,
-      _index: number
+      feature: Feature<MultiPolygon, MunicipalityProperties>
     ) => {
       return <path key={`feature-${feature.properties.gemcode}`} />;
     };
@@ -57,9 +53,7 @@ describe('Component: Choropleth', () => {
     };
 
     const hoverCallback = (
-      feature: Feature<MultiPolygon, MunicipalityProperties>,
-      _path: string,
-      _index: number
+      feature: Feature<MultiPolygon, MunicipalityProperties>
     ) => {
       return <path key={`hover-${feature.properties.gemcode}`} />;
     };
@@ -90,8 +84,7 @@ describe('Component: Choropleth', () => {
     } catch (e) {}
 
     // Assert
-    // Check if there are exactly 4 <g> elements. One container, and one for each feature collection
-    expect(groups?.[0].children.length).toEqual(3);
+    expect(groups?.[0].children.length).toEqual(3); // main group holding 3 groups
     expect(groups?.[1].children.length).toEqual(355); // municipal features
     expect(groups?.[2].children.length).toEqual(1); // country outline
     expect(groups?.[3].children.length).toEqual(355); // hover outlines
@@ -105,9 +98,7 @@ describe('Component: Choropleth', () => {
     mockMatchMedia(true);
 
     const featureCallback = (
-      feature: Feature<MultiPolygon, MunicipalityProperties>,
-      _path: string,
-      _index: number
+      feature: Feature<MultiPolygon, MunicipalityProperties>
     ) => {
       return (
         <path
@@ -118,9 +109,9 @@ describe('Component: Choropleth', () => {
       );
     };
 
-    let pathReceiveClick = false;
+    let hasPathReceivedClick = false;
     const onPathClick = (id: string) => {
-      pathReceiveClick = true;
+      hasPathReceivedClick = true;
       expect(id).toEqual(testMunicipalCode);
     };
 
@@ -146,7 +137,7 @@ describe('Component: Choropleth', () => {
     fireEvent.click(gemeente);
 
     // Assert
-    expect(pathReceiveClick).toBeTruthy();
+    expect(hasPathReceivedClick).toBeTruthy();
   });
 
   it('Should show the tooltip content handler when paths are clicked on on a small screen', () => {
@@ -156,9 +147,7 @@ describe('Component: Choropleth', () => {
     mockMatchMedia(false);
 
     const featureCallback = (
-      feature: Feature<MultiPolygon, MunicipalityProperties>,
-      _path: string,
-      _index: number
+      feature: Feature<MultiPolygon, MunicipalityProperties>
     ) => {
       return (
         <path
@@ -169,9 +158,9 @@ describe('Component: Choropleth', () => {
       );
     };
 
-    let pathReceiveClick = false;
+    let hasPathReceivedClick = false;
     const onPathClick = (id: string) => {
-      pathReceiveClick = true;
+      hasPathReceivedClick = true;
       expect(id).toEqual(testMunicipalCode);
     };
 
@@ -201,7 +190,7 @@ describe('Component: Choropleth', () => {
     fireEvent.click(gemeente);
 
     // Assert
-    expect(pathReceiveClick).toBeFalsy();
+    expect(hasPathReceivedClick).toBeFalsy();
     const tooltips = renderResult.getAllByText(`Tooltip:${testMunicipalCode}`);
     expect(tooltips.length).toEqual(1);
   });

--- a/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
+++ b/src/components/chloropleth/__tests__/Chloropleth.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Chloropleth, TProps } from '~/components/chloropleth/Chloropleth';
+import { MunicipalityProperties } from '../shared';
+import { Feature, MultiPolygon } from 'geojson';
+import { countryGeo, municipalGeo } from '../topology';
+
+describe('Component: Choropleth', () => {
+  it('Should call onPathClick handler when paths are clicked on on a large screen', () => {
+    const testMunicipalCode = 'GM0003';
+
+    const featureCollection = municipalGeo;
+    const overlays = countryGeo;
+    const hovers = municipalGeo;
+    const boundingbox = municipalGeo;
+    const dimensions = {
+      boundedWidth: 500,
+      boundedHeight: 500,
+    };
+
+    const featureCallback = (
+      feature: Feature<MultiPolygon, MunicipalityProperties>,
+      _path: string,
+      _index: number
+    ) => {
+      expect(featureCollection.features.indexOf(feature)).toBeGreaterThan(-1);
+      return (
+        <path
+          data-id={feature.properties.gemcode}
+          data-testid={`feature-${feature.properties.gemcode}`}
+          key={`feature-${feature.properties.gemcode}`}
+        />
+      );
+    };
+
+    const overlayCallback = (
+      feature: Feature<MultiPolygon>,
+      _path: string,
+      index: number
+    ) => {
+      expect(overlays.features.indexOf(feature)).toBeGreaterThan(-1);
+      return <path data-testid={`overlay-${index}`} key={`overlay-${index}`} />;
+    };
+
+    const hoverCallback = (
+      feature: Feature<MultiPolygon, MunicipalityProperties>,
+      _path: string,
+      _index: number
+    ) => {
+      expect(featureCollection.features.indexOf(feature)).toBeGreaterThan(-1);
+      return (
+        <path
+          data-id={feature.properties.gemcode}
+          data-testid={`hover-${feature.properties.gemcode}`}
+          key={`hover-${feature.properties.gemcode}`}
+        />
+      );
+    };
+
+    const onPathClick = (id: string) => {
+      expect(id).toEqual(testMunicipalCode);
+    };
+
+    const getTooltipContent = (_id: string) => {
+      return <div />;
+    };
+
+    const props: TProps<MunicipalityProperties> = {
+      featureCollection,
+      overlays,
+      hovers,
+      boundingbox,
+      dimensions,
+      featureCallback,
+      overlayCallback,
+      hoverCallback,
+      onPathClick,
+      getTooltipContent,
+    };
+
+    const renderResult = render(<Chloropleth {...props} />);
+    const gemeente = renderResult.getAllByTestId(
+      `feature-${testMunicipalCode}`
+    )[0];
+
+    fireEvent.click(gemeente);
+  });
+});

--- a/src/utils/testhelpers/mockMatchMedia.ts
+++ b/src/utils/testhelpers/mockMatchMedia.ts
@@ -1,0 +1,7 @@
+export function mockMatchMedia(shouldMatchMedia: boolean) {
+  global.window.matchMedia = jest.fn().mockReturnValue({
+    matches: shouldMatchMedia,
+    addListener: () => {},
+    removeListener: () => {},
+  });
+}


### PR DESCRIPTION
## Summary

Since we are now able to run jest tests successfully, these are some first unit tests

## Motivation

Testing is good

## Detailed design

These tests make sure that the correct callbacks are invoked for the correct feature collections. They check if the onclick handler is called with the correct corresponding id and if the click or tooltip is triggered correctly based on the screen size.
It adds a small test helper called mockMatchMedia that can help developers mock a specific screen size.

Choropleth is a rather large component, so it needs quite a bit of scaffolding to setup.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
