### PR TITLE
Extend prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+package.json
+schema
+public
+out

--- a/next.config.js
+++ b/next.config.js
@@ -62,9 +62,6 @@ const nextConfig = {
   },
 };
 
-const plugins = [
-  withTM,
-  withBundleAnalyzer,
-];
+const plugins = [withTM, withBundleAnalyzer];
 
 module.exports = withPlugins(plugins, nextConfig);

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "start": "next start",
     "test": "jest --watch",
     "test:ci": "jest --ci",
-    "format": "prettier --write **/*.{js,ts,tsx}",
+    "format": "prettier --write **/*.{js,ts,tsx} *.{js,json,md,yml}",
     "lint": "eslint .",
     "type-check": "tsc --pretty --noEmit",
     "validate-json": "node schema/validator/validate-json.js",


### PR DESCRIPTION
Due to I suspect a recent merge of an outside PR, one file outside src didn't have proper formatting and generated a prettier linting error. This error could not be fixed by running `yarn format` because it was configured to only format files inside the src directory.

This PR extends the range of prettier so that it can format all relevant files.