### PR TITLE
fix: Wrong chloropleth classname on index page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -95,7 +95,7 @@ const Home: FCWithLayout<INationalData> = (props) => {
         </div>
       </article>
 
-      <article className="metric-article chloropleth-layout">
+      <article className="metric-article layout-chloropleth">
         <div className="chloropleth-header">
           <h3>{text.positief_geteste_personen.map_titel}</h3>
           <p>{text.positief_geteste_personen.map_toelichting}</p>


### PR DESCRIPTION
Chloropleth on index page had a classname typo, messing up the grid layout.