### PR TITLE
Bugfix/r date

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -224,12 +224,12 @@ export default function AreaChart(props: AreaChartProps) {
   const rangeData: TRange[] = useMemo(() => {
     return data
       .sort((a, b) => a.date - b.date)
-      .map((d) => [new Date(d.date * 1000), d.min, d.max]);
+      .map((d) => [new Date(d.date), d.min, d.max]);
   }, [data]);
 
   const lineData: TLine[] = useMemo(() => {
     return data.map((value) => {
-      return [new Date(value.date * 1000), value.avg];
+      return [new Date(value.date), value.avg];
     });
   }, [data]);
 

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -33,8 +33,9 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: data?.last_value?.date_of_report_unix,
-          dateInsertedUnix: data?.last_value?.date_of_insertion_unix,
+          dateUnix: lastKnownValidData?.last_value?.date_of_report_unix,
+          dateInsertedUnix:
+            lastKnownValidData?.last_value?.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />


### PR DESCRIPTION
## Summary

Fix: date displayed at top uses the correct data point now.
Fix: areachart for both R and besmettelijke personen are fixed (unix timestamps were multiplied by 1000 on accident here)
