### PR TITLE
Adds back button / menu button at footer of the page for mobile

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -260,6 +260,13 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
         </aside>
 
         <section className="municipality-content">{children}</section>
+
+        <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>
+          <a className="back-button back-button-footer" onClick={openMenu}>
+            <Arrow />
+            {siteText.nav.terug_naar_alle_cijfers}
+          </a>
+        </Link>
       </div>
     </>
   );

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -349,6 +349,15 @@ function NationalLayout(props: WithChildren<INationalData>) {
         </aside>
 
         <section className="national-content">{children}</section>
+
+        <Link href="/landelijk">
+          <a className="back-button back-button-footer" onClick={openMenu}>
+            <Arrow />
+            {router.pathname === '/'
+              ? siteText.nav.terug_naar_alle_cijfers_homepage
+              : siteText.nav.terug_naar_alle_cijfers}
+          </a>
+        </Link>
       </div>
     </>
   );

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -227,6 +227,13 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
         </aside>
 
         <section className="safety-region-content">{children}</section>
+
+        <Link href="/veiligheidsregio/[code]" as={`/veiligheidsregio/${code}`}>
+          <a className="back-button back-button-footer" onClick={openMenu}>
+            <Arrow />
+            {siteText.nav.terug_naar_alle_cijfers}
+          </a>
+        </Link>
       </div>
     </>
   );

--- a/src/components/layout/useMenuState.ts
+++ b/src/components/layout/useMenuState.ts
@@ -21,6 +21,11 @@ export function useMenuState(defaultOpen = false): MenuState {
   ): void => {
     event?.preventDefault();
     setMenuOpen(true);
+
+    /* Ensure the top of the menu is in view */
+    requestAnimationFrame(() => {
+      window.document.querySelector('aside')?.scrollIntoView(true);
+    });
   };
 
   const handleMenuClick = (

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -150,10 +150,9 @@
     z-index: 2;
     text-decoration: none;
 
-    &.back-button-big {
-      font-size: 1.42383rem;
-      padding: 2em 1em;
-      text-align: center;
+    &.back-button-footer {
+      background: none;
+      box-shadow: none;
     }
 
     &:hover,


### PR DESCRIPTION
## Summary

Adds a "back to all metric" button toopen the menu at the bottom of the page.

## Detailed design

* This also adds an instant scroll to the top of the menu.
* The PR also cleans up a leftover classname for the `back-button-big` that is no longer used.