### PR TITLE
Improve chloropleth tiles part 2

### DIFF
--- a/src/components/chartRegionControls/chartregioncontrols.module.scss
+++ b/src/components/chartRegionControls/chartregioncontrols.module.scss
@@ -7,4 +7,5 @@
   overflow: hidden;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto;
 }

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -39,7 +39,8 @@
 
   path {
     pointer-events: all;
-    stroke: #01689b;
+    stroke: #505050;
+    // stroke: hotpink;
     stroke-width: 0.5;
   }
 
@@ -60,13 +61,20 @@
     cursor: pointer;
   }
 
+  /**
+  Overlay is used outlining the VRs, but is currently styled the same
+  as municipalities paths. Faded is used to style VRs
+  when they have no data OR are not selected. This one is now also set to the
+  same color, so now probably redundant.
+  */
+
   path.faded {
-    stroke: #c4c4c4;
+    stroke: #505050;
   }
 
   path.overlay {
     pointer-events: none;
-    stroke: #01689b;
+    stroke: #505050;
     stroke-width: 0.5;
     fill: transparent;
   }

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -40,7 +40,6 @@
   path {
     pointer-events: all;
     stroke: #505050;
-    // stroke: hotpink;
     stroke-width: 0.5;
   }
 

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -7,7 +7,7 @@ import { WithChildren } from '~/types/index';
 import municipalities from '~/data/gemeente_veiligheidsregio.json';
 import { IMunicipalityData } from '~/static-props/municipality-data';
 
-import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
+import { getLocalTitleForMunicipality } from '~/utils/getLocalTitleForCode';
 import { getSafetyRegionForMunicipalityCode } from '~/utils/getSafetyRegionForMunicipalityCode';
 import { getSewerWaterBarScaleData } from '~/utils/sewer-water/municipality-sewer-water.util';
 import { useMediaQuery } from '~/utils/useMediaQuery';
@@ -135,7 +135,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
             <nav aria-label="metric navigation">
               <div className="region-names">
                 <h2>
