### PR TITLE
Removes all unneeded use of typeof siteText

### DIFF
--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -42,7 +42,7 @@ export function BarScale({
 
   const { scale: x } = useDynamicScale(min, max, rangeKey, value);
 
-  const text: typeof siteText.common.barScale = siteText.common.barScale;
+  const text = siteText.common.barScale;
 
   if (!x) {
     return null;

--- a/src/components/gemeente/intake-hospital-barscale.tsx
+++ b/src/components/gemeente/intake-hospital-barscale.tsx
@@ -2,8 +2,7 @@ import { BarScale } from '~/components/barScale';
 import { HospitalAdmissions } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
-  siteText.gemeente_ziekenhuisopnames_per_dag;
+const text = siteText.gemeente_ziekenhuisopnames_per_dag;
 
 export function IntakeHospitalBarScale(props: {
   data: HospitalAdmissions | undefined;

--- a/src/components/gemeente/positively-tested-people-barscale.tsx
+++ b/src/components/gemeente/positively-tested-people-barscale.tsx
@@ -2,8 +2,7 @@ import { BarScale } from '~/components/barScale';
 import { PositiveTestedPeople } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.gemeente_positief_geteste_personen =
-  siteText.gemeente_positief_geteste_personen;
+const text = siteText.gemeente_positief_geteste_personen;
 
 export function PositivelyTestedPeopleBarScale(props: {
   data: PositiveTestedPeople | undefined;

--- a/src/components/gemeente/sewer-water-barscale.tsx
+++ b/src/components/gemeente/sewer-water-barscale.tsx
@@ -3,8 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { SewerWaterBarScaleData } from '~/utils/sewer-water/municipality-sewer-water.util';
 import siteText from '~/locale/index';
 
-const text: typeof siteText.gemeente_rioolwater_metingen =
-  siteText.gemeente_rioolwater_metingen;
+const text = siteText.gemeente_rioolwater_metingen;
 
 export function SewerWaterBarScale(props: {
   data: SewerWaterBarScaleData | null;

--- a/src/components/landelijk/infectious-people-barscale.tsx
+++ b/src/components/landelijk/infectious-people-barscale.tsx
@@ -3,8 +3,7 @@ import { InfectiousPeopleCountNormalized } from '~/types/data.d';
 
 import siteText from '~/locale/index';
 
-const text: typeof siteText.besmettelijke_personen =
-  siteText.besmettelijke_personen;
+const text = siteText.besmettelijke_personen;
 
 export function InfectiousPeopleBarScale(props: {
   data: InfectiousPeopleCountNormalized | undefined;

--- a/src/components/landelijk/intake-hospital-barscale.tsx
+++ b/src/components/landelijk/intake-hospital-barscale.tsx
@@ -3,8 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { IntakeHospitalMa } from '~/types/data.d';
 import siteText from '~/locale/index';
 
-const text: typeof siteText.ziekenhuisopnames_per_dag =
-  siteText.ziekenhuisopnames_per_dag;
+const text = siteText.ziekenhuisopnames_per_dag;
 
 export function IntakeHospitalBarScale(props: {
   data: IntakeHospitalMa | undefined;

--- a/src/components/landelijk/intake-intensive-care-barscale.tsx
+++ b/src/components/landelijk/intake-intensive-care-barscale.tsx
@@ -3,7 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { IntakeIntensivecareMa } from '~/types/data.d';
 import siteText from '~/locale/index';
 
-const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
+const text = siteText.ic_opnames_per_dag;
 
 export function IntakeIntensiveCareBarscale(props: {
   data: IntakeIntensivecareMa | undefined;

--- a/src/components/landelijk/nursing-home-deaths-barscale.tsx
+++ b/src/components/landelijk/nursing-home-deaths-barscale.tsx
@@ -2,8 +2,7 @@ import { BarScale } from '~/components/barScale';
 import siteText from '~/locale/index';
 import { DeceasedPeopleNurseryCountDaily } from '~/types/data.d';
 
-const text: typeof siteText.verpleeghuis_oversterfte =
-  siteText.verpleeghuis_oversterfte;
+const text = siteText.verpleeghuis_oversterfte;
 
 export function NursingHomeDeathsBarScale(props: {
   data: DeceasedPeopleNurseryCountDaily | undefined;

--- a/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-locations-barscale.tsx
@@ -4,8 +4,7 @@ import { TotalReportedLocations } from '~/types/data.d';
 
 import siteText from '~/locale/index';
 
-const text: typeof siteText.verpleeghuis_besmette_locaties =
-  siteText.verpleeghuis_besmette_locaties;
+const text = siteText.verpleeghuis_besmette_locaties;
 
 export function NursingHomeInfectedLocationsBarScale(props: {
   data: TotalReportedLocations | undefined;

--- a/src/components/landelijk/nursing-home-infected-people-barscale.tsx
+++ b/src/components/landelijk/nursing-home-infected-people-barscale.tsx
@@ -2,8 +2,7 @@ import { BarScale } from '~/components/barScale';
 import { InfectedPeopleNurseryCountDaily } from '~/types/data.d';
 import siteText from '~/locale/index';
 
-const text: typeof siteText.verpleeghuis_positief_geteste_personen =
-  siteText.verpleeghuis_positief_geteste_personen;
+const text = siteText.verpleeghuis_positief_geteste_personen;
 
 export function NursingHomeInfectedPeopleBarScale(props: {
   data: InfectedPeopleNurseryCountDaily | undefined;

--- a/src/components/landelijk/positive-tested-people-barscale.tsx
+++ b/src/components/landelijk/positive-tested-people-barscale.tsx
@@ -3,8 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { InfectedPeopleDeltaNormalized } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.positief_geteste_personen =
-  siteText.positief_geteste_personen;
+const text = siteText.positief_geteste_personen;
 
 export function PositiveTestedPeopleBarScale(props: {
   data: InfectedPeopleDeltaNormalized | undefined;

--- a/src/components/landelijk/reproduction-index-barscale.tsx
+++ b/src/components/landelijk/reproduction-index-barscale.tsx
@@ -3,7 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
+const text = siteText.reproductiegetal;
 
 export function ReproductionIndexBarScale(props: {
   data: ReproductionIndexData | undefined;

--- a/src/components/landelijk/sewer-water-barscale.tsx
+++ b/src/components/landelijk/sewer-water-barscale.tsx
@@ -3,7 +3,7 @@ import { BarScale } from '~/components/barScale';
 import { RioolwaterMetingen } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
+const text = siteText.rioolwater_metingen;
 
 export function SewerWaterBarScale(props: {
   data: RioolwaterMetingen | undefined;

--- a/src/components/landelijk/suspected-patients-barscale.tsx
+++ b/src/components/landelijk/suspected-patients-barscale.tsx
@@ -2,8 +2,7 @@ import { BarScale } from '~/components/barScale';
 import { NationalHuisartsVerdenkingen } from '~/types/data.d';
 
 import siteText from '~/locale/index';
-const text: typeof siteText.verdenkingen_huisartsen =
-  siteText.verdenkingen_huisartsen;
+const text = siteText.verdenkingen_huisartsen;
 
 export function SuspectedPatientsBarScale(props: {
   data: NationalHuisartsVerdenkingen | undefined;

--- a/src/components/metadata/index.tsx
+++ b/src/components/metadata/index.tsx
@@ -18,7 +18,7 @@ interface IProps {
   datumsText: string;
 }
 
-const text: typeof siteText.common.metadata = siteText.common.metadata;
+const text = siteText.common.metadata;
 
 export function Metadata(props: IProps) {
   const { dataSource, datumsText, dateUnix, dateInsertedUnix } = props;

--- a/src/components/veiligheidsregio/intake-hospital-barscale.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-barscale.tsx
@@ -10,8 +10,7 @@ export function IntakeHospitalBarScale(props: {
 
   if (!data) return null;
 
-  const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
-    siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
+  const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
 
   return (
     <BarScale

--- a/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-barscale.tsx
@@ -10,8 +10,7 @@ export function PositivelyTestedPeopleBarScale(props: {
 
   if (!data) return null;
 
-  const text: typeof siteText.veiligheidsregio_positief_geteste_personen =
-    siteText.veiligheidsregio_positief_geteste_personen;
+  const text = siteText.veiligheidsregio_positief_geteste_personen;
 
   return (
     <BarScale

--- a/src/components/veiligheidsregio/sewer-water-barscale.tsx
+++ b/src/components/veiligheidsregio/sewer-water-barscale.tsx
@@ -10,8 +10,7 @@ export function SewerWaterBarScale(props: {
 
   if (!data) return null;
 
-  const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
-    siteText.veiligheidsregio_rioolwater_metingen;
+  const text = siteText.veiligheidsregio_rioolwater_metingen;
 
   return (
     <BarScale

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -24,8 +24,7 @@ import Getest from '~/assets/test.svg';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
-const text: typeof siteText.gemeente_positief_geteste_personen =
-  siteText.gemeente_positief_geteste_personen;
+const text = siteText.gemeente_positief_geteste_personen;
 
 const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
   const { data, municipalityName } = props;

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -23,8 +23,7 @@ import {
 import siteText from '~/locale/index';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
-const text: typeof siteText.gemeente_rioolwater_metingen =
-  siteText.gemeente_rioolwater_metingen;
+const text = siteText.gemeente_rioolwater_metingen;
 
 const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
   const { data, municipalityName } = props;

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -22,8 +22,7 @@ import { useMunicipalLegendaData } from '~/components/chloropleth/legenda/hooks/
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
-const text: typeof siteText.gemeente_ziekenhuisopnames_per_dag =
-  siteText.gemeente_ziekenhuisopnames_per_dag;
+const text = siteText.gemeente_ziekenhuisopnames_per_dag;
 
 const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
   const { data, municipalityName } = props;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import fs from 'fs';
 import styles from './index.module.scss';
 import { National } from '~/types/data';
 import { INationalData } from '~/static-props/nl-data';
-import siteText from '~/locale/index';
+import { TALLLanguages } from '~/locale/index';
 
 import { FCWithLayout } from '~/components/layout';
 import { getNationalLayout } from '~/components/layout/NationalLayout';
@@ -132,7 +132,7 @@ Home.getLayout = getNationalLayout();
 interface StaticProps {
   props: {
     data: National;
-    text: typeof siteText;
+    text: TALLLanguages;
     lastGenerated: string;
   };
 }

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -19,8 +19,7 @@ import {
 import { ContentHeader } from '~/components/layout/Content';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.besmettelijke_personen =
-  siteText.besmettelijke_personen;
+const text = siteText.besmettelijke_personen;
 
 const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
   const { data } = props;

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -12,7 +12,7 @@ import { IntakeIntensivecareMa } from '~/types/data.d';
 
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.ic_opnames_per_dag = siteText.ic_opnames_per_dag;
+const text = siteText.ic_opnames_per_dag;
 
 const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -14,7 +14,7 @@ import { ReproductionIndex as ReproductionIndexData } from '~/types/data.d';
 
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.reproductiegetal = siteText.reproductiegetal;
+const text = siteText.reproductiegetal;
 
 const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -10,7 +10,7 @@ import { SewerWaterBarScale } from '~/components/landelijk/sewer-water-barscale'
 
 import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
 
-const text: typeof siteText.rioolwater_metingen = siteText.rioolwater_metingen;
+const text = siteText.rioolwater_metingen;
 
 const SewerWater: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -14,8 +14,7 @@ import { SuspectedPatientsBarScale } from '~/components/landelijk/suspected-pati
 import Arts from '~/assets/arts.svg';
 import { formatNumber } from '~/utils/formatNumber';
 
-const text: typeof siteText.verdenkingen_huisartsen =
-  siteText.verdenkingen_huisartsen;
+const text = siteText.verdenkingen_huisartsen;
 
 const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -17,8 +17,7 @@ import {
 
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.verpleeghuis_besmette_locaties =
-  siteText.verpleeghuis_besmette_locaties;
+const text = siteText.verpleeghuis_besmette_locaties;
 
 const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -12,8 +12,7 @@ import siteText from '~/locale/index';
 import { InfectedPeopleNurseryCountDaily } from '~/types/data.d';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.verpleeghuis_positief_geteste_personen =
-  siteText.verpleeghuis_positief_geteste_personen;
+const text = siteText.verpleeghuis_positief_geteste_personen;
 
 const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -12,8 +12,7 @@ import siteText from '~/locale/index';
 import { DeceasedPeopleNurseryCountDaily } from '~/types/data.d';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 
-const text: typeof siteText.verpleeghuis_oversterfte =
-  siteText.verpleeghuis_oversterfte;
+const text = siteText.verpleeghuis_oversterfte;
 
 const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -22,8 +22,7 @@ import { useSafetyRegionLegendaData } from '~/components/chloropleth/legenda/hoo
 
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 
-const text: typeof siteText.ziekenhuisopnames_per_dag =
-  siteText.ziekenhuisopnames_per_dag;
+const text = siteText.ziekenhuisopnames_per_dag;
 
 const IntakeHospital: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;

--- a/src/pages/over-risiconiveaus.tsx
+++ b/src/pages/over-risiconiveaus.tsx
@@ -7,13 +7,13 @@ import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
 import { MaxWidth } from '~/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from '~/locale/index';
+import siteText, { TALLLanguages } from '~/locale/index';
 
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
 interface StaticProps {
   props: {
-    text: typeof siteText;
+    text: TALLLanguages;
     lastGenerated: string;
   };
 }

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -8,7 +8,7 @@ import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
 import { MaxWidth } from '~/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from '~/locale/index';
+import siteText, { TALLLanguages } from '~/locale/index';
 
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
@@ -19,7 +19,7 @@ interface IVraagEnAntwoord {
 
 interface StaticProps {
   props: {
-    text: typeof siteText;
+    text: TALLLanguages;
     lastGenerated: string;
   };
 }
@@ -41,7 +41,7 @@ export async function getStaticProps(): Promise<StaticProps> {
   return { props: { text, lastGenerated } };
 }
 
-const Over: FCWithLayout<{ text: typeof siteText }> = (props) => {
+const Over: FCWithLayout<{ text: TALLLanguages }> = (props) => {
   const { text } = props;
 
   return (

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -23,8 +23,7 @@ import {
 } from '~/static-props/safetyregion-data';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
-const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
-  siteText.veiligheidsregio_rioolwater_metingen;
+const text = siteText.veiligheidsregio_rioolwater_metingen;
 
 const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data, safetyRegionName } = props;

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -23,8 +23,7 @@ import { ContentHeader } from '~/components/layout/Content';
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
-const text: typeof siteText.veiligheidsregio_ziekenhuisopnames_per_dag =
-  siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
+const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
 
 const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data, safetyRegionName } = props;

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -9,7 +9,7 @@ import EscalationLevel2 from '~/assets/niveau-2.svg';
 import EscalationLevel3 from '~/assets/niveau-3.svg';
 import styles from '~/components/chloropleth/tooltips/tooltip.module.scss';
 
-import siteText from '~/locale/index';
+import { TALLLanguages } from '~/locale/index';
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
 import {
@@ -100,7 +100,7 @@ SafetyRegion.getLayout = getSafetyRegionLayout();
 
 interface StaticProps {
   props: {
-    text: typeof siteText;
+    text: TALLLanguages;
     lastGenerated: string;
   };
 }

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -8,7 +8,7 @@ import { getLayoutWithMetadata, FCWithLayout } from '~/components/layout';
 import { MaxWidth } from '~/components/maxWidth';
 
 import styles from './over.module.scss';
-import siteText from '~/locale/index';
+import siteText, { TALLLanguages } from '~/locale/index';
 
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
@@ -19,7 +19,7 @@ interface ICijfer {
 
 interface StaticProps {
   props: {
-    text: typeof siteText;
+    text: TALLLanguages;
     lastGenerated: string;
   };
 }

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -11,8 +11,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
 import siteText from '~/locale/index';
 
-const text: typeof siteText.gemeente_rioolwater_metingen =
-  siteText.gemeente_rioolwater_metingen;
+const text = siteText.gemeente_rioolwater_metingen;
 
 // Specific interfaces to pass data between the formatting functions and the highcharts configs
 export interface SewerWaterMetadata {

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -10,8 +10,7 @@ import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import siteText from '~/locale/index';
 
-const text: typeof siteText.veiligheidsregio_rioolwater_metingen =
-  siteText.veiligheidsregio_rioolwater_metingen;
+const text = siteText.veiligheidsregio_rioolwater_metingen;
 
 // Specific interfaces to pass data between the formatting functions and the highcharts configs
 export interface SewerWaterMetadata {


### PR DESCRIPTION
## Summary

Removes all unneeded use of `typeof siteText`

## Detailed design

* removes all uses of `typeof siteText` and use `TALLLanguages`
* removes all uses of `: typeof siteText.foo` in eg `const text: typeof siteText.foo = siteText.foo`