### PR TITLE
Add workaround for content header metadata sources

### DIFF
--- a/src/components/contentHeaderMetadataHack/index.tsx
+++ b/src/components/contentHeaderMetadataHack/index.tsx
@@ -1,0 +1,61 @@
+import { TitleWithIcon } from '~/components/titleWithIcon';
+import styles from './layout.module.scss';
+import { MetadataHack } from './metadataHack';
+
+/**
+ * An alteration from layout/ContentHeader in order to render two sources in metadata.
+ * This component will be thrown out in the next sprint probably because then
+ * metadata will be taken out and the original is not worth fixing since it
+ * requires a different kind of abstraction.
+ *
+ * The Metadata component is also copied and adjusted here locally for the same
+ * reasons.
+ */
+export function ContentHeaderMetadataHack(props: IContentHeaderProps) {
+  const { category, Icon, title, subtitle, metadata, id } = props;
+
+  const layoutClasses = [styles.contentHeader];
+
+  if (!category) {
+    layoutClasses.push(styles.withoutCategory);
+  }
+  if (!Icon) {
+    layoutClasses.push(styles.withoutIcon);
+  }
+
+  return (
+    <header id={id} className={layoutClasses.join(' ')}>
+      {category && <p className={styles.category}>{category}</p>}
+      <TitleWithIcon Icon={Icon} title={title} as="h2" />
+
+      <div className={styles.text}>
+        <p>{subtitle}</p>
+
+        <div>
+          <MetadataHack {...metadata} />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+interface IContentHeaderProps {
+  title: string;
+  subtitle: string;
+  metadata: {
+    datumsText: string;
+    dateUnix?: number;
+    dateInsertedUnix?: number;
+    dataSourceA: {
+      href: string;
+      text: string;
+    };
+    dataSourceB: {
+      href: string;
+      text: string;
+    };
+  };
+  category?: string;
+  Icon?: React.ComponentType;
+  id?: string;
+}

--- a/src/components/contentHeaderMetadataHack/layout.module.scss
+++ b/src/components/contentHeaderMetadataHack/layout.module.scss
@@ -1,0 +1,290 @@
+@import '~/scss/variables.scss';
+
+$language-switcher-offset: 55px;
+
+.logoWrapper {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  align-items: flex-start;
+  background: white;
+  width: 100%;
+}
+
+.logo {
+  margin-left: -50px;
+  transform: translateX(50%);
+}
+
+.header {
+  background: #cd005a;
+  color: white;
+  z-index: 4;
+  position: relative;
+
+  a:focus {
+    outline: 2px dotted #fff;
+    outline-offset: 0;
+  }
+
+  h1 {
+    margin-top: $default-margin * 2.5;
+    margin-bottom: 0;
+  }
+
+  p {
+    margin-bottom: $default-margin * 2;
+  }
+}
+
+.languageActive {
+  font-weight: 700;
+}
+
+.languageSwitcher {
+  height: $language-switcher-offset;
+  margin-top: -1 * $language-switcher-offset;
+  text-align: right;
+  color: $text-color;
+
+  a {
+    border-bottom-color: transparent;
+    border-bottom: 2px solid transparent;
+    color: inherit;
+    display: inline-block;
+    margin: 0 4px;
+    text-align: center;
+    text-decoration: none;
+    min-width: 24px;
+
+    &.languageActive,
+    &:hover,
+    &:focus {
+      border-color: $button-color;
+    }
+  }
+}
+
+.readMoreLink {
+  color: white;
+}
+
+.nav {
+  background: #aa004b;
+
+  @media (min-width: 768px) {
+    display: block;
+  }
+}
+
+.navList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  overflow-x: auto;
+
+  li {
+    white-space: nowrap;
+  }
+
+  > li:last-child {
+    display: none;
+    margin-left: auto;
+  }
+
+  @media (min-width: 768px) {
+    > li:last-child {
+      display: block;
+      margin-left: auto;
+    }
+  }
+}
+
+.link {
+  display: block;
+  background: transparent;
+  padding: 1em 0.75em;
+  color: white;
+  text-decoration: none;
+  font-size: 1em;
+
+  @media (min-width: 420px) {
+    font-size: 1.125em;
+  }
+
+  @media (min-width: 768px) {
+    padding: 1em 1.5em;
+  }
+
+  &:hover {
+    color: white;
+    background: rgba(255, 255, 255, 0.1);
+    text-decoration: underline;
+    text-decoration-thickness: from-font;
+  }
+
+  &:focus {
+    outline: 2px dotted #fff;
+    outline-offset: -2px;
+  }
+
+  &.active {
+    background: rgba(255, 255, 255, 0.8);
+    color: black;
+    outline: 0;
+  }
+}
+
+.footer {
+  background: #01689b;
+  color: white;
+  padding: 2em 0;
+  z-index: 4;
+  position: relative;
+}
+
+.grid {
+  display: flex;
+  flex-direction: column;
+
+  p {
+    font-size: 1.125em;
+    max-width: 25em;
+  }
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+
+    & > div:not(:first-child) {
+      margin-left: 2em;
+      h3 {
+        margin-bottom: 1.125em;
+      }
+    }
+  }
+}
+
+.footerList {
+  padding: 0;
+  list-style: none;
+  font-size: 1.125em;
+
+  li {
+    display: flex;
+    justify-content: flex-start;
+    align-items: baseline;
+  }
+
+  li:before {
+    content: '\203a';
+    margin-right: $default-margin / 2;
+  }
+}
+
+.footerLink {
+  display: inline-block;
+  color: white;
+  text-decoration: none;
+  padding: $default-padding / 2;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline: 2px dotted #fff;
+    outline-offset: 0;
+  }
+}
+
+.skiplinks {
+  position: absolute;
+  z-index: 100;
+  top: 0;
+  left: 50%;
+  width: 100%;
+  transform: translateX(-50%);
+
+  a {
+    position: absolute;
+    font-size: 1.2em;
+    width: auto;
+    min-height: 44px;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    color: white;
+    background-color: $icon-color;
+    text-decoration: none;
+    top: -100vh;
+    left: -100vw;
+
+    &:focus {
+      position: absolute;
+      outline: 2px dotted white;
+      outline-offset: -2px;
+      top: $default-padding;
+      left: $default-margin;
+    }
+  }
+}
+
+.text {
+  p {
+    max-width: 30em;
+    margin-right: $default-margin;
+  }
+}
+
+.category {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #6b6b6b;
+  margin: 0;
+  margin-bottom: 0.3rem;
+  margin-left: 4rem;
+}
+
+/*
+  Ensure skip link anchors to have a (non visible) start at the left side of the screen
+  This fixes odd skip-link behaviour in IE11
+*/
+.contentHeader[id] {
+  margin-left: -100vw;
+  padding-left: 100vw;
+}
+
+.withoutCategory {
+  margin-top: 2rem;
+}
+
+.withoutIcon h2 {
+  margin-left: 4rem;
+}
+
+@media (min-width: 1200px) {
+  .text {
+    display: flex;
+    margin-left: 4rem;
+
+    p {
+      flex: 1 1 60%;
+    }
+
+    div {
+      flex: 0 1 40%;
+    }
+  }
+}
+
+.two-column {
+  display: flex;
+  flex-direction: column;
+
+  > * {
+    flex: 1 1 50%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+}

--- a/src/components/contentHeaderMetadataHack/metadata.module.scss
+++ b/src/components/contentHeaderMetadataHack/metadata.module.scss
@@ -1,0 +1,18 @@
+@import '~/scss/variables.scss';
+
+.item {
+  display: flex;
+  align-items: center;
+  color: $text-color-grey;
+  margin: 1rem 0;
+
+  p:first-of-type {
+    margin: 0;
+  }
+
+  span {
+    display: flex;
+    align-items: center;
+    min-width: 1.8rem;
+  }
+}

--- a/src/components/contentHeaderMetadataHack/metadataHack.tsx
+++ b/src/components/contentHeaderMetadataHack/metadataHack.tsx
@@ -1,0 +1,74 @@
+import siteText from '~/locale/index';
+
+import styles from './metadata.module.scss';
+
+import ClockIcon from '~/assets/clock.svg';
+import DatabaseIcon from '~/assets/database.svg';
+
+import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { formatDateFromSeconds } from '~/utils/formatDate';
+
+interface IProps {
+  dataSourceA: {
+    href: string;
+    text: string;
+  };
+  dataSourceB: {
+    href: string;
+    text: string;
+  };
+  dateUnix?: number;
+  dateInsertedUnix?: number;
+  datumsText: string;
+}
+
+const text = siteText.common.metadata;
+
+export function MetadataHack(props: IProps) {
+  const {
+    dataSourceA,
+    dataSourceB,
+    datumsText,
+    dateUnix,
+    dateInsertedUnix,
+  } = props;
+
+  if (!dateUnix) return null;
+
+  const dateOfReport = formatDateFromSeconds(dateUnix, 'relative');
+  const dateOfInsertion = dateInsertedUnix
+    ? formatDateFromSeconds(dateInsertedUnix, 'relative')
+    : undefined;
+
+  return (
+    <div>
+      <div className={styles.item}>
+        <span>
+          <ClockIcon aria-hidden />
+        </span>
+        <p>
+          {replaceVariablesInText(datumsText, {
+            dateOfReport,
+            dateOfInsertion,
+          })}
+        </p>
+      </div>
+
+      <div className={styles.item}>
+        <span>
+          <DatabaseIcon aria-hidden />
+        </span>
+        <p>
+          {text.source}:{' '}
+          <a href={dataSourceA.href} rel="noopener noreferrer" target="_blank">
+            {dataSourceA.text}
+          </a>
+          {' & '}
+          <a href={dataSourceB.href} rel="noopener noreferrer" target="_blank">
+            {dataSourceB.text}
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -1,8 +1,8 @@
 import Arts from '~/assets/arts.svg';
 import { LineChart } from '~/components/charts/index';
+import { ContentHeaderMetadataHack } from '~/components/contentHeaderMetadataHack';
 import { IntakeIntensiveCareBarscale } from '~/components/landelijk/intake-intensive-care-barscale';
 import { FCWithLayout } from '~/components/layout';
-import { ContentHeader } from '~/components/layout/Content';
 import { getNationalLayout } from '~/components/layout/NationalLayout';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
@@ -19,7 +19,7 @@ const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
 
   return (
     <>
-      <ContentHeader
+      <ContentHeaderMetadataHack
         category={siteText.nationaal_layout.headings.medisch}
         title={text.titel}
         Icon={Arts}
@@ -28,7 +28,8 @@ const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
           datumsText: text.datums,
           dateUnix: dataIntake.last_value.date_of_report_unix,
           dateInsertedUnix: dataIntake.last_value.date_of_insertion_unix,
-          dataSource: text.bronnen.nice,
+          dataSourceA: text.bronnen.nice,
+          dataSourceB: text.bronnen.lnaz,
         }}
       />
 

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -11,9 +11,9 @@ import { createSelectMunicipalHandler } from '~/components/chloropleth/selectHan
 import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/chloropleth/tooltips/municipal/createMunicipalHospitalAdmissionsTooltip';
 import { createRegionHospitalAdmissionsTooltip } from '~/components/chloropleth/tooltips/region/createRegionHospitalAdmissionsTooltip';
+import { ContentHeaderMetadataHack } from '~/components/contentHeaderMetadataHack';
 import { IntakeHospitalBarScale } from '~/components/landelijk/intake-hospital-barscale';
 import { FCWithLayout } from '~/components/layout';
-import { ContentHeader } from '~/components/layout/Content';
 import { getNationalLayout } from '~/components/layout/NationalLayout';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
@@ -33,7 +33,7 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
 
   return (
     <>
-      <ContentHeader
+      <ContentHeaderMetadataHack
         category={siteText.nationaal_layout.headings.medisch}
         title={text.titel}
         Icon={Ziekenhuis}
@@ -42,7 +42,8 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
           datumsText: text.datums,
           dateUnix: dataIntake.last_value.date_of_report_unix,
           dateInsertedUnix: dataIntake.last_value.date_of_insertion_unix,
-          dataSource: text.bronnen.rivm,
+          dataSourceA: text.bronnen.rivm,
+          dataSourceB: text.bronnen.lnaz,
         }}
       />
 


### PR DESCRIPTION
For national IC and ziekenhuis opnames pages we need a double content header metadata mention for sources. The current abstractions do not allow this. Since this data is likely removed from the headers in the next sprint, the problem is now solved via copy-paste-hack. No need to spend any real effort to make this right.