### PR TITLE
Add createDate factory method to turn unix timestamps into dates and fix areachart bug

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -42,6 +42,83 @@ type IGetOptions = Omit<AreaChartProps, 'data' | 'title' | 'description'> & {
   lineData: TLine[];
 };
 
+export default function AreaChart(props: AreaChartProps) {
+  const {
+    rangeLegendLabel,
+    lineLegendLabel,
+    data,
+    signaalwaarde,
+    timeframeOptions,
+    title,
+    description,
+  } = props;
+
+  const rangeData: TRange[] = useMemo(() => {
+    return data
+      .sort((a, b) => a.date - b.date)
+      .map((d) => [createDate(d.date), d.min, d.max]);
+  }, [data]);
+
+  const lineData: TLine[] = useMemo(() => {
+    return data.map((value) => {
+      return [createDate(value.date), value.avg];
+    });
+  }, [data]);
+
+  const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
+
+  const chartOptions = useMemo(() => {
+    const getOptionsThunk = (rangeData: TRange[], lineData: TLine[]) =>
+      getChartOptions({
+        rangeData,
+        lineData,
+        signaalwaarde,
+        rangeLegendLabel,
+        lineLegendLabel,
+      });
+
+    const filteredRange = getFilteredValues<TRange>(
+      rangeData,
+      timeframe,
+      (value: TRange) => value[0].getTime()
+    );
+
+    const filteredLine = getFilteredValues<TLine>(
+      lineData,
+      timeframe,
+      (value: TLine) => value[0].getTime()
+    );
+
+    return getOptionsThunk(filteredRange, filteredLine);
+  }, [
+    lineData,
+    rangeData,
+    signaalwaarde,
+    lineLegendLabel,
+    rangeLegendLabel,
+    timeframe,
+  ]);
+
+  return (
+    <section className={styles.root}>
+      <header className={styles.header}>
+        <div className={styles.titleAndDescription}>
+          {title && <h3>{title}</h3>}
+          {description && <p>{description}</p>}
+        </div>
+        <div className={styles.timeControls}>
+          <ChartTimeControls
+            timeframe={timeframe}
+            timeframeOptions={timeframeOptions}
+            onChange={(value) => setTimeframe(value)}
+          />
+        </div>
+      </header>
+      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+    </section>
+  );
+}
+
 function getChartOptions(props: IGetOptions): Highcharts.Options {
   const {
     rangeData,
@@ -209,83 +286,6 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
   };
 
   return options;
-}
-
-export default function AreaChart(props: AreaChartProps) {
-  const {
-    rangeLegendLabel,
-    lineLegendLabel,
-    data,
-    signaalwaarde,
-    timeframeOptions,
-    title,
-    description,
-  } = props;
-
-  const rangeData: TRange[] = useMemo(() => {
-    return data
-      .sort((a, b) => a.date - b.date)
-      .map((d) => [createDate(d.date), d.min, d.max]);
-  }, [data]);
-
-  const lineData: TLine[] = useMemo(() => {
-    return data.map((value) => {
-      return [createDate(value.date), value.avg];
-    });
-  }, [data]);
-
-  const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
-
-  const chartOptions = useMemo(() => {
-    const getOptionsThunk = (rangeData: TRange[], lineData: TLine[]) =>
-      getChartOptions({
-        rangeData,
-        lineData,
-        signaalwaarde,
-        rangeLegendLabel,
-        lineLegendLabel,
-      });
-
-    const filteredRange = getFilteredValues<TRange>(
-      rangeData,
-      timeframe,
-      (value: TRange) => value[0].getTime()
-    );
-
-    const filteredLine = getFilteredValues<TLine>(
-      lineData,
-      timeframe,
-      (value: TLine) => value[0].getTime()
-    );
-
-    return getOptionsThunk(filteredRange, filteredLine);
-  }, [
-    lineData,
-    rangeData,
-    signaalwaarde,
-    lineLegendLabel,
-    rangeLegendLabel,
-    timeframe,
-  ]);
-
-  return (
-    <section className={styles.root}>
-      <header className={styles.header}>
-        <div className={styles.titleAndDescription}>
-          {title && <h3>{title}</h3>}
-          {description && <p>{description}</p>}
-        </div>
-        <div className={styles.timeControls}>
-          <ChartTimeControls
-            timeframe={timeframe}
-            timeframeOptions={timeframeOptions}
-            onChange={(value) => setTimeframe(value)}
-          />
-        </div>
-      </header>
-      <HighchartsReact highcharts={Highcharts} options={chartOptions} />
-    </section>
-  );
 }
 
 /**

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -8,9 +8,10 @@ import {
 } from '~/components/chartTimeControls';
 
 import { formatNumber } from '~/utils/formatNumber';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromMilliseconds } from '~/utils/formatDate';
 import text from '~/locale/index';
 import { getFilteredValues } from '~/components/chartTimeControls/chartTimeControlUtils';
+import { createDate } from '~/utils/createDate';
 
 if (typeof Highcharts === 'object') {
   require('highcharts/highcharts-more')(Highcharts);
@@ -96,7 +97,7 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
         rotation: '0' as any,
         formatter: function () {
           return this.isFirst || this.isLast
-            ? formatDate(this.value, 'axis')
+            ? formatDateFromMilliseconds(this.value, 'axis')
             : '';
         },
       },
@@ -173,7 +174,7 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
         );
         const x = this.x;
         return `
-            ${formatDate(x, 'medium')}<br/>
+            ${formatDateFromMilliseconds(x, 'medium')}<br/>
             <strong>${rangeLegendLabel}</strong> ${formatNumber(
           minRangePoint
         )} - ${formatNumber(maxRangePoint)}<br/>
@@ -224,12 +225,12 @@ export default function AreaChart(props: AreaChartProps) {
   const rangeData: TRange[] = useMemo(() => {
     return data
       .sort((a, b) => a.date - b.date)
-      .map((d) => [new Date(d.date), d.min, d.max]);
+      .map((d) => [createDate(d.date), d.min, d.max]);
   }, [data]);
 
   const lineData: TLine[] = useMemo(() => {
     return data.map((value) => {
-      return [new Date(value.date), value.avg];
+      return [createDate(value.date), value.avg];
     });
   }, [data]);
 
@@ -248,13 +249,13 @@ export default function AreaChart(props: AreaChartProps) {
     const filteredRange = getFilteredValues<TRange>(
       rangeData,
       timeframe,
-      (value: TRange) => value[0].getTime() * 1000
+      (value: TRange) => value[0].getTime()
     );
 
     const filteredLine = getFilteredValues<TLine>(
       lineData,
       timeframe,
-      (value: TLine) => value[0].getTime() * 1000
+      (value: TLine) => value[0].getTime()
     );
 
     return getOptionsThunk(filteredRange, filteredLine);

--- a/src/components/chartTimeControls/__tests__/getDaysForTimeframe.spec.ts
+++ b/src/components/chartTimeControls/__tests__/getDaysForTimeframe.spec.ts
@@ -1,0 +1,18 @@
+import { getDaysForTimeframe } from '../chartTimeControlUtils';
+
+describe('Utils: getDaysForTimeframe', () => {
+  it('should return 8 for week', () => {
+    const result = getDaysForTimeframe('week');
+    expect(result).toEqual(8);
+  });
+
+  it('should return 36 for 5weeks', () => {
+    const result = getDaysForTimeframe('5weeks');
+    expect(result).toEqual(36);
+  });
+
+  it('should return Infinity for all', () => {
+    const result = getDaysForTimeframe('all');
+    expect(result).toEqual(Infinity);
+  });
+});

--- a/src/components/chartTimeControls/__tests__/getFilteredValues.spec.ts
+++ b/src/components/chartTimeControls/__tests__/getFilteredValues.spec.ts
@@ -1,0 +1,61 @@
+import { getFilteredValues } from '../chartTimeControlUtils';
+
+const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
+function createTestDate(numberOfDays: number): Date {
+  return new Date(new Date().getTime() - numberOfDays * oneDayInMilliseconds);
+}
+
+type TestValue = {
+  date: Date;
+};
+
+function createTestValues(): TestValue[] {
+  const testValueList = [
+    {
+      date: createTestDate(1),
+    },
+    {
+      date: createTestDate(2),
+    },
+    {
+      date: createTestDate(9),
+    },
+    {
+      date: createTestDate(12),
+    },
+    {
+      date: createTestDate(60),
+    },
+  ];
+
+  return testValueList;
+}
+
+const testCallback = (item: TestValue) => item.date.getTime();
+
+describe('Utils: getFilteredValues', () => {
+  let _testList: any[];
+
+  beforeEach(() => {
+    _testList = createTestValues();
+  });
+
+  it('should filter the list by week', () => {
+    const result = getFilteredValues(_testList, 'week', testCallback);
+
+    expect(result.length).toEqual(2);
+  });
+
+  it('should filter the list by 5weeks', () => {
+    const result = getFilteredValues(_testList, '5weeks', testCallback);
+
+    expect(result.length).toEqual(4);
+  });
+
+  it('should filter the list by all', () => {
+    const result = getFilteredValues(_testList, 'all', testCallback);
+
+    expect(result.length).toEqual(5);
+  });
+});

--- a/src/components/chartTimeControls/__tests__/getMinimumUnixForTimeframe.spec.ts
+++ b/src/components/chartTimeControls/__tests__/getMinimumUnixForTimeframe.spec.ts
@@ -1,0 +1,31 @@
+import { getMinimumUnixForTimeframe } from '../chartTimeControlUtils';
+
+describe('Utils: getMinimumUnixForTimeframe', () => {
+  it('should return zero for all', () => {
+    const result = getMinimumUnixForTimeframe('all');
+
+    expect(result).toEqual(0);
+  });
+
+  it('should return greater than zero for week', () => {
+    const result = getMinimumUnixForTimeframe('week');
+
+    const today = new Date().getTime();
+
+    var secondsDelta = Math.abs(today - result) / 1000;
+    var daysDelta = Math.floor(secondsDelta / 86400);
+
+    expect(daysDelta).toEqual(8);
+  });
+
+  it('should return greater than zero for 5weeks', () => {
+    const result = getMinimumUnixForTimeframe('5weeks');
+
+    const today = new Date().getTime();
+
+    var secondsDelta = Math.abs(today - result) / 1000;
+    var daysDelta = Math.floor(secondsDelta / 86400);
+
+    expect(daysDelta).toEqual(36);
+  });
+});

--- a/src/components/chartTimeControls/chartTimeControlUtils.ts
+++ b/src/components/chartTimeControls/chartTimeControlUtils.ts
@@ -1,6 +1,6 @@
 import { TimeframeOption } from '.';
 
-const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
+export const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
   // adds 1 extra day to capture the intended amount of days
   if (timeframe === 'week') {
     return 8;
@@ -13,7 +13,9 @@ const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
 
 const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
 
-const getMinimumUnixForTimeframe = (timeframe: TimeframeOption): number => {
+export const getMinimumUnixForTimeframe = (
+  timeframe: TimeframeOption
+): number => {
   if (timeframe === 'all') {
     return 0;
   }

--- a/src/components/chartTimeControls/chartTimeControlUtils.ts
+++ b/src/components/chartTimeControls/chartTimeControlUtils.ts
@@ -11,13 +11,14 @@ const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
   return Infinity;
 };
 
+const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+
 const getMinimumUnixForTimeframe = (timeframe: TimeframeOption): number => {
   if (timeframe === 'all') {
     return 0;
   }
   const days = getDaysForTimeframe(timeframe);
-  const oneDay = 24 * 60 * 60 * 1000;
-  return new Date().getTime() - days * oneDay;
+  return new Date().getTime() - days * oneDayInMilliseconds;
 };
 
 type CompareCallbackFunction<T> = (value: T) => number;

--- a/src/components/chartTimeControls/index.tsx
+++ b/src/components/chartTimeControls/index.tsx
@@ -9,11 +9,15 @@ export type TimeframeOption = 'all' | '5weeks' | 'week';
 interface IProps {
   timeframe: TimeframeOption;
   onChange: (value: TimeframeOption) => void;
-  timeframeOptions: TimeframeOption[];
+  timeframeOptions?: TimeframeOption[];
 }
 
 export function ChartTimeControls(props: IProps) {
-  const { timeframe, onChange, timeframeOptions } = props;
+  const {
+    timeframe,
+    onChange,
+    timeframeOptions = ['all', '5weeks', 'week'],
+  } = props;
 
   const values = timeframeOptions.map<IRadioGroupItem>((key) => ({
     label: text.charts.time_controls[key],
@@ -29,7 +33,3 @@ export function ChartTimeControls(props: IProps) {
     />
   );
 }
-
-ChartTimeControls.defaultProps = {
-  timeframeOptions: ['all', '5weeks', 'week'],
-};

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -1,6 +1,6 @@
 import { NextRouter } from 'next/router';
 import { ReactNode } from 'react';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
 import text from '~/locale/index';
@@ -56,7 +56,10 @@ export const escalationTooltip = (router: NextRouter) => {
                 </strong>
                 <br />
                 {replaceVariablesInText(text.escalatie_niveau.valid_from, {
-                  validFrom: formatDate(context.valid_from_unix, 'short'),
+                  validFrom: formatDateFromSeconds(
+                    context.valid_from_unix,
+                    'short'
+                  ),
                 })}
               </div>
             </div>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -8,7 +8,7 @@ import { ILastGeneratedData } from '~/static-props/last-generated-data';
 import styles from './layout.module.scss';
 
 import { useMediaQuery } from '~/utils/useMediaQuery';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { getLocale } from '~/utils/getLocale';
 
@@ -65,9 +65,9 @@ function Layout(props: WithChildren<LayoutProps & ILastGeneratedData>) {
   const locale = getLocale();
   const showSmallLogo = useMediaQuery('(max-width: 480px)', true);
 
-  const dateTime = formatDate(Number(lastGenerated), 'iso');
+  const dateTime = formatDateFromSeconds(Number(lastGenerated), 'iso');
   const dateOfInsertion = lastGenerated
-    ? formatDate(Number(lastGenerated), 'long')
+    ? formatDateFromSeconds(Number(lastGenerated), 'long')
     : undefined;
 
   return (

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '~/components/chartTimeControls';
 
 import { formatNumber } from '~/utils/formatNumber';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { getFilteredValues } from '~/components/chartTimeControls/chartTimeControlUtils';
 import { isDefined } from 'ts-is-present';
 
@@ -65,7 +65,7 @@ function getChartOptions(values: Value[], signaalwaarde?: number) {
         rotation: '0' as any,
         formatter: function () {
           return this.isFirst || this.isLast
-            ? formatDate(this.value, 'axis')
+            ? formatDateFromSeconds(this.value, 'axis')
             : '';
         },
       },
@@ -75,7 +75,7 @@ function getChartOptions(values: Value[], signaalwaarde?: number) {
       borderColor: '#01689B',
       borderRadius: 0,
       formatter: function (): string {
-        return `${formatDate(this.x)}: ${formatNumber(this.y)}`;
+        return `${formatDateFromSeconds(this.x)}: ${formatNumber(this.y)}`;
       },
     },
     yAxis: {

--- a/src/components/lineChart/lineChartWithWeekTooltip.tsx
+++ b/src/components/lineChart/lineChartWithWeekTooltip.tsx
@@ -10,7 +10,7 @@ import { getFilteredValues } from '~/components/chartTimeControls/chartTimeContr
 
 import styles from './lineChart.module.scss';
 import { formatNumber } from '~/utils/formatNumber';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { getItemFromArray } from '~/utils/getItemFromArray';
 
 interface Value {
@@ -105,7 +105,7 @@ function getOptions(values: Value[]): Highcharts.Options {
         rotation: '0' as any,
         formatter: function () {
           return this.isFirst || this.isLast
-            ? formatDate(this.value, 'axis')
+            ? formatDateFromSeconds(this.value, 'axis')
             : '';
         },
       },
@@ -120,10 +120,12 @@ function getOptions(values: Value[]): Highcharts.Options {
           this.point.index
         );
 
-        return `<strong>${formatDate(start, 'short')} - ${formatDate(
-          end,
+        return `<strong>${formatDateFromSeconds(
+          start,
           'short'
-        )}:</strong> ${formatNumber(this.y)}`;
+        )} - ${formatDateFromSeconds(end, 'short')}:</strong> ${formatNumber(
+          this.y
+        )}`;
       },
     },
     yAxis: {

--- a/src/components/lineChart/lineChartWithWeekTooltip.tsx
+++ b/src/components/lineChart/lineChartWithWeekTooltip.tsx
@@ -100,7 +100,7 @@ function getOptions(values: Value[]): Highcharts.Options {
       categories: values.map((value) => value?.date.toString()),
       labels: {
         align: 'right',
-        // types say `rotation` needs to be a number,
+        // type definition says `rotation` needs to be a number,
         // but that doesn’t work.
         rotation: '0' as any,
         formatter: function () {
@@ -139,7 +139,6 @@ function getOptions(values: Value[]): Highcharts.Options {
       },
       labels: {
         formatter: function (): string {
-          // @ts-ignore
           return formatNumber(this.value);
         },
       },

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -3,7 +3,7 @@ import Highcharts, { SeriesLineOptions } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
 import { formatNumber } from '~/utils/formatNumber';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { getItemFromArray } from '~/utils/getItemFromArray';
 
 type TranslationStrings = Record<string, string>;
@@ -105,7 +105,7 @@ function getOptions(
         rotation: '0' as any,
         formatter: function () {
           return this.isFirst || this.isLast
-            ? formatDate(this.value, 'axis')
+            ? formatDateFromSeconds(this.value, 'axis')
             : '';
         },
       },
@@ -119,10 +119,12 @@ function getOptions(
           return false;
         }
         const { start, end } = getItemFromArray(weekSet, this.point.index);
-        return `<strong>${formatDate(start, 'short')} - ${formatDate(
-          end,
+        return `<strong>${formatDateFromSeconds(
+          start,
           'short'
-        )}:</strong> ${formatNumber(this.y)}`;
+        )} - ${formatDateFromSeconds(end, 'short')}:</strong> ${formatNumber(
+          this.y
+        )}`;
       },
     },
     yAxis: {

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -6,7 +6,7 @@ import ClockIcon from '~/assets/clock.svg';
 import DatabaseIcon from '~/assets/database.svg';
 
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 
 interface IProps {
   dataSource: {
@@ -25,9 +25,9 @@ export function Metadata(props: IProps) {
 
   if (!dateUnix) return null;
 
-  const dateOfReport = formatDate(dateUnix, 'relative');
+  const dateOfReport = formatDateFromSeconds(dateUnix, 'relative');
   const dateOfInsertion = dateInsertedUnix
-    ? formatDate(dateInsertedUnix, 'relative')
+    ? formatDateFromSeconds(dateInsertedUnix, 'relative')
     : undefined;
 
   return (

--- a/src/utils/createDate.ts
+++ b/src/utils/createDate.ts
@@ -1,10 +1,8 @@
-const milliseconds = 1000;
-
 /**
  * JavaScript uses milliseconds since EPOCH, therefore the value
  * used to create the new Date instance needs to be multiplied by 1000
  * to create an accurate dateTime
  */
 export function createDate(seconds: number): Date {
-  return new Date(seconds * milliseconds);
+  return new Date(seconds * 1000);
 }

