### PR TITLE
fix: make metric component more narrow through class

### DIFF
--- a/src/components/barScale/styles.module.scss
+++ b/src/components/barScale/styles.module.scss
@@ -2,14 +2,13 @@
 
 .root {
   width: 100%;
-  height: 3rem;
+  height: 5rem;
 
   svg {
     width: 100%;
     height: 100%;
     overflow: visible;
     shape-rendering: crispEdges;
-    margin-top: -1em;
   }
 }
 

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -135,7 +135,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                       Icon={GetestIcon}
                       title={siteText.positief_geteste_personen.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <PositiveTestedPeopleMetric
                         data={data.infected_people_total.last_value}
                       />
@@ -159,7 +159,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                       Icon={ReproIcon}
                       title={siteText.reproductiegetal.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <ReproductionIndexMetric
                         data={
                           data.reproduction_index_last_known_average.last_value
@@ -206,7 +206,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                       Icon={Ziekenhuis}
                       title={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <IntakeHospitalMetric
                         data={data.intake_hospital_ma.last_value}
                       />
@@ -232,7 +232,7 @@ function NationalLayout(props: WithChildren<INationalData>) {
                       Icon={Arts}
                       title={siteText.ic_opnames_per_dag.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <IntakeIntensiveCareMetric
                         data={data.intake_intensivecare_ma.last_value}
                       />

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -161,7 +161,7 @@ function SafetyRegionLayout(props: WithChildren<ISafetyRegionData>) {
                             .titel_sidebar
                         }
                       />
-                      <span>
+                      <span className="metric-wrapper">
                         <PositivelyTestedPeopleMetric
                           data={data.results_per_region.last_value}
                         />

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -354,6 +354,11 @@
       }
     }
   }
+
+  .metric-wrapper > div:not(:first-child) {
+    height: 4rem;
+    margin-top: -1em;
+  }
 }
 
 .region-names {


### PR DESCRIPTION
## Summary

Adds a class `metric-wrapper` to make the metric components (with `barScale`) more narrow in the sidebar, without affecting the styles in the rest of the pages.

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
