### PR TITLE
Fixes not visible data in verpleeghuis locations

### DIFF
--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
@@ -73,7 +73,7 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         </article>
 
         <article className="metric-article column-item">
-          {infectedLocationsTotal && (
+          {infectedLocationsTotal !== undefined && (
             <h3>
               {text.kpi_titel}{' '}
               <span className="text-blue kpi">
@@ -86,7 +86,7 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         </article>
       </div>
 
-      {infectedLocationsTotal && (
+      {infectedLocationsTotal !== undefined && (
         <article className="metric-article">
           <LineChart
             title={text.linechart_titel}


### PR DESCRIPTION
## Summary

Fixes data in verpleeghuis page not being visible.

## Detailed design

* The check in question would show/hide things based on `infectedLocationsTotal && ....` Since this variable contains a number, it would be falsey for 0, and just show a 0 and no content.