### PR TITLE
Fix vr ggd total tested display

### DIFF
--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -176,7 +176,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
               <h3>
                 {ggdText.totaal_getest_week_titel}{' '}
                 <span className="text-blue kpi">
-                  {formatNumber(ggdData.infected_daily)}
+                  {formatNumber(ggdData.tested_total_daily)}
                 </span>
               </h3>
 


### PR DESCRIPTION
GGD total tested on VR was displaying the wrong data.