### PR TITLE
Some minor fixes to the VPH choropleths

### DIFF
--- a/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
+++ b/src/components/chloropleth/legenda/chloroplethlegenda.module.scss
@@ -16,6 +16,19 @@
       height: 10px;
       flex-grow: 0;
       flex-shrink: 0;
+      border-bottom: 1px solid lightgrey;
+      border-top: 1px solid lightgrey;
+    }
+
+    &:last-of-type {
+      .box {
+        border-right: 1px solid lightgrey;
+      }
+    }
+    &:first-of-type {
+      .box {
+        border-left: 1px solid lightgrey;
+      }
     }
   }
 }

--- a/src/components/chloropleth/regionThresholds.ts
+++ b/src/components/chloropleth/regionThresholds.ts
@@ -119,5 +119,6 @@ export const regionThresholds: Record<
   escalation_levels: escalationThresholds,
   nursing_home: {
     infected_locations_total: nursingHomeThresholds,
+    newly_infected_people: nursingHomeThresholds,
   } as Record<Partial<TRegionsNursingHomeMetricName>, ChoroplethThresholds>,
 };

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -291,8 +291,8 @@
       "titel": "Aantal per 100.000 inwoners",
       "geen_meldingen": "Geen meldingen"
     },
-    "map_titel": "Verdeling positief geteste mensen in Nederland",
-    "map_toelichting": "Deze kaarten laten zien van hoeveel mensen gisteren is gemeld dat ze positief getest zijn op COVID-19, per 100.000 inwoners."
+    "map_titel": "Verdeling positief geteste bewoners in Nederland",
+    "map_toelichting": "Deze kaarten laten zien van hoeveel bewoners gisteren is gemeld dat ze positief getest zijn op COVID-19, per 100.000 inwoners."
   },
   "verpleeghuis_oversterfte": {
     "datums": "Waarde van {{dateOfReport}}. Verkregen: {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -96,18 +96,6 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
         </article>
       </div>
 
-      {totalLocations && (
-        <article className="metric-article">
-          <LineChart
-            title={text.linechart_titel}
-            values={totalLocations.values.map((value) => ({
-              value: value.total_reported_locations,
-              date: value.date_of_report_unix,
-            }))}
-          />
-        </article>
-      )}
-
       <article className="metric-article layout-chloropleth">
         <div className="chloropleth-header">
           <h3>{text.map_titel}</h3>
@@ -135,6 +123,18 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
           )}
         </div>
       </article>
+
+      {totalLocations && (
+        <article className="metric-article">
+          <LineChart
+            title={text.linechart_titel}
+            values={totalLocations.values.map((value) => ({
+              value: value.total_reported_locations,
+              date: value.date_of_report_unix,
+            }))}
+          />
+        </article>
+      )}
     </>
   );
 };

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -24,7 +24,10 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;
   const router = useRouter();
 
-  const legendItems = useSafetyRegionLegendaData('positive_tested_people');
+  const legendItems = useSafetyRegionLegendaData(
+    'nursing_home',
+    'newly_infected_people'
+  );
 
   const data: InfectedPeopleNurseryCountDaily | undefined =
     state?.infected_people_nursery_count_daily;
@@ -59,18 +62,6 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
         </div>
       </article>
 
-      {data && (
-        <article className="metric-article">
-          <LineChart
-            title={text.linechart_titel}
-            values={data.values.map((value) => ({
-              value: value.infected_nursery_daily,
-              date: value.date_of_report_unix,
-            }))}
-          />
-        </article>
-      )}
-
       <article className="metric-article layout-chloropleth">
         <div className="chloropleth-header">
           <h3>{text.map_titel}</h3>
@@ -94,6 +85,18 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
           )}
         </div>
       </article>
+
+      {data && (
+        <article className="metric-article">
+          <LineChart
+            title={text.linechart_titel}
+            values={data.values.map((value) => ({
+              value: value.infected_nursery_daily,
+              date: value.date_of_report_unix,
+            }))}
+          />
+        </article>
+      )}
     </>
   );
 };

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -72,7 +72,10 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = (props) => {
           <SafetyRegionChloropleth
             metricName="positive_tested_people"
             tooltipContent={createPositiveTestedPeopleRegionalTooltip(router)}
-            onSelect={createSelectRegionHandler(router)}
+            onSelect={createSelectRegionHandler(
+              router,
+              'verpleeghuis-positief-geteste-personen'
+            )}
           />
         </div>
 


### PR DESCRIPTION
## Summary

Some visual tweaks to the choropleths on the VPH pages. Both choropleths are moved up above the trendline.
A grey outline was added to the legenda.
The correct data is shown for the positive tested bewoners.
Positive tested bewoners links through to the correct region page.

## Motivation

Bug report.

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

What other designs have been considered? What is the impact of not doing this?

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
