### PR TITLE
Fixes barscales that were not rendered with value=0

### DIFF
--- a/src/components/common/nursing-home-deaths-barscale.tsx
+++ b/src/components/common/nursing-home-deaths-barscale.tsx
@@ -9,7 +9,7 @@ export function NursingHomeDeathsBarScale(props: {
 }) {
   const { value, showAxis } = props;
 
-  if (!value) return null;
+  if (value === undefined) return null;
 
   return (
     <BarScale

--- a/src/components/common/nursing-home-infected-locations-barscale.tsx
+++ b/src/components/common/nursing-home-infected-locations-barscale.tsx
@@ -10,7 +10,7 @@ export function NursingHomeInfectedLocationsBarScale(props: {
 }) {
   const { value, showAxis } = props;
 
-  if (!value) return null;
+  if (value === undefined) return null;
 
   return (
     <BarScale

--- a/src/components/common/nursing-home-infected-people-barscale.tsx
+++ b/src/components/common/nursing-home-infected-people-barscale.tsx
@@ -9,7 +9,7 @@ export function NursingHomeInfectedPeopleBarScale(props: {
 }) {
   const { value, showAxis } = props;
 
-  if (!value) return null;
+  if (value === undefined) return null;
 
   return (
     <BarScale

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -249,7 +249,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                             .titel_sidebar
                         }
                       />
-                      {data?.nursing_home?.last_value.newly_infected_people && (
+                      {data?.nursing_home?.last_value && (
                         <span>
                           <NursingHomeInfectedPeopleBarScale
                             value={


### PR DESCRIPTION
## Summary

Fixes for barscales when they have a value equal to 0.

## Detailed design

Out checks to see if there is not a value were too strict. Since 0 is a falsey value, some barscale components were not rendered (properly).

