### PR TITLE
Fixes clipping of region control due to overflow

### DIFF
--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -556,7 +556,6 @@ a.metric-link {
 
     margin: 0 0 1rem;
     max-width: 100%;
-    overflow: hidden;
 
     @media (min-width: $chloropleth-breakpoint) {
       justify-content: flex-start;


### PR DESCRIPTION
## Summary

Outline is now visible again.

As far as I could see on different screen sizes, the overflow did not do anything for the maps.