### PR TITLE
Add line chart tile components

### DIFF
--- a/src/components-styled/kpi-tile.tsx
+++ b/src/components-styled/kpi-tile.tsx
@@ -2,6 +2,7 @@ import locale from '~/locale/index';
 import { Box, Spacer } from './base';
 import { ExternalLink } from './external-link';
 import { Text, Heading } from './typography';
+import { Tile } from './layout';
 
 interface KpiTileProps {
   title: string;
@@ -24,16 +25,7 @@ export function KpiTile({
   sourcedFrom,
 }: KpiTileProps) {
   return (
-    <Box
-      as="article"
-      display="flex"
-      flexDirection="column"
-      bg="white"
-      p={4}
-      borderRadius={1}
-      boxShadow="tile"
-      height="100%"
-    >
+    <Tile height="100%">
       <Heading level={3}>{title}</Heading>
       <Box mb={4}>{children}</Box>
       {description && (
@@ -53,6 +45,6 @@ export function KpiTile({
           </Text>
         </>
       )}
-    </Box>
+    </Tile>
   );
 }

--- a/src/components-styled/layout/index.ts
+++ b/src/components-styled/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './tile';

--- a/src/components-styled/layout/tile.tsx
+++ b/src/components-styled/layout/tile.tsx
@@ -1,0 +1,39 @@
+import { Box } from '../base';
+import { css } from '@styled-system/css';
+import styled from 'styled-components';
+
+// interface TileProps {
+//   children: React.ReactNode;
+// }
+
+// /**
+//  * A generic KPI tile which composes its value content using the children prop.
+//  * Description can be both plain text and html strings.
+//  */
+// export function Tile({ children }: TileProps) {
+//   return (
+//     <Box
+//       as="article"
+//       display="flex"
+//       flexDirection="column"
+//       bg="white"
+//       p={4}
+//       borderRadius={1}
+//       boxShadow="tile"
+//       // height="100%"
+//     >
+//       {children}
+//     </Box>
+//   );
+// }
+
+export const Tile = styled(Box)(
+  css({
+    display: 'flex',
+    flexDirection: 'column',
+    bg: 'white',
+    p: 4,
+    borderRadius: 1,
+    boxShadow: 'tile',
+  })
+);

--- a/src/components-styled/layout/tile.tsx
+++ b/src/components-styled/layout/tile.tsx
@@ -2,31 +2,6 @@ import { Box } from '../base';
 import { css } from '@styled-system/css';
 import styled from 'styled-components';
 
-// interface TileProps {
-//   children: React.ReactNode;
-// }
-
-// /**
-//  * A generic KPI tile which composes its value content using the children prop.
-//  * Description can be both plain text and html strings.
-//  */
-// export function Tile({ children }: TileProps) {
-//   return (
-//     <Box
-//       as="article"
-//       display="flex"
-//       flexDirection="column"
-//       bg="white"
-//       p={4}
-//       borderRadius={1}
-//       boxShadow="tile"
-//       // height="100%"
-//     >
-//       {children}
-//     </Box>
-//   );
-// }
-
 export const Tile = styled(Box)(
   css({
     display: 'flex',

--- a/src/components-styled/line-chart-tile.tsx
+++ b/src/components-styled/line-chart-tile.tsx
@@ -1,0 +1,53 @@
+import { LineChart } from '~/components/charts';
+// Props type needs to be imported from lineChart directly because charts only works with
+// default export.
+import { LineChartProps } from '~/components/lineChart';
+import locale from '~/locale/index';
+import { Spacer } from './base';
+import { ExternalLink } from './external-link';
+import { Tile } from './layout';
+import { Text } from './typography';
+
+interface LineChartTileProps extends LineChartProps {
+  sourcedFrom?: {
+    text: string;
+    href: string;
+  };
+}
+
+export function LineChartTile({
+  sourcedFrom,
+  ...chartProps
+}: LineChartTileProps) {
+  return (
+    <Tile
+      /**
+       * The mb here could alternatively be applied using a <Spacer/> in the
+       * page markup. It's a choice, whether we like to include the bottom
+       * margin on all our commonly used components or keep everything flexible
+       * and use spacers in the context where the component is used.
+       */
+      mb={4}
+      /**
+       * The ml and mr negative margins should not be part of this component
+       * ideally, but are the results of the page layout having paddings even on
+       * small screens. We can remove this once we make all page section
+       * elements full-width and remove the padding from the page layout.
+       */
+      ml={{ _: -4, sm: 0 }}
+      mr={{ _: -4, sm: 0 }}
+    >
+      <LineChart {...chartProps} />
+
+      {sourcedFrom && (
+        <>
+          {/* Using a spacer to push the footer down */}
+          <Spacer m="auto" />
+          <Text as="footer" mt={3}>
+            {locale.common.metadata.source}: <ExternalLink {...sourcedFrom} />
+          </Text>
+        </>
+      )}
+    </Tile>
+  );
+}

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -9,14 +9,14 @@ import { formatNumber } from '~/utils/formatNumber';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
 import styles from './lineChart.module.scss';
 
-type Value = {
+export type Value = {
   date: number;
-  value?: number;
+  value: number;
 };
 
 const SIGNAALWAARDE_Z_INDEX = 5;
 
-interface LineChartProps {
+export interface LineChartProps {
   title: string;
   description?: string;
   values: Value[];

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -6,7 +6,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { ChartRegionControls } from '~/components-styled/chart-region-controls';
-import { LineChart } from '~/components/charts/index';
 import { ChloroplethLegenda } from '~/components/chloropleth/legenda/ChloroplethLegenda';
 import { useSafetyRegionLegendaData } from '~/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData';
 import { MunicipalityChloropleth } from '~/components/chloropleth/MunicipalityChloropleth';
@@ -23,6 +22,7 @@ import { getNationalLayout } from '~/components/layout/NationalLayout';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
+import { LineChartTile } from '~/components-styled/line-chart-tile';
 
 const text = siteText.ziekenhuisopnames_per_dag;
 
@@ -75,48 +75,26 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
         </KpiTile>
       </TwoKpiSection>
 
-      <article className="metric-article">
-        <LineChart
-          title={text.linechart_titel}
-          description={text.linechart_description}
-          values={dataIntake.values.map((value: any) => ({
-            value: value.moving_average_hospital,
-            date: value.date_of_report_unix,
-          }))}
-          signaalwaarde={40}
-        />
-        <footer className="article-footer">
-          {siteText.common.metadata.source}:{' '}
-          <a
-            href={text.bronnen.rivm.href}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {text.bronnen.rivm.text}
-          </a>
-        </footer>
-      </article>
+      <LineChartTile
+        title={text.linechart_titel}
+        description={text.linechart_description}
+        values={dataIntake.values.map((value: any) => ({
+          value: value.moving_average_hospital,
+          date: value.date_of_report_unix,
+        }))}
+        signaalwaarde={40}
+        sourcedFrom={text.bronnen.rivm}
+      />
 
-      <article className="metric-article">
-        <LineChart
-          title={text.chart_bedbezetting.title}
-          description={text.chart_bedbezetting.description}
-          values={dataBeds.values.map((value) => ({
-            value: value.covid_occupied,
-            date: value.date_of_report_unix,
-          }))}
-        />
-        <footer className="article-footer">
-          {siteText.common.metadata.source}:{' '}
-          <a
-            href={text.bronnen.lnaz.href}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {text.bronnen.lnaz.text}
-          </a>
-        </footer>
-      </article>
+      <LineChartTile
+        title={text.chart_bedbezetting.title}
+        description={text.chart_bedbezetting.description}
+        values={dataBeds.values.map((value) => ({
+          value: value.covid_occupied,
+          date: value.date_of_report_unix,
+        }))}
+        sourcedFrom={text.bronnen.lnaz}
+      />
 
       <article className="metric-article layout-chloropleth">
         <div className="data-warning">


### PR DESCRIPTION
I have replaced the global-css based line chart page layouts with styled-system based tile abstractions. Also, the tile part of kpi-tile is extracted so that it can be reused.