### PR TITLE
Add sewerwater tile redesign

### DIFF
--- a/src/components-styled/line-chart-tile.tsx
+++ b/src/components-styled/line-chart-tile.tsx
@@ -1,7 +1,6 @@
-import { LineChart } from '~/components/charts';
 // Props type needs to be imported from lineChart directly because charts only works with
 // default export.
-import { LineChartProps } from '~/components/lineChart';
+import LineChart, { LineChartProps } from '~/components/lineChart';
 import locale from '~/locale/index';
 import { Spacer } from './base';
 import { ExternalLink } from './external-link';

--- a/src/components/collapsable/index.tsx
+++ b/src/components/collapsable/index.tsx
@@ -69,7 +69,8 @@ export function Collapsable(props: CollapsableProps) {
     return () => {
       window.removeEventListener('hashchange', checkLocationHash, false);
     };
-  }, []); // should not use dependancies in array: use effect mimics mount / unmount
+    /* eslint-disable-next-line */
+  }, []); // should not use dependencies in array: use effect mimics mount / unmount
 
   useWindowResizeDebounce(setContentHeight, 400);
 

--- a/src/components/lineChart/lineChartWithWeekTooltip.tsx
+++ b/src/components/lineChart/lineChartWithWeekTooltip.tsx
@@ -8,18 +8,18 @@ import { getItemFromArray } from '~/utils/getItemFromArray';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
 import styles from './lineChart.module.scss';
 
