### PR TITLE
refactor: use router.query.code

### DIFF
--- a/src/components/comboBox/index.tsx
+++ b/src/components/comboBox/index.tsx
@@ -44,13 +44,12 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const { options, placeholder, handleSelect } = props;
 
   const router = useRouter();
+  const { code } = router.query;
   const inputRef = useRef<HTMLInputElement>();
   const [term, setTerm] = useState<string>('');
   const results = useSearchedOptions<Option>(term, options);
   const isLargeScreen = useMediaQuery('(min-width: 1000px)');
-  const hasRegionSelected =
-    router.pathname === '/gemeente/[code]/positief-geteste-mensen' ||
-    router.pathname === '/veiligheidsregio/[code]/positief-geteste-mensen';
+  const hasRegionSelected = !!code;
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setTerm(event.target.value);


### PR DESCRIPTION
## Summary

Improvement on [fix combobox appearing bug #451](https://github.com/minvws/nl-covid19-data-dashboard/pull/451)

The combobox should automatically expand when the user navigates to `/veiligheidsregio` or to `/gemeente`, when a safety region or municipality has been selected already, the combobox should not expand automatically and can be opened by clicking on it. This fix adds one more check (`bool`) called `hasRegionSelected` that variable routes to assert if the user has a safetyregion selected using the `code` in `router.query`.


### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
