### PR TITLE
fix lastEdited in footer

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -65,8 +65,7 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
   const locale = getLocale();
   const showSmallLogo = useMediaQuery('(max-width: 480px)', true);
 
-  const dateTime = new Date(Number(lastGenerated) * 1000).toISOString();
-
+  const dateTime = formatDate(Number(lastGenerated), 'iso');
   const dateOfInsertion = lastGenerated
     ? formatDate(Number(lastGenerated), 'long')
     : undefined;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -255,7 +255,7 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
                     __html: replaceVariablesInText(
                       text.laatst_bijgewerkt.message,
                       {
-                        dateOfInsertion: `<time dateTime=${dateTime}>${dateOfInsertion}</time>`,
+                        dateOfInsertion: `<time datetime=${dateTime}>${dateOfInsertion}</time>`,
                       }
                     ),
                   }}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -65,14 +65,10 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
   const locale = getLocale();
   const showSmallLogo = useMediaQuery('(max-width: 480px)', true);
 
-  const { dateTime, dateOfInsertion } = useMemo(() => {
-    const dateTime = formatDate(Number(lastGenerated), 'iso');
-    const dateOfInsertion = lastGenerated
-      ? formatDate(Number(lastGenerated), 'long')
-      : undefined;
-
-    return { dateTime, dateOfInsertion };
-  }, [lastGenerated]);
+  const dateTime = formatDate(Number(lastGenerated), 'iso');
+  const dateOfInsertion = lastGenerated
+    ? formatDate(Number(lastGenerated), 'long')
+    : undefined;
 
   return (
     <>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -65,10 +65,14 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
   const locale = getLocale();
   const showSmallLogo = useMediaQuery('(max-width: 480px)', true);
 
-  const dateTime = formatDate(Number(lastGenerated), 'iso');
-  const dateOfInsertion = lastGenerated
-    ? formatDate(Number(lastGenerated), 'long')
-    : undefined;
+  const { dateTime, dateOfInsertion } = useMemo(() => {
+    const dateTime = formatDate(Number(lastGenerated), 'iso');
+    const dateOfInsertion = lastGenerated
+      ? formatDate(Number(lastGenerated), 'long')
+      : undefined;
+
+    return { dateTime, dateOfInsertion };
+  }, [lastGenerated]);
 
   return (
     <>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -15,24 +15,29 @@ interface DateTimeFormatOptions extends Intl.DateTimeFormatOptions {
 const Long = new Intl.DateTimeFormat(locale, {
   dateStyle: 'long',
   timeStyle: 'short',
+  timeZone: 'Europe/Amsterdam',
 } as DateTimeFormatOptions);
 
 const Medium = new Intl.DateTimeFormat(locale, {
   dateStyle: 'long',
+  timeZone: 'Europe/Amsterdam',
 } as DateTimeFormatOptions);
 
 // Day Month or Month Day depending on the locale
 const DayMonth = new Intl.DateTimeFormat(locale, {
   month: 'long',
   day: 'numeric',
+  timeZone: 'Europe/Amsterdam',
 });
 
 const MonthShort = new Intl.DateTimeFormat(locale, {
   month: 'short',
+  timeZone: 'Europe/Amsterdam',
 });
 
 const Day = new Intl.DateTimeFormat(locale, {
   day: 'numeric',
+  timeZone: 'Europe/Amsterdam',
 });
 
 export function formatDate(


### PR DESCRIPTION
## Summary

There's an inconsistency on how the time on which the dashboard was last edited is interpreted across different browsers, environments and languages (locales).
- it seems that there is a timezone malfunction (being two hours ahead on production when new data is generated)
- when you view the time on page visit, the right time is shown, but after browsing across several pages this time changes (hydration issue perhaps)
- the formatted string shows an English time formatting `September 16, 2020 at 2:00 PM` on the Dutch translation (locale)
- the formatted string leaves out the entire formatted timestring on the English pages

## Motivation

Why are we doing this? What use cases does it support? What is the expected
outcome?

Please focus on explaining the motivation so that if this PR is not accepted,
the motivation could be used to develop alternative solutions. In other words,
enumerate the constraints you are trying to solve without coupling them too
closely to the solution you have in mind.

## Detailed design

This is the bulk of the PR. Explain the design in enough detail for somebody
familiar with Opus to understand, and for somebody familiar with the
front-end to implement. This should get into specifics and corner-cases,
and include examples of how the feature is used. Any new terminology should be
defined here.

## Drawbacks

Why should we _not_ do this? Please consider:

- implementation cost, both in term of code size and complexity
- maintenance cost, how complex is the solution and how prone to change is it?
- integration of this feature with other existing and planned features

There are tradeoffs to choosing any path. Attempt to identify them here.

## Alternatives

What other designs have been considered? What is the impact of not doing this?

## Unresolved questions

Optional, but suggested for bigger features. What parts of the design are still
TBD or not implemented? How will you deal with that in the future?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
