### PR TITLE
fix: legend design fixes

### DIFF
--- a/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
+++ b/src/components/chloropleth/legenda/ChloroplethLegenda.tsx
@@ -14,7 +14,7 @@ export function ChloroplethLegenda(props: TProps) {
   const { items, title } = props;
 
   return (
-    <>
+    <div>
       <h4>{title}</h4>
       <ul className={styles.legenda} aria-label="legend">
         {items.map((item) => (
@@ -22,11 +22,11 @@ export function ChloroplethLegenda(props: TProps) {
             <div
               className={styles.box}
               style={{ backgroundColor: item.color }}
-            ></div>
+            />
             <div>{item.label}</div>
           </li>
         ))}
       </ul>
-    </>
+    </div>
   );
 }

--- a/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
+++ b/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
@@ -2,12 +2,13 @@
   margin-top: 0;
   padding-left: 0;
   list-style: none;
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
 
   .legendaItem {
     display: flex;
     flex-direction: column;
+    align-items: center;
     font-size: 14px;
 
     .box {

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -466,6 +466,13 @@ a.metric-link {
 
   .chloropleth-legend {
     grid-area: b;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    @media (min-width: $chloropleth-breakpoint) {
+      align-items: flex-start;
+    }
   }
 
   .chloropleth-chart {


### PR DESCRIPTION
## Summary

This PR aligns the legend centrally below the chloropleth chart on tablet and mobile screens. Furthermore it applies a center-align to the labels of the legend.

### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
