### PR TITLE
Add schemas for behavior for nl, vr and regions

### DIFF
--- a/schema/national/__index.json
+++ b/schema/national/__index.json
@@ -23,7 +23,8 @@
     "hospital_beds_occupied",
     "intensive_care_beds_occupied",
     "ggd",
-    "nursing_home"
+    "nursing_home",
+    "behavior"
   ],
   "additionalProperties": false,
   "properties": {
@@ -98,6 +99,9 @@
     },
     "restrictions": {
       "$ref": "restrictions.json"
+    },
+    "behavior": {
+      "$ref": "behavior.json"
     }
   }
 }

--- a/schema/national/behavior.json
+++ b/schema/national/behavior.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "national_behavior",
+  "type": "object",
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "definitions": {
+    "value_trend": {
+      "type": "string",
+      "enum": ["up", "down", "equal"]
+    },
+    "value": {
+      "title": "national_behavior_value",
+      "type": "object",
+      "properties": {
+        "number_of_participants": {
+          "type": "integer"
+        },
+        "wash_hands_compliance": {
+          "type": "integer"
+        },
+        "wash_hands_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "keep_distance_compliance": {
+          "type": "integer"
+        },
+        "keep_distance_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "work_from_home_compliance": {
+          "type": "integer"
+        },
+        "work_from_home_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "avoid_crowds_compliance": {
+          "type": "integer"
+        },
+        "avoid_crowds_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_stay_home_compliance": {
+          "type": "integer"
+        },
+        "symptoms_stay_home_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_get_tested_compliance": {
+          "type": "integer"
+        },
+        "symptoms_get_tested_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_indoors_compliance": {
+          "type": "integer"
+        },
+        "wear_mask_public_indoors_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_transport_compliance": {
+          "type": "integer"
+        },
+        "wear_mask_public_transport_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "sneeze_cough_elbow_compliance": {
+          "type": "integer"
+        },
+        "sneeze_cough_elbow_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "max_visitors_compliance": {
+          "type": "integer"
+        },
+        "max_visitors_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wash_hands_support": {
+          "type": "integer"
+        },
+        "wash_hands_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "keep_distance_support": {
+          "type": "integer"
+        },
+        "keep_distance_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "work_from_home_support": {
+          "type": "integer"
+        },
+        "work_from_home_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "avoid_crowds_support": {
+          "type": "integer"
+        },
+        "avoid_crowds_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_stay_home_support": {
+          "type": "integer"
+        },
+        "symptoms_stay_home_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_get_tested_support": {
+          "type": "integer"
+        },
+        "symptoms_get_tested_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_indoors_support": {
+          "type": "integer"
+        },
+        "wear_mask_public_indoors_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_transport_support": {
+          "type": "integer"
+        },
+        "wear_mask_public_transport_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "sneeze_cough_elbow_support": {
+          "type": "integer"
+        },
+        "sneeze_cough_elbow_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "max_visitors_support": {
+          "type": "integer"
+        },
+        "max_visitors_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "number_of_participants",
+        "number_of_participants_trend",
+        "wash_hands_compliance",
+        "wash_hands_compliance_trend",
+        "keep_distance_compliance",
+        "keep_distance_compliance_trend",
+        "work_from_home_compliance",
+        "work_from_home_compliance_trend",
+        "avoid_crowds_compliance",
+        "avoid_crowds_compliance_trend",
+        "symptoms_stay_home_compliance",
+        "symptoms_stay_home_compliance_trend",
+        "symptoms_get_tested_compliance",
+        "symptoms_get_tested_compliance_trend",
+        "wash_hands_support",
+        "wash_hands_support_trend",
+        "keep_distance_support",
+        "keep_distance_support_trend",
+        "work_from_home_support",
+        "work_from_home_support_trend",
+        "avoid_crowds_support",
+        "avoid_crowds_support_trend",
+        "symptoms_stay_home_support",
+        "symptoms_stay_home_support_trend",
+        "symptoms_get_tested_support",
+        "symptoms_get_tested_support_trend",
+        "max_visitors_support",
+        "max_visitors_support_trend",
+        "week_start_unix",
+        "week_end_unix",
+        "date_of_insertion_unix"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -11,7 +11,8 @@
     "ggd",
     "nursing_home",
     "sewer",
-    "sewer_per_installation"
+    "sewer_per_installation",
+    "behavior"
   ],
   "additionalProperties": false,
   "properties": {
@@ -47,6 +48,9 @@
     },
     "restrictions": {
       "$ref": "restrictions.json"
+    },
+    "behavior": {
+      "$ref": "behavior.json"
     }
   }
 }

