### PR TITLE
Add Lokalise automerge GitHub action

### DIFF
--- a/.github/workflows/lokalise-automerger.yml
+++ b/.github/workflows/lokalise-automerger.yml
@@ -1,4 +1,4 @@
-name: Lokalize PR check
+name: Lokalise PR validation, auto approve and merge
 on:
   pull_request:
     branches:

--- a/.github/workflows/lokalise-automerger.yml
+++ b/.github/workflows/lokalise-automerger.yml
@@ -8,11 +8,12 @@ on:
       - 'src/locale/*.json'
 jobs:
   autocheckandapprove:
+    # More handy functions: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#startswith
+    if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+    name: Validate, label and approve
     runs-on: ubuntu-latest
     steps:
       - name: Remove label
-        # More handy functions: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#startswith
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{ github.token }}
@@ -21,29 +22,24 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v2
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
 
       - name: yarn install
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         uses: borales/actions-yarn@v2.0.0
         with:
           cmd: install
 
       - name: EN locale validation
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         uses: borales/actions-yarn@v2.0.0
         with:
           cmd: validate-single locale en.json
 
       - name: NL locale validation
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         uses: borales/actions-yarn@v2.0.0
         with:
           cmd: validate-single locale nl.json
 
       - name: Add label
         uses: buildsville/add-remove-label@v1
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         with:
           token: ${{ github.token }}
           label: lokalise
@@ -51,12 +47,12 @@ jobs:
 
       - name: Auto approve
         uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         with:
           github-token: ${{ github.token }}
 
   automerge:
     name: Auto merge after successful checks
+    if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
     # By default, jobs run in parallel. To run the jobs sequentially, the keyword "needs" is needed.
     # Auto merge action can be done only when the PR is approved, hence this automerge needs autocheckandapprove as a prerequisite
     needs: autocheckandapprove
@@ -64,7 +60,6 @@ jobs:
     steps:
       - name: Auto merge
         uses: pascalgn/automerge-action@v0.12.0
-        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MERGE_LABELS: lokalise

--- a/.github/workflows/lokalise-automerger.yml
+++ b/.github/workflows/lokalise-automerger.yml
@@ -56,7 +56,7 @@ jobs:
           github-token: ${{ github.token }}
   automerge:
     name: Auto merge after successful checks
-    # By default, jobs run in parallel. To run the jobs sequentially, they keywords "needs" is needed.
+    # By default, jobs run in parallel. To run the jobs sequentially, the keyword "needs" is needed.
     # Auto merge action can be done only when the PR is approved, hence this automerge needs autocheckandapprove as a prerequisite
     needs: autocheckandapprove
     runs-on: ubuntu-latest

--- a/.github/workflows/lokalise-automerger.yml
+++ b/.github/workflows/lokalise-automerger.yml
@@ -54,6 +54,7 @@ jobs:
         if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         with:
           github-token: ${{ github.token }}
+
   automerge:
     name: Auto merge after successful checks
     # By default, jobs run in parallel. To run the jobs sequentially, the keyword "needs" is needed.

--- a/.github/workflows/lokalize.yml
+++ b/.github/workflows/lokalize.yml
@@ -2,31 +2,70 @@ name: Lokalize PR check
 on:
   pull_request:
     branches:
-      - 'lokalize-*'
+      - master
+      - develop
+    paths:
+      - 'src/locale/*.json'
 jobs:
-  autoapprove:
+  autocheckandapprove:
     runs-on: ubuntu-latest
     steps:
-      - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
-      - name: test
-        run: cat $HOME/files.json
+      - name: Remove label
+        # More handy functions: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#startswith
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        uses: buildsville/add-remove-label@v1
         with:
-          script: |
-            if steps.file_changes.outputs.files.length !== 2 {
-              throw new Error("More than 2 files were changed in this lokalize PR");
-            }
-            throw new Error("I really wanna fail");
+          token: ${{ github.token }}
+          label: lokalise
+          type: remove
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+
+      - name: yarn install
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: install
+
+      - name: EN locale validation
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: validate-single locale en.json
+
+      - name: NL locale validation
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        uses: borales/actions-yarn@v2.0.0
+        with:
+          cmd: validate-single locale nl.json
+
+      - name: Add label
+        uses: buildsville/add-remove-label@v1
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        with:
+          token: ${{ github.token }}
+          label: lokalise
+          type: add
+
+      - name: Auto approve
+        uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
+        with:
+          github-token: ${{ github.token }}
   automerge:
     name: Auto merge after successful checks
     # By default, jobs run in parallel. To run the jobs sequentially, they keywords "needs" is needed.
