### PR TITLE
Fix disappearing choropleth on infected locations page

### DIFF
--- a/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
+++ b/src/components/chloropleth/legenda/hooks/useSafetyRegionLegendaData.ts
@@ -7,8 +7,6 @@ import {
 import { useLegendaItems } from './useLegendaItems';
 import { regionThresholds } from '~/components/chloropleth/regionThresholds';
 
-import { get } from 'lodash';
-
 export function getSelectedThreshold(
   metricName?: TRegionMetricName,
   metricValueName?: string
@@ -20,10 +18,10 @@ export function getSelectedThreshold(
   // Even if a metricValueName is passed in, there's not necessarily
   // a threshold defined for this. In that case we fall back to the threshold
   // that exists for the metric name.
-  const thresholdInfo = metricValueName
-    ? get(regionThresholds, `${metricName}.${metricValueName}`) ??
-      regionThresholds[metricName]
-    : regionThresholds[metricName];
+  const thresholdInfo =
+    (metricValueName
+      ? (regionThresholds as any)?.[metricName]?.[metricValueName]
+      : regionThresholds[metricName]) ?? regionThresholds[metricName];
 
   return thresholdInfo as ChoroplethThresholds;
 }


### PR DESCRIPTION
## Summary

For some reason the thresholds for the infected locations wasn't resolved properly anymore, resulting in a completely white map.

## Motivation

bug report

## Detailed design

Lodash/get didn't resolve the given path anymore, for some reason. This code wasn't changed, but all of a sudden this didn't work anymore.
I couldn't quickly enough figure out why this happened so I just opted for resolving the property manually.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
