### PR TITLE
fix decimals on tooltip besmette locaties

### DIFF
--- a/src/components/chloropleth/tooltips/region/createInfectedLocationsRegionalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/createInfectedLocationsRegionalTooltip.tsx
@@ -4,7 +4,7 @@ import { SafetyRegionProperties } from '../../shared';
 import { createSelectRegionHandler } from '../../selectHandlers/createSelectRegionHandler';
 import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent';
 import { RegionsNursingHome } from '~/types/data';
-import { formatNumber } from '~/utils/formatNumber';
+import { formatPercentage } from '~/utils/formatNumber';
 
 export const createInfectedLocationsRegionalTooltip = (router: NextRouter) => (
   context: RegionsNursingHome & SafetyRegionProperties & { value: number }
@@ -22,7 +22,7 @@ export const createInfectedLocationsRegionalTooltip = (router: NextRouter) => (
         <strong>
           {`${
             context.value !== undefined ? context.value : '-'
-          } (${formatNumber(context.infected_locations_percentage)}%)`}
+          } (${formatPercentage(context.infected_locations_percentage)}%)`}
         </strong>
       </TooltipContent>
     )


### PR DESCRIPTION
## Summary

This PR implements the `formatPercentage` to the tooltip used in `landelijk/verpleeghuis-besmette-locaties` so that the tooltip shows one decimal. This implementation must have been overlooked during [this PR](https://github.com/minvws/nl-covid19-data-dashboard/pull/568).


### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