-    # Auto merge action can be done only when the PR is approved, hence this automerge needs autoapprove as a prerequisite
-    needs: autoapprove
+    # Auto merge action can be done only when the PR is approved, hence this automerge needs autocheckandapprove as a prerequisite
+    needs: autocheckandapprove
     runs-on: ubuntu-latest
     steps:
       - name: Auto merge
-        # Custom action for auto merging already available on marketplace
         uses: pascalgn/automerge-action@v0.12.0
+        if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          MERGE_LABELS: lokalise
           MERGE_METHOD: squash
+          MERGE_DELETE_BRANCH: true

--- a/.github/workflows/lokalize.yml
+++ b/.github/workflows/lokalize.yml
@@ -16,6 +16,7 @@ jobs:
             if steps.file_changes.outputs.files.length !== 2 {
               throw new Error("More than 2 files were changed in this lokalize PR");
             }
+            throw new Error("I really wanna fail");
   automerge:
     name: Auto merge after successful checks
     # By default, jobs run in parallel. To run the jobs sequentially, they keywords "needs" is needed.

--- a/.github/workflows/lokalize.yml
+++ b/.github/workflows/lokalize.yml
@@ -1,0 +1,31 @@
+name: Lokalize PR check
+on:
+  pull_request:
+    branches:
+      - 'lokalize-*'
+jobs:
+  autoapprove:
+    runs-on: ubuntu-latest
+    steps:
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+      - name: test
+        run: cat $HOME/files.json
+        with:
+          script: |
+            if steps.file_changes.outputs.files.length !== 2 {
+              throw new Error("More than 2 files were changed in this lokalize PR");
+            }
+  automerge:
+    name: Auto merge after successful checks
+    # By default, jobs run in parallel. To run the jobs sequentially, they keywords "needs" is needed.
+    # Auto merge action can be done only when the PR is approved, hence this automerge needs autoapprove as a prerequisite
+    needs: autoapprove
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto merge
+        # Custom action for auto merging already available on marketplace
+        uses: pascalgn/automerge-action@v0.12.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_METHOD: squash


### PR DESCRIPTION
## Summary

This adds a Github action that is able to validate, approve, and merge pull requests from Lokalise automatically.

## Motivation

Feature request.

## Detailed design

The action only triggers on pull requests on the develop and master branches. It also only triggers when the json files in the src/locale directory have been changed.

Each step of action checks if the current actor is called VWSCoronaDashboard (the user under which Lokalise runs) and if the PR branch name is prefixed like 'lokalise-*'. With these checks we can be fairly certain that the PR originates from Lokalise.

If these conditions are met, the repository gets pulled and a yarn install is performed.
After that two yarn commands are run: `yarn validate-single locale en.json` and `yarn validate-single locale nl.json`

If these validations come back without errors, the PR is given the label 'lokalise' and is auto-approved.

The final job checks for the existence of the 'lokalise' label in which case the PR is automatically merged and deleted afterwards.

## Drawbacks

This action will also run during normal PRs where the locale files are changed. In that case the action will not DO anything, but it will take a few moments longer to run the checks.

## Alternatives

Please let me know.

## Unresolved questions

Ideally, this action will only run when either the **src/locale/nl.json** file or the **src/locale/en.json** has been changed. Unfortunately, I haven't been able to get this to work in this way. 
Consider this configuration:
```
paths:
  - 'src/locale/*.json'
```
This ensures that the action triggers when the locale files are changed, but unfortunately not exclusively. So, when apart from these files also other files have been changed (like in a regular PR), the action will still trigger. (Just without ending up doing anything).
I would really like this action to trigger exclusively when only the locale files are in the changeset. So if anyone has ideas about this, I am all ears.

~~You'll also see that in each step of the action this if statement is added:
`if: github.actor == 'VWSCoronaDashboard' && startsWith(github.head_ref, 'lokalise-') == true`
Again ideally, I'd like to be able to perform such a check at the start of a job and be able to end the job when the condition is not met. I have not found a clean way of actually doing this. Therefore the check is added to each step. Any suggestions here are welcome too.~~

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