-interface Value {
+export interface Value {
   date: number;
   value?: number;
   week: Week;
 }
 
-type Week = {
+export type Week = {
   start: number;
   end: number;
 };
 
-type LineChartProps = {
+export type LineChartProps = {
   values: Value[];
   title: string;
   description?: string;
@@ -148,9 +148,9 @@ function getOptions(values: Value[]): Highcharts.Options {
 }
 
 export function LineChart({
-  values,
   title,
   description,
+  values,
   timeframeOptions,
 }: LineChartProps) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -411,7 +411,9 @@
       "description": "Average number of virus particles in one milliliter of sewage water, collected from about 300 sites in the Netherlands."
     },
     "titel_sidebar": "",
-    "titel_kpi": ""
+    "titel_kpi": "",
+    "total_installation_count_titel": "Aantal RWZI-locaties",
+    "total_installation_count_description": "Aantal locaties dat wordt meegenomen in het berekenen van het gemiddelde.\nRWZI = Rioolwaterzuiveringsinstallatie."
   },
   "notfound_titel": {
     "text": "Something went wrong"
@@ -766,7 +768,9 @@
     "graph_daily_label_text_rwzi": "",
     "graph_selected_rwzi_placeholder": "",
     "graph_range_description": "",
-    "titel_kpi": ""
+    "titel_kpi": "",
+    "total_installation_count_titel": "Aantal RWZI-locaties",
+    "total_installation_count_description": "Aantal locaties dat wordt meegenomen in het berekenen van het gemiddelde.\nRWZI = Rioolwaterzuiveringsinstallatie."
   },
   "gemeente_ziekenhuisopnames_per_dag": {
     "titel_sidebar": "Hospital admissions by day",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -411,7 +411,9 @@
       "description": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater, afkomstig van circa 300 locaties in Nederland."
     },
     "titel_sidebar": "Rioolwatermeting",
-    "titel_kpi": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater"
+    "titel_kpi": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater",
+    "total_installation_count_titel": "Aantal RWZI-locaties",
+    "total_installation_count_description": "Aantal locaties dat wordt meegenomen in het berekenen van het gemiddelde.\nRWZI = Rioolwaterzuiveringsinstallatie."
   },
   "notfound_titel": {
     "text": "Er is iets misgegaan"
@@ -766,7 +768,9 @@
     "graph_daily_label_text_rwzi": "Dagwaarde aantal virusdeeltjes in 1 mL rioolwater ({{name}})",
     "graph_selected_rwzi_placeholder": "Selecteer RWZI",
     "graph_range_description": "Verloop over tijd",
-    "titel_kpi": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater"
+    "titel_kpi": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater",
+    "total_installation_count_titel": "Aantal RWZI-locaties",
+    "total_installation_count_description": "Aantal locaties dat wordt meegenomen in het berekenen van het gemiddelde.\nRWZI = Rioolwaterzuiveringsinstallatie."
   },
   "gemeente_ziekenhuisopnames_per_dag": {
     "titel_sidebar": "Ziekenhuisopnames per dag",

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,20 +1,22 @@
 import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
+import { LineChartTile } from '~/components-styled/line-chart-tile';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { FCWithLayout } from '~/components/layout';
 import { ContentHeader } from '~/components/layout/Content';
 import { getNationalLayout } from '~/components/layout/NationalLayout';
-import { LineChart } from '~/components/lineChart/lineChartWithWeekTooltip';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { RioolwaterMetingen } from '~/types/data.d';
-import { formatNumber } from '~/utils/formatNumber';
 
 const text = siteText.rioolwater_metingen;
 
 const SewerWater: FCWithLayout<INationalData> = (props) => {
   const { data: state } = props;
 
-  const data: RioolwaterMetingen | undefined = state?.rioolwater_metingen;
+  const data: RioolwaterMetingen = state?.rioolwater_metingen;
 
   return (
     <>
@@ -30,37 +32,35 @@ const SewerWater: FCWithLayout<INationalData> = (props) => {
         metadata={{
           datumsText: text.datums,
           dateUnix: data?.last_value?.week_unix,
-          dateInsertedUnix: data?.last_value?.date_of_insertion_unix,
+          dateInsertedUnix: data.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <p className="text-blue kpi" data-cy="infected_daily_total">
-            {formatNumber(data.last_value.average)}
-          </p>
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
-
-      {data?.values && (
-        <article className="metric-article">
-          <LineChart
-            title={text.linechart_titel}
-            timeframeOptions={['all', '5weeks']}
-            values={data.values.map((value) => ({
-              value: Number(value.average),
-              date: value.week_unix,
-              week: { start: value.week_start_unix, end: value.week_end_unix },
-            }))}
+      <TwoKpiSection>
+        <KpiTile title={text.barscale_titel} description={text.extra_uitleg}>
+          <KpiValue
+            absolute={data.last_value.average}
+            data-cy="infected_daily_total"
           />
-        </article>
-      )}
+        </KpiTile>
+        <KpiTile
+          title={text.total_installation_count_titel}
+          description={text.total_installation_count_description}
+        >
+          <KpiValue absolute={data.last_value.total_installation_count} />
+        </KpiTile>
+      </TwoKpiSection>
+
+      <LineChartTile
+        title={text.linechart_titel}
+        timeframeOptions={['all', '5weeks']}
+        values={data.values.map((value) => ({
+          value: Number(value.average),
+          date: value.week_unix,
+          week: { start: value.week_start_unix, end: value.week_end_unix },
+        }))}
+      />
     </>
   );
 };

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -25,6 +25,9 @@ import {
   getSewerWaterScatterPlotData,
 } from '~/utils/sewer-water/safety-region-sewer-water.util';
 import { TimeframeOption } from '~/utils/timeframe';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.veiligheidsregio_rioolwater_metingen;
 
@@ -76,6 +79,28 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
           dataSource: text.bron,
         }}
       />
+
+      {barScaleData && barScaleData.value !== undefined && (
+        <TwoKpiSection>
+          <KpiTile title={text.barscale_titel} description={text.extra_uitleg}>
+            <KpiValue
+              absolute={barScaleData.value}
+              data-cy="infected_daily_total"
+            />
+          </KpiTile>
+          <KpiTile
+            title={text.total_installation_count_titel}
+            description={text.total_installation_count_description}
+          >
+            <KpiValue
+              absolute={
+                data.average_sewer_installation_per_region.last_value
+                  .total_installation_count
+              }
+            />
+          </KpiTile>
+        </TwoKpiSection>
+      )}
 
       <article className="metric-article layout-two-column">
         <div className="column-item column-item-extra-margin">

--- a/src/utils/useWindowResizeDebounce.ts
+++ b/src/utils/useWindowResizeDebounce.ts
@@ -18,5 +18,6 @@ export const useWindowResizeDebounce = (
     return () => {
       window.removeEventListener('resize', handleResize);
     };
+    /* eslint-disable-next-line */
   }, []);
 };


### PR DESCRIPTION
## Summary

Replaces the single upper tile on the sewerwater pages with two separate tiles explaining the numbers and showing the total installation count.

## Motivation

Feature request

## Detailed design

Changed the two tiles and refactored the specified pages into using styled components.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
