### PR TITLE
Fixes bug in collapsable that prevents them from closing

### DIFF
--- a/src/components-styled/collapsable.tsx
+++ b/src/components-styled/collapsable.tsx
@@ -86,7 +86,6 @@ export const Collapsable = ({ summary, children, id }: CollapsableProps) => {
       return;
     }
     setOpen(!open);
-    setLinkTabability(!open);
     startAnimation(!open);
   }
 
@@ -141,16 +140,10 @@ export const Collapsable = ({ summary, children, id }: CollapsableProps) => {
     [panelReference]
   );
 
-  useEffect(() => {
-    setLinkTabability(open);
-  }, [setLinkTabability, open]);
+  useEffect(() => setLinkTabability(open), [setLinkTabability, open]);
 
   useEffect(() => {
     requestAnimationFrame(() => checkLocationHash());
-    window.addEventListener('hashchange', checkLocationHash, false);
-    return () => {
-      window.removeEventListener('hashchange', checkLocationHash, false);
-    };
   }, [checkLocationHash]);
 
   return (

--- a/src/components-styled/collapsable.tsx
+++ b/src/components-styled/collapsable.tsx
@@ -142,11 +142,11 @@ export const Collapsable = ({ summary, children, id }: CollapsableProps) => {
   );
 
   useEffect(() => {
-    checkLocationHash();
     setLinkTabability(open);
-  }, [checkLocationHash, setLinkTabability, open]);
+  }, [setLinkTabability, open]);
 
   useEffect(() => {
+    requestAnimationFrame(() => checkLocationHash());
     window.addEventListener('hashchange', checkLocationHash, false);
     return () => {
       window.removeEventListener('hashchange', checkLocationHash, false);


### PR DESCRIPTION
## Summary

Collapsables linked with an anchor link should open on page load, and then be able to get closed. This fixes a bug in the closing bit.

## Detailed design

Since the `open` state was part of the dependencies for `useEffect`, the `checkLocationHash` got re-evaluated for every toggle. Fixed by shuffling the logic a bit apart. `requestAnimationFrame` fixes odd scrolling behavior on page load when using these links (it would stop mid-page).