### PR TITLE
Fixes skip link scroll behaviour in IE11

### DIFF
--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -5,7 +5,7 @@ import styles from './layout.module.scss';
 export function ContentHeader(props: IContentHeaderProps) {
   const { category, Icon, title, subtitle, metadata, id } = props;
 
-  const layoutClasses = [];
+  const layoutClasses = [styles.contentHeader];
 
   if (!category) {
     layoutClasses.push(styles.withoutCategory);

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -245,6 +245,15 @@ $language-switcher-offset: 55px;
   margin-left: 4rem;
 }
 
+/*
+  Ensure skip link anchors to have a (non visible) start at the left side of the screen
+  This fixes odd skip-link behaviour in IE11
+*/
+.contentHeader[id] {
+  margin-left: -100vw;
+  padding-left: 100vw;
+}
+
 .withoutCategory {
   margin-top: 2rem;
 }


### PR DESCRIPTION
## Summary

Fixes a bug in IE11 that skip links (to the GGD data in this case) cause an odd cut off of the page, resulting a fairly un-usuable page.

Fixed it by making sure the skip link target has an invisible part of it rendered at the left edge of the screen.