### PR TITLE
Fixes small issues for GGD axis labels, legends

### DIFF
--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -23,12 +23,14 @@ export interface LineChartProps {
   signaalwaarde?: number;
   timeframeOptions?: TimeframeOption[];
   formatTooltip?: (x: number, y: number) => string;
+  formatYAxis?: (y: number) => string;
 }
 
 function getChartOptions(
   values: Value[],
   signaalwaarde?: number,
-  formatTooltip?: (x: number, y: number) => string
+  formatTooltip?: (x: number, y: number) => string,
+  formatYAxis?: (y: number) => string
 ) {
   const yMax = calculateYMax(values, signaalwaarde);
 
@@ -90,6 +92,9 @@ function getChartOptions(
       },
       labels: {
         formatter: function () {
+          if (formatYAxis) {
+            return formatYAxis(this.value);
+          }
           return formatNumber(this.value);
         },
       },
@@ -175,6 +180,7 @@ export default function LineChart({
   signaalwaarde,
   timeframeOptions,
   formatTooltip,
+  formatYAxis,
 }: LineChartProps) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
 
@@ -184,8 +190,13 @@ export default function LineChart({
       timeframe,
       (value: Value) => value.date * 1000
     );
-    return getChartOptions(filteredValues, signaalwaarde, formatTooltip);
-  }, [values, timeframe, signaalwaarde, formatTooltip]);
+    return getChartOptions(
+      filteredValues,
+      signaalwaarde,
+      formatTooltip,
+      formatYAxis
+    );
+  }, [values, timeframe, signaalwaarde, formatTooltip, formatYAxis]);
 
   return (
     <section className={styles.root}>

--- a/src/components/lineChart/multipleLineChart.tsx
+++ b/src/components/lineChart/multipleLineChart.tsx
@@ -57,7 +57,7 @@ function getChartOptions(
       borderWidth: 0,
       colorCount: 10,
       displayErrors: true,
-      height: 175,
+      height: 212,
     },
     credits: {
       enabled: false,
@@ -176,6 +176,12 @@ function getChartOptions(
         enabled: false,
       },
     })),
+    legend: {
+      align: 'left',
+      itemStyle: {
+        fontWeight: 'normal',
+      },
+    },
     plotOptions: {
       line: {
         marker: {

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -256,6 +256,9 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           formatTooltip={(x: number, y: number) => {
             return `${formatDateFromSeconds(x)}: ${formatPercentage(y)}%`;
           }}
+          formatYAxis={(y: number) => {
+            return `${formatPercentage(y)}%`;
+          }}
         />
       </KpiSection>
 

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -38,6 +38,7 @@ import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
+import { formatDateFromSeconds } from '~/utils/formatDate';
 
 const text = siteText.veiligheidsregio_positief_geteste_personen;
 const ggdText = siteText.veiligheidsregio_positief_geteste_personen_ggd;
@@ -218,7 +219,12 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
             value: value.infected_percentage_daily,
             date: value.date_of_report_unix,
           }))}
-          signaalwaarde={7}
+          formatTooltip={(x: number, y: number) => {
+            return `${formatDateFromSeconds(x)}: ${formatPercentage(y)}%`;
+          }}
+          formatYAxis={(y: number) => {
+            return `${formatPercentage(y)}%`;
+          }}
         />
       </KpiSection>
 
@@ -246,7 +252,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
               legendLabel: ggdText.linechart_positivetests_legend_label,
             },
           ]}
-          signaalwaarde={7}
         />
       </KpiSection>
     </>


### PR DESCRIPTION
## Summary

Small adjustments to GGD linecharts: y axis formatter, alignment/styling of legends.

## Detailed design

Height of the multi line chart is stretched to make room for the legend.

Also applies https://github.com/minvws/nl-covid19-data-dashboard/pull/730  to safety region level.

