### PR TITLE
Fix SSR size of barchart

### DIFF
--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -178,7 +178,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           />
         </article>
       )}
-
+      {/* the barscale's initial SSR output was incorrect, giving both columns a fixed width solves this*/}
       <article className="metric-article layout-two-column">
         <div className="column-item-fixed">
           <h3>{text.barchart_titel}</h3>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -180,25 +180,27 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
       )}
 
       <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
+        <div className="column-item-fixed">
           <h3>{text.barchart_titel}</h3>
           <p>{text.barchart_toelichting}</p>
         </div>
-        {age && (
-          <BarChart
-            keys={text.barscale_keys}
-            data={age.values.map((value) => ({
-              y: value.infected_per_agegroup_increase || 0,
-              label: value?.infected_per_agegroup_increase
-                ? `${(
-                    ((value.infected_per_agegroup_increase as number) * 100) /
-                    barChartTotal
-                  ).toFixed(0)}%`
-                : false,
-            }))}
-            axisTitle={text.barchart_axis_titel}
-          />
-        )}
+        <div className="column-item-fixed">
+          {age && (
+            <BarChart
+              keys={text.barscale_keys}
+              data={age.values.map((value) => ({
+                y: value.infected_per_agegroup_increase || 0,
+                label: value?.infected_per_agegroup_increase
+                  ? `${(
+                      ((value.infected_per_agegroup_increase as number) * 100) /
+                      barChartTotal
+                    ).toFixed(0)}%`
+                  : false,
+              }))}
+              axisTitle={text.barchart_axis_titel}
+            />
+          )}
+        </div>
       </article>
 
       {ggdData && (

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -432,6 +432,12 @@ a.metric-link {
       margin: 0;
     }
 
+    .column-item-fixed {
+      flex: 0 0 50%;
+      display: flex;
+      flex-direction: column;
+    }
+
     .column-item {
       flex: 1 1 50%;
       display: flex;

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -432,6 +432,7 @@ a.metric-link {
       margin: 0;
     }
 
+    // in some cases a fixed column width is needed in order to make sure 'SSR-ed' charts render correctly:
     .column-item-fixed {
       flex: 0 0 50%;
       display: flex;


### PR DESCRIPTION
## Summary

The SSR size of the infected people barchart tile caused the barchart to initially render with a wrong size that displayed faulty axis values. This PR fixes that.

## Motivation

Bug report

## Detailed design

Having the flex shrink and grow options set to true caused the SSR problem. A new class was added called column-item-fixed that defines a column with a fixed width of 50%. This fixes the SSR issue.

## Drawbacks

n/a

## Alternatives

Let's hear it ;)

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