--- a/schema/regional/behavior.json
+++ b/schema/regional/behavior.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "regional_behavior",
+  "type": "object",
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "definitions": {
+    "value_trend": {
+      "type": "string",
+      "enum": ["up", "down", "equal"]
+    },
+    "value": {
+      "title": "regional_behavior_value",
+      "type": "object",
+      "properties": {
+        "number_of_participants": {
+          "type": "integer"
+        },
+        "wash_hands_compliance": {
+          "type": "integer"
+        },
+        "wash_hands_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "keep_distance_compliance": {
+          "type": "integer"
+        },
+        "keep_distance_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "work_from_home_compliance": {
+          "type": "integer"
+        },
+        "work_from_home_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "avoid_crowds_compliance": {
+          "type": "integer"
+        },
+        "avoid_crowds_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_stay_home_compliance": {
+          "type": "integer"
+        },
+        "symptoms_stay_home_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_get_tested_compliance": {
+          "type": "integer"
+        },
+        "symptoms_get_tested_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_indoors_compliance": {
+          "type": "integer"
+        },
+        "wear_mask_public_indoors_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_transport_compliance": {
+          "type": "integer"
+        },
+        "wear_mask_public_transport_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "sneeze_cough_elbow_compliance": {
+          "type": "integer"
+        },
+        "sneeze_cough_elbow_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "max_visitors_compliance": {
+          "type": "integer"
+        },
+        "max_visitors_compliance_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wash_hands_support": {
+          "type": "integer"
+        },
+        "wash_hands_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "keep_distance_support": {
+          "type": "integer"
+        },
+        "keep_distance_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "work_from_home_support": {
+          "type": "integer"
+        },
+        "work_from_home_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "avoid_crowds_support": {
+          "type": "integer"
+        },
+        "avoid_crowds_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_stay_home_support": {
+          "type": "integer"
+        },
+        "symptoms_stay_home_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "symptoms_get_tested_support": {
+          "type": "integer"
+        },
+        "symptoms_get_tested_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_indoors_support": {
+          "type": "integer"
+        },
+        "wear_mask_public_indoors_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "wear_mask_public_transport_support": {
+          "type": "integer"
+        },
+        "wear_mask_public_transport_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "sneeze_cough_elbow_support": {
+          "type": "integer"
+        },
+        "sneeze_cough_elbow_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "max_visitors_support": {
+          "type": "integer"
+        },
+        "max_visitors_support_trend": {
+          "$ref": "#/definitions/value_trend"
+        },
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "number_of_participants",
+        "number_of_participants_trend",
+        "wash_hands_compliance",
+        "wash_hands_compliance_trend",
+        "keep_distance_compliance",
+        "keep_distance_compliance_trend",
+        "work_from_home_compliance",
+        "work_from_home_compliance_trend",
+        "avoid_crowds_compliance",
+        "avoid_crowds_compliance_trend",
+        "symptoms_stay_home_compliance",
+        "symptoms_stay_home_compliance_trend",
+        "symptoms_get_tested_compliance",
+        "symptoms_get_tested_compliance_trend",
+        "wash_hands_support",
+        "wash_hands_support_trend",
+        "keep_distance_support",
+        "keep_distance_support_trend",
+        "work_from_home_support",
+        "work_from_home_support_trend",
+        "avoid_crowds_support",
+        "avoid_crowds_support_trend",
+        "symptoms_stay_home_support",
+        "symptoms_stay_home_support_trend",
+        "symptoms_get_tested_support",
+        "symptoms_get_tested_support_trend",
+        "max_visitors_support",
+        "max_visitors_support_trend",
+        "week_start_unix",
+        "week_end_unix",
+        "date_of_insertion_unix"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/regions/__index.json
+++ b/schema/regions/__index.json
@@ -13,7 +13,8 @@
     "positive_tested_people",
     "deceased",
     "nursing_home",
-    "sewer"
+    "sewer",
+    "behavior"
   ],
   "properties": {
     "last_generated": {
@@ -72,6 +73,13 @@
       "maxItems": 25,
       "items": {
         "$ref": "sewer.json"
+      }
+    },
+    "behavior": {
+      "type": "array",
+      "maxItems": 25,
+      "items": {
+        "$ref": "behavior.json"
       }
     }
   }

