### PR TITLE
Add total_installation_count key to average_sewer_installation_per_region schema

### DIFF
--- a/schema/regional/average_sewer_installation_per_region.json
+++ b/schema/regional/average_sewer_installation_per_region.json
@@ -9,6 +9,7 @@
         "week_end_unix",
         "vrcode",
         "average",
+        "total_installation_count",
         "date_of_insertion_unix"
       ],
       "properties": {
@@ -26,6 +27,9 @@
           "pattern": "^VR[0-9]+$"
         },
         "average": {
+          "type": "number"
+        },
+        "total_installation_count": {
           "type": "number"
         },
         "date_of_insertion_unix": {


### PR DESCRIPTION
## Summary

The installation count that was used to calculate the averages needs to be shown in the dashboard. We cannot simply use the installation count from the results_per_sewer_installation_per_region struct since apparently some logic is involved. So therefore this count will need to be added to the average_sewer_installation_per_region data.

## Motivation

Feature request

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
