### PR TITLE
Remove grid layout from gemeente selection map

### DIFF
--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -52,12 +52,12 @@ const Municipality: FCWithLayout<any> = () => {
   const mapHeight = isLargeScreen ? '800px' : '400px';
 
   return (
-    <article className="map-article layout-chloropleth">
-      <div className="chloropleth-header">
+    <article className="map-article">
+      <div>
         <h2>{text.gemeente_index.selecteer_titel}</h2>
         <p>{text.gemeente_index.selecteer_toelichting}</p>
       </div>
-      <div className="chloropleth-chart">
+      <div>
         <MunicipalityChloropleth
           tooltipContent={tooltipContent(router)}
           style={{ height: mapHeight }}


### PR DESCRIPTION
Municipality selection map as rendered in the same 50/50 column layout as other Chloroplets, but that is not preferable. This PR removes the grid layout so that the map takes up the full width.

<img width="1390" alt="Screenshot 2020-09-29 at 10 10 33" src="https://user-images.githubusercontent.com/71320230/94538090-ddab7d80-0243-11eb-8097-9a9e84d29655.png">
