### PR TITLE
Add no-data state to municipal sewerwater sidebar item

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -100,6 +100,8 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
     | { name: string; code: string; id: number }
     | undefined = getSafetyRegionForMunicipalityCode(code as string);
 
+  const sewerWaterBarScaleData = getSewerWaterBarScaleData(data);
+
   return (
     <>
       <Head>
@@ -209,7 +211,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
               <h2>{siteText.nationaal_layout.headings.overig}</h2>
               <ul>
                 <li>
-                  {getSewerWaterBarScaleData(data) ? (
+                  {sewerWaterBarScaleData ? (
                     <Link
                       href="/gemeente/[code]/rioolwater"
                       as={`/gemeente/${code}/rioolwater`}
@@ -225,9 +227,7 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
                           }
                         />
                         <span>
-                          <SewerWaterMetric
-                            data={getSewerWaterBarScaleData(data)}
-                          />
+                          <SewerWaterMetric data={sewerWaterBarScaleData} />
                         </span>
                       </a>
                     </Link>
@@ -239,11 +239,9 @@ function MunicipalityLayout(props: WithChildren<IMunicipalityData>) {
                           siteText.gemeente_rioolwater_metingen.titel_sidebar
                         }
                       />
-                      <span>
-                        <SewerWaterMetric
-                          data={getSewerWaterBarScaleData(data)}
-                        />
-                      </span>
+                      <p>
+                        {siteText.gemeente_rioolwater_metingen.nodata_sidebar}
+                      </p>
                     </div>
                   )}
                 </li>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -832,6 +832,7 @@
   },
   "gemeente_rioolwater_metingen": {
     "titel_sidebar": "Sewage water examination",
+    "nodata_sidebar": "This information is unavailable for this municipality.",
     "titel": "Sewage water examination in {{municipality}}",
     "pagina_toelichting": "Average number of virus particles in one milliliter of sewage water of this municipality. To calculate this, the total number of measured virus particles in one week, is divided by the number of measurements.",
     "datums": "Value of {{weekStart}} to {{weekEnd}}. Obtained: {{dateOfInsertion}}. Is updated on a daily basis.",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -832,6 +832,7 @@
   },
   "gemeente_rioolwater_metingen": {
     "titel_sidebar": "Rioolwatermeting",
+    "nodata_sidebar": "Deze informatie is niet beschikbaar voor deze gemeente.",
     "titel": "Rioolwatermeting in {{municipality}}",
     "pagina_toelichting": "Gemiddeld aantal virusdeeltjes in een milliliter rioolwater van deze gemeente. Voor deze berekening wordt uitgegaan van het totaal aantal gemeten virusdeeltjes in één week, gedeeld door het aantal metingen.",
     "datums": "Waarde van {{weekStart}} tot {{weekEnd}}. Verkregen: {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",


### PR DESCRIPTION
## Summary

The sewer water sidebar item for municipalities wasn't showing a no-data indicator correctly. This PR fixes that.

## Motivation

Bug report

## Detailed design

Not much to say really. Just an additional locale key and some text placement.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
