### PR TITLE
Fix gemeente selection map line color

### DIFF
--- a/src/components/chloropleth/Chloropleth.tsx
+++ b/src/components/chloropleth/Chloropleth.tsx
@@ -73,6 +73,11 @@ export type TProps<TFeatureProperties> = {
   // This callback is invoked right before a tooltip is shown for one of the features in the featureCollection property.
   // The id is the value that is assigned to the data-id attribute in the featureCallback.
   getTooltipContent: (id: string) => ReactNode;
+
+  /**
+   * Some maps like the gemeente selection map needs different path styling
+   */
+  isSelectorMap?: boolean;
 };
 
 /**
@@ -96,6 +101,7 @@ export function Chloropleth<T>(props: TProps<T>) {
     hoverCallback,
     onPathClick,
     getTooltipContent,
+    isSelectorMap,
   } = props;
 
   const tooltipStore = useRef<UseStore<TooltipState>>(
@@ -147,7 +153,9 @@ export function Chloropleth<T>(props: TProps<T>) {
       <svg
         width={width}
         height={height}
-        className={styles.svgMap}
+        className={`${styles.svgMap} ${
+          isSelectorMap ? styles.selectorMap : ''
+        }`}
         onMouseOver={createSvgMouseOverHandler(timeout, showTooltip)}
         onMouseOut={createSvgMouseOutHandler(timeout, hideTooltip)}
         onClick={createSvgClickHandler(onPathClick, showTooltip, isLargeScreen)}

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -97,6 +97,7 @@ export type TProps<
   style?: CSSProperties;
   onSelect?: (context: TContext) => void;
   tooltipContent?: (context: TContext) => ReactNode;
+  isSelectorMap?: boolean;
 };
 
 /**
@@ -126,6 +127,7 @@ export function MunicipalityChloropleth<
     onSelect,
     tooltipContent,
     highlightSelection = true,
+    isSelectorMap,
   } = props;
 
   const [ref, dimensions] = useChartDimensions();
@@ -263,6 +265,7 @@ export function MunicipalityChloropleth<
         hoverCallback={hoverCallback}
         onPathClick={onClick}
         getTooltipContent={getTooltipContent}
+        isSelectorMap={isSelectorMap}
       />
     </div>
   );

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -33,6 +33,17 @@
   }
 }
 
+.selectorMap {
+  path {
+    /**
+    When a map is a selector map like gemeente/index, we need the line color
+    to be blue. There is a better way to do this once we move to styled
+    components, but for now this works.
+    */
+    stroke: #01689b !important;
+  }
+}
+
 .svgMap {
   display: block;
   background: transparent;

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -62,6 +62,7 @@ const Municipality: FCWithLayout<any> = () => {
           tooltipContent={tooltipContent(router)}
           style={{ height: mapHeight }}
           onSelect={onSelectMunicipal}
+          isSelectorMap={true}
         />
       </div>
     </article>


### PR DESCRIPTION
The selector map at gemeente/index needs blue lines. This is not the most elegant solution maybe but usable as a temporary workaround until we move to something like styled-components.