### PR TITLE
Fix font rendering for MacOS

### DIFF
--- a/src/style/global-style.tsx
+++ b/src/style/global-style.tsx
@@ -52,6 +52,8 @@ html {
 */
 html {
   -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   line-height: 1.15;
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
Restores font-rendering for MacOS to what it was before. Not sure why it changed, but it probably caused by the styled-system spike.