### PR TITLE
Fixes alignment of barchart tooltip

### DIFF
--- a/src/components/barChart/index.tsx
+++ b/src/components/barChart/index.tsx
@@ -20,15 +20,17 @@ export default function BarChart(props: IProps) {
         borderColor: '#000',
         borderRadius: 0,
         borderWidth: 0,
-        className: 'undefined',
+        className: 'barchart-container',
         colorCount: 10,
         displayErrors: true,
         margin: [],
         height: data.length * 35 + 50,
+        maxWidth: 500,
       },
       title: { text: '' },
       tooltip: {
         enabled: true,
+        outside: true,
         formatter: function (): string | false {
           // @ts-ignore
           if (this.point.label) {


### PR DESCRIPTION
## Summary

Fixes two problems with the barchart:

* the tooltip is not rendered due to an overflow. This is resolved with highcharts `outside` option.
* the barchart did not have a certain width. It rendered the extreme points of the barchart incorrectly for the small barchart in the "Positief geteste mensen" page. The maxwidth makes it render properly, while still allowing flexbox to render it as it wishes.