### PR TITLE
absolute positive tested tooltip

### DIFF
--- a/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
@@ -33,7 +33,7 @@ export const createPositiveTestedPeopleMunicipalTooltip = (
               <p className="info-value">{value} per 100.000</p>
               <p className="info-total">
                 {replaceVariablesInText(text.positive_tested_people, {
-                  total_positive_tested_people,
+                  totalPositiveTestedPeople: total_positive_tested_people,
                 })}
               </p>
             </>

--- a/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
@@ -3,11 +3,21 @@ import { ReactNode } from 'react';
 import { MunicipalityProperties } from '../../shared';
 import { createSelectMunicipalHandler } from '../../selectHandlers/createSelectMunicipalHandler';
 import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent';
+import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import siteText from '~/locale/index';
+const text = siteText.common.tooltip;
 
 export const createPositiveTestedPeopleMunicipalTooltip = (
   router: NextRouter
-) => (context: MunicipalityProperties & { value: number }): ReactNode => {
+) => (
+  context: MunicipalityProperties & {
+    value: number;
+    total_positive_tested_people: number;
+  }
+): ReactNode => {
   const onSelectHandler = createSelectMunicipalHandler(router);
+
+  const { gemnaam, value, total_positive_tested_people } = context;
 
   const onSelect = (event: any) => {
     event.stopPropagation();
@@ -16,9 +26,20 @@ export const createPositiveTestedPeopleMunicipalTooltip = (
 
   return (
     context && (
-      <TooltipContent title={context.gemnaam} onSelect={onSelect}>
+      <TooltipContent title={gemnaam} onSelect={onSelect}>
         <span>
-          {context.value !== undefined ? `${context.value} per 100.000` : '-'}
+          {value !== undefined ? (
+            <>
+              <p className="info-value">{value} per 100.000</p>
+              <p className="info-total">
+                {replaceVariablesInText(text.positive_tested_people, {
+                  total_positive_tested_people,
+                })}
+              </p>
+            </>
+          ) : (
+            '-'
+          )}
         </span>
       </TooltipContent>
     )

--- a/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/municipal/createPositiveTestedPeopleMunicipalTooltip.tsx
@@ -33,7 +33,7 @@ export const createPositiveTestedPeopleMunicipalTooltip = (
               <p className="info-value">{value} per 100.000</p>
               <p className="info-total">
                 {replaceVariablesInText(text.positive_tested_people, {
-                  totalPositiveTestedPeople: total_positive_tested_people,
+                  totalPositiveTestedPeople: `${total_positive_tested_people}`,
                 })}
               </p>
             </>

--- a/src/components/chloropleth/tooltips/region/createPositiveTestedPeopleRegionalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/createPositiveTestedPeopleRegionalTooltip.tsx
@@ -31,7 +31,7 @@ export const createPositiveTestedPeopleRegionalTooltip = (
         <p className="info-value">{formatNumber(value)} per 100.000</p>
         <p className="info-total">
           {replaceVariablesInText(text.positive_tested_people, {
-            totalPositiveTestedPeople: total_positive_tested_people,
+            totalPositiveTestedPeople: `${total_positive_tested_people}`,
           })}
         </p>
       </TooltipContent>

--- a/src/components/chloropleth/tooltips/region/createPositiveTestedPeopleRegionalTooltip.tsx
+++ b/src/components/chloropleth/tooltips/region/createPositiveTestedPeopleRegionalTooltip.tsx
@@ -4,11 +4,21 @@ import { TooltipContent } from '~/components/chloropleth/tooltips/tooltipContent
 import { formatNumber } from '~/utils/formatNumber';
 import { createSelectRegionHandler } from '../../selectHandlers/createSelectRegionHandler';
 import { SafetyRegionProperties } from '../../shared';
+import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import siteText from '~/locale/index';
+const text = siteText.common.tooltip;
 
 export const createPositiveTestedPeopleRegionalTooltip = (
   router: NextRouter
-) => (context: SafetyRegionProperties & { value: number }): ReactNode => {
+) => (
+  context: SafetyRegionProperties & {
+    value: number;
+    total_positive_tested_people: number;
+  }
+): ReactNode => {
   const handler = createSelectRegionHandler(router);
+
+  const { vrname, value, total_positive_tested_people } = context;
 
   const onSelect = (event: any) => {
     event.stopPropagation();
@@ -17,8 +27,13 @@ export const createPositiveTestedPeopleRegionalTooltip = (
 
   return (
     context && (
-      <TooltipContent title={context.vrname} onSelect={onSelect}>
-        <strong>{`${formatNumber(context.value)} per 100.000`}</strong>
+      <TooltipContent title={vrname} onSelect={onSelect}>
+        <p className="info-value">{formatNumber(value)} per 100.000</p>
+        <p className="info-total">
+          {replaceVariablesInText(text.positive_tested_people, {
+            totalPositiveTestedPeople: total_positive_tested_people,
+          })}
+        </p>
       </TooltipContent>
     )
   );

--- a/src/components/chloropleth/tooltips/tooltip.module.scss
+++ b/src/components/chloropleth/tooltips/tooltip.module.scss
@@ -73,6 +73,16 @@
     font-size: 1rem;
     cursor: pointer;
     border-top: 1px solid #c4c4c4;
+
+    p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    p:first-child {
+      font-weight: bold;
+      margin-bottom: 4px;
+    }
   }
 }
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -637,6 +637,9 @@
     "veiligheidsregio_label": "Safety region:",
     "metricKPI": {
       "dateOfReport": ""
+    },
+    "tooltip": {
+      "positive_tested_people": "{{totalPositiveTestedPeople}} in total"
     }
   },
   "seoHead": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -637,6 +637,9 @@
     "veiligheidsregio_label": "Veiligheidsregio:",
     "metricKPI": {
       "dateOfReport": "Waarde van {{dateOfReport}}"
+    },
+    "tooltip": {
+      "positive_tested_people": "{{totalPositiveTestedPeople}} in totaal"
     }
   },
   "seoHead": {


### PR DESCRIPTION
## Summary

This adds the total number of positive tested people per region to the tooltip. The tooltip now shows the value per 100.000 first, followed by the total amount.


### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
