### PR TITLE
Fix padding for region control

### DIFF
--- a/src/components/chartRegionControls/chartregioncontrols.module.scss
+++ b/src/components/chartRegionControls/chartregioncontrols.module.scss
@@ -5,7 +5,12 @@
   margin: 0 0 1rem;
   max-width: 100%;
   overflow: hidden;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto;
+
+  /* Extra specificity to overrule radio-group rules */
+  &.select-region-group {
+    label {
+      padding: 0.2em 1.5em;
+      flex: 0 1 auto;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes paddings on region select

The removed grid properties did not have any effect, elsewhere the display is set to flex.
