### PR TITLE
change 'verdeling naar leeftijd' layout

### DIFF
--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -173,12 +173,12 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         }))}
       />
 
-      <KpiSection>
-        <Box flex="0 0 50%">
+      <KpiSection flexDirection="column">
+        <Box>
           <Heading level={3}>{text.barchart_titel}</Heading>
           <Text>{text.barchart_toelichting}</Text>
         </Box>
-        <Box flex="0 0 50%">
+        <Box>
           <BarChart
             keys={text.barscale_keys}
             data={age.values.map((value) => ({


### PR DESCRIPTION
## Summary

This PR changes the layout of the 'verdeling naar leeftijd' section by chaning the `flexDirection` to `column`.


### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