-                  {getLocalTitleForMuncipality(
+                  {getLocalTitleForMunicipality(
                     '{{municipality}}',
                     code as string
                   )}

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -16,7 +16,7 @@ import {
   getMunicipalityPaths,
   IMunicipalityData,
 } from '~/static-props/municipality-data';
-import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
+import { getLocalTitleForMunicipality } from '~/utils/getLocalTitleForCode';
 
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
 import { positiveTestedPeopleTooltip } from '~/components/chloropleth/tooltips/municipal/positiveTestedPeopleTooltip';
@@ -27,7 +27,7 @@ import { useRouter } from 'next/router';
 const text: typeof siteText.gemeente_positief_geteste_personen =
   siteText.gemeente_positief_geteste_personen;
 
-const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
+const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
   const { data } = props;
   const router = useRouter();
 
@@ -38,7 +38,7 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
     <>
       <ContentHeader
         category={siteText.gemeente_layout.headings.medisch}
-        title={getLocalTitleForMuncipality(text.titel, data.code)}
+        title={getLocalTitleForMunicipality(text.titel, data.code)}
         Icon={Getest}
         subtitle={text.pagina_toelichting}
         metadata={{
@@ -91,18 +91,13 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
         </article>
       )}
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{getLocalTitleForMuncipality(text.map_titel, data.code)}</h3>
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
+          <h3>{getLocalTitleForMunicipality(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
-
-          <MunicipalityLegenda
-            metricName="positive_tested_people"
-            title={siteText.positief_geteste_personen.chloropleth_legenda.titel}
-          />
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           <MunicipalityChloropleth
             selected={data.code}
             metricName="positive_tested_people"
@@ -110,14 +105,21 @@ const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
             onSelect={createSelectMunicipalHandler(router)}
           />
         </div>
+
+        <div className="chloropleth-legend">
+          <MunicipalityLegenda
+            metricName="positive_tested_people"
+            title={siteText.positief_geteste_personen.chloropleth_legenda.titel}
+          />
+        </div>
       </article>
     </>
   );
 };
 
-PostivelyTestedPeople.getLayout = getMunicipalityLayout();
+PositivelyTestedPeople.getLayout = getMunicipalityLayout();
 
 export const getStaticProps = getMunicipalityData();
 export const getStaticPaths = getMunicipalityPaths();
 
-export default PostivelyTestedPeople;
+export default PositivelyTestedPeople;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -19,7 +19,7 @@ import {
   getMunicipalityPaths,
   IMunicipalityData,
 } from '~/static-props/municipality-data';
-import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
+import { getLocalTitleForMunicipality } from '~/utils/getLocalTitleForCode';
 
 import siteText from '~/locale/index';
 
@@ -41,7 +41,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
     <>
       <ContentHeader
         category={siteText.gemeente_layout.headings.overig}
-        title={getLocalTitleForMuncipality(text.titel, data.code)}
+        title={getLocalTitleForMunicipality(text.titel, data.code)}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}
         metadata={{
@@ -81,7 +81,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
       {barChartData && (
         <article className="metric-article">
           <h3>
-            {getLocalTitleForMuncipality(text.bar_chart_title, data.code)}
+            {getLocalTitleForMunicipality(text.bar_chart_title, data.code)}
           </h3>
           <BarChart
             keys={barChartData.keys}

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -16,7 +16,7 @@ import {
 
 import { IntakeHospitalBarScale } from '~/components/gemeente/intake-hospital-barscale';
 
-import { getLocalTitleForMuncipality } from '~/utils/getLocalTitleForCode';
+import { getLocalTitleForMunicipality } from '~/utils/getLocalTitleForCode';
 
 const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
   siteText.gemeente_ziekenhuisopnames_per_dag;
@@ -38,7 +38,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
     <>
       <ContentHeader
         category={siteText.gemeente_layout.headings.medisch}
-        title={getLocalTitleForMuncipality(text.titel, data.code)}
+        title={getLocalTitleForMunicipality(text.titel, data.code)}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}
         metadata={{
@@ -74,23 +74,25 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         </article>
       )}
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{getLocalTitleForMuncipality(text.map_titel, data.code)}</h3>
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
+          <h3>{getLocalTitleForMunicipality(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
-
-          <MunicipalityLegenda
-            metricName="hospital_admissions"
-            title={siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel}
-          />
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           <MunicipalityChloropleth
             selected={data.code}
             metricName="hospital_admissions"
             tooltipContent={hospitalAdmissionsTooltip}
             onSelect={createSelectMunicipalHandler(router)}
+          />
+        </div>
+
+        <div className="chloropleth-legend">
+          <MunicipalityLegenda
+            metricName="hospital_admissions"
+            title={siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel}
           />
         </div>
       </article>

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -52,25 +52,19 @@ const Municipality: FCWithLayout<any> = () => {
   const mapHeight = isLargeScreen ? '800px' : '400px';
 
   return (
-    <>
-      <article className="map-article layout-two-column">
-        <div className="column-item-no-margin column-item-small">
-          <h2 className="text-max-width">
-            {text.gemeente_index.selecteer_titel}
-          </h2>
-          <p className="text-max-width">
-            {text.gemeente_index.selecteer_toelichting}
-          </p>
-        </div>
-        <div className="column-item-no-margin column-item">
-          <MunicipalityChloropleth
-            tooltipContent={tooltipContent(router)}
-            style={{ height: mapHeight }}
-            onSelect={onSelectMunicipal}
-          />
-        </div>
-      </article>
-    </>
+    <article className="map-article layout-chloropleth">
+      <div className="chloropleth-header">
+        <h2>{text.gemeente_index.selecteer_titel}</h2>
+        <p>{text.gemeente_index.selecteer_toelichting}</p>
+      </div>
+      <div className="chloropleth-chart">
+        <MunicipalityChloropleth
+          tooltipContent={tooltipContent(router)}
+          style={{ height: mapHeight }}
+          onSelect={onSelectMunicipal}
+        />
+      </div>
+    </article>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,20 +74,17 @@ const Home: FCWithLayout<INationalData> = (props) => {
         </Link>
       </article>
 
-      <article className="index-article layout-two-column">
-        <div className="column-item-no-margin column-item-small">
-          <h2 className="text-max-width">
-            {text.veiligheidsregio_index.selecteer_titel}
-          </h2>
-          <div
-            className="text-max-width"
+      <article className="index-article layout-chloropleth">
+        <div className="chloropleth-header">
+          <h2>{text.veiligheidsregio_index.selecteer_titel}</h2>
+          <p
             dangerouslySetInnerHTML={{
               __html: text.veiligheidsregio_index.selecteer_toelichting,
             }}
           />
           <EscalationMapLegenda text={text} />
         </div>
-        <div className="column-item-no-margin column-item">
+        <div className="chloropleth-chart">
           <SafetyRegionChloropleth
             metricName="escalation_levels"
             metricProperty="escalation_level"
@@ -98,34 +95,18 @@ const Home: FCWithLayout<INationalData> = (props) => {
         </div>
       </article>
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
+      <article className="metric-article chloropleth-layout">
+        <div className="chloropleth-header">
           <h3>{text.positief_geteste_personen.map_titel}</h3>
           <p>{text.positief_geteste_personen.map_toelichting}</p>
-          <ChartRegionControls
-            onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
-          />
-
-          {selectedMap === 'municipal' && (
-            <>
-              <MunicipalityLegenda
-                metricName="positive_tested_people"
-                title={text.positief_geteste_personen.chloropleth_legenda.titel}
-              />
-            </>
-          )}
-
-          {selectedMap === 'region' && (
-            <>
-              <SafetyRegionLegenda
-                metricName="positive_tested_people"
-                title={text.positief_geteste_personen.chloropleth_legenda.titel}
-              />
-            </>
-          )}
+          <div className="chloropleth-controls">
+            <ChartRegionControls
+              onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
+            />
+          </div>
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           {selectedMap === 'municipal' && (
             <MunicipalityChloropleth
               metricName="positive_tested_people"
@@ -138,6 +119,22 @@ const Home: FCWithLayout<INationalData> = (props) => {
               metricName="positive_tested_people"
               tooltipContent={regionPositiveTestedPeopleTooltip}
               onSelect={createSelectRegionHandler(router)}
+            />
+          )}
+        </div>
+
+        <div className="chloropleth-legend">
+          {selectedMap === 'municipal' && (
+            <MunicipalityLegenda
+              metricName="positive_tested_people"
+              title={text.positief_geteste_personen.chloropleth_legenda.titel}
+            />
+          )}
+
+          {selectedMap === 'region' && (
+            <SafetyRegionLegenda
+              metricName="positive_tested_people"
+              title={text.positief_geteste_personen.chloropleth_legenda.titel}
             />
           )}
         </div>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -33,7 +33,7 @@ import { useRouter } from 'next/router';
 const text: typeof siteText.positief_geteste_personen =
   siteText.positief_geteste_personen;
 
-const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
+const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
   const { data } = props;
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'municipal'
@@ -93,7 +93,10 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         </article>
       </div>
 
-      <article className="metric-article layout-chloropleth">
+      <article
+        className="metric-article layout-chloropleth"
+        data-cy="chloropleths"
+      >
         <div className="chloropleth-header">
           <h3>{text.map_titel}</h3>
           <p>{text.map_toelichting}</p>
@@ -121,7 +124,7 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           )}
         </div>
 
-        <div className="chloropleth-legend" data-cy="chloropleths">
+        <div className="chloropleth-legend">
           {selectedMap === 'municipal' && (
             <MunicipalityLegenda
               metricName="positive_tested_people"
@@ -158,29 +161,27 @@ const PostivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           <p>{text.barchart_toelichting}</p>
         </div>
         {age && (
-          <>
-            <BarChart
-              keys={text.barscale_keys}
-              data={age.values.map((value) => ({
-                y: value.infected_per_agegroup_increase || 0,
-                label: value?.infected_per_agegroup_increase
-                  ? `${(
-                      ((value.infected_per_agegroup_increase as number) * 100) /
-                      barChartTotal
-                    ).toFixed(0)}%`
-                  : false,
-              }))}
-              axisTitle={text.barchart_axis_titel}
-            />
-          </>
+          <BarChart
+            keys={text.barscale_keys}
+            data={age.values.map((value) => ({
+              y: value.infected_per_agegroup_increase || 0,
+              label: value?.infected_per_agegroup_increase
+                ? `${(
+                    ((value.infected_per_agegroup_increase as number) * 100) /
+                    barChartTotal
+                  ).toFixed(0)}%`
+                : false,
+            }))}
+            axisTitle={text.barchart_axis_titel}
+          />
         )}
       </article>
     </>
   );
 };
 
-PostivelyTestedPeople.getLayout = getNationalLayout();
+PositivelyTestedPeople.getLayout = getNationalLayout();
 
 export const getStaticProps = getNlData();
 
-export default PostivelyTestedPeople;
+export default PositivelyTestedPeople;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -61,29 +61,18 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
         </div>
       </article>
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
           <h3>{text.map_titel}</h3>
           <p>{text.map_toelichting}</p>
-          <ChartRegionControls
-            onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
-          />
-          {selectedMap === 'municipal' && (
-            <MunicipalityLegenda
-              metricName="hospital_admissions"
-              title={text.chloropleth_legenda.titel}
+          <div className="chloropleth-controls">
+            <ChartRegionControls
+              onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
             />
-          )}
-
-          {selectedMap === 'region' && (
-            <SafetyRegionLegenda
-              metricName="hospital_admissions"
-              title={text.chloropleth_legenda.titel}
-            />
-          )}
+          </div>
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           {selectedMap === 'municipal' && (
             <MunicipalityChloropleth
               metricName="hospital_admissions"
@@ -96,6 +85,22 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
               metricName="hospital_admissions"
               tooltipContent={regionHospitalAdmissionsTooltip}
               onSelect={createSelectRegionHandler(router)}
+            />
+          )}
+        </div>
+
+        <div className="chloropleth-legend">
+          {selectedMap === 'municipal' && (
+            <MunicipalityLegenda
+              metricName="hospital_admissions"
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
+
+          {selectedMap === 'region' && (
+            <SafetyRegionLegenda
+              metricName="hospital_admissions"
+              title={text.chloropleth_legenda.titel}
             />
           )}
         </div>

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -95,24 +95,25 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           />
         </article>
       )}
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
           <h3>{getLocalTitleForRegion(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
-
-          <MunicipalityLegenda
-            metricName="positive_tested_people"
-            title={siteText.positief_geteste_personen.chloropleth_legenda.titel}
-          />
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           <MunicipalityChloropleth
             selected={selectedMunicipalCode}
             highlightSelection={false}
             metricName="positive_tested_people"
             tooltipContent={positiveTestedPeopleTooltip}
             onSelect={createSelectMunicipalHandler(router)}
+          />
+        </div>
+        <div className="chloropleth-legend">
+          <MunicipalityLegenda
+            metricName="positive_tested_people"
+            title={siteText.positief_geteste_personen.chloropleth_legenda.titel}
           />
         </div>
       </article>

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -74,24 +74,26 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           />
         </article>
       )}
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
           <h3>{getLocalTitleForRegion(text.map_titel, data.code)}</h3>
           <p>{text.map_toelichting}</p>
-
-          <MunicipalityLegenda
-            metricName="hospital_admissions"
-            title={siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel}
-          />
         </div>
 
-        <div className="column-item column-item-extra-margin">
+        <div className="chloropleth-chart">
           <MunicipalityChloropleth
             selected={selectedMunicipalCode}
             highlightSelection={false}
             metricName="hospital_admissions"
             tooltipContent={hospitalAdmissionsTooltip}
             onSelect={createSelectMunicipalHandler(router)}
+          />
+        </div>
+
+        <div className="chloropleth-legend">
+          <MunicipalityLegenda
+            metricName="hospital_admissions"
+            title={siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel}
           />
         </div>
       </article>

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -65,31 +65,34 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
   const mapHeight = isLargeScreen ? '500px' : '400px';
 
   return (
-    <>
-      <article className="index-article layout-two-column">
-        <div className="column-item-no-margin column-item-small">
-          <h2 className="text-max-width">
-            {text.veiligheidsregio_index.selecteer_titel}
-          </h2>
-          <div
-            className="text-max-width"
-            dangerouslySetInnerHTML={{
-              __html: text.veiligheidsregio_index.selecteer_toelichting,
-            }}
-          />
-          <EscalationMapLegenda text={text} />
-        </div>
-        <div className="column-item-no-margin column-item">
-          <SafetyRegionChloropleth
-            metricName="escalation_levels"
-            metricProperty="escalation_level"
-            style={{ height: mapHeight }}
-            onSelect={createSelectRegionHandler(router)}
-            tooltipContent={escalationTooltip(router)}
-          />
-        </div>
-      </article>
-    </>
+    <article className="index-article layout-chloropleth">
+      <div className="chloropleth-header">
+        <h2>{text.veiligheidsregio_index.selecteer_titel}</h2>
+        {/**
+         * This is rendering html content which has been generated from
+         * markdown text.
+         */}
+        <p
+          dangerouslySetInnerHTML={{
+            __html: text.veiligheidsregio_index.selecteer_toelichting,
+          }}
+        />
+      </div>
+
+      <div className="chloropleth-chart">
+        <SafetyRegionChloropleth
+          metricName="escalation_levels"
+          metricProperty="escalation_level"
+          style={{ height: mapHeight }}
+          onSelect={createSelectRegionHandler(router)}
+          tooltipContent={escalationTooltip(router)}
+        />
+      </div>
+
+      <div className="chloropleth-legend">
+        <EscalationMapLegenda text={text} />
+      </div>
+    </article>
   );
 };
 

--- a/src/utils/getLocalTitleForCode.ts
+++ b/src/utils/getLocalTitleForCode.ts
@@ -3,9 +3,7 @@ import { replaceVariablesInText } from './replaceVariablesInText';
 import regios from '~/data/index';
 import municipalities from '~/data/gemeente_veiligheidsregio.json';
 
-export { getLocalTitleForRegion, getLocalTitleForMuncipality };
-
-function getLocalTitleForRegion(title: string, code: string): string {
+export function getLocalTitleForRegion(title: string, code: string): string {
   const regio = regios.find((regio) => regio.code === code);
 
   if (!regio) return '';
@@ -15,7 +13,10 @@ function getLocalTitleForRegion(title: string, code: string): string {
   });
 }
 
-function getLocalTitleForMuncipality(title: string, code: string): string {
+export function getLocalTitleForMunicipality(
+  title: string,
+  code: string
+): string {
   const municipality = municipalities.find((mun) => mun.gemcode === code);
 
   if (!municipality) return '';


### PR DESCRIPTION
This PR continues on the grid layout changes that were in part 1, applying them to all remaining Chloropeth charts. 

In addition, it fixes some spelling mistakes.