--- a/schema/regions/behavior.json
+++ b/schema/regions/behavior.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "regions_behavior",
+  "type": "object",
+  "definitions": {
+    "value_trend": {
+      "type": "string",
+      "enum": ["up", "down", "equal"]
+    }
+  },
+  "properties": {
+    "vrcode": {
+      "type": "string",
+      "pattern": "^VR[0-9]+$"
+    },
+    "number_of_participants": {
+      "type": "integer"
+    },
+    "wash_hands_compliance": {
+      "type": "integer"
+    },
+    "wash_hands_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "keep_distance_compliance": {
+      "type": "integer"
+    },
+    "keep_distance_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "work_from_home_compliance": {
+      "type": "integer"
+    },
+    "work_from_home_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "avoid_crowds_compliance": {
+      "type": "integer"
+    },
+    "avoid_crowds_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "symptoms_stay_home_compliance": {
+      "type": "integer"
+    },
+    "symptoms_stay_home_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "symptoms_get_tested_compliance": {
+      "type": "integer"
+    },
+    "symptoms_get_tested_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "wear_mask_public_indoors_compliance": {
+      "type": "integer"
+    },
+    "wear_mask_public_indoors_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "wear_mask_public_transport_compliance": {
+      "type": "integer"
+    },
+    "wear_mask_public_transport_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "sneeze_cough_elbow_compliance": {
+      "type": "integer"
+    },
+    "sneeze_cough_elbow_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "max_visitors_compliance": {
+      "type": "integer"
+    },
+    "max_visitors_compliance_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "wash_hands_support": {
+      "type": "integer"
+    },
+    "wash_hands_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "keep_distance_support": {
+      "type": "integer"
+    },
+    "keep_distance_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "work_from_home_support": {
+      "type": "integer"
+    },
+    "work_from_home_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "avoid_crowds_support": {
+      "type": "integer"
+    },
+    "avoid_crowds_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "symptoms_stay_home_support": {
+      "type": "integer"
+    },
+    "symptoms_stay_home_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "symptoms_get_tested_support": {
+      "type": "integer"
+    },
+    "symptoms_get_tested_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "wear_mask_public_indoors_support": {
+      "type": "integer"
+    },
+    "wear_mask_public_indoors_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "wear_mask_public_transport_support": {
+      "type": "integer"
+    },
+    "wear_mask_public_transport_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "sneeze_cough_elbow_support": {
+      "type": "integer"
+    },
+    "sneeze_cough_elbow_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "max_visitors_support": {
+      "type": "integer"
+    },
+    "max_visitors_support_trend": {
+      "$ref": "#/definitions/value_trend"
+    },
+    "week_start_unix": {
+      "type": "integer"
+    },
+    "week_end_unix": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "vrcode",
+    "number_of_participants",
+    "number_of_participants_trend",
+    "wash_hands_compliance",
+    "wash_hands_compliance_trend",
+    "keep_distance_compliance",
+    "keep_distance_compliance_trend",
+    "work_from_home_compliance",
+    "work_from_home_compliance_trend",
+    "avoid_crowds_compliance",
+    "avoid_crowds_compliance_trend",
+    "symptoms_stay_home_compliance",
+    "symptoms_stay_home_compliance_trend",
+    "symptoms_get_tested_compliance",
+    "symptoms_get_tested_compliance_trend",
+    "wash_hands_support",
+    "wash_hands_support_trend",
+    "keep_distance_support",
+    "keep_distance_support_trend",
+    "work_from_home_support",
+    "work_from_home_support_trend",
+    "avoid_crowds_support",
+    "avoid_crowds_support_trend",
+    "symptoms_stay_home_support",
+    "symptoms_stay_home_support_trend",
+    "symptoms_get_tested_support",
+    "symptoms_get_tested_support_trend",
+    "max_visitors_support",
+    "max_visitors_support_trend",
+    "week_start_unix",
+    "week_end_unix",
+    "date_of_insertion_unix"
+  ],
+  "additionalProperties": false
+}

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -123,6 +123,7 @@ export interface National {
   intensive_care_beds_occupied: IntensiveCareBedsOccupied;
   ggd: NationalGgd;
   nursing_home: NationalNursingHome;
+  behavior: NationalBehavior;
   restrictions?: NationalRestrictions;
 }
 export interface NationalHuisartsVerdenkingen {
@@ -336,6 +337,56 @@ export interface NationalNursingHomeValue {
   date_of_report_unix: number;
   date_of_insertion_unix: number;
 }
+export interface NationalBehavior {
+  values: NationalBehaviorValue[];
+  last_value: NationalBehaviorValue;
+}
+export interface NationalBehaviorValue {
+  number_of_participants: number;
+  wash_hands_compliance: number;
+  wash_hands_compliance_trend: "up" | "down" | "equal";
+  keep_distance_compliance: number;
+  keep_distance_compliance_trend: "up" | "down" | "equal";
+  work_from_home_compliance: number;
+  work_from_home_compliance_trend: "up" | "down" | "equal";
+  avoid_crowds_compliance: number;
+  avoid_crowds_compliance_trend: "up" | "down" | "equal";
+  symptoms_stay_home_compliance: number;
+  symptoms_stay_home_compliance_trend: "up" | "down" | "equal";
+  symptoms_get_tested_compliance: number;
+  symptoms_get_tested_compliance_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_compliance?: number;
+  wear_mask_public_indoors_compliance_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_compliance?: number;
+  wear_mask_public_transport_compliance_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_compliance?: number;
+  sneeze_cough_elbow_compliance_trend?: "up" | "down" | "equal";
+  max_visitors_compliance?: number;
+  max_visitors_compliance_trend?: "up" | "down" | "equal";
+  wash_hands_support: number;
+  wash_hands_support_trend: "up" | "down" | "equal";
+  keep_distance_support: number;
+  keep_distance_support_trend: "up" | "down" | "equal";
+  work_from_home_support: number;
+  work_from_home_support_trend: "up" | "down" | "equal";
+  avoid_crowds_support: number;
+  avoid_crowds_support_trend: "up" | "down" | "equal";
+  symptoms_stay_home_support: number;
+  symptoms_stay_home_support_trend: "up" | "down" | "equal";
+  symptoms_get_tested_support: number;
+  symptoms_get_tested_support_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_support?: number;
+  wear_mask_public_indoors_support_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_support?: number;
+  wear_mask_public_transport_support_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_support?: number;
+  sneeze_cough_elbow_support_trend?: "up" | "down" | "equal";
+  max_visitors_support: number;
+  max_visitors_support_trend: "up" | "down" | "equal";
+  week_start_unix: number;
+  week_end_unix: number;
+  date_of_insertion_unix: number;
+}
 export interface NationalRestrictions {
   values: NationalRestrictionValue[];
 }
@@ -443,6 +494,7 @@ export interface Regionaal {
   results_per_region: ResultsPerRegion;
   ggd: RegionalGgd;
   nursing_home: RegionalNursingHome;
+  behavior: RegionalBehavior;
   restrictions?: RegionalRestrictions;
 }
 export interface RegionalSewer {
@@ -524,6 +576,56 @@ export interface RegionalNursingHomeValue {
   date_of_insertion_unix: number;
   vrcode: string;
 }
+export interface RegionalBehavior {
+  values: RegionalBehaviorValue[];
+  last_value: RegionalBehaviorValue;
+}
+export interface RegionalBehaviorValue {
+  number_of_participants: number;
+  wash_hands_compliance: number;
+  wash_hands_compliance_trend: "up" | "down" | "equal";
+  keep_distance_compliance: number;
+  keep_distance_compliance_trend: "up" | "down" | "equal";
+  work_from_home_compliance: number;
+  work_from_home_compliance_trend: "up" | "down" | "equal";
+  avoid_crowds_compliance: number;
+  avoid_crowds_compliance_trend: "up" | "down" | "equal";
+  symptoms_stay_home_compliance: number;
+  symptoms_stay_home_compliance_trend: "up" | "down" | "equal";
+  symptoms_get_tested_compliance: number;
+  symptoms_get_tested_compliance_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_compliance?: number;
+  wear_mask_public_indoors_compliance_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_compliance?: number;
+  wear_mask_public_transport_compliance_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_compliance?: number;
+  sneeze_cough_elbow_compliance_trend?: "up" | "down" | "equal";
+  max_visitors_compliance?: number;
+  max_visitors_compliance_trend?: "up" | "down" | "equal";
+  wash_hands_support: number;
+  wash_hands_support_trend: "up" | "down" | "equal";
+  keep_distance_support: number;
+  keep_distance_support_trend: "up" | "down" | "equal";
+  work_from_home_support: number;
+  work_from_home_support_trend: "up" | "down" | "equal";
+  avoid_crowds_support: number;
+  avoid_crowds_support_trend: "up" | "down" | "equal";
+  symptoms_stay_home_support: number;
+  symptoms_stay_home_support_trend: "up" | "down" | "equal";
+  symptoms_get_tested_support: number;
+  symptoms_get_tested_support_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_support?: number;
+  wear_mask_public_indoors_support_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_support?: number;
+  wear_mask_public_transport_support_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_support?: number;
+  sneeze_cough_elbow_support_trend?: "up" | "down" | "equal";
+  max_visitors_support: number;
+  max_visitors_support_trend: "up" | "down" | "equal";
+  week_start_unix: number;
+  week_end_unix: number;
+  date_of_insertion_unix: number;
+}
 export interface RegionalRestrictions {
   values: RegionalRestrictionValue[];
 }
@@ -560,6 +662,7 @@ export interface Regions {
   deceased: RegionDeceased[];
   escalation_levels: EscalationLevels[];
   nursing_home: RegionsNursingHome[];
+  behavior: RegionsBehavior[];
   sewer: RegionsSewer[];
 }
 export interface RegionHospitalAdmissions {
@@ -597,6 +700,53 @@ export interface RegionsNursingHome {
   date_of_report_unix: number;
   date_of_insertion_unix: number;
   vrcode: string;
+}
+export interface RegionsBehavior {
+  vrcode: string;
+  number_of_participants: number;
+  wash_hands_compliance: number;
+  wash_hands_compliance_trend: "up" | "down" | "equal";
+  keep_distance_compliance: number;
+  keep_distance_compliance_trend: "up" | "down" | "equal";
+  work_from_home_compliance: number;
+  work_from_home_compliance_trend: "up" | "down" | "equal";
+  avoid_crowds_compliance: number;
+  avoid_crowds_compliance_trend: "up" | "down" | "equal";
+  symptoms_stay_home_compliance: number;
+  symptoms_stay_home_compliance_trend: "up" | "down" | "equal";
+  symptoms_get_tested_compliance: number;
+  symptoms_get_tested_compliance_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_compliance?: number;
+  wear_mask_public_indoors_compliance_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_compliance?: number;
+  wear_mask_public_transport_compliance_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_compliance?: number;
+  sneeze_cough_elbow_compliance_trend?: "up" | "down" | "equal";
+  max_visitors_compliance?: number;
+  max_visitors_compliance_trend?: "up" | "down" | "equal";
+  wash_hands_support: number;
+  wash_hands_support_trend: "up" | "down" | "equal";
+  keep_distance_support: number;
+  keep_distance_support_trend: "up" | "down" | "equal";
+  work_from_home_support: number;
+  work_from_home_support_trend: "up" | "down" | "equal";
+  avoid_crowds_support: number;
+  avoid_crowds_support_trend: "up" | "down" | "equal";
+  symptoms_stay_home_support: number;
+  symptoms_stay_home_support_trend: "up" | "down" | "equal";
+  symptoms_get_tested_support: number;
+  symptoms_get_tested_support_trend: "up" | "down" | "equal";
+  wear_mask_public_indoors_support?: number;
+  wear_mask_public_indoors_support_trend?: "up" | "down" | "equal";
+  wear_mask_public_transport_support?: number;
+  wear_mask_public_transport_support_trend?: "up" | "down" | "equal";
+  sneeze_cough_elbow_support?: number;
+  sneeze_cough_elbow_support_trend?: "up" | "down" | "equal";
+  max_visitors_support: number;
+  max_visitors_support_trend: "up" | "down" | "equal";
+  week_start_unix: number;
+  week_end_unix: number;
+  date_of_insertion_unix: number;
 }
 export interface RegionsSewer {
   week_unix: number;


### PR DESCRIPTION
## Summary

Adds schemas for implementing charts based on behavior research.

## Changes Affecting Backend

### Root key changes

- NL `behavior` ADD
- VR `behavior` ADD
- REGIONS `behavior` ADD

### Property changes

All three added schemas use the following properties/ids for labeling behavior

- wash_hands
- keep_distance
- work_from_home
- avoid_crowds
- symptoms_stay_home
- symptoms_get_tested
- wear_mask_public_indoors
- wear_mask_public_transport
- sneeze_cough_elbow
- max_visitors_home

To accompany the data which is split between support and compliance, all of these keys have a `_support` or `_compliance` suffix in the schemas.

Then for each of the keys there is another key with an extra suffix to indicate the trend using `_trend` which can be up/down/equal. These trend values are not the same as other calculated differences. If the results over time change from 90% to 92% the trend can still be considered "equal" due to error margins in the data.

I have kept all values type integer because even though they are represented as percentages, they are by nature of "steekproef" not accurate at all.

There are 3 properties that have not been included in the first research so I have left them (and their suffixed properties) out of the required list. These are:

- wear_mask_public_indoors
- wear_mask_public_transport
- sneeze_cough_elbow