### PR TITLE
Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,8 +125,7 @@
     "cy:open": "cypress open",
     "e2e:ci": "yarn build && start-test 3000 cy:ci",
     "cy:ci": "cypress run --headless --browser chrome",
-    "download": "download https://coronadashboard.rijksoverheid.nl/latest-data.zip -e -o public/",
-    "compile": "tsc --noEmit"
+    "download": "download https://coronadashboard.rijksoverheid.nl/latest-data.zip -e -o public/"
   },
   "browserslist": [
     "defaults",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "cy:open": "cypress open",
     "e2e:ci": "yarn build && start-test 3000 cy:ci",
     "cy:ci": "cypress run --headless --browser chrome",
-    "download": "download https://coronadashboard.rijksoverheid.nl/latest-data.zip -e -o public/"
+    "download": "download https://coronadashboard.rijksoverheid.nl/latest-data.zip -e -o public/",
+    "compile": "tsc --noEmit"
   },
   "browserslist": [
     "defaults",

--- a/src/components-styled/anchor.tsx
+++ b/src/components-styled/anchor.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 interface AnchorProps {
   text: string;
-  anchorName: string;
+  name: string;
 }
 
-export function Anchor({ text, anchorName }: AnchorProps) {
-  return <a href={`#${anchorName}`}>{text}</a>;
+export function Anchor({ text, name }: AnchorProps) {
+  return <a href={`#${name}`}>{text}</a>;
 }

--- a/src/components-styled/chart-region-controls.tsx
+++ b/src/components-styled/chart-region-controls.tsx
@@ -6,19 +6,19 @@ export interface ChartRegionControlsProps {
   onChange: (value: 'municipal' | 'region') => void;
 }
 
+const items = [
+  {
+    label: text.charts.region_controls.municipal,
+    value: 'municipal',
+  },
+  {
+    label: text.charts.region_controls.region,
+    value: 'region',
+  },
+];
+
 export function ChartRegionControls(props: ChartRegionControlsProps) {
   const { onChange } = props;
-
-  const items = [
-    {
-      label: text.charts.region_controls.municipal,
-      value: 'municipal',
-    },
-    {
-      label: text.charts.region_controls.region,
-      value: 'region',
-    },
-  ];
 
   return <RadioGroup items={items} onChange={onChange} />;
 }

--- a/src/components-styled/kpi-section.tsx
+++ b/src/components-styled/kpi-section.tsx
@@ -12,5 +12,5 @@ export const KpiSection = (props: { children: React.ReactNode } & BoxProps) => (
     ml={{ _: -4, sm: 0 }}
     mr={{ _: -4, sm: 0 }}
     {...(props as any)}
-  ></Box>
+  />
 );

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -158,14 +158,18 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
       lineColor: '#C4C4C4',
       gridLineColor: '#ca005d',
       type: 'datetime',
-      categories: rangeData.map((el) => el[0].getTime() as any),
+      categories: rangeData.map((el) => el[0].getTime().toString()),
       title: {
         text: null,
       },
       labels: {
         align: 'right',
         x: 10,
-        rotation: '0' as any,
+        /**
+         * The number 0 doesn't work properly, probably because highcharts does
+         * some buggy `if(labels.rotation) {}` which yields false for the number 0.
+         */
+        rotation: ('0' as unknown) as number,
         formatter: function () {
           return this.isFirst || this.isLast
             ? formatDateFromMilliseconds(this.value, 'axis')
@@ -240,9 +244,7 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
         if (!rangePoint) return;
 
         const [, minRangePoint, maxRangePoint] = rangePoint;
-        const linePoint = lineData.find(
-          (el: any) => el[0].getTime() === this.x
-        );
+        const linePoint = lineData.find((el) => el[0].getTime() === this.x);
         const x = this.x;
         return `
             ${formatDateFromMilliseconds(x, 'medium')}<br/>

--- a/src/components/areaChart/index.tsx
+++ b/src/components/areaChart/index.tsx
@@ -147,7 +147,7 @@ function getChartOptions(props: IGetOptions): Highcharts.Options {
       displayErrors: true,
       height: 175,
     },
-    legend: false as any,
+    legend: { enabled: false },
     credits: {
       enabled: false,
     },

--- a/src/components/barChart/index.tsx
+++ b/src/components/barChart/index.tsx
@@ -32,10 +32,8 @@ export default function BarChart(props: IProps) {
         enabled: true,
         outside: true,
         formatter: function (): string | false {
-          // @ts-ignore
-          if (this.point.label) {
-            // @ts-ignore
-            return this.point.label;
+          if ((this.point as any).label) {
+            return (this.point as any).label;
           }
           return false;
         },

--- a/src/components/barScale/index.tsx
+++ b/src/components/barScale/index.tsx
@@ -46,13 +46,13 @@ export function BarScale({
 
   const [xMin, xMax] = scale.domain();
 
-  const textAlign = scaleThreshold()
+  const textAlign = scaleThreshold<number, 'start' | 'middle' | 'end'>()
     .domain([20, 80])
-    .range(['start', 'middle', 'end'] as any);
+    .range(['start', 'middle', 'end']);
 
-  const color = scaleQuantile()
+  const color = scaleQuantile<string>()
     .domain(gradient.map((el) => el.value))
-    .range(gradient.map((el) => el.color) as any);
+    .range(gradient.map((el) => el.color));
 
   return (
     <>
@@ -81,10 +81,10 @@ export function BarScale({
               id={`barColor${id}-${rand.current}`}
               gradientUnits="userSpaceOnUse"
             >
-              {color.domain().map((value: any) => (
+              {color.domain().map((value) => (
                 <stop
                   key={`stop-${value}`}
-                  stopColor={color(value) as any}
+                  stopColor={color(value)}
                   offset={`${scale(value)}%`}
                 />
               ))}
@@ -128,7 +128,7 @@ export function BarScale({
                 className={styles.value}
                 x={`${scale(value)}%`}
                 y={16}
-                textAnchor={textAlign(scale(value) ?? 0) as any}
+                textAnchor={textAlign(scale(value) ?? 0)}
               >
                 {`${formatNumber(value)}`}
               </text>
@@ -149,7 +149,7 @@ export function BarScale({
                 className={styles.criticalValue}
                 x={`${scale(signaalwaarde)}%`}
                 y={72}
-                textAnchor={textAlign(scale(signaalwaarde) ?? 0) as any}
+                textAnchor={textAlign(scale(signaalwaarde) ?? 0)}
               >
                 {text.signaalwaarde}: {`${formatNumber(signaalwaarde)}`}
               </text>

--- a/src/components/choropleth/MunicipalityChoropleth.tsx
+++ b/src/components/choropleth/MunicipalityChoropleth.tsx
@@ -61,7 +61,7 @@ export function MunicipalityChoropleth<
     isSelectorMap,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions(1.2);
+  const [ref, dimensions] = useChartDimensions<HTMLDivElement>(1.2);
 
   const [boundingbox, selectedVrCode] = useMunicipalityBoundingbox(
     regionGeo,
@@ -180,13 +180,7 @@ export function MunicipalityChoropleth<
   };
 
   return (
-    <div
-      ref={(elm) => {
-        ref.current = elm;
-      }}
-      className={styles.choroplethContainer}
-      style={style}
-    >
+    <div ref={ref} className={styles.choroplethContainer} style={style}>
       <Choropleth
         featureCollection={municipalGeo}
         overlays={overlays}

--- a/src/components/choropleth/SafetyRegionChoropleth.tsx
+++ b/src/components/choropleth/SafetyRegionChoropleth.tsx
@@ -59,7 +59,7 @@ export function SafetyRegionChoropleth<
     tooltipContent,
   } = props;
 
-  const [ref, dimensions] = useChartDimensions(1.2);
+  const [ref, dimensions] = useChartDimensions<HTMLDivElement>(1.2);
 
   const boundingBox = useSafetyRegionBoundingbox(regionGeo, selected);
 
@@ -158,13 +158,7 @@ export function SafetyRegionChoropleth<
   );
 
   return (
-    <div
-      ref={(elm) => {
-        ref.current = elm;
-      }}
-      className={className}
-      style={style}
-    >
+    <div ref={ref} className={className} style={style}>
       <Choropleth
         featureCollection={regionGeo}
         overlays={countryGeo}

--- a/src/components/choropleth/hooks/useChartDimensions.tsx
+++ b/src/components/choropleth/hooks/useChartDimensions.tsx
@@ -46,16 +46,16 @@ export type TCombinedChartDimensions = TChartDimensions & {
   boundedHeight: number;
 };
 
-export const useChartDimensions = (
+export const useChartDimensions = <T extends HTMLElement>(
   aspectRatio?: number
-): [MutableRefObject<HTMLElement | null>, TCombinedChartDimensions] => {
+) => {
   /**
    * The ref will be initialized from the outside by mutating the return value of this
    * hook. This is a bit funky.
    *
    * @REF https://trello.com/c/i25FG3jk/548-usechartdemensions-pass-ref-as-prop
    */
-  const ref = useRef<HTMLElement | null>(null);
+  const ref = useRef<T>(null);
 
   const { width, height } = useResizeObserver({ ref });
 
@@ -67,5 +67,5 @@ export const useChartDimensions = (
       width,
       height: calculatedHeight,
     }),
-  ];
+  ] as const;
 };

--- a/src/components/choropleth/hooks/useChartDimensions.tsx
+++ b/src/components/choropleth/hooks/useChartDimensions.tsx
@@ -1,4 +1,4 @@
-import { useRef, MutableRefObject } from 'react';
+import { useRef } from 'react';
 import useResizeObserver from 'use-resize-observer/polyfilled';
 
 /**

--- a/src/components/choropleth/tooltips/tooltipContainer.tsx
+++ b/src/components/choropleth/tooltips/tooltipContainer.tsx
@@ -10,7 +10,7 @@ export type TTooltipProps = {
 
 export function Tooltip(props: TTooltipProps) {
   const { tooltipStore, getTooltipContent } = props;
-  const ref = useRef<HTMLDivElement | undefined>();
+  const ref = useRef<HTMLDivElement>(null);
   const [tooltip, updateTooltip] = tooltipStore((state: TooltipState) => [
     state.tooltip,
     state.updateTooltip,
@@ -43,7 +43,7 @@ export function Tooltip(props: TTooltipProps) {
 
   return tooltip ? (
     <div
-      ref={ref as any}
+      ref={ref}
       className={styles.tooltipContainer}
       style={{
         left: tooltip.left,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import Router from 'next/router';
 import { AppProps } from 'next/app';
 import { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
+import { FCWithLayout } from '~/components/layout';
 import '~/components/comboBox/comboBox.scss';
 import '~/components/legenda/legenda.scss';
 import * as piwik from '~/lib/piwik';
@@ -11,12 +12,7 @@ import { GlobalStyle } from '~/style/global-style';
 import theme from '~/style/theme';
 
 type AppPropsWithLayout = AppProps & {
-  Component: AppProps['Component'] & {
-    getLayout: (
-      page: React.ReactNode,
-      props: AppProps['pageProps']
-    ) => JSX.Element;
-  };
+  Component: FCWithLayout;
 };
 
 export default function App(props: AppPropsWithLayout) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '@reach/combobox/styles.css';
 import Router from 'next/router';
+import { AppProps } from 'next/app';
 import { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
 import '~/components/comboBox/comboBox.scss';
@@ -9,19 +10,16 @@ import '~/scss/style.scss';
 import { GlobalStyle } from '~/style/global-style';
 import theme from '~/style/theme';
 
-// Import Preact DevTools in development
-// if (process.env.NODE_ENV === 'development') {
-//   // Must use require here as import statements are only allowed
-//   // to exist at the top of a file.
-//   require('preact/debug');
-// }
+type AppPropsWithLayout = AppProps & {
+  Component: AppProps['Component'] & {
+    getLayout: (
+      page: React.ReactNode,
+      props: AppProps['pageProps']
+    ) => JSX.Element;
+  };
+};
 
-interface AppProps {
-  Component: any;
-  pageProps: any;
-}
-
-export default function App(props: AppProps) {
+export default function App(props: AppPropsWithLayout) {
   const { Component, pageProps } = props;
   const page = (page: React.ReactNode) => page;
   const getLayout = Component.getLayout || page;
@@ -30,7 +28,7 @@ export default function App(props: AppProps) {
     window.document.documentElement.className += ' js';
     const handleRouteChange = (url: string) => {
       if (url.indexOf('?menu') !== -1) {
-        /* Ope ing a menu on mobile scrolls to the top of the menus */
+        /* Opening a menu on mobile scrolls to the top of the menus */
         window.document
           .querySelector('#main-navigation,aside')
           ?.scrollIntoView(true);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -180,7 +180,7 @@ const getEscalationCounts = (
 };
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text = require('../locale/index').default;
+  const text = (await import('../locale/index')).default;
 
   const serializedContent = MDToHTMLString(
     text.veiligheidsregio_index.selecteer_toelichting

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,13 +41,13 @@ interface INationalHomepageData {
  * Adjustments here need to be applied in Lokalize too.
  * This is also why the keys are a bit more verbose.
  */
-interface EscalationLevelCounts {
+type EscalationLevelCounts = {
   escalationLevel1: number;
   escalationLevel2: number;
   escalationLevel3: number;
   escalationLevel4: number;
   escalationLevel5: number;
-}
+};
 
 const Home: FCWithLayout<INationalHomepageData> = (props) => {
   const { text, escalationLevelCounts } = props;
@@ -71,7 +71,7 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
           <p>
             {replaceVariablesInText(
               text.notificatie.bericht,
-              (escalationLevelCounts as unknown) as { [key: string]: string }
+              escalationLevelCounts
             )}
           </p>
         </div>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -119,7 +119,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
               ></span>
             </Heading>
             <Text mt={0} lineHeight={1}>
-              <Anchor anchorName="ggd" text={ggdText.summary_link_cta} />
+              <Anchor name="ggd" text={ggdText.summary_link_cta} />
             </Text>
           </Box>
         </KpiTile>

--- a/src/pages/over-risiconiveaus.tsx
+++ b/src/pages/over-risiconiveaus.tsx
@@ -17,7 +17,8 @@ interface OverRisiconiveausProps {
 }
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text = require('../locale/index').default;
+  const text = (await import('../locale/index')).default;
+
   text.over_risiconiveaus.toelichting = MDToHTMLString(
     text.over_risiconiveaus.toelichting
   );

--- a/src/pages/over.tsx
+++ b/src/pages/over.tsx
@@ -16,7 +16,7 @@ interface OverProps {
 }
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text = require('../locale/index').default;
+  const text = (await import('../locale/index')).default;
 
   const filePath = path.join(process.cwd(), 'public', 'json', 'NL.json');
   const fileContents = fs.readFileSync(filePath, 'utf8');

--- a/src/pages/veelgestelde-vragen.tsx
+++ b/src/pages/veelgestelde-vragen.tsx
@@ -25,7 +25,7 @@ interface VeelgesteldeVragenProps {
 }
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text: TALLLanguages = require('../locale/index').default;
+  const text: TALLLanguages = (await import('../locale/index')).default;
   const serializedContent = text.over_veelgestelde_vragen.vragen.map(function (
     item: IVraagEnAntwoord
   ) {

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -114,7 +114,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
               ></span>
             </Heading>
             <Text mt={0} lineHeight={1}>
-              <Anchor anchorName="ggd" text={ggdText.summary_link_cta} />
+              <Anchor name="ggd" text={ggdText.summary_link_cta} />
             </Text>
           </Box>
         </KpiTile>

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -107,7 +107,7 @@ interface StaticProps {
 }
 
 export async function getStaticProps(): Promise<{ props: StaticProps }> {
-  const text = require('../../locale/index').default;
+  const text = (await import('../../locale/index')).default;
 
   const serializedContent = MDToHTMLString(
     text.veiligheidsregio_index.selecteer_toelichting

--- a/src/pages/verantwoording.tsx
+++ b/src/pages/verantwoording.tsx
@@ -25,7 +25,7 @@ interface VerantwoordingProps {
 }
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text = require('../locale/index').default;
+  const text = (await import('../locale/index')).default;
   const serializedContent = text.verantwoording.cijfers.map(
     (item: ICijfer) => ({
       ...item,

--- a/src/utils/replaceVariablesInText.ts
+++ b/src/utils/replaceVariablesInText.ts
@@ -18,13 +18,17 @@ const curlyBracketRegex = /\{\{(.+?)\}\}/g;
 
 export function replaceVariablesInText(
   translation?: string | undefined | null,
-  variables?: { [key: string]: string | undefined }
+  variables?: { [key: string]: string | number | undefined }
 ): string {
   if (!translation) return '';
 
   return translation.replace(curlyBracketRegex, (_string, variableName) => {
+    /**
+     * @TODO Why are we replacing variables with empty strings? It feels like
+     * these cases should be reported somewhere.
+     */
     if (!variables) return '';
 
-    return variables[variableName.trim()] ?? '';
+    return (variables[variableName.trim()] ?? '').toString();
   });
 }


### PR DESCRIPTION
## Summary

In my journey to discover the codebase I've ran into several improvements I tried to pick up, here's a summary of some changes:
- add `compile` script in package.json to be able to detect project-wide compilation issues
- renamed prop `anchorName` to `name` because it looks better compared to `<Anchor anchorName={name} />`
- removed several `any` types
- tried to wrap my head around the types used in the Choropleth. I believe there are some problems with types from different libraries. They have previously been ignored by casting stuff to `any`, but the result is that it's currently not very easy to fix these.
- Fixed several instances of react refs
- import locale data with `import` syntax instead of `require` in order to enable TS typings
