### PR TITLE
fix: z index signaalwaarde (areachart, linechart)

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -20,7 +20,7 @@ if (typeof Highcharts === 'object') {
 type TRange = [Date, number | null, number | null];
 type TLine = [Date, number | null];
 
-const SIGNAALWAARDE_Z_INDEX = 10;
+const SIGNAALWAARDE_Z_INDEX = 5;
 
 interface AreaChartProps {
   title: string;

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -19,7 +19,7 @@ type Value = {
   value?: number;
 };
 
-const SIGNAALWAARDE_Z_INDEX = 10;
+const SIGNAALWAARDE_Z_INDEX = 5;
 
 interface LineChartProps {
   title: string;


### PR DESCRIPTION
## Summary

The `z-index` for the signaalwaarde (dotted line) was set to a value that caused the tooltip to be positioned behind the signaalwaarde line. This PR changes this value so that the z-order is as follows:
1. the line of the chart
2. signaalwaarde (straight dotted line)
3. tooltip

### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
