### PR TITLE
Custom JSON validation for vrcodes

### DIFF
--- a/schema/municipal/__index.json
+++ b/schema/municipal/__index.json
@@ -20,12 +20,10 @@
       "pattern": "^GM[0-9]+$"
     },
     "name": {
-      "type": "string",
-      "pattern": "^GM[0-9]+$"
+      "const": { "$data": "1/proto_name" }
     },
     "code": {
-      "type": "string",
-      "pattern": "^GM[0-9]+$"
+      "const": { "$data": "1/proto_name" }
     },
     "hospital_admissions": {
       "$ref": "hospital_admissions.json"

--- a/schema/municipal/hospital_admissions.json
+++ b/schema/municipal/hospital_admissions.json
@@ -16,8 +16,7 @@
           "type": "integer"
         },
         "gmcode": {
-          "type": "string",
-          "pattern": "^GM[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "municipality_name": {
           "type": "string"

--- a/schema/municipal/positive_tested_people.json
+++ b/schema/municipal/positive_tested_people.json
@@ -17,8 +17,7 @@
           "type": "integer"
         },
         "gmcode": {
-          "type": "string",
-          "pattern": "^GM[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "municipality_name": {
           "type": "string"

--- a/schema/municipal/results_per_sewer_installation_per_municipality.json
+++ b/schema/municipal/results_per_sewer_installation_per_municipality.json
@@ -35,8 +35,7 @@
           "type": "string"
         },
         "gmcode": {
-          "type": "string",
-          "pattern": "^GM[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "rna_per_ml": {
           "type": "number"

--- a/schema/municipal/sewer_measurements.json
+++ b/schema/municipal/sewer_measurements.json
@@ -24,8 +24,7 @@
           "type": "integer"
         },
         "gmcode": {
-          "type": "string",
-          "pattern": "^GM[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "average": {
           "type": "number"

--- a/schema/municipalities/__index.json
+++ b/schema/municipalities/__index.json
@@ -21,12 +21,10 @@
       "enum": ["MUNICIPALITIES"]
     },
     "name": {
-      "type": "string",
-      "enum": ["MUNICIPALITIES"]
+      "const": { "$data": "1/proto_name" }
     },
     "code": {
-      "type": "string",
-      "enum": ["MUNICIPALITIES"]
+      "const": { "$data": "1/proto_name" }
     },
     "hospital_admissions": {
       "type": "array",

--- a/schema/national/__index.json
+++ b/schema/national/__index.json
@@ -12,7 +12,6 @@
     "infectious_people_count",
     "infectious_people_count_normalized",
     "intake_intensivecare_ma",
-    "infected_people_percentage",
     "infected_people_total",
     "infected_people_delta_normalized",
     "intake_share_age_groups",
@@ -35,12 +34,10 @@
       "enum": ["NL"]
     },
     "name": {
-      "type": "string",
-      "enum": ["NL"]
+      "const": { "$data": "1/proto_name" }
     },
     "code": {
-      "type": "string",
-      "enum": ["NL"]
+      "const": { "$data": "1/proto_name" }
     },
     "verdenkingen_huisartsen": {
       "$ref": "verdenkingen_huisartsen.json"

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "index",
   "type": "object",
   "title": "regionaal",
   "required": [

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "index",
   "type": "object",
   "title": "regionaal",
   "required": [
@@ -24,12 +23,10 @@
       "pattern": "^VR[0-9]+$"
     },
     "name": {
-      "type": "string",
-      "pattern": "^VR[0-9]+$"
+      "const": { "$data": "1/proto_name" }
     },
     "code": {
-      "type": "string",
-      "pattern": "^VR[0-9]+$"
+      "const": { "$data": "1/proto_name" }
     },
     "results_per_sewer_installation_per_region": {
       "$ref": "results_per_sewer_installation_per_region.json"

--- a/schema/regional/average_sewer_installation_per_region.json
+++ b/schema/regional/average_sewer_installation_per_region.json
@@ -23,8 +23,7 @@
           "type": "integer"
         },
         "vrcode": {
-          "type": "string",
-          "pattern": "^VR[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "average": {
           "type": "number"

--- a/schema/regional/ggd.json
+++ b/schema/regional/ggd.json
@@ -36,8 +36,7 @@
           "type": "integer"
         },
         "vrcode": {
-          "type": "string",
-          "pattern": "^VR[0-9]+$"
+          "equalsRootProperty": "code"
         }
       },
       "required": [

--- a/schema/regional/nursing_home.json
+++ b/schema/regional/nursing_home.json
@@ -42,8 +42,7 @@
           "type": "integer"
         },
         "vrcode": {
-          "type": "string",
-          "pattern": "^VR[0-9]+$"
+          "equalsRootProperty": "code"
         }
       },
       "required": [

--- a/schema/regional/results_per_region.json
+++ b/schema/regional/results_per_region.json
@@ -16,7 +16,7 @@
       ],
       "properties": {
         "date_of_report_unix": { "type": "integer" },
-        "vrcode": { "type": "string", "pattern": "^VR[0-9]+$" },
+        "vrcode": { "equalsRootProperty": "code" },
         "total_reported_increase_per_region": { "type": "number" },
         "infected_total_counts_per_region": { "type": "number" },
         "hospital_total_counts_per_region": { "type": "number" },

--- a/schema/regional/results_per_sewer_installation_per_region.json
+++ b/schema/regional/results_per_sewer_installation_per_region.json
@@ -55,8 +55,7 @@
           "type": "string"
         },
         "vrcode": {
-          "type": "string",
-          "pattern": "^VR[0-9]+$"
+          "equalsRootProperty": "code"
         },
         "vrnaam": {
           "type": "string"

--- a/schema/regions/__index.json
+++ b/schema/regions/__index.json
@@ -23,12 +23,10 @@
       "enum": ["REGIONS"]
     },
     "name": {
-      "type": "string",
-      "enum": ["REGIONS"]
+      "const": { "$data": "1/proto_name" }
     },
     "code": {
-      "type": "string",
-      "enum": ["REGIONS"]
+      "const": { "$data": "1/proto_name" }
     },
     "hospital_admissions": {
       "type": "array",

--- a/src/tools/validator/createValidateFunction.ts
+++ b/src/tools/validator/createValidateFunction.ts
@@ -51,7 +51,7 @@ export function createValidateFunction(schemaPath: string) {
           (equalsRootProperty as any).errors = [
             {
               keyword: 'equalsRootProperty',
-              message: `the property ${_dataPath}'s value '${data}' must be equal to the root property ${schema}'s value '${rootValue}'`,
+              message: `the property '${_dataPath}' value '${data}' must be equal to the root property '${schema}' value '${rootValue}'`,
               params: {
                 keyword: 'equalsRootProperty',
                 value: schema,

--- a/src/tools/validator/createValidateFunction.ts
+++ b/src/tools/validator/createValidateFunction.ts
@@ -31,6 +31,39 @@ export function createValidateFunction(schemaPath: string) {
   const validator = new Ajv({
     loadSchema: loadSchema.bind(null, basePath),
     $data: true,
+    allErrors: true,
+  });
+  validator.addKeyword('equalsRootProperty', {
+    type: 'string',
+    validate: function equalsRootProperty(
+      schema: any,
+      data: any,
+      _parentSchema?: any,
+      _dataPath?: string,
+      _parentData?: any | any[],
+      _parentDataProperty?: string | number,
+      rootData?: any | any[]
+    ): boolean {
+      if (rootData) {
+        const rootValue = (rootData as any)[schema as string];
+        const validated = data === rootValue;
+        if (!validated) {
+          (equalsRootProperty as any).errors = [
+            {
+              keyword: 'equalsRootProperty',
+              message: `the property ${_dataPath}'s value '${data}' must be equal to the root property ${schema}'s value '${rootValue}'`,
+              params: {
+                keyword: 'equalsRootProperty',
+                value: schema,
+              },
+            },
+          ];
+        }
+        return validated;
+      }
+      return true;
+    },
+    errors: true,
   });
   return validator.compileAsync(schema).then((validate) => {
     return validate;

--- a/src/tools/validator/validate-json.ts
+++ b/src/tools/validator/validate-json.ts
@@ -8,7 +8,7 @@ import chalk from 'chalk';
 
 const allJsonFiles = fs.readdirSync(jsonBasePath);
 
-// This struct defines which JSON files should be validated with which schema
+// This struct defines which JSON files should be validated with which schema.
 const schemaToJsonLookup: Record<string, string[]> = {
   national: ['NL.json'],
   ranges: ['RANGES.json'],

--- a/src/tools/validator/validate-json.ts
+++ b/src/tools/validator/validate-json.ts
@@ -18,6 +18,24 @@ const schemaToJsonLookup: Record<string, string[]> = {
   regions: ['REGIONS.json'],
 };
 
+if (schemaToJsonLookup.regional.length !== 25) {
+  console.error(
+    chalk.bgRed.bold(
+      `\n Expected 25 region files, actually found ${schemaToJsonLookup.regional.length} \n`
+    )
+  );
+  process.exit(1);
+}
+
+if (schemaToJsonLookup.municipal.length !== 355) {
+  console.error(
+    chalk.bgRed.bold(
+      `\n Expected 355 municipal files, actually found ${schemaToJsonLookup.municipal.length} \n`
+    )
+  );
+  process.exit(1);
+}
+
 // The validations are asynchronous so this reducer gathers all the Promises in one array.
 const validationPromises = Object.keys(schemaToJsonLookup).map<
   Promise<boolean[]>


### PR DESCRIPTION
## Summary

We encountered a data drop where the blocks of data from one region were added to all of the other regions.
In this case the average_sewer_installation_per_region data for region VR25 was added to all the other regions.
To prevent another situation like this a custom keyword was added to the JSON validation that is able to check
whether the VRCode on a subobject is equal to the 'code' property on the root object.

## Motivation

Bug report

## Detailed design

A custom keyword called 'equalsRootProperty' was added in the createValidateFunction.ts file.
equalsRootProperty can be configured with the name of a property that ought to exist on the root document.
For example:
``
"gmcode": {
   "equalsRootProperty": "code"
},
``
This will check if the value of the property 'gmcode ' is equal to the value of the property 'code' on the root object.

Lastly, some simple sanity checks were added to validate-json.ts that checks the correct number of regional and municipal files.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
