### PR TITLE
chore: Use typeof window instead of process.env for browser checking

### DIFF
--- a/src/lib/piwik.ts
+++ b/src/lib/piwik.ts
@@ -1,3 +1,5 @@
+import { isBrowser } from '~/utils/isBrowser';
+
 /* eslint-disable no-console */
 declare global {
   interface Window {
@@ -5,14 +7,12 @@ declare global {
   }
 }
 // client-side-only code
-if (process.browser) {
-  if (window) {
-    window._paq = window._paq || {};
-  }
+if (isBrowser) {
+  window._paq = window._paq || {};
 }
 
 export const pageview = (): void => {
-  if (process.browser) {
+  if (isBrowser) {
     if (window?._paq?.push) {
       window._paq.push(['trackPageView']);
     } else {
@@ -31,7 +31,7 @@ type EventTypes = {
 
 export function event(eventOptions: EventTypes): void {
   const { category, action, name, value, dimensions } = eventOptions;
-  if (process.browser) {
+  if (isBrowser) {
     if (window?._paq?.push) {
       window._paq.push([
         'trackEvent',

--- a/src/utils/isBrowser.ts
+++ b/src/utils/isBrowser.ts
@@ -1,0 +1,1 @@
+export const isBrowser = typeof window !== 'undefined';


### PR DESCRIPTION
## Summary

Implemented a utility for checking whenever code is running client side, to replace the usage of process.browser 

## Motivation

To not use the process.browser which is already removed from the next.js core and marked legacy / deprecated (https://github.com/vercel/next.js/pull/7651)
