### PR TITLE
Update ggd schemas with week range and remove daily suffix

### DIFF
--- a/schema/national/ggd.json
+++ b/schema/national/ggd.json
@@ -20,16 +20,22 @@
       "title": "national_ggd_value",
       "type": "object",
       "properties": {
-        "infected_daily": {
+        "infected": {
           "type": "integer"
         },
-        "infected_percentage_daily": {
+        "infected_percentage": {
           "type": "number"
         },
-        "tested_total_daily": {
+        "tested_total": {
           "type": "integer"
         },
-        "date_of_report_unix": {
+        "week_unix": {
+          "type": "integer"
+        },
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {
@@ -37,10 +43,12 @@
         }
       },
       "required": [
-        "tested_total_daily",
-        "infected_percentage_daily",
-        "infected_daily",
-        "date_of_report_unix",
+        "tested_total",
+        "infected_percentage",
+        "infected",
+        "week_unix",
+        "week_start_unix",
+        "week_end_unix",
         "date_of_insertion_unix"
       ],
       "additionalProperties": false

--- a/schema/regional/ggd.json
+++ b/schema/regional/ggd.json
@@ -20,16 +20,22 @@
       "title": "regional_ggd_value",
       "type": "object",
       "properties": {
-        "infected_daily": {
+        "infected": {
           "type": "integer"
         },
-        "infected_percentage_daily": {
+        "infected_percentage": {
           "type": "number"
         },
-        "tested_total_daily": {
+        "tested_total": {
           "type": "integer"
         },
-        "date_of_report_unix": {
+        "week_unix": {
+          "type": "integer"
+        },
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {
@@ -41,10 +47,12 @@
         }
       },
       "required": [
-        "infected_daily",
-        "infected_percentage_daily",
-        "tested_total_daily",
-        "date_of_report_unix",
+        "infected",
+        "infected_percentage",
+        "tested_total",
+        "week_unix",
+        "week_start_unix",
+        "week_end_unix",
         "date_of_insertion_unix",
         "vrcode"
       ],


### PR DESCRIPTION
## Summary

The GGD data is measured weekly so we needed week range information. For that same reason the misleading _daily suffix was removed.

## Changes Affecting Backend

### Root key changes

(none)

### Property changes

- NL ggd `tested_total_daily` => `tested_total`
- NL ggd `infected_percentage_daily` => `infected_percentage`
- NL ggd `infected_daily` => `infected`
- NL ggd `week_unix` ADD
- NL ggd `week_start_unix` ADD
- NL ggd `week_end_unix` ADD
- NL ggd `date_of_report_unix` DELETE
- VR ggd `tested_total_daily` => `tested_total`
- VR ggd `infected_percentage_daily` => `infected_percentage`
- VR ggd `infected_daily` => `infected`
- VR ggd `week_unix` ADD
- VR ggd `week_start_unix` ADD
- VR ggd `week_end_unix` ADD
- VR ggd `date_of_report_unix` DELETE

