### PR TITLE
chore: Upgrade SWR and remove the now unnecessary SWR provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "remark-external-links": "^7.0.0",
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",
-    "swr": "^0.3.1",
+    "swr": "^0.3.4",
     "topojson-client": "^3.1.0",
     "ts-is-present": "^1.1.5",
     "unfetch": "^4.1.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,14 +16,10 @@ import { useEffect } from 'react';
 import Router from 'next/router';
 import * as piwik from '../lib/piwik';
 
-import { SWRConfig } from 'swr';
-
 interface IProps {
   Component: any;
   pageProps: any;
 }
-
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 export default MyApp;
 
@@ -45,13 +41,5 @@ function MyApp(props: IProps): React.ReactElement {
     };
   }, []);
 
-  return (
-    <SWRConfig
-      value={{
-        fetcher,
-      }}
-    >
-      {getLayout(<Component {...pageProps} />, pageProps)}
-    </SWRConfig>
-  );
+  return getLayout(<Component {...pageProps} />, pageProps);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11560,7 +11560,7 @@ svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swr@^0.3.1:
+swr@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/swr/-/swr-0.3.4.tgz#921a48b4caedd06a972791232e1f0597d734f8d0"
   integrity sha512-i1fmnADcwZxETcmdyr0w2VGLggLHHEUH61FuBDxl2fxBmp8gNg5GFd+tVp00pc5oOUunKKzWp4UrlI1rc8gjuw==


### PR DESCRIPTION
## Summary

Upgrade the swr depedency and remove <SWRconfig>

## Motivation

<SWRConfig> includes a default fetcher since 0.3.3, meaning that in the case of this project it's not necessary anymore to provide the <SWRConfig>. The default fetcher is exactly the same as provided in the current config. https://github.com/vercel/swr/pull/367