### PR TITLE
layout fix for gemeente page (ziekenhuis-opnames)

### DIFF
--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -51,16 +51,17 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         }}
       />
 
-      <article className="metric-article layout-two-column">
+      <article className="metric-article layout-two-column-two-row">
         <DataWarning />
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
+        <div className="row-item">
+          <div className="column-item column-item-extra-margin">
+            <h3>{text.barscale_titel}</h3>
+            <IntakeHospitalBarScale data={hospitalAdmissions} showAxis={true} />
+          </div>
 
-          <IntakeHospitalBarScale data={hospitalAdmissions} showAxis={true} />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
+          <div className="column-item column-item-extra-margin">
+            <p>{text.extra_uitleg}</p>
+          </div>
         </div>
       </article>
 


### PR DESCRIPTION
## Summary

This PR fixes a layout issue on the page of `ziekenhuis-opnames` on `gemeente` level.

### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
