### PR TITLE
Hotfix time series data sorting

### DIFF
--- a/src/components/lineChart/regionalSewerWaterLineChart.tsx
+++ b/src/components/lineChart/regionalSewerWaterLineChart.tsx
@@ -135,8 +135,7 @@ function getOptions(
         text: null,
       },
       labels: {
-        formatter: function (): string {
-          // @ts-ignore
+        formatter: function () {
           return formatNumber(this.value);
         },
       },

--- a/src/static-props/data-sorting.ts
+++ b/src/static-props/data-sorting.ts
@@ -1,0 +1,155 @@
+import { Municipal, National, Regionaal } from '~/types/data.d';
+
+export function sortNationalTimeSeriesInDataInPlace(data: National) {
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+export function sortRegionalTimeSeriesInDataInPlace(data: Regionaal) {
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    /**
+     * There is one property in the dataset that contains timeseries nested
+     * inside values, so we need to process that separately.
+     */
+    if (propertyName === 'results_per_sewer_installation_per_region') {
+      const nestedSeries = data[propertyName] as SewerTimeSeriesData<
+        Timestamped
+      >;
+
+      nestedSeries.values = nestedSeries.values.map((x) => {
+        x.values = sortTimeSeriesValues(x.values);
+        return x;
+      });
+
+      // Skip the remainder of this loop
+      continue;
+    }
+
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+export function sortMunicipalTimeSeriesInDataInPlace(data: Municipal) {
+  const timeSeriesPropertyNames = getTimeSeriesPropertyNames(data);
+
+  for (const propertyName of timeSeriesPropertyNames) {
+    /**
+     * There is one property in the dataset that contains timeseries nested
+     * inside values, so we need to process that separately.
+     */
+    if (propertyName === 'results_per_sewer_installation_per_municipality') {
+      const nestedSeries = data[propertyName] as SewerTimeSeriesData<
+        Timestamped
+      >;
+
+      nestedSeries.values = nestedSeries.values.map((x) => {
+        x.values = sortTimeSeriesValues(x.values);
+        return x;
+      });
+
+      // Skip the remainder of this loop
+      continue;
+    }
+
+    const timeSeries = data[propertyName] as TimeSeriesData<Timestamped>;
+    timeSeries.values = sortTimeSeriesValues(timeSeries.values);
+  }
+}
+
+/**
+ * From the data structure, retrieve all properties that hold a "values" field
+ * in their content. All time series data is kept in this values field.
+ */
+function getTimeSeriesPropertyNames<T>(data: T) {
+  return Object.entries(data).reduce(
+    (acc, [propertyKey, propertyValue]) =>
+      isTimeSeries(propertyValue) ? [...acc, propertyKey as keyof T] : acc,
+    [] as (keyof T)[]
+  );
+}
+
+function sortTimeSeriesValues(values: Timestamped[]) {
+  /**
+   * There are 3 ways in which time series data can be timestamped. We need
+   * to detect and handle each of them.
+   */
+  if (isReportTimestamped(values)) {
+    return values.sort((a, b) => a.date_of_report_unix - b.date_of_report_unix);
+  } else if (isWeekTimestamped(values)) {
+    return values.sort((a, b) => a.week_unix - b.week_unix);
+  } else if (isMeasurementTimestamped(values)) {
+    return values.sort(
+      (a, b) => a.date_measurement_unix - b.date_measurement_unix
+    );
+  }
+
+  /**
+   * If none match we throw, since it means an unknown timestamp is used and we
+   * want to be sure we sort all data.
+   */
+  throw new Error(
+    `Unknown timestamp in value ${JSON.stringify(values[0], null, 2)}`
+  );
+}
+
+type Timestamped = ReportTimestamped | WeekTimestamped | MeasurementTimestamped;
+
+interface ReportTimestamped {
+  date_of_report_unix: number;
+}
+
+interface WeekTimestamped {
+  week_unix: number;
+}
+
+interface MeasurementTimestamped {
+  date_measurement_unix: number;
+}
+
+interface TimeSeriesData<T> {
+  values: T[];
+}
+
+interface SewerTimeSeriesData<T> {
+  values: TimeSeriesData<T>[];
+}
+
+/**
+ * Some type guards to figure out types based on runtime properties.
+ * See: https://basarat.gitbook.io/typescript/type-system/typeguard#user-defined-type-guards
+ */
+function isTimeSeries(
+  value: unknown | TimeSeriesData<Timestamped>
+): value is TimeSeriesData<Timestamped> {
+  return (value as TimeSeriesData<Timestamped>).values !== undefined;
+}
+
+function isReportTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is ReportTimestamped[] {
+  return (
+    (timeSeries as ReportTimestamped[])[0].date_of_report_unix !== undefined
+  );
+}
+
+function isWeekTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is WeekTimestamped[] {
+  return (timeSeries as WeekTimestamped[])[0].week_unix !== undefined;
+}
+
+function isMeasurementTimestamped(
+  timeSeries: Timestamped[]
+): timeSeries is MeasurementTimestamped[] {
+  return (
+    (timeSeries as MeasurementTimestamped[])[0].date_measurement_unix !==
+    undefined
+  );
+}

--- a/src/static-props/municipality-data.ts
+++ b/src/static-props/municipality-data.ts
@@ -1,11 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
 import { Municipal } from '~/types/data.d';
 
 import municipalities from '~/data/gemeente_veiligheidsregio.json';
-import { getSafetyRegionData } from './safetyregion-data';
+import { sortMunicipalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface IMunicipalityData {
   data: Municipal;
   lastGenerated: string;
+  municipalityName: string;
 }
 
 interface IPaths {
@@ -13,7 +17,61 @@ interface IPaths {
   fallback: boolean;
 }
 
-export const getMunicipalityData = getSafetyRegionData;
+interface IProps {
+  props: IMunicipalityData;
+}
+
+interface IParams {
+  params: {
+    code: string;
+  };
+}
+
+/*
+ * getMunicipalityData loads the data for /gemeente pages.
+ * It needs to be used as the Next.js `getStaticProps` function.
+ *
+ * Example:
+ * ```ts
+ * PositivelyTestedPeople.getLayout = getMunicipalityLayout();
+ *
+ * export const getStaticProps = getMunicipalityData();
+ *
+ * export default PositivelyTestedPeople;
+ * ```
+ *
+ * The `IMunicipalityData` should be used in conjunction with `FCWithLayout`
+ *
+ * Example:
+ * ```ts
+ * const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = props => {
+ *   // ...
+ * }
+ * ```
+ */
+export function getMunicipalityData() {
+  return function ({ params }: IParams): IProps {
+    const { code } = params;
+
+    const filePath = path.join(process.cwd(), 'public', 'json', `${code}.json`);
+    const fileContents = fs.readFileSync(filePath, 'utf8');
+    const data = JSON.parse(fileContents) as Municipal;
+
+    sortMunicipalTimeSeriesInDataInPlace(data);
+
+    const municipalityName =
+      municipalities.find((r) => r.gemcode === code)?.name || '';
+    const lastGenerated = data.last_generated;
+
+    return {
+      props: {
+        data,
+        municipalityName,
+        lastGenerated,
+      },
+    };
+  };
+}
 
 /*
  * getMunicipalityPaths creates an array of all the allowed

--- a/src/static-props/nl-data.ts
+++ b/src/static-props/nl-data.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-
 import { National } from '~/types/data.d';
+import { sortNationalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface INationalData {
   data: National;
@@ -19,18 +19,18 @@ interface IProps {
  *
  * Example:
  * ```ts
- * PostivelyTestedPeople.getLayout = getNationalLayout();
+ * PositivelyTestedPeople.getLayout = getNationalLayout();
  *
  * export const getStaticProps = getNlData();
  *
- * export default PostivelyTestedPeople;
+ * export default PositivelyTestedPeople;
  * ```
  *
- * The `INationalData` should be used in conjuction with `FCWithLayout`
+ * The `INationalData` should be used in conjunction with `FCWithLayout`
  *
  * Example:
  * ```ts
- * const PostivelyTestedPeople: FCWithLayout<INationalData> = props => {
+ * const PositivelyTestedPeople: FCWithLayout<INationalData> = props => {
  *   // ...
  * }
  * ```
@@ -42,6 +42,8 @@ export default function getNlData(): () => IProps {
     const data = JSON.parse(fileContents) as National;
 
     const lastGenerated = data.last_generated;
+
+    sortNationalTimeSeriesInDataInPlace(data);
 
     return {
       props: {

--- a/src/static-props/safetyregion-data.ts
+++ b/src/static-props/safetyregion-data.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { Regionaal } from '~/types/data.d';
 
 import safetyRegions from '~/data/index';
+import { sortRegionalTimeSeriesInDataInPlace } from './data-sorting';
 
 export interface ISafetyRegionData {
   data: Regionaal;
@@ -55,6 +56,8 @@ export function getSafetyRegionData() {
     const filePath = path.join(process.cwd(), 'public', 'json', `${code}.json`);
     const fileContents = fs.readFileSync(filePath, 'utf8');
     const data = JSON.parse(fileContents) as Regionaal;
+
+    sortRegionalTimeSeriesInDataInPlace(data);
 
     const lastGenerated = data.last_generated;
 

--- a/src/utils/sewer-water/municipality-sewer-water.util.ts
+++ b/src/utils/sewer-water/municipality-sewer-water.util.ts
@@ -127,15 +127,15 @@ export function getSewerWaterLineChartData(
       data?.results_per_sewer_installation_per_municipality?.values[0].values ||
       [];
     return {
-      averageValues: averageValues
-        .map((value: ResultsPerSewerInstallationPerMunicipalityLastValue) => {
+      averageValues: averageValues.map(
+        (value: ResultsPerSewerInstallationPerMunicipalityLastValue) => {
           return {
             ...value,
             value: value.rna_per_ml,
             date: value.date_measurement_unix,
           };
-        })
-        .sort((a: any, b: any) => b.date - a.date),
+        }
+      ),
       averageLabelText: replaceVariablesInText(
         text.graph_average_label_text_rwzi,
         {
@@ -153,15 +153,13 @@ export function getSewerWaterLineChartData(
   const averageValues = data?.sewer_measurements?.values || [];
 
   return {
-    averageValues: averageValues
-      .map((value: SewerMeasurementsLastValue) => {
-        return {
-          ...value,
-          value: value.average,
-          date: value.week_unix,
-        };
-      })
-      .sort((a: any, b: any) => b.date - a.date),
+    averageValues: averageValues.map((value: SewerMeasurementsLastValue) => {
+      return {
+        ...value,
+        value: value.average,
+        date: value.week_unix,
+      };
+    }),
     averageLabelText: text.graph_average_label_text,
   };
 }

--- a/src/utils/sewer-water/safety-region-sewer-water.util.ts
+++ b/src/utils/sewer-water/safety-region-sewer-water.util.ts
@@ -111,15 +111,13 @@ export function getSewerWaterLineChartData(
     const averageValues =
       data?.results_per_sewer_installation_per_region?.values[0].values || [];
     return {
-      averageValues: averageValues
-        .map((value: SewerValue) => {
-          return {
-            ...value,
-            value: value.rna_per_ml,
-            date: value.date_measurement_unix,
-          };
-        })
-        .sort((a: any, b: any) => b.date - a.date),
+      averageValues: averageValues.map((value: SewerValue) => {
+        return {
+          ...value,
+          value: value.rna_per_ml,
+          date: value.date_measurement_unix,
+        };
+      }),
       averageLabelText: replaceVariablesInText(
         text.graph_average_label_text_rwzi,
         {
@@ -138,15 +136,15 @@ export function getSewerWaterLineChartData(
     data?.average_sewer_installation_per_region?.values || [];
 
   return {
-    averageValues: averageValues
-      .map((value: AverageSewerInstallationPerRegionItem) => {
+    averageValues: averageValues.map(
+      (value: AverageSewerInstallationPerRegionItem) => {
         return {
           ...value,
           value: value.average,
           date: value.week_unix,
         };
-      })
-      .sort((a: any, b: any) => b.date - a.date),
+      }
+    ),
     averageLabelText: text.graph_average_label_text,
   };
 }


### PR DESCRIPTION
Cherry-picked and adapted from #553, as a hotfix for master

* Implement data sorting on national level

* Implement data sorting for all

* Flip the sorting back to normal

* Prevent nursing home missing data errors

* Deal with sewage data on municipal level

* Remove redundant data sorting

* Clean up

* Simplify code and improve comments

* Rename sewer time series data type

```
# Conflicts:
#	src/components/areaChart/index.tsx
#	src/components/layout/SafetyRegionLayout.tsx
#	src/static-props/municipality-data.ts
```