### PR TITLE
Fix bar scale layout

### DIFF
--- a/src/components/barScale/styles.module.scss
+++ b/src/components/barScale/styles.module.scss
@@ -2,14 +2,13 @@
 
 .root {
   width: 100%;
-  height: 3rem;
+  height: 5rem;
 
   svg {
     width: 100%;
     height: 100%;
     overflow: visible;
     shape-rendering: crispEdges;
-    margin-top: -1em;
   }
 }
 


### PR DESCRIPTION
## Summary

Bar scale components were rendering outside of their own bounding box, causing them to collide with headers.