### PR TITLE
Update and standardize schemas

### DIFF
--- a/schema/regional/hospitals.json
+++ b/schema/regional/hospitals.json
@@ -5,9 +5,12 @@
   "type": "object",
   "properties": {
     "intake_average": { "$ref": "#/definitions/time_series_value" },
+    "beds_occupied": {
+      "type": "number"
+    },
     "sourced_from": { "$ref": "#/definitions/sourced_from" }
   },
-  "required": ["intake_average", "capacity_percentage", "sourced_from"],
+  "required": ["intake_average", "beds_occupied", "sourced_from"],
   "additionalProperties": false,
   "definitions": {
     "time_series": {

--- a/schema/regional/hospitals.json
+++ b/schema/regional/hospitals.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "regional_hospitals",
+  "title": "hospitals",
+  "type": "object",
+  "properties": {
+    "intake_average": { "$ref": "#/definitions/time_series_value" },
+    "sourced_from": { "$ref": "#/definitions/sourced_from" }
+  },
+  "required": ["intake_average", "capacity_percentage", "sourced_from"],
+  "additionalProperties": false,
+  "definitions": {
+    "time_series": {
+      "title": "time_series",
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/time_series_value"
+          }
+        },
+        "last_value": {
+          "$ref": "#/definitions/time_series_value"
+        }
+      },
+      "required": ["values", "last_value"],
+      "additionalProperties": false
+    },
+    "time_series_value": {
+      "title": "time_series_value",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "reported_at": {
+          "type": "integer"
+        },
+        "inserted_at": {
+          "type": "integer"
+        }
+      },
+      "required": ["value", "reported_at", "inserted_at"],
+      "additionalProperties": false
+    },
+    "sourced_from": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": ["title", "url"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/regional/intensive_cares.json
+++ b/schema/regional/intensive_cares.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "regional_intensive_cares",
+  "title": "intensive_cares",
+  "type": "object",
+  "properties": {
+    "intake_average": { "$ref": "#/definitions/time_series_value" },
+    "capacity_percentage": {
+      "type": "number"
+    },
+    "sourced_from": { "$ref": "#/definitions/sourced_from" }
+  },
+  "required": ["intake_average", "capacity_percentage", "sourced_from"],
+  "additionalProperties": false,
+  "definitions": {
+    "time_series": {
+      "title": "time_series",
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/time_series_value"
+          }
+        },
+        "last_value": {
+          "$ref": "#/definitions/time_series_value"
+        }
+      },
+      "required": ["values", "last_value"],
+      "additionalProperties": false
+    },
+    "time_series_value": {
+      "title": "time_series_value",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "reported_at": {
+          "type": "integer"
+        },
+        "inserted_at": {
+          "type": "integer"
+        }
+      },
+      "required": ["value", "reported_at", "inserted_at"],
+      "additionalProperties": false
+    },
+    "sourced_from": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": ["title", "url"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/regional/nursing_homes.json
+++ b/schema/regional/nursing_homes.json
@@ -5,9 +5,10 @@
   "type": "object",
   "properties": {
     "newly_reported": { "$ref": "#/definitions/time_series_value" },
+    "total_reported": { "$ref": "#/definitions/time_series_value" },
     "sourced_from": { "$ref": "#/definitions/sourced_from" }
   },
-  "required": ["newly_reported", "sourced_from"],
+  "required": ["newly_reported", "total_reported", "sourced_from"],
   "additionalProperties": false,
   "definitions": {
     "time_series": {

--- a/schema/regional/nursing_homes.json
+++ b/schema/regional/nursing_homes.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "regional_nursing_homes",
+  "title": "nursing_homes",
+  "type": "object",
+  "properties": {
+    "newly_reported": { "$ref": "#/definitions/time_series_value" },
+    "sourced_from": { "$ref": "#/definitions/sourced_from" }
+  },
+  "required": ["newly_reported", "sourced_from"],
+  "additionalProperties": false,
+  "definitions": {
+    "time_series": {
+      "title": "time_series",
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/time_series_value"
+          }
+        },
+        "last_value": {
+          "$ref": "#/definitions/time_series_value"
+        }
+      },
+      "required": ["values", "last_value"],
+      "additionalProperties": false
+    },
+    "time_series_value": {
+      "title": "time_series_value",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "reported_at": {
+          "type": "integer"
+        },
+        "inserted_at": {
+          "type": "integer"
+        }
+      },
+      "required": ["value", "reported_at", "inserted_at"],
+      "additionalProperties": false
+    },
+    "sourced_from": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": ["title", "url"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

New schemas were required for building some upcoming regional charts. I have attempted to standardize and simplify the way we define schemas so that we can use this as a basis for standardizing the other existing schemas down the line.

- All data belonging to a single subject is grouped in a single schema.
- Adds reusable definitions for time series and other types.
- Adds new regional schemas for intensive-cares, hospitals, and nursing homes.

Note that the "definitions" at the bottom of each file are now just copy-pasted. We might find a way to put these in a separate file so we can keep it DRY, but for now, it's already valuable if things can be copied I think.



