### PR TITLE
Enable use of css-prop

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
   "plugins": [
     "lodash",
     [
-      "styled-components",
+      "babel-plugin-styled-components",
       {
         "ssr": true,
         "displayName": true

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,12 @@
+import { CssFunctionReturnType } from '@styled-system/css';
+import {} from 'react';
+
+declare module 'react' {
+  interface HTMLAttributes<T> extends DOMAttributes<T> {
+    css?: CssFunctionReturnType;
+  }
+
+  interface SVGAttributes<T> extends DOMAttributes<T> {
+    css?: CssFunctionReturnType;
+  }
+}

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,5 +1,4 @@
 import { CssFunctionReturnType } from '@styled-system/css';
-import {} from 'react';
 
 declare module 'react' {
   interface HTMLAttributes<T> extends DOMAttributes<T> {


### PR DESCRIPTION
This PR allows us to use the `css` prop on styled components and dom elements. The css prop accepts the return value of styled-systems `css`-function. TS will warn when anything else is received, but the app keeps working.

```tsx
const Foo = styled.div``

<Foo css={css({ p: [1, 2, 3] })}>
  <img css={css({ my: 5 })} />
</Foo>