### PR TITLE
Fix gemeente selection tooltip and clickthrough

### DIFF
--- a/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
@@ -7,11 +7,11 @@ import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent
 export const createPositiveTestedPeopleMunicipalTooltip = (
   router: NextRouter
 ) => (context: MunicipalityProperties & { value: number }): ReactNode => {
-  const handler = createSelectMunicipalHandler(router);
+  const onSelectHandler = createSelectMunicipalHandler(router);
 
   const onSelect = (event: any) => {
     event.stopPropagation();
-    handler(context);
+    onSelectHandler(context);
   };
 
   return (

--- a/src/components/chloropleth/tooltips/tooltipContent.tsx
+++ b/src/components/chloropleth/tooltips/tooltipContent.tsx
@@ -4,7 +4,7 @@ import styles from '~/components/chloropleth/tooltips/tooltip.module.scss';
 interface IProps {
   title: string;
   onSelect: (event: React.MouseEvent<HTMLInputElement>) => void;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 export function TooltipContent(props: IProps) {
@@ -15,7 +15,7 @@ export function TooltipContent(props: IProps) {
       <div className={styles.tooltipHeader}>
         <h3>{title}</h3>
       </div>
-      <div className={styles.tooltipInfo}>{children}</div>
+      {children && <div className={styles.tooltipInfo}>{children}</div>}
     </div>
   );
 }

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,31 +1,34 @@
 import { FCWithLayout } from '~/components/layout';
 import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
-import { NextRouter, useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 
 import getLastGeneratedData from '~/static-props/last-generated-data';
 
 import text from '~/locale/index';
-import styles from '~/components/chloropleth/chloropleth.module.scss';
 
 import { ReactNode } from 'react';
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
 import { MunicipalityProperties } from '~/components/chloropleth/shared';
+import {
+  createSelectMunicipalHandler,
+  MunicipalitySelectionHandler,
+} from '~/components/chloropleth/selectHandlers/createSelectMunicipalHandler';
+import { useMediaQuery } from '~/utils/useMediaQuery';
+import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent';
 
-const tooltipContent = (router: NextRouter) => {
+const tooltipContent = (selectedHandler: MunicipalitySelectionHandler) => {
   return (context: MunicipalityProperties): ReactNode => {
     const onSelectMunicipal = (event: any) => {
       event.stopPropagation();
-      router.push(
-        '/gemeente/[code]/positief-geteste-mensen',
-        `/gemeente/${context.gemcode}/positief-geteste-mensen`
-      );
+      selectedHandler(context);
     };
 
     return (
       context && (
-        <div className={styles.clickableTooltip} onClick={onSelectMunicipal}>
-          <strong>{context.gemnaam}</strong>
-        </div>
+        <TooltipContent
+          title={context.gemnaam}
+          onSelect={onSelectMunicipal}
+        ></TooltipContent>
       )
     );
   };
@@ -39,11 +42,13 @@ const tooltipContent = (router: NextRouter) => {
 // lots of unnecessary null checks on those pages.
 const Municipality: FCWithLayout<any> = () => {
   const router = useRouter();
+  const isLargeScreen = useMediaQuery('(min-width: 1000px)');
 
   const onSelectMunicipal = (context: MunicipalityProperties) => {
+    const pageName = isLargeScreen ? '/positief-geteste-mensen' : '';
     router.push(
-      '/gemeente/[code]/positief-geteste-mensen',
-      `/gemeente/${context.gemcode}/positief-geteste-mensen`
+      `/gemeente/[code]${pageName}`,
+      `/gemeente/${context.gemcode}${pageName}`
     );
   };
 
@@ -55,8 +60,11 @@ const Municipality: FCWithLayout<any> = () => {
       </div>
       <div className="map-container">
         <MunicipalityChloropleth
-          tooltipContent={tooltipContent(router)}
-          onSelect={onSelectMunicipal}
+          tooltipContent={tooltipContent(onSelectMunicipal)}
+          onSelect={createSelectMunicipalHandler(
+            router,
+            'positief-geteste-mensen'
+          )}
           isSelectorMap={true}
         />
       </div>


### PR DESCRIPTION
## Summary

On mobile the municipality tooltip now links through to the numbers page instead of directly to positive tested people.

## Motivation

Bug report

## Detailed design

Added a media query to the tooltip in the municipal selector map that chooses between the two routes based on a mediaquery.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
