### PR TITLE
fixes IE11 alignment of metadata footers

### DIFF
--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -113,7 +113,7 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
             />
           )}
         </div>
-        <footer className="article-footer">
+        <footer className="chloropleth-footer">
           {siteText.common.metadata.source}:{' '}
           <a href={text.bronnen.rivm.href}>{text.bronnen.rivm.text}</a>
         </footer>

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -96,7 +96,7 @@
   is pushed to the bottom.
   */
   .article-top {
-    flex: 1;
+    flex: 1 1 auto;
   }
 
   .article-footer {
@@ -474,10 +474,11 @@ a.metric-link {
   @media (min-width: $chloropleth-breakpoint) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto 1fr auto;
     grid-template-areas:
       'a c'
-      'b c';
+      'b c'
+      'd c';
   }
 
   .chloropleth-header {
@@ -510,5 +511,9 @@ a.metric-link {
     @media (min-width: $chloropleth-breakpoint) {
       justify-content: flex-start;
     }
+  }
+
+  .chloropleth-footer {
+    grid-area: d;
   }
 }


### PR DESCRIPTION
## Summary

Fixes the alignment of metadata footers in IE11.

## Detailed design

* The flexbox use in `article-top` goes funky in IE11 because it does not understand the shorthand. Specifying it in full works.
* The choropleth did not specify where the metadata should be placed. Extended the grid and put it in place.