--- a/src/utils/createDate.ts
+++ b/src/utils/createDate.ts
@@ -1,0 +1,10 @@
+const milliseconds = 1000;
+
+/**
+ * JavaScript uses milliseconds since EPOCH, therefore the value
+ * used to create the new Date instance needs to be multiplied by 1000
+ * to create an accurate dateTime
+ */
+export function createDate(seconds: number): Date {
+  return new Date(seconds * milliseconds);
+}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -64,7 +64,7 @@ const Day = new Intl.DateTimeFormat(locale, {
   timeZone: 'Europe/Amsterdam',
 });
 
-export function formatDate(
+export function formatDateFromSeconds(
   seconds: number,
   style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
 ): string {
@@ -73,18 +73,25 @@ export function formatDate(
    * formatted by the format() function needs to be multiplied by 1000
    * to format to an accurate dateTime
    */
-  const value = seconds * 1000;
+  const milliseconds = seconds * 1000;
 
-  if (style === 'iso') return new Date(value).toISOString(); // '2020-07-23T10:01:16.000Z'
-  if (style === 'long') return Long.format(value); // '23 juli 2020 om 12:01'
-  if (style === 'medium') return Medium.format(value); // '23 juli 2020'
+  return formatDateFromMilliseconds(milliseconds, style);
+}
+
+export function formatDateFromMilliseconds(
+  milliseconds: number,
+  style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
+): string {
+  if (style === 'iso') return new Date(milliseconds).toISOString(); // '2020-07-23T10:01:16.000Z'
+  if (style === 'long') return Long.format(milliseconds); // '23 juli 2020 om 12:01'
+  if (style === 'medium') return Medium.format(milliseconds); // '23 juli 2020'
   if (style === 'axis')
-    return `${Day.format(value)} ${MonthShort.format(value)}`; // '23 jul.'
+    return `${Day.format(milliseconds)} ${MonthShort.format(milliseconds)}`; // '23 jul.'
 
   if (style === 'relative') {
-    if (isToday(value)) return siteText.utils.date_today;
-    if (isYesterday(value)) return siteText.utils.date_yesterday;
+    if (isToday(milliseconds)) return siteText.utils.date_today;
+    if (isYesterday(milliseconds)) return siteText.utils.date_yesterday;
   }
 
-  return DayMonth.format(value);
+  return DayMonth.format(milliseconds);
 }

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -4,7 +4,7 @@ import {
   SewerMeasurementsLastValue,
   ResultsPerSewerInstallationPerMunicipalityLastValue,
 } from '~/types/data.d';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { XrangePointOptionsObject } from 'highcharts';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -205,7 +205,7 @@ export function getSewerWaterBarChartData(
         y: data?.sewer_measurements?.last_value.average,
         color: '#3391CC',
         label: data?.sewer_measurements?.last_value
-          ? `${formatDate(
+          ? `${formatDateFromSeconds(
               data.sewer_measurements.last_value.week_unix,
               'short'
             )}: ${formatNumber(data.sewer_measurements.last_value.average)}`
@@ -219,7 +219,7 @@ export function getSewerWaterBarChartData(
             y: installation?.last_value?.rna_per_ml,
             color: '#C1C1C1',
             label: installation?.last_value
-              ? `${formatDate(
+              ? `${formatDateFromSeconds(
                   installation.last_value.date_measurement_unix,
                   'short'
                 )}: ${formatNumber(installation.last_value.rna_per_ml)}`

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -6,7 +6,7 @@ import {
   SewerValueElement,
 } from '~/types/data.d';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
-import { formatDate } from '~/utils/formatDate';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import siteText from '~/locale/index';
 
@@ -181,7 +181,7 @@ export function getSewerWaterBarChartData(
         y: data?.average_sewer_installation_per_region?.last_value.average,
         color: '#3391CC',
         label: data?.average_sewer_installation_per_region?.last_value
-          ? `${formatDate(
+          ? `${formatDateFromSeconds(
               data.average_sewer_installation_per_region.last_value.week_unix,
               'short'
             )}: ${formatNumber(
@@ -195,7 +195,7 @@ export function getSewerWaterBarChartData(
             y: installation?.last_value?.rna_per_ml,
             color: '#C1C1C1',
             label: installation?.last_value
-              ? `${formatDate(
+              ? `${formatDateFromSeconds(
                   installation.last_value.date_measurement_unix,
                   'short'
                 )}: ${formatNumber(installation.last_value.rna_per_ml)}`


### PR DESCRIPTION
## Summary

- Add createDate factory method to turn unix timestamps into dates
- Use createDate everywhere necessary to create Date objects
- Refactor formatDate into two methods: formatDateFromSeconds and formatDateFromMilliseconds
- Fix date bug in areachart where dates where milliseconds where multiplied too often

## Motivation

Bug report

## Detailed design

In the areachart milliseconds were incorrectly multiplied by 1000 and that value was then given to the formatDate method, which multiplied it y a thousand again, leading to all sorts of illogical results.
To avoid any direct new Date() calls a factory method was added that takes a unix timestamp (in seconds) and creates a JS Date from that.
The formatDate method was split into a formatDateFromSeconds  and formatDateFromMilliseconds method so that the areachart can use the formatDateFromMilliseconds in its tooltip and axis formatters.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
