### PR TITLE
add datawarning to chloropleths VR & GM

### DIFF
--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -79,6 +79,9 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
       )}
 
       <article className="metric-article layout-chloropleth">
+        <div className="data-warning">
+          <DataWarning />
+        </div>
         <div className="chloropleth-header">
           <h3>
             {replaceVariablesInText(text.map_titel, {

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,8 +1,17 @@
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import Ziekenhuis from '~/assets/ziekenhuis.svg';
+
+import siteText from '~/locale/index';
+import getNlData, { INationalData } from '~/static-props/nl-data';
+
+import { IntakeHospitalBarScale } from '~/components/landelijk/intake-hospital-barscale';
+import { FCWithLayout } from '~/components/layout';
+import { getNationalLayout } from '~/components/layout/NationalLayout';
+
 import { ChartRegionControls } from '~/components/chartRegionControls';
 import { LineChart } from '~/components/charts/index';
+import { ContentHeaderMetadataHack } from '~/components/contentHeaderMetadataHack';
+
 import { ChloroplethLegenda } from '~/components/chloropleth/legenda/ChloroplethLegenda';
 import { useSafetyRegionLegendaData } from '~/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData';
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
@@ -11,14 +20,10 @@ import { createSelectMunicipalHandler } from '~/components/chloropleth/selectHan
 import { createSelectRegionHandler } from '~/components/chloropleth/selectHandlers/createSelectRegionHandler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/chloropleth/tooltips/municipal/createMunicipalHospitalAdmissionsTooltip';
 import { createRegionHospitalAdmissionsTooltip } from '~/components/chloropleth/tooltips/region/createRegionHospitalAdmissionsTooltip';
-import { ContentHeaderMetadataHack } from '~/components/contentHeaderMetadataHack';
-import { IntakeHospitalBarScale } from '~/components/landelijk/intake-hospital-barscale';
-import { FCWithLayout } from '~/components/layout';
-import { getNationalLayout } from '~/components/layout/NationalLayout';
-import siteText from '~/locale/index';
-import getNlData, { INationalData } from '~/static-props/nl-data';
-import { formatNumber } from '~/utils/formatNumber';
 import { DataWarning } from '~/components/dataWarning';
+
+import Ziekenhuis from '~/assets/ziekenhuis.svg';
+import { formatNumber } from '~/utils/formatNumber';
 
 const text = siteText.ziekenhuisopnames_per_dag;
 

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -81,6 +81,9 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
         </article>
       )}
       <article className="metric-article layout-chloropleth">
+        <div className="data-warning">
+          <DataWarning />
+        </div>
         <div className="chloropleth-header">
           <h3>
             {replaceVariablesInText(text.map_titel, {


### PR DESCRIPTION
## Summary

This PR implements the Data Warning component in the chloropleth maps on ziekenhuis-opnames (VR & GM)


### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
