### PR TITLE
Add infected locations percentage to kpi and choropleth

### DIFF
--- a/schema/regions/__index.json
+++ b/schema/regions/__index.json
@@ -10,7 +10,9 @@
     "code",
     "escalation_levels",
     "hospital_admissions",
-    "positive_tested_people"
+    "positive_tested_people",
+    "deceased",
+    "nursing_home"
   ],
   "properties": {
     "last_generated": {

--- a/src/components/chloropleth/MunicipalityChloropleth.tsx
+++ b/src/components/chloropleth/MunicipalityChloropleth.tsx
@@ -1,9 +1,5 @@
 import classNames from 'classnames';
-import {
-  ChloroplethThresholds,
-  SafetyRegionProperties,
-  TMunicipalityMetricName,
-} from './shared';
+import { SafetyRegionProperties, TMunicipalityMetricName } from './shared';
 
 import { Chloropleth } from './Chloropleth';
 import { Feature, GeoJsonProperties, MultiPolygon } from 'geojson';
@@ -18,72 +14,7 @@ import { useMunicipalityBoundingbox } from './hooks/useMunicipalityBoundingbox';
 import { MunicipalityProperties } from './shared';
 import { useRegionMunicipalities } from './hooks/useRegionMunicipalities';
 import { countryGeo, municipalGeo, regionGeo } from './topology';
-
-type MunicipalThresholds = ChloroplethThresholds<TMunicipalityMetricName>;
-
-const positiveTestedThresholds: MunicipalThresholds = {
-  dataKey: 'positive_tested_people',
-  thresholds: [
-    {
-      color: '#C0E8FC',
-      threshold: 0,
-    },
-    {
-      color: '#8BD1FF',
-      threshold: 4,
-    },
-    {
-      color: '#61B6ED',
-      threshold: 7,
-    },
-    {
-      color: '#3597D4',
-      threshold: 10,
-    },
-    {
-      color: '#046899',
-      threshold: 20,
-    },
-    {
-      color: '#034566',
-      threshold: 30,
-    },
-  ],
-};
-
-const hospitalAdmissionsThresholds: MunicipalThresholds = {
-  dataKey: 'hospital_admissions',
-  thresholds: [
-    {
-      color: '#c0e8fc',
-      threshold: 0,
-    },
-    {
-      color: '#87cbf8',
-      threshold: 3,
-    },
-    {
-      color: '#5dafe4',
-      threshold: 6,
-    },
-    {
-      color: '#3391cc',
-      threshold: 9,
-    },
-    {
-      color: '#0579b3',
-      threshold: 15,
-    },
-  ],
-};
-
-export const thresholds: Record<
-  TMunicipalityMetricName,
-  MunicipalThresholds
-> = {
-  positive_tested_people: positiveTestedThresholds,
-  hospital_admissions: hospitalAdmissionsThresholds,
-};
+import { municipalThresholds } from './municipalThresholds';
 
 export type TProps<
   T extends TMunicipalityMetricName,
@@ -141,7 +72,9 @@ export function MunicipalityChloropleth<
 
   const safetyRegionMunicipalCodes = useRegionMunicipalities(selected);
 
-  const thresholdValues = metricName ? thresholds[metricName] : undefined;
+  const thresholdValues = metricName
+    ? municipalThresholds[metricName]
+    : undefined;
   const getFillColor = useChloroplethColorScale(
     getData,
     thresholdValues?.thresholds

--- a/src/components/chloropleth/SafetyRegionChloropleth.tsx
+++ b/src/components/chloropleth/SafetyRegionChloropleth.tsx
@@ -1,9 +1,5 @@
 import classNames from 'classnames';
-import {
-  ChloroplethThresholds,
-  SafetyRegionProperties,
-  TRegionMetricName,
-} from './shared';
+import { SafetyRegionProperties, TRegionMetricName } from './shared';
 import { Regions } from '~/types/data';
 import { CSSProperties, ReactNode, useCallback } from 'react';
 import { useChartDimensions } from './hooks/useChartDimensions';
@@ -14,89 +10,7 @@ import styles from './chloropleth.module.scss';
 import { useSafetyRegionBoundingbox } from './hooks/useSafetyRegionBoundingbox';
 import { useChloroplethColorScale } from './hooks/useChloroplethColorScale';
 import { useSafetyRegionData } from './hooks/useSafetyRegionData';
-
-type RegionalThresholds = ChloroplethThresholds<TRegionMetricName>;
-
-const positiveTestedThresholds: RegionalThresholds = {
-  dataKey: 'positive_tested_people',
-  thresholds: [
-    {
-      color: '#C0E8FC',
-      threshold: 0,
-    },
-    {
-      color: '#8BD1FF',
-      threshold: 4,
-    },
-    {
-      color: '#61B6ED',
-      threshold: 7,
-    },
-    {
-      color: '#3597D4',
-      threshold: 10,
-    },
-    {
-      color: '#046899',
-      threshold: 20,
-    },
-    {
-      color: '#034566',
-      threshold: 30,
-    },
-  ],
-};
-
-const hospitalAdmissionsThresholds: RegionalThresholds = {
-  dataKey: 'hospital_admissions',
-  thresholds: [
-    {
-      color: '#c0e8fc',
-      threshold: 0,
-    },
-    {
-      color: '#87cbf8',
-      threshold: 10,
-    },
-    {
-      color: '#5dafe4',
-      threshold: 16,
-    },
-    {
-      color: '#3391cc',
-      threshold: 24,
-    },
-    {
-      color: '#0579b3',
-      threshold: 31,
-    },
-  ],
-};
-
-const escalationThresholds: RegionalThresholds = {
-  dataKey: 'escalation_levels',
-  svgClass: 'escalationMap',
-  thresholds: [
-    {
-      color: '#F291BC',
-      threshold: 1,
-    },
-    {
-      color: '#D95790',
-      threshold: 2,
-    },
-    {
-      color: '#A11050',
-      threshold: 3,
-    },
-  ],
-};
-
-export const thresholds: Record<TRegionMetricName, RegionalThresholds> = {
-  positive_tested_people: positiveTestedThresholds,
-  hospital_admissions: hospitalAdmissionsThresholds,
-  escalation_levels: escalationThresholds,
-};
+import { regionThresholds } from './regionThresholds';
 
 export type TProps<
   T extends TRegionMetricName,
@@ -146,7 +60,7 @@ export function SafetyRegionChloropleth<
 
   const [ref, dimensions] = useChartDimensions(1.2);
 
-  const boundingbox = useSafetyRegionBoundingbox(regionGeo, selected);
+  const boundingBox = useSafetyRegionBoundingbox(regionGeo, selected);
 
   const [getData, hasData] = useSafetyRegionData(
     metricName,
@@ -154,7 +68,9 @@ export function SafetyRegionChloropleth<
     metricProperty
   );
 
-  const selectedThreshold = metricName ? thresholds[metricName] : undefined;
+  const selectedThreshold = metricName
+    ? regionThresholds[metricName]
+    : undefined;
   const getFillColor = useChloroplethColorScale(
     getData,
     selectedThreshold?.thresholds
@@ -253,7 +169,7 @@ export function SafetyRegionChloropleth<
         featureCollection={regionGeo}
         overlays={countryGeo}
         hovers={hasData ? regionGeo : undefined}
-        boundingBox={boundingbox || countryGeo}
+        boundingBox={boundingBox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}
         overlayCallback={overlayCallback}

--- a/src/components/chloropleth/hooks/useChloroplethColorScale.ts
+++ b/src/components/chloropleth/hooks/useChloroplethColorScale.ts
@@ -1,6 +1,6 @@
 import { scaleThreshold } from 'd3-scale';
 import { useCallback, useMemo } from 'react';
-import { ChloroplethThresholdsValue } from '../shared';
+import { ChoroplethThresholdsValue } from '../shared';
 
 export type TGetFillColor = (id: string) => string;
 
@@ -20,7 +20,7 @@ export type TGetFillColor = (id: string) => string;
  */
 export function useChloroplethColorScale(
   getData: (id: string) => any,
-  thresholds?: ChloroplethThresholdsValue[],
+  thresholds?: ChoroplethThresholdsValue[],
   defaultColor = 'white'
 ): TGetFillColor {
   const colorScale = useMemo<any>(() => {

--- a/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
+++ b/src/components/chloropleth/legenda/hooks/useLegendaItems.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { ILegendaItem } from '../ChloroplethLegenda';
 
-import { ChloroplethThresholdsValue } from '~/components/chloropleth/shared';
+import { ChoroplethThresholdsValue } from '~/components/chloropleth/shared';
 
-const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
+const createLabel = (list: ChoroplethThresholdsValue[], index: number) => {
   if (index === 0) {
     return `< ${list[1].threshold}`;
   }
@@ -13,14 +13,14 @@ const createLabel = (list: ChloroplethThresholdsValue[], index: number) => {
   return `${list[index].threshold} - ${list[index + 1].threshold}`;
 };
 
-export function useLegendaItems(thresholds?: ChloroplethThresholdsValue[]) {
+export function useLegendaItems(thresholds?: ChoroplethThresholdsValue[]) {
   return useMemo(() => {
     if (!thresholds) {
       return;
     }
 
     const legendaItems: ILegendaItem[] = thresholds.map<ILegendaItem>(
-      (threshold: ChloroplethThresholdsValue, index: number) => {
+      (threshold: ChoroplethThresholdsValue, index: number) => {
         return {
           color: threshold.color,
           label: createLabel(thresholds, index),

--- a/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useMunicipalLegendaData.ts
@@ -1,10 +1,10 @@
-import { thresholds } from '~/components/chloropleth/MunicipalityChloropleth';
 import { TMunicipalityMetricName } from '~/components/chloropleth/shared';
+import { municipalThresholds } from '~/components/chloropleth/municipalThresholds';
 
 import { useLegendaItems } from './useLegendaItems';
 
 export function useMunicipalLegendaData(metric: TMunicipalityMetricName) {
-  const ths = thresholds[metric];
+  const ths = municipalThresholds[metric];
 
   return useLegendaItems(ths.thresholds);
 }

--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -1,10 +1,10 @@
 import { TRegionMetricName } from '../../shared';
 
 import { useLegendaItems } from './useLegendaItems';
-import { thresholds } from '~/components/chloropleth/SafetyRegionChloropleth';
+import { regionThresholds } from '~/components/chloropleth/regionThresholds';
 
 export function useSafetyRegionLegendaData(metric: TRegionMetricName) {
-  const ths = thresholds[metric];
+  const ths = regionThresholds[metric];
 
   return useLegendaItems(ths.thresholds);
 }

--- a/src/components/chloropleth/municipalThresholds.ts
+++ b/src/components/chloropleth/municipalThresholds.ts
@@ -1,0 +1,67 @@
+import { ChoroplethThresholds, TMunicipalityMetricName } from './shared';
+
+type MunicipalThresholds = ChoroplethThresholds<TMunicipalityMetricName>;
+
+const positiveTestedThresholds: MunicipalThresholds = {
+  dataKey: 'positive_tested_people',
+  thresholds: [
+    {
+      color: '#C0E8FC',
+      threshold: 0,
+    },
+    {
+      color: '#8BD1FF',
+      threshold: 4,
+    },
+    {
+      color: '#61B6ED',
+      threshold: 7,
+    },
+    {
+      color: '#3597D4',
+      threshold: 10,
+    },
+    {
+      color: '#046899',
+      threshold: 20,
+    },
+    {
+      color: '#034566',
+      threshold: 30,
+    },
+  ],
+};
+
+const hospitalAdmissionsThresholds: MunicipalThresholds = {
+  dataKey: 'hospital_admissions',
+  thresholds: [
+    {
+      color: '#c0e8fc',
+      threshold: 0,
+    },
+    {
+      color: '#87cbf8',
+      threshold: 3,
+    },
+    {
+      color: '#5dafe4',
+      threshold: 6,
+    },
+    {
+      color: '#3391cc',
+      threshold: 9,
+    },
+    {
+      color: '#0579b3',
+      threshold: 15,
+    },
+  ],
+};
+
+export const municipalThresholds: Record<
+  TMunicipalityMetricName,
+  MunicipalThresholds
+> = {
+  positive_tested_people: positiveTestedThresholds,
+  hospital_admissions: hospitalAdmissionsThresholds,
+};

--- a/src/components/chloropleth/regionThresholds.ts
+++ b/src/components/chloropleth/regionThresholds.ts
@@ -1,0 +1,119 @@
+import { ChoroplethThresholds, TRegionMetricName } from './shared';
+
+type RegionalThresholds = ChoroplethThresholds<TRegionMetricName>;
+
+const positiveTestedThresholds: RegionalThresholds = {
+  dataKey: 'positive_tested_people',
+  thresholds: [
+    {
+      color: '#C0E8FC',
+      threshold: 0,
+    },
+    {
+      color: '#8BD1FF',
+      threshold: 4,
+    },
+    {
+      color: '#61B6ED',
+      threshold: 7,
+    },
+    {
+      color: '#3597D4',
+      threshold: 10,
+    },
+    {
+      color: '#046899',
+      threshold: 20,
+    },
+    {
+      color: '#034566',
+      threshold: 30,
+    },
+  ],
+};
+
+const hospitalAdmissionsThresholds: RegionalThresholds = {
+  dataKey: 'hospital_admissions',
+  thresholds: [
+    {
+      color: '#c0e8fc',
+      threshold: 0,
+    },
+    {
+      color: '#87cbf8',
+      threshold: 10,
+    },
+    {
+      color: '#5dafe4',
+      threshold: 16,
+    },
+    {
+      color: '#3391cc',
+      threshold: 24,
+    },
+    {
+      color: '#0579b3',
+      threshold: 31,
+    },
+  ],
+};
+
+const escalationThresholds: RegionalThresholds = {
+  dataKey: 'escalation_levels',
+  svgClass: 'escalationMap',
+  thresholds: [
+    {
+      color: '#F291BC',
+      threshold: 1,
+    },
+    {
+      color: '#D95790',
+      threshold: 2,
+    },
+    {
+      color: '#A11050',
+      threshold: 3,
+    },
+  ],
+};
+
+const nursingHomeThresholds: RegionalThresholds = {
+  dataKey: 'nursing_home',
+  thresholds: [
+    {
+      color: '#CFFFFFF',
+      threshold: 0,
+    },
+    {
+      color: '#C0E8FC',
+      threshold: 1,
+    },
+    {
+      color: '#87CBF8',
+      threshold: 3,
+    },
+    {
+      color: '#5DAFE4',
+      threshold: 7,
+    },
+    {
+      color: '#3391CC',
+      threshold: 11,
+    },
+    {
+      color: '#0579B3',
+      threshold: 21,
+    },
+    {
+      color: '#034566',
+      threshold: 30,
+    },
+  ],
+};
+
+export const regionThresholds: Record<TRegionMetricName, RegionalThresholds> = {
+  positive_tested_people: positiveTestedThresholds,
+  hospital_admissions: hospitalAdmissionsThresholds,
+  escalation_levels: escalationThresholds,
+  nursing_home: nursingHomeThresholds,
+};

--- a/src/components/chloropleth/shared.d.ts
+++ b/src/components/chloropleth/shared.d.ts
@@ -1,5 +1,5 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
-import { Municipalities, Regions } from '~/types/data';
+import { Municipalities, Regions, RegionsNursingHome } from '~/types/data';
 
 type TMetricHolder<T> = keyof Omit<
   T,
@@ -11,6 +11,11 @@ export type TMunicipalityMetricName = TMetricHolder<
 >;
 
 export type TRegionMetricName = TMetricHolder<Omit<Regions, 'deceased'>>;
+
+export type TRegionsNursingHomeMetricName = keyof Omit<
+  RegionsNursingHome,
+  'date_of_report_unix' | 'date_of_insertion_unix' | 'vrcode'
+>;
 
 export interface SafetyRegionProperties {
   vrcode: string;
@@ -31,13 +36,18 @@ export type RegionGeoJSON = FeatureCollection<
   SafetyRegionProperties
 >;
 
-export type ChloroplethThresholds<T extends string> = {
+export type ChoroplethThresholds<
+  T extends
+    | TMunicipalityMetricName
+    | TRegionMetricName
+    | TRegionsNursingHomeMetricName
+> = {
   dataKey: T;
   svgClass?: string;
-  thresholds: ChloroplethThresholdsValue[];
+  thresholds: ChoroplethThresholdsValue[];
 };
 
-export type ChloroplethThresholdsValue = {
+export type ChoroplethThresholdsValue = {
   color: string;
   threshold: number;
 };

--- a/src/components/chloropleth/tooltips/region/createInfectedLocationsRegionalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/createInfectedLocationsRegionalTooltip.tsx
@@ -1,0 +1,30 @@
+import { NextRouter } from 'next/router';
+import { ReactNode } from 'react';
+import { SafetyRegionProperties } from '../../shared';
+import { createSelectRegionHandler } from '../../selectHandlers/createSelectRegionHandler';
+import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent';
+import { RegionsNursingHome } from '~/types/data';
+import { formatNumber } from '~/utils/formatNumber';
+
+export const createInfectedLocationsRegionalTooltip = (router: NextRouter) => (
+  context: RegionsNursingHome & SafetyRegionProperties & { value: number }
+): ReactNode => {
+  const handler = createSelectRegionHandler(router);
+
+  const onSelect = (event: any) => {
+    event.stopPropagation();
+    handler(context);
+  };
+
+  return (
+    context && (
+      <TooltipContent title={context.vrname} onSelect={onSelect}>
+        <strong>
+          {context.value !== undefined ? context.value : '-'}
+          {' ('}
+          {formatNumber(context.infected_locations_percentage)}%)
+        </strong>
+      </TooltipContent>
+    )
+  );
+};

--- a/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/escalationTooltip.tsx
@@ -11,9 +11,9 @@ import EscalationLevel2 from '~/assets/niveau-2.svg';
 import EscalationLevel3 from '~/assets/niveau-3.svg';
 
 import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent';
-import { thresholds } from '~/components/chloropleth/SafetyRegionChloropleth';
+import { regionThresholds } from '~/components/chloropleth/regionThresholds';
 
-const escalationThresholds = thresholds.escalation_levels.thresholds;
+const escalationThresholds = regionThresholds.escalation_levels.thresholds;
 
 export const escalationTooltip = (router: NextRouter) => {
   return (context: any): ReactNode => {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -147,13 +147,7 @@
     "barchart_titel": "New cases by age group (total number of new cases)",
     "barchart_toelichting": "This figure shows the progression over time in the number of new cases by age group.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "cluster_datums": "Value of {{dateOfReport}}. Obtained: {{dateOfInsertion}}. Is updated on a daily basis.",
     "cluster_bron": {
       "href": "https://www.rivm.nl/documenten/dagelijkse-update-epidemiologische-situatie-covid-19-in-nederland",
@@ -272,7 +266,13 @@
     "kpi_titel": "Total number of infected locations",
     "kpi_toelichting": "This figure is an estimate of the number of nursing homes where in the past 28 days at least one (new) COVID-19 infection (confirmed by a positive test) is reported.",
     "linechart_titel": "Progression over time",
-    "barscale_screenreader_text": "{{value}} new locations where there is at least one confirmed case, per day."
+    "barscale_screenreader_text": "{{value}} new locations where there is at least one confirmed case, per day.",
+    "chloropleth_legenda": {
+      "titel": "Number per 100.000 residents",
+      "geen_meldingen": "No confirmed cases"
+    },
+    "map_titel": "Number of infected locations in the Netherlands",
+    "map_toelichting": ""
   },
   "verpleeghuis_positief_geteste_personen": {
     "datums": "Value of {{dateOfReport}}. Obtained:{{dateOfInsertion}}. Is updated on a daily basis.",
@@ -610,13 +610,7 @@
     "barchart_titel": "New cases by age group (total number of new cases)",
     "barchart_toelichting": "This figure shows the progression over time in the number of positive tests by age group.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -692,13 +686,7 @@
     "barchart_titel": "New cases by age group (total number of new cases)",
     "barchart_toelichting": "This figure shows the change in the number of confirmed cases by age group.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -852,12 +840,6 @@
     "pagina_toelichting": "Number of confirmed cases in nursing homes per day in {{safetyRegion}}. This number is an estimation of the number confirmed cases in nursing home inhabitants.\n\nThe calculation method has been changed on the 29th of September. Please also see the data explanation section.",
     "linechart_titel": "Progression over time",
     "barscale_screenreader_text": "{{value}} Number of residents who tested positive (confirmed cases).",
-    "titel_sidebar": "Confirmed cases per day",
-    "chloropleth_legenda": {
-      "titel": "Number per 100.000 residents",
-      "geen_meldingen": "No confirmed cases"
-    },
-    "map_titel": "Confirmed cases in the Netherlands",
-    "map_toelichting": "These maps show the number of confirmed cases per 100.000 residents."
+    "titel_sidebar": "Confirmed cases per day"
   }
 }

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -147,13 +147,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de trend van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "cluster_datums": "Waarde van {{dateOfReport}}. Verkregen: {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",
     "cluster_bron": {
       "href": "https://www.rivm.nl/documenten/dagelijkse-update-epidemiologische-situatie-covid-19-in-nederland",
@@ -272,7 +266,13 @@
     "kpi_titel": "Totaal aantal besmette locaties",
     "kpi_toelichting": "Dit getal is een inschatting van het totaal aantal verpleeghuislocaties waar in de afgelopen 28 dagen minstens één (nieuwe) COVID-19 besmetting op basis van een positieve test, is gemeld.",
     "linechart_titel": "Verloop over tijd",
-    "barscale_screenreader_text": "{{value}} nieuwe locaties waarbij tenminste één bewoner positief getest is, per dag."
+    "barscale_screenreader_text": "{{value}} nieuwe locaties waarbij tenminste één bewoner positief getest is, per dag.",
+    "chloropleth_legenda": {
+      "titel": "Aantal per 100.000 inwoners",
+      "geen_meldingen": "Geen meldingen"
+    },
+    "map_titel": "Verdeling besmette locaties in Nederland",
+    "map_toelichting": "map_toelichting"
   },
   "verpleeghuis_positief_geteste_personen": {
     "datums": "Waarde van {{dateOfReport}}. Verkregen: {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",
@@ -610,13 +610,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de trend van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -692,13 +686,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de trend van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 to 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -852,12 +840,6 @@
     "pagina_toelichting": "Aantal positief geteste bewoners in verpleeghuizen per dag in {{safetyRegion}}. Dit getal is een inschatting van het aantal gemelde bewoners in verpleeghuizen dat in Nederland positief getest is en COVID-19 heeft.\n\nDe rekenmethode is per 29 september verbeterd. Zie ook de cijferverantwoording.",
     "linechart_titel": "Verloop over tijd",
     "barscale_screenreader_text": "{{value}} positief geteste bewoners.",
-    "titel_sidebar": "Aantal positief geteste bewoners per dag",
-    "chloropleth_legenda": {
-      "titel": "Aantal per 100.000 inwoners",
-      "geen_meldingen": "Geen meldingen"
-    },
-    "map_titel": "Verdeling positief geteste mensen in Nederland",
-    "map_toelichting": "Deze kaarten laten zien van hoeveel mensen gisteren is gemeld dat ze positief getest zijn op COVID-19, per 100.000 inwoners."
+    "titel_sidebar": "Aantal positief geteste bewoners per dag"
   }
 }

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -16,6 +16,12 @@ import {
 } from '~/types/data.d';
 
 import getNlData, { INationalData } from '~/static-props/nl-data';
+import { SafetyRegionChloropleth } from '~/components/chloropleth/SafetyRegionChloropleth';
+import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
+import { useRouter } from 'next/router';
+import { useSafetyRegionLegendaData } from '~/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData';
+import { ChloroplethLegenda } from '~/components/chloropleth/legenda/ChloroplethLegenda';
+import { createInfectedLocationsRegionalTooltip } from '~/components/chloropleth/tooltips/region/createInfectedLocationsRegionalTooltip';
 
 const text = siteText.verpleeghuis_besmette_locaties;
 
@@ -26,6 +32,9 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
     state?.total_newly_reported_locations;
   const totalLocations: TotalReportedLocations | undefined =
     state?.total_reported_locations;
+
+  const router = useRouter();
+  const legendItems = useSafetyRegionLegendaData('nursing_home');
 
   return (
     <>
@@ -71,7 +80,12 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
               <span className="text-blue kpi">
                 {formatNumber(
                   totalLocations.last_value.total_reported_locations
+                )}{' '}
+                (
+                {formatNumber(
+                  state.nursing_home.last_value.infected_locations_percentage
                 )}
+                %)
               </span>
             </h3>
           )}
@@ -90,6 +104,34 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
           />
         </article>
       )}
+
+      <article className="metric-article layout-chloropleth">
+        <div className="chloropleth-header">
+          <h3>{text.map_titel}</h3>
+          <p>{text.map_toelichting}</p>
+        </div>
+
+        <div className="chloropleth-chart">
+          <SafetyRegionChloropleth
+            metricName="nursing_home"
+            metricProperty="infected_locations_total"
+            tooltipContent={createInfectedLocationsRegionalTooltip(router)}
+            onSelect={createSelectRegionHandler(
+              router,
+              'verpleeghuis-besmette-locaties'
+            )}
+          />
+        </div>
+
+        <div className="chloropleth-legend">
+          {legendItems && (
+            <ChloroplethLegenda
+              items={legendItems}
+              title={text.chloropleth_legenda.titel}
+            />
+          )}
+        </div>
+      </article>
     </>
   );
 };

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
@@ -29,6 +29,9 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
   const infectedLocationsTotal =
     state?.nursing_home.last_value.infected_locations_total;
 
+  const infectedLocationsPercentage =
+    state?.nursing_home.last_value.infected_locations_percentage;
+
   return (
     <>
       <ContentHeader
@@ -74,7 +77,8 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
             <h3>
               {text.kpi_titel}{' '}
               <span className="text-blue kpi">
-                {formatNumber(infectedLocationsTotal)}
+                {formatNumber(infectedLocationsTotal)} (
+                {formatNumber(infectedLocationsPercentage)}%)
               </span>
             </h3>
           )}

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
@@ -16,12 +16,6 @@ import {
   ISafetyRegionData,
 } from '~/static-props/safetyregion-data';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
-import { SafetyRegionChloropleth } from '~/components/chloropleth/SafetyRegionChloropleth';
-import { createPositiveTestedPeopleRegionalTooltip } from '~/components/chloropleth/tooltips/region/createPositiveTestedPeopleRegionalTooltip';
-import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
-import { ChloroplethLegenda } from '~/components/chloropleth/legenda/ChloroplethLegenda';
-import { useSafetyRegionLegendaData } from '~/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData';
-import { useRouter } from 'next/router';
 
 const text = siteText.veiligheidsregio_verpleeghuis_positief_geteste_personen;
 
@@ -29,9 +23,6 @@ const NursingHomeInfectedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data: state, safetyRegionName } = props;
 
   const data: RegionalNursingHome | undefined = state?.nursing_home;
-
-  const router = useRouter();
-  const legendItems = useSafetyRegionLegendaData('positive_tested_people');
 
   return (
     <>
@@ -78,33 +69,6 @@ const NursingHomeInfectedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           />
         </article>
       )}
-
-      <article className="metric-article layout-chloropleth">
-        <div className="chloropleth-header">
-          <h3>{text.map_titel}</h3>
-          <p>{text.map_toelichting}</p>
-        </div>
-
-        <div className="chloropleth-chart">
-          <SafetyRegionChloropleth
-            metricName="positive_tested_people"
-            tooltipContent={createPositiveTestedPeopleRegionalTooltip(router)}
-            onSelect={createSelectRegionHandler(
-              router,
-              'verpleeghuis-positief-geteste-personen'
-            )}
-          />
-        </div>
-
-        <div className="chloropleth-legend">
-          {legendItems && (
-            <ChloroplethLegenda
-              items={legendItems}
-              title={text.chloropleth_legenda.titel}
-            />
-          )}
-        </div>
-      </article>
     </>
   );
 };

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -12,14 +12,12 @@ import styles from '~/components/chloropleth/tooltips/tooltip.module.scss';
 import { TALLLanguages } from '~/locale/index';
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
-import {
-  SafetyRegionChloropleth,
-  thresholds,
-} from '~/components/chloropleth/SafetyRegionChloropleth';
+import { SafetyRegionChloropleth } from '~/components/chloropleth/SafetyRegionChloropleth';
 import { escalationTooltip } from '~/components/chloropleth/tooltips/region/escalationTooltip';
 import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
+import { regionThresholds } from '~/components/chloropleth/regionThresholds';
 
-const escalationThresholds = thresholds.escalation_levels.thresholds;
+const escalationThresholds = regionThresholds.escalation_levels.thresholds;
 
 export const EscalationMapLegenda = (props: any) => {
   const { text } = props;

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -89,7 +89,7 @@ export interface PositiveTestedPeople {
   date_of_report_unix: number;
   gmcode: string;
   positive_tested_people: number;
-  total_positive_tested_people?: number;
+  total_positive_tested_people: number;
   date_of_insertion_unix: number;
 }
 export interface Deceased {
@@ -124,12 +124,12 @@ export interface National {
   rioolwater_metingen_per_rwzi: RioolwaterMetingenPerRwzi;
   hospital_beds_occupied: HospitalBedsOccupied;
   intensive_care_beds_occupied: IntensiveCareBedsOccupied;
-  nursing_home?: NationalNursingHome;
+  nursing_home: NationalNursingHome;
 }
 export interface NationalHuisartsVerdenkingen {
   values: NationalHuisartsVerdenkingenValue[];
   last_value: NationalHuisartsVerdenkingenValue;
-  difference?: NationalHuisartsVerdenkingenValueDifference;
+  last_value_difference?: NationalHuisartsVerdenkingenValueDifference;
   [k: string]: unknown;
 }
 export interface NationalHuisartsVerdenkingenValue {
@@ -141,15 +141,11 @@ export interface NationalHuisartsVerdenkingenValue {
   date_of_insertion_unix: number;
 }
 export interface NationalHuisartsVerdenkingenValueDifference {
-  incidentie_new: number;
   incidentie_old: number;
   incidentie_difference: number;
-  geschat_aantal_new: number;
   geschat_aantal_old: number;
   geschat_aantal_difference: number;
-  date_of_report_unix_new: number;
   date_of_report_unix_old: number;
-  date_of_insertion_unix: number;
 }
 export interface IntakeHospitalMa {
   values: IntakeHospitalMaLastValue[];
@@ -251,7 +247,7 @@ export interface TotalNewlyReportedLocationsLastValue {
 export interface NationalInfectedPeopleTotal {
   values: NationalInfectedPeopleTotalValue[];
   last_value: NationalInfectedPeopleTotalValue;
-  difference?: NationalInfectedPeopleTotalValueDifference;
+  last_value_difference?: NationalInfectedPeopleTotalValueDifference;
   [k: string]: unknown;
 }
 export interface NationalInfectedPeopleTotalValue {
@@ -260,12 +256,9 @@ export interface NationalInfectedPeopleTotalValue {
   date_of_insertion_unix: number;
 }
 export interface NationalInfectedPeopleTotalValueDifference {
-  infected_daily_total_new: number;
   infected_daily_total_old: number;
   infected_daily_total_difference: number;
-  date_of_report_unix_new: number;
   date_of_report_unix_old: number;
-  date_of_insertion_unix: number;
 }
 export interface InfectedPeopleDeltaNormalized {
   values: InfectedPeopleDeltaNormalizedLastValue[];
@@ -503,8 +496,8 @@ export interface RegionalGgd {
 }
 export interface RegionalGgdValue {
   infected_daily: number;
-  infected_percentage_daily?: number;
-  tested_total_daily?: number;
+  infected_percentage_daily: number;
+  tested_total_daily: number;
   date_of_report_unix: number;
   date_of_insertion_unix: number;
   vrcode: string;
@@ -531,8 +524,9 @@ export interface Regions {
   code: 'REGIONS';
   hospital_admissions: RegionHospitalAdmissions[];
   positive_tested_people: RegionPositiveTestedPeople[];
-  deceased?: RegionDeceased[];
+  deceased: RegionDeceased[];
   escalation_levels: EscalationLevels[];
+  nursing_home: RegionsNursingHome[];
 }
 export interface RegionHospitalAdmissions {
   date_of_report_unix: number;
@@ -544,7 +538,7 @@ export interface RegionPositiveTestedPeople {
   date_of_report_unix: number;
   vrcode: string;
   positive_tested_people: number;
-  total_positive_tested_people?: number;
+  total_positive_tested_people: number;
   date_of_insertion_unix: number;
 }
 export interface RegionDeceased {
@@ -559,4 +553,14 @@ export interface EscalationLevels {
   escalation_level: number;
   valid_from_unix: number;
   date_of_insertion_unix: number;
+}
+export interface RegionsNursingHome {
+  newly_infected_people: number;
+  newly_infected_locations: number;
+  infected_locations_total: number;
+  infected_locations_percentage: number;
+  deceased_daily: number;
+  date_of_report_unix: number;
+  date_of_insertion_unix: number;
+  vrcode: string;
 }


### PR DESCRIPTION
## Summary

Show the percentage of infected location the country and region page.
Adds choropleth to country location page.

## Motivation

Feature request

## Detailed design

Mostly just some tweaks in where some extra data is rendered.
Added new threshold data for the nursinghome infected location choropleth and legenda colors.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
