### PR TITLE
Bugfix/markdown map

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,7 @@ const Home: FCWithLayout<INationalData> = (props) => {
       <article className="index-article layout-chloropleth">
         <div className="chloropleth-header">
           <h2>{text.veiligheidsregio_index.selecteer_titel}</h2>
-          <p
+          <div
             dangerouslySetInnerHTML={{
               __html: text.veiligheidsregio_index.selecteer_toelichting,
             }}

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -72,7 +72,7 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
          * This is rendering html content which has been generated from
          * markdown text.
          */}
-        <p
+        <div
           dangerouslySetInnerHTML={{
             __html: text.veiligheidsregio_index.selecteer_toelichting,
           }}


### PR DESCRIPTION
## Summary

Bugfix to render markdown properly.

`<p>` cannot contain a markdown formatted `<p>`; so the wrapper could be a `<div>` which I changed it to.