### PR TITLE
Add regions/nursing_home schema

### DIFF
--- a/schema/regions/__index.json
+++ b/schema/regions/__index.json
@@ -56,6 +56,13 @@
       "items": {
         "$ref": "escalation_levels.json"
       }
+    },
+    "nursing_home": {
+      "type": "array",
+      "maxItems": 25,
+      "items": {
+        "$ref": "nursing_home.json"
+      }
     }
   }
 }

--- a/schema/regions/nursing_home.json
+++ b/schema/regions/nursing_home.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "regions_nursing_home",
+  "type": "object",
+  "properties": {
+    "newly_infected_people": {
+      "type": "integer"
+    },
+    "newly_infected_locations": {
+      "type": "integer"
+    },
+    "infected_locations_total": {
+      "type": "integer"
+    },
+    "infected_locations_percentage": {
+      "type": "number"
+    },
+    "deceased_daily": {
+      "type": "integer"
+    },
+    "date_of_report_unix": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    },
+    "vrcode": {
+      "type": "string",
+      "pattern": "^VR[0-9]+$"
+    }
+  },
+  "required": [
+    "newly_infected_people",
+    "newly_infected_locations",
+    "infected_locations_total",
+    "infected_locations_percentage",
+    "deceased_daily",
+    "date_of_report_unix",
+    "date_of_insertion_unix",
+    "vrcode"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This adds a schema definition for the regional nursing home data for use in Chloropleths. 