### PR TITLE
Improve data difference schema

### DIFF
--- a/schema/national/infected_people_total.json
+++ b/schema/national/infected_people_total.json
@@ -13,7 +13,7 @@
     "last_value": {
       "$ref": "#/definitions/value"
     },
-    "difference": {
+    "last_value_difference": {
       "$ref": "#/definitions/value_difference"
     }
   },
@@ -45,32 +45,21 @@
       "title": "national_infected_people_total_value_difference",
       "type": "object",
       "properties": {
-        "infected_daily_total_new": {
-          "type": "integer"
-        },
         "infected_daily_total_old": {
           "type": "integer"
         },
         "infected_daily_total_difference": {
           "type": "integer"
         },
-        "date_of_report_unix_new": {
-          "type": "integer"
-        },
+
         "date_of_report_unix_old": {
-          "type": "integer"
-        },
-        "date_of_insertion_unix": {
           "type": "integer"
         }
       },
       "required": [
-        "infected_daily_total_new",
         "infected_daily_total_old",
         "infected_daily_total_difference",
-        "date_of_report_unix_new",
-        "date_of_report_unix_old",
-        "date_of_insertion_unix"
+        "date_of_report_unix_old"
       ],
       "additionalProperties": false
     }

--- a/schema/national/verdenkingen_huisartsen.json
+++ b/schema/national/verdenkingen_huisartsen.json
@@ -12,7 +12,7 @@
     "last_value": {
       "$ref": "#/definitions/value"
     },
-    "difference": {
+    "last_value_difference": {
       "$ref": "#/definitions/value_difference"
     }
   },
@@ -56,16 +56,10 @@
       "title": "national_huisarts_verdenkingen_value_difference",
       "type": "object",
       "properties": {
-        "incidentie_new": {
-          "type": "integer"
-        },
         "incidentie_old": {
           "type": "integer"
         },
         "incidentie_difference": {
-          "type": "integer"
-        },
-        "geschat_aantal_new": {
           "type": "integer"
         },
         "geschat_aantal_old": {
@@ -74,26 +68,16 @@
         "geschat_aantal_difference": {
           "type": "integer"
         },
-        "date_of_report_unix_new": {
-          "type": "integer"
-        },
         "date_of_report_unix_old": {
-          "type": "integer"
-        },
-        "date_of_insertion_unix": {
           "type": "integer"
         }
       },
       "required": [
-        "incidentie_new",
         "incidentie_old",
         "incidentie_difference",
-        "geschat_aantal_new",
         "geschat_aantal_old",
         "geschat_aantal_difference",
-        "date_of_report_unix_new",
-        "date_of_report_unix_old",
-        "date_of_insertion_unix"
+        "date_of_report_unix_old"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
A slightly leaner implementation for the value difference in data sets.

* Remove the new values because they are already present in last_value
* Rename difference to last_value_difference to make clear that part of the values live there
* Remove date_of_insertion from difference data because it is redundant