### PR TITLE
Feature/map aspect ratio

### DIFF
--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -130,7 +130,7 @@ export function MunicipalityChloropleth<
     isSelectorMap,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions(undefined, 1.2);
+  const [ref, dimensions] = useChartDimensions(1.2);
 
   const [boundingbox, selectedVrCode] = useMunicipalityBoundingbox(
     regionGeo,

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -130,7 +130,7 @@ export function MunicipalityChloropleth<
     isSelectorMap,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions();
+  const [ref, dimensions] = useChartDimensions(undefined, 1.2);
 
   const [boundingbox, selectedVrCode] = useMunicipalityBoundingbox(
     regionGeo,

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -144,7 +144,7 @@ export function SafetyRegionChloropleth<
     tooltipContent,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions(undefined, 1.2);
+  const [ref, dimensions] = useChartDimensions(1.2);
 
   const boundingbox = useSafetyRegionBoundingbox(regionGeo, selected);
 

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -144,7 +144,7 @@ export function SafetyRegionChloropleth<
     tooltipContent,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions();
+  const [ref, dimensions] = useChartDimensions(undefined, 1.2);
 
   const boundingbox = useSafetyRegionBoundingbox(regionGeo, selected);
 

--- a/src/components/chloropleth/chloropleth.module.scss
+++ b/src/components/chloropleth/chloropleth.module.scss
@@ -17,7 +17,6 @@
 
 .chloroplethContainer {
   position: relative;
-  height: 400px;
   background: transparent;
 }
 

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -47,7 +47,6 @@ export type TCombinedChartDimensions = TChartDimensions & {
 };
 
 export const useChartDimensions = (
-  chartDimensions: TChartDimensions = {},
   aspectRatio?: number
 ): [MutableRefObject<HTMLElement | null>, TCombinedChartDimensions] => {
   /**
@@ -60,23 +59,13 @@ export const useChartDimensions = (
 
   const { width, height } = useResizeObserver({ ref });
 
-  /**
-   * The previous useChartDimensions implementation allowed the passed in width and height to overrule any
-   * observed sizes. This is not currently used in the app, so we could decide
-   * to take it out. This implementation follows that same behavior for now.
-   */
-  const shouldOverruleWidthAndHeight =
-    chartDimensions.width && chartDimensions.height;
-
   const calculatedHeight = aspectRatio && width ? width * aspectRatio : height;
 
   return [
     ref,
     combineChartDimensions({
-      width: shouldOverruleWidthAndHeight ? chartDimensions.width : width,
-      height: shouldOverruleWidthAndHeight
-        ? chartDimensions.height
-        : calculatedHeight,
+      width,
+      height: calculatedHeight,
     }),
   ];
 };

--- a/src/components/chloropleth/hooks/useChartDimensions.tsx
+++ b/src/components/chloropleth/hooks/useChartDimensions.tsx
@@ -47,7 +47,8 @@ export type TCombinedChartDimensions = TChartDimensions & {
 };
 
 export const useChartDimensions = (
-  chartDimensions: TChartDimensions = {}
+  chartDimensions: TChartDimensions = {},
+  aspectRatio?: number
 ): [MutableRefObject<HTMLElement | null>, TCombinedChartDimensions] => {
   /**
    * The ref will be initialized from the outside by mutating the return value of this
@@ -67,11 +68,15 @@ export const useChartDimensions = (
   const shouldOverruleWidthAndHeight =
     chartDimensions.width && chartDimensions.height;
 
+  const calculatedHeight = aspectRatio && width ? width * aspectRatio : height;
+
   return [
     ref,
     combineChartDimensions({
       width: shouldOverruleWidthAndHeight ? chartDimensions.width : width,
-      height: shouldOverruleWidthAndHeight ? chartDimensions.height : height,
+      height: shouldOverruleWidthAndHeight
+        ? chartDimensions.height
+        : calculatedHeight,
     }),
   ];
 };

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -10,7 +10,7 @@ import styles from '~/components/chloropleth/chloropleth.module.scss';
 import { ReactNode } from 'react';
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
 import { MunicipalityProperties } from '~/components/chloropleth/shared';
-import { useMediaQuery } from '~/utils/useMediaQuery';
+// import { useMediaQuery } from '~/utils/useMediaQuery';
 
 const tooltipContent = (router: NextRouter) => {
   return (context: MunicipalityProperties): ReactNode => {
@@ -40,7 +40,7 @@ const tooltipContent = (router: NextRouter) => {
 // lots of unnecessary null checks on those pages.
 const Municipality: FCWithLayout<any> = () => {
   const router = useRouter();
-  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
+  // const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const onSelectMunicipal = (context: MunicipalityProperties) => {
     router.push(
@@ -49,7 +49,7 @@ const Municipality: FCWithLayout<any> = () => {
     );
   };
 
-  const mapHeight = isLargeScreen ? '800px' : '400px';
+  // const mapHeight = isLargeScreen ? '800px' : '400px';
 
   return (
     <article className="map-article">
@@ -57,10 +57,9 @@ const Municipality: FCWithLayout<any> = () => {
         <h2>{text.gemeente_index.selecteer_titel}</h2>
         <p>{text.gemeente_index.selecteer_toelichting}</p>
       </div>
-      <div>
+      <div style={{ maxWidth: '667px' }}>
         <MunicipalityChloropleth
           tooltipContent={tooltipContent(router)}
-          style={{ height: mapHeight }}
           onSelect={onSelectMunicipal}
           isSelectorMap={true}
         />

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -10,7 +10,6 @@ import styles from '~/components/chloropleth/chloropleth.module.scss';
 import { ReactNode } from 'react';
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
 import { MunicipalityProperties } from '~/components/chloropleth/shared';
-// import { useMediaQuery } from '~/utils/useMediaQuery';
 
 const tooltipContent = (router: NextRouter) => {
   return (context: MunicipalityProperties): ReactNode => {
@@ -40,7 +39,6 @@ const tooltipContent = (router: NextRouter) => {
 // lots of unnecessary null checks on those pages.
 const Municipality: FCWithLayout<any> = () => {
   const router = useRouter();
-  // const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const onSelectMunicipal = (context: MunicipalityProperties) => {
     router.push(
@@ -49,15 +47,13 @@ const Municipality: FCWithLayout<any> = () => {
     );
   };
 
-  // const mapHeight = isLargeScreen ? '800px' : '400px';
-
   return (
     <article className="map-article">
       <div>
         <h2>{text.gemeente_index.selecteer_titel}</h2>
         <p>{text.gemeente_index.selecteer_toelichting}</p>
       </div>
-      <div style={{ maxWidth: '667px' }}>
+      <div className="map-container">
         <MunicipalityChloropleth
           tooltipContent={tooltipContent(router)}
           onSelect={onSelectMunicipal}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,6 @@ import Notification from '~/assets/notification.svg';
 import ExternalLink from '~/assets/external-link.svg';
 
 import { EscalationMapLegenda } from './veiligheidsregio';
-import { useMediaQuery } from '~/utils/useMediaQuery';
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
 const Home: FCWithLayout<INationalData> = (props) => {
@@ -36,9 +35,7 @@ const Home: FCWithLayout<INationalData> = (props) => {
     'municipal'
   );
 
-  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
   const legendItems = useSafetyRegionLegendaData('positive_tested_people');
-  const mapHeight = isLargeScreen ? '500px' : '400px';
 
   return (
     <>
@@ -77,7 +74,6 @@ const Home: FCWithLayout<INationalData> = (props) => {
           <SafetyRegionChloropleth
             metricName="escalation_levels"
             metricProperty="escalation_level"
-            style={{ height: mapHeight }}
             onSelect={createSelectRegionHandler(router)}
             tooltipContent={escalationTooltip(router)}
           />

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -16,7 +16,6 @@ import {
   SafetyRegionChloropleth,
   thresholds,
 } from '~/components/chloropleth/SafetyRegionChloropleth';
-import { useMediaQuery } from '~/utils/useMediaQuery';
 import { escalationTooltip } from '~/components/chloropleth/tooltips/region/escalationTooltip';
 import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
 
@@ -58,11 +57,8 @@ export const EscalationMapLegenda = (props: any) => {
 // lots of unnecessary null checks on those pages.
 const SafetyRegion: FCWithLayout<any> = (props) => {
   const router = useRouter();
-  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const { text } = props;
-
-  const mapHeight = isLargeScreen ? '500px' : '400px';
 
   return (
     <article className="index-article layout-chloropleth">
@@ -83,7 +79,6 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
         <SafetyRegionChloropleth
           metricName="escalation_levels"
           metricProperty="escalation_level"
-          style={{ height: mapHeight }}
           onSelect={createSelectRegionHandler(router)}
           tooltipContent={escalationTooltip(router)}
         />

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -65,6 +65,13 @@
   padding: 0 2em 2em 2em;
   border-radius: 5px;
   margin: 0 -2rem;
+
+  .map-container {
+    max-width: 750px;
+    height: 120vw;
+    max-height: 960px;
+    margin: 0 auto;
+  }
 }
 
 .index-article,


### PR DESCRIPTION
## Summary

Enlarge maps to full width of parent container (especially noticeable on smaller/medium screens), ensuring aspect ratio.

## Detailed design

* `useChartDimensions` now accepts an aspect ratio param;
* aspect ratio of 1.2 is passed for our current safety region and municipality maps
* fixed and semi-fixed widths using `isLargeScreen` are removed
* the large map on the `/gemeentes` endpoint has styling for the container to ensure the map does not render too big
