### PR TITLE
Sort time-series data

### DIFF
--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -54,9 +54,7 @@ export default function AreaChart(props: AreaChartProps) {
   } = props;
 
   const rangeData: TRange[] = useMemo(() => {
-    return data
-      .sort((a, b) => a.date - b.date)
-      .map((d) => [createDate(d.date), d.min, d.max]);
+    return data.map((d) => [createDate(d.date), d.min, d.max]);
   }, [data]);
 
   const lineData: TLine[] = useMemo(() => {

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -249,7 +249,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                             .titel_sidebar
                         }
                       />
-                      {data?.nursing_home.last_value.newly_infected_people && (
+                      {data?.nursing_home?.last_value.newly_infected_people && (
                         <span>
                           <NursingHomeInfectedPeopleBarScale
                             value={
@@ -281,7 +281,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                       <span>
                         <NursingHomeInfectedLocationsBarScale
                           value={
-                            data?.nursing_home.last_value
+                            data?.nursing_home?.last_value
                               .infected_locations_total
                           }
                           showAxis={true}
@@ -308,7 +308,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                       />
                       <span>
                         <NursingHomeDeathsBarScale
-                          value={data?.nursing_home.last_value.deceased_daily}
+                          value={data?.nursing_home?.last_value.deceased_daily}
                           showAxis={true}
                         />
                       </span>

--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -137,8 +137,7 @@ function getOptions(
         text: null,
       },
       labels: {
-        formatter: function (): string {
-          // @ts-ignore
+        formatter: function () {
           return formatNumber(this.value);
         },
       },

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -1,0 +1,161 @@
+import { Municipal, National, Regionaal } from '~/types/data.d';
+
+export function sortNationalTimeSeriesInDataInPlace(data: National) {
+  const timeSeriesPropertyNames = getNationalTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    (data[propertyName] as TimeSeriesData<
+      Timestamped
+    >).values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+export function sortRegionalTimeSeriesInDataInPlace(data: Regionaal) {
+  const timeSeriesPropertyNames = getRegionalTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    /**
+     * There is one property in the dataset that contains timeseries nested
+     * inside values, so we need to process that separately.
+     */
+    if (propertyName === 'results_per_sewer_installation_per_region') {
+      const nestedSeries = data[propertyName] as RegionalSewerTimeSeriesData<
+        Timestamped
+      >;
+
+      nestedSeries.values = nestedSeries.values.map((x) => {
+        x.values = sortTimeSeriesValues(x.values);
+        return x;
+      });
+
+      // Skip the remainder of this loop
+      continue;
+    }
+
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+
+    (data[propertyName] as TimeSeriesData<
+      Timestamped
+    >).values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
+  const timeSeriesPropertyNames = getMunicipalTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    (data[propertyName] as TimeSeriesData<
+      Timestamped
+    >).values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+/**
+ * From the data structure, retrieve all properties that hold a "values" field
+ * in their content. All time series data is kept in this values field.
+ */
+function getNationalTimeSeriesPropertyNames(data: National) {
+  return Object.entries(data).reduce(
+    (acc, [propertyKey, propertyValue]) =>
+      isTimeSeries(propertyValue)
+        ? [...acc, propertyKey as keyof National]
+        : acc,
+    [] as (keyof National)[]
+  );
+}
+
+function getRegionalTimeSeriesPropertyNames(data: Regionaal) {
+  return Object.entries(data).reduce(
+    (acc, [propertyKey, propertyValue]) =>
+      isTimeSeries(propertyValue)
+        ? [...acc, propertyKey as keyof Regionaal]
+        : acc,
+    [] as (keyof Regionaal)[]
+  );
+}
+
+function getMunicipalTimeSeriesPropertyNames(data: Municipal) {
+  return Object.entries(data).reduce(
+    (acc, [propertyKey, propertyValue]) =>
+      isTimeSeries(propertyValue)
+        ? [...acc, propertyKey as keyof Municipal]
+        : acc,
+    [] as (keyof Municipal)[]
+  );
+}
+
+function sortTimeSeriesValues(values: Timestamped[]) {
+  /**
+   * There are 3 types of ways in which time series data is timestamped. We need
+   * to detect each of them.
+   */
+  if (isReportTimestamped(values)) {
+    return values.sort((a, b) => b.date_of_report_unix - a.date_of_report_unix);
+  } else if (isWeekTimestamped(values)) {
+    return values.sort((a, b) => b.week_unix - a.week_unix);
+  } else if (isMeasurementTimestamped(values)) {
+    return values.sort(
+      (a, b) => b.date_measurement_unix - a.date_measurement_unix
+    );
+  }
+
+  /**
+   * If none match we throw, since it means an unknown timestamp is used and we
+   * want to be sure we sort all data.
+   */
+  throw new Error(
+    `Unknown timestamp in value ${JSON.stringify(values[0], null, 2)}`
+  );
+}
+
+type Timestamped = ReportTimestamped | WeekTimestamped | MeasurementTimestamped;
+
+interface ReportTimestamped {
+  date_of_report_unix: number;
+}
+
+interface WeekTimestamped {
+  week_unix: number;
+}
+
+interface MeasurementTimestamped {
+  date_measurement_unix: number;
+}
+
+interface TimeSeriesData<T> {
+  values: T[];
+}
+
+interface RegionalSewerTimeSeriesData<T> {
+  values: TimeSeriesData<T>[];
+}
+function isTimeSeries(
+  value: unknown | TimeSeriesData<Timestamped>
+): value is TimeSeriesData<Timestamped> {
+  return (value as TimeSeriesData<Timestamped>).values !== undefined;
+}
+
+function isReportTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is ReportTimestamped[] {
+  return (
+    (timeSeries as ReportTimestamped[])[0].date_of_report_unix !== undefined
+  );
+}
+
+function isWeekTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is WeekTimestamped[] {
+  return (timeSeries as WeekTimestamped[])[0].week_unix !== undefined;
+}
+
+function isMeasurementTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is MeasurementTimestamped[] {
+  return (
+    (timeSeries as MeasurementTimestamped[])[0].date_measurement_unix !==
+    undefined
+  );
+}

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -92,12 +92,12 @@ function sortTimeSeriesValues(values: Timestamped[]) {
    * to detect each of them.
    */
   if (isReportTimestamped(values)) {
-    return values.sort((a, b) => b.date_of_report_unix - a.date_of_report_unix);
+    return values.sort((a, b) => a.date_of_report_unix - b.date_of_report_unix);
   } else if (isWeekTimestamped(values)) {
-    return values.sort((a, b) => b.week_unix - a.week_unix);
+    return values.sort((a, b) => a.week_unix - b.week_unix);
   } else if (isMeasurementTimestamped(values)) {
     return values.sort(
-      (a, b) => b.date_measurement_unix - a.date_measurement_unix
+      (a, b) => a.date_measurement_unix - b.date_measurement_unix
     );
   }
 

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -18,7 +18,7 @@ export function sortRegionalTimeSeriesInDataInPlace(data: Regionaal) {
      * inside values, so we need to process that separately.
      */
     if (propertyName === 'results_per_sewer_installation_per_region') {
-      const nestedSeries = data[propertyName] as RegionalSewerTimeSeriesData<
+      const nestedSeries = data[propertyName] as SewerTimeSeriesData<
         Timestamped
       >;
 
@@ -45,7 +45,7 @@ export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
      * inside values, so we need to process that separately.
      */
     if (propertyName === 'results_per_sewer_installation_per_municipality') {
-      const nestedSeries = data[propertyName] as RegionalSewerTimeSeriesData<
+      const nestedSeries = data[propertyName] as SewerTimeSeriesData<
         Timestamped
       >;
 
@@ -117,7 +117,7 @@ interface TimeSeriesData<T> {
   values: T[];
 }
 
-interface RegionalSewerTimeSeriesData<T> {
+interface SewerTimeSeriesData<T> {
   values: TimeSeriesData<T>[];
 }
 

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -1,18 +1,16 @@
 import { Municipal, National, Regionaal } from '~/types/data.d';
 
 export function sortNationalTimeSeriesInDataInPlace(data: National) {
-  const timeSeriesPropertyNames = getNationalTimeSeriesPropertyNames(data);
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
 
   for (const propertyName of timeSeriesPropertyNames) {
     const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
-    (data[propertyName] as TimeSeriesData<
-      Timestamped
-    >).values = sortTimeSeriesValues(timeSeries.values);
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
   }
 }
 
 export function sortRegionalTimeSeriesInDataInPlace(data: Regionaal) {
-  const timeSeriesPropertyNames = getRegionalTimeSeriesPropertyNames(data);
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
 
   for (const propertyName of timeSeriesPropertyNames) {
     /**
@@ -34,15 +32,12 @@ export function sortRegionalTimeSeriesInDataInPlace(data: Regionaal) {
     }
 
     const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
-
-    (data[propertyName] as TimeSeriesData<
-      Timestamped
-    >).values = sortTimeSeriesValues(timeSeries.values);
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
   }
 }
 
 export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
-  const timeSeriesPropertyNames = getMunicipalTimeSeriesPropertyNames(data);
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
 
   for (const propertyName of timeSeriesPropertyNames) {
     /**
@@ -64,9 +59,7 @@ export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
     }
 
     const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
-    (data[propertyName] as TimeSeriesData<
-      Timestamped
-    >).values = sortTimeSeriesValues(timeSeries.values);
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
   }
 }
 
@@ -74,40 +67,18 @@ export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
  * From the data structure, retrieve all properties that hold a "values" field
  * in their content. All time series data is kept in this values field.
  */
-function getNationalTimeSeriesPropertyNames(data: National) {
+function getTimeSeriesPropertyNames<T>(data: T) {
   return Object.entries(data).reduce(
     (acc, [propertyKey, propertyValue]) =>
-      isTimeSeries(propertyValue)
-        ? [...acc, propertyKey as keyof National]
-        : acc,
-    [] as (keyof National)[]
-  );
-}
-
-function getRegionalTimeSeriesPropertyNames(data: Regionaal) {
-  return Object.entries(data).reduce(
-    (acc, [propertyKey, propertyValue]) =>
-      isTimeSeries(propertyValue)
-        ? [...acc, propertyKey as keyof Regionaal]
-        : acc,
-    [] as (keyof Regionaal)[]
-  );
-}
-
-function getMunicipalTimeSeriesPropertyNames(data: Municipal) {
-  return Object.entries(data).reduce(
-    (acc, [propertyKey, propertyValue]) =>
-      isTimeSeries(propertyValue)
-        ? [...acc, propertyKey as keyof Municipal]
-        : acc,
-    [] as (keyof Municipal)[]
+      isTimeSeries(propertyValue) ? [...acc, propertyKey as keyof T] : acc,
+    [] as (keyof T)[]
   );
 }
 
 function sortTimeSeriesValues(values: Timestamped[]) {
   /**
-   * There are 3 types of ways in which time series data is timestamped. We need
-   * to detect each of them.
+   * There are 3 ways in which time series data can be timestamped. We need
+   * to detect and handle each of them.
    */
   if (isReportTimestamped(values)) {
     return values.sort((a, b) => a.date_of_report_unix - b.date_of_report_unix);
@@ -149,6 +120,11 @@ interface TimeSeriesData<T> {
 interface RegionalSewerTimeSeriesData<T> {
   values: TimeSeriesData<T>[];
 }
+
+/**
+ * Some type guards to figure out types based on runtime properties.
+ * See: https://basarat.gitbook.io/typescript/type-system/typeguard#user-defined-type-guards
+ */
 function isTimeSeries(
   value: unknown | TimeSeriesData<Timestamped>
 ): value is TimeSeriesData<Timestamped> {

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -45,6 +45,24 @@ export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
   const timeSeriesPropertyNames = getMunicipalTimeSeriesPropertyNames(data);
 
   for (const propertyName of timeSeriesPropertyNames) {
+    /**
+     * There is one property in the dataset that contains timeseries nested
+     * inside values, so we need to process that separately.
+     */
+    if (propertyName === 'results_per_sewer_installation_per_municipality') {
+      const nestedSeries = data[propertyName] as RegionalSewerTimeSeriesData<
+        Timestamped
+      >;
+
+      nestedSeries.values = nestedSeries.values.map((x) => {
+        x.values = sortTimeSeriesValues(x.values);
+        return x;
+      });
+
+      // Skip the remainder of this loop
+      continue;
+    }
+
     const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
     (data[propertyName] as TimeSeriesData<
       Timestamped

--- a/src/static-props/municipality-data.ts
+++ b/src/static-props/municipality-data.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { Municipal } from '~/types/data.d';
 
 import municipalities from '~/data/gemeente_veiligheidsregio.json';
+import { sortMunicipalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface IMunicipalityData {
   data: Municipal;
@@ -32,18 +33,18 @@ interface IParams {
  *
  * Example:
  * ```ts
- * PostivelyTestedPeople.getLayout = getMunicipalityLayout();
+ * PositivelyTestedPeople.getLayout = getMunicipalityLayout();
  *
  * export const getStaticProps = getMunicipalityData();
  *
- * export default PostivelyTestedPeople;
+ * export default PositivelyTestedPeople;
  * ```
  *
- * The `IMunicipalityData` should be used in conjuction with `FCWithLayout`
+ * The `IMunicipalityData` should be used in conjunction with `FCWithLayout`
  *
  * Example:
  * ```ts
- * const PostivelyTestedPeople: FCWithLayout<IMunicipalityData> = props => {
+ * const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = props => {
  *   // ...
  * }
  * ```
@@ -54,7 +55,9 @@ export function getMunicipalityData() {
 
     const filePath = path.join(process.cwd(), 'public', 'json', `${code}.json`);
     const fileContents = fs.readFileSync(filePath, 'utf8');
-    const data = JSON.parse(fileContents);
+    const data = JSON.parse(fileContents) as Municipal;
+
+    sortMunicipalTimeSeriesInDataInPlace(data);
 
     const municipalityName =
       municipalities.find((r) => r.gemcode === code)?.name || '';

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-
 import { National } from '~/types/data.d';
 
 export interface INationalData {
@@ -19,18 +18,18 @@ interface IProps {
  *
  * Example:
  * ```ts
- * PostivelyTestedPeople.getLayout = getNationalLayout();
+ * PositivelyTestedPeople.getLayout = getNationalLayout();
  *
  * export const getStaticProps = getNlData();
  *
- * export default PostivelyTestedPeople;
+ * export default PositivelyTestedPeople;
  * ```
  *
- * The `INationalData` should be used in conjuction with `FCWithLayout`
+ * The `INationalData` should be used in conjunction with `FCWithLayout`
  *
  * Example:
  * ```ts
- * const PostivelyTestedPeople: FCWithLayout<INationalData> = props => {
+ * const PositivelyTestedPeople: FCWithLayout<INationalData> = props => {
  *   // ...
  * }
  * ```
@@ -43,6 +42,8 @@ export default function getNlData(): () => IProps {
 
     const lastGenerated = data.last_generated;
 
+    sortTimeSeriesInDataInPlace(data);
+
     return {
       props: {
         data,
@@ -50,4 +51,96 @@ export default function getNlData(): () => IProps {
       },
     };
   };
+}
+
+/**
+ * Sort all time series properties in the data in-place, meaning the input
+ * data is mutated.
+ */
+function sortTimeSeriesInDataInPlace(data: National) {
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
+  // console.log('+++ timeSeriesPropertyNames', timeSeriesPropertyNames);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    (data[propertyName] as TimeSeriesData<
+      Timestamped
+    >).values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+/**
+ * From the data structure, retrieve all properties that hold a "values" field
+ * in their content. All time series data is kept in this values field.
+ */
+function getTimeSeriesPropertyNames(data: National) {
+  return Object.entries(data).reduce(
+    (acc, [propertyKey, propertyValue]) =>
+      isTimeSeries(propertyValue)
+        ? [...acc, propertyKey as keyof National]
+        : acc,
+    [] as (keyof National)[]
+  );
+}
+
+type Timestamped = ReportTimestamped | WeekTimestamped | MeasurementTimestamped;
+
+interface ReportTimestamped {
+  date_of_report_unix: number;
+}
+
+interface WeekTimestamped {
+  week_unix: number;
+}
+
+interface MeasurementTimestamped {
+  date_measurement_unix: number;
+}
+
+interface TimeSeriesData<T> {
+  values: T[];
+}
+
+function sortTimeSeriesValues(values: Timestamped[]): Timestamped[] {
+  if (isReportTimestamped(values)) {
+    return values.sort((a, b) => a.date_of_report_unix - b.date_of_report_unix);
+  } else if (isWeekTimestamped(values)) {
+    return values.sort((a, b) => a.week_unix - b.week_unix);
+  } else if (isMeasurementTimestamped(values)) {
+    return values.sort(
+      (a, b) => a.date_measurement_unix - b.date_measurement_unix
+    );
+  }
+
+  throw new Error(
+    `Unknown timestamp in value ${JSON.stringify(values[0], null, 2)}`
+  );
+}
+
+function isTimeSeries(
+  value: unknown | TimeSeriesData<Timestamped>
+): value is TimeSeriesData<Timestamped> {
+  return (value as TimeSeriesData<Timestamped>).values !== undefined;
+}
+
+function isReportTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is ReportTimestamped[] {
+  return (
+    (timeSeries as ReportTimestamped[])[0].date_of_report_unix !== undefined
+  );
+}
+
+function isWeekTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is WeekTimestamped[] {
+  return (timeSeries as WeekTimestamped[])[0].week_unix !== undefined;
+}
+
+function isMeasurementTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is MeasurementTimestamped[] {
+  return (
+    (timeSeries as MeasurementTimestamped[])[0].date_measurement_unix !==
+    undefined
+  );
 }

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { National } from '~/types/data.d';
+import { sortNationalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface INationalData {
   data: National;
@@ -42,7 +43,7 @@ export default function getNlData(): () => IProps {
 
     const lastGenerated = data.last_generated;
 
-    sortTimeSeriesInDataInPlace(data);
+    sortNationalTimeSeriesInDataInPlace(data);
 
     return {
       props: {
@@ -51,96 +52,4 @@ export default function getNlData(): () => IProps {
       },
     };
   };
-}
-
-/**
- * Sort all time series properties in the data in-place, meaning the input
- * data is mutated.
- */
-function sortTimeSeriesInDataInPlace(data: National) {
-  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
-  // console.log('+++ timeSeriesPropertyNames', timeSeriesPropertyNames);
-
-  for (const propertyName of timeSeriesPropertyNames) {
-    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
-    (data[propertyName] as TimeSeriesData<
-      Timestamped
-    >).values = sortTimeSeriesValues(timeSeries.values);
-  }
-}
-/**
- * From the data structure, retrieve all properties that hold a "values" field
- * in their content. All time series data is kept in this values field.
- */
-function getTimeSeriesPropertyNames(data: National) {
-  return Object.entries(data).reduce(
-    (acc, [propertyKey, propertyValue]) =>
-      isTimeSeries(propertyValue)
-        ? [...acc, propertyKey as keyof National]
-        : acc,
-    [] as (keyof National)[]
-  );
-}
-
-type Timestamped = ReportTimestamped | WeekTimestamped | MeasurementTimestamped;
-
-interface ReportTimestamped {
-  date_of_report_unix: number;
-}
-
-interface WeekTimestamped {
-  week_unix: number;
-}
-
-interface MeasurementTimestamped {
-  date_measurement_unix: number;
-}
-
-interface TimeSeriesData<T> {
-  values: T[];
-}
-
-function sortTimeSeriesValues(values: Timestamped[]): Timestamped[] {
-  if (isReportTimestamped(values)) {
-    return values.sort((a, b) => a.date_of_report_unix - b.date_of_report_unix);
-  } else if (isWeekTimestamped(values)) {
-    return values.sort((a, b) => a.week_unix - b.week_unix);
-  } else if (isMeasurementTimestamped(values)) {
-    return values.sort(
-      (a, b) => a.date_measurement_unix - b.date_measurement_unix
-    );
-  }
-
-  throw new Error(
-    `Unknown timestamp in value ${JSON.stringify(values[0], null, 2)}`
-  );
-}
-
-function isTimeSeries(
-  value: unknown | TimeSeriesData<Timestamped>
-): value is TimeSeriesData<Timestamped> {
-  return (value as TimeSeriesData<Timestamped>).values !== undefined;
-}
-
-function isReportTimestamped(
-  timeSeries: Timestamped[]
-): timeSeries is ReportTimestamped[] {
-  return (
-    (timeSeries as ReportTimestamped[])[0].date_of_report_unix !== undefined
-  );
-}
-
-function isWeekTimestamped(
-  timeSeries: Timestamped[]
-): timeSeries is WeekTimestamped[] {
-  return (timeSeries as WeekTimestamped[])[0].week_unix !== undefined;
-}
-
-function isMeasurementTimestamped(
-  timeSeries: Timestamped[]
-): timeSeries is MeasurementTimestamped[] {
-  return (
-    (timeSeries as MeasurementTimestamped[])[0].date_measurement_unix !==
-    undefined
-  );
 }

--- a/src/static-props/safetyregion-data.ts
+++ b/src/static-props/safetyregion-data.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { Regionaal } from '~/types/data.d';
 
 import safetyRegions from '~/data/index';
+import { sortRegionalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface ISafetyRegionData {
   data: Regionaal;
@@ -56,6 +57,8 @@ export function getSafetyRegionData() {
     const filePath = path.join(process.cwd(), 'public', 'json', `${code}.json`);
     const fileContents = fs.readFileSync(filePath, 'utf8');
     const data = JSON.parse(fileContents) as Regionaal;
+
+    sortRegionalTimeSeriesInDataInPlace(data);
 
     const lastGenerated = data.last_generated;
 

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -126,15 +126,15 @@ export function getSewerWaterLineChartData(
       data?.results_per_sewer_installation_per_municipality?.values[0].values ||
       [];
     return {
-      averageValues: averageValues
-        .map((value: ResultsPerSewerInstallationPerMunicipalityLastValue) => {
+      averageValues: averageValues.map(
+        (value: ResultsPerSewerInstallationPerMunicipalityLastValue) => {
           return {
             ...value,
             value: value.rna_per_ml,
             date: value.date_measurement_unix,
           };
-        })
-        .sort((a: any, b: any) => b.date - a.date),
+        }
+      ),
       averageLabelText: replaceVariablesInText(
         text.graph_average_label_text_rwzi,
         {
@@ -152,15 +152,13 @@ export function getSewerWaterLineChartData(
   const averageValues = data?.sewer_measurements?.values || [];
 
   return {
-    averageValues: averageValues
-      .map((value: SewerMeasurementsLastValue) => {
-        return {
-          ...value,
-          value: value.average,
-          date: value.week_unix,
-        };
-      })
-      .sort((a: any, b: any) => b.date - a.date),
+    averageValues: averageValues.map((value: SewerMeasurementsLastValue) => {
+      return {
+        ...value,
+        value: value.average,
+        date: value.week_unix,
+      };
+    }),
     averageLabelText: text.graph_average_label_text,
   };
 }

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -110,15 +110,13 @@ export function getSewerWaterLineChartData(
     const averageValues =
       data?.results_per_sewer_installation_per_region?.values[0].values || [];
     return {
-      averageValues: averageValues
-        .map((value: SewerValue) => {
-          return {
-            ...value,
-            value: value.rna_per_ml,
-            date: value.date_measurement_unix,
-          };
-        })
-        .sort((a: any, b: any) => b.date - a.date),
+      averageValues: averageValues.map((value: SewerValue) => {
+        return {
+          ...value,
+          value: value.rna_per_ml,
+          date: value.date_measurement_unix,
+        };
+      }),
       averageLabelText: replaceVariablesInText(
         text.graph_average_label_text_rwzi,
         {
@@ -137,15 +135,15 @@ export function getSewerWaterLineChartData(
     data?.average_sewer_installation_per_region?.values || [];
 
   return {
-    averageValues: averageValues
-      .map((value: AverageSewerInstallationPerRegionItem) => {
+    averageValues: averageValues.map(
+      (value: AverageSewerInstallationPerRegionItem) => {
         return {
           ...value,
           value: value.average,
           date: value.week_unix,
         };
-      })
-      .sort((a: any, b: any) => b.date - a.date),
+      }
+    ),
     averageLabelText: text.graph_average_label_text,
   };
 }


### PR DESCRIPTION
In this PR all time-series data gets sorted in the page build/bundle stage. 

First, all properties are identified that contain a { values: [] } object. Then for each of those time-series, the used timestamp is detected (there are currently 3). If no known timestamp is found, the code will throw and the application build will break. This way we can be sure that all data is sorted.

There was some additional runtime sorting happening in the code, which I have removed since it should be redundant.