### PR TITLE
ailgn legend on flex-start

### DIFF
--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -539,11 +539,7 @@ a.metric-link {
     grid-area: b;
     display: flex;
     flex-direction: column;
-    align-items: center;
-
-    @media (min-width: $chloropleth-breakpoint) {
-      align-items: flex-start;
-    }
+    align-items: flex-start;
   }
 
   .chloropleth-chart {


### PR DESCRIPTION
## Summary

Fixes the alignment of the legend to `flex-start` using the `layout.scss` file, this should be refactured to use the inline styled systems components soon.

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
