### PR TITLE
Bug/remove error pages from sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ If you want to change locale from `nl` - the default - to `en`, you need to make
 NEXT_PUBLIC_LOCALE=en
 ```
 
+The sitemap is dynamically generated when Next.js builds. To improve developer experience, this can be disabled using the `DISABLE_SITEMAP=1` environment variable.
+
 Run `yarn` to install all required packages.
 
 ### Data

--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,11 @@ const nextConfig = {
   reactStrictMode: true, // Enables react strict mode https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode
 
   webpack(config, { isServer }) {
-    if (isServer) {
+    if (
+      isServer &&
+      process.env.DISABLE_SITEMAP !== '1' &&
+      !process.env.DISABLE_SITEMAP
+    ) {
       sitemap.generateSitemap(process.env.NEXT_PUBLIC_LOCALE);
     }
 

--- a/src/tools/sitemap/generate-sitemap.js
+++ b/src/tools/sitemap/generate-sitemap.js
@@ -25,10 +25,12 @@ const generateSitemap = async function (locale) {
   // Ignore Next.js specific files and API routes.
   const pages = await globby([
     './src/pages/**/*{.tsx,.mdx}',
+    '!./src/pages/404.tsx',
+    '!./src/pages/500.tsx',
     '!./src/pages/_*.tsx',
     '!./src/pages/api',
   ]);
-
+  
   const pathsFromPages = pages.map((page) =>
     page
       .replace('./src/pages', '')
@@ -38,8 +40,6 @@ const generateSitemap = async function (locale) {
   );
 
   const priorities = [
-    { path: '404', value: 0 },
-    { path: '500', value: 0 },
     { path: 'landelijk', value: 0.8 },
     { path: 'gemeente', value: 0.8 },
     { path: 'regio', value: 0.8 },


### PR DESCRIPTION
## Summary

Tiny PR to remove error pages from Sitemap and add a DISABLE_SITEMAP env variable.

## Motivation

To improve accuracy of the sitemap and improve DX.

### Governance

- [x] Documentation is added
- [ ] Test cases are added or updated (N/A)
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
