### PR TITLE
fix combobox appearing bug

### DIFF
--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -48,9 +48,9 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const [term, setTerm] = useState<string>('');
   const results = useSearchedOptions<Option>(term, options);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)');
-  const hasNoRegionSelected =
-    router.pathname !== '/gemeente/[code]/positief-geteste-mensen' &&
-    router.pathname !== '/veiligheidsregio/[code]/positief-geteste-mensen';
+  const hasRegionSelected =
+    router.pathname === '/gemeente/[code]/positief-geteste-mensen' ||
+    router.pathname === '/veiligheidsregio/[code]/positief-geteste-mensen';
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setTerm(event.target.value);
@@ -71,10 +71,10 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   }
 
   useEffect(() => {
-    if (!inputRef?.current?.value && isLargeScreen && hasNoRegionSelected) {
+    if (!inputRef?.current?.value && isLargeScreen && !hasRegionSelected) {
       inputRef?.current?.focus();
     }
-  }, [isLargeScreen, hasNoRegionSelected]);
+  }, [isLargeScreen, hasRegionSelected]);
 
   return (
     <Combobox openOnFocus onSelect={onSelect}>

--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 import matchSorter from 'match-sorter';
 import {
   Combobox,
@@ -42,10 +43,14 @@ type TProps<Option extends TOption> = {
 export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const { options, placeholder, handleSelect } = props;
 
+  const router = useRouter();
   const inputRef = useRef<HTMLInputElement>();
   const [term, setTerm] = useState<string>('');
   const results = useSearchedOptions<Option>(term, options);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)');
+  const hasNoRegionSelected =
+    router.pathname !== '/gemeente/[code]/positief-geteste-mensen' &&
+    router.pathname !== '/veiligheidsregio/[code]/positief-geteste-mensen';
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setTerm(event.target.value);
@@ -66,10 +71,10 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   }
 
   useEffect(() => {
-    if (!inputRef?.current?.value && isLargeScreen) {
+    if (!inputRef?.current?.value && isLargeScreen && hasNoRegionSelected) {
       inputRef?.current?.focus();
     }
-  }, [isLargeScreen]);
+  }, [isLargeScreen, hasNoRegionSelected]);
 
   return (
     <Combobox openOnFocus onSelect={onSelect}>


### PR DESCRIPTION
## Summary

The combobox should automatically expand when the user navigates to `/veiligheidsregio` or to `/gemeente`, when a safety region or municipality has been selected already, the combobox should not expand automatically and can be opened by clicking on it. This fix adds one more check (`bool`) called `hasNoRegionSelected` that variable routes to assert if the user has a safetyregion selected. 

### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
