### PR TITLE
Changed threshold and color for regions and municipals

### DIFF
--- a/src/components/choropleth/municipalThresholds.ts
+++ b/src/components/choropleth/municipalThresholds.ts
@@ -8,23 +8,27 @@ const positiveTestedThresholds: ChoroplethThresholds = {
     },
     {
       color: '#8BD1FF',
-      threshold: 4,
-    },
-    {
-      color: '#61B6ED',
-      threshold: 7,
-    },
-    {
-      color: '#3597D4',
       threshold: 10,
     },
     {
-      color: '#046899',
+      color: '#61B6ED',
       threshold: 20,
     },
     {
-      color: '#034566',
-      threshold: 30,
+      color: '#3389c4',
+      threshold: 40,
+    },
+    {
+      color: '#04537e',
+      threshold: 60,
+    },
+    {
+      color: '#06416e',
+      threshold: 80,
+    },
+    {
+      color: '#2f2657',
+      threshold: 100,
     },
   ],
 };

--- a/src/components/choropleth/regionThresholds.ts
+++ b/src/components/choropleth/regionThresholds.ts
@@ -12,23 +12,27 @@ const positiveTestedThresholds: ChoroplethThresholds = {
     },
     {
       color: '#8BD1FF',
-      threshold: 4,
-    },
-    {
-      color: '#61B6ED',
-      threshold: 7,
-    },
-    {
-      color: '#3597D4',
       threshold: 10,
     },
     {
-      color: '#046899',
+      color: '#61B6ED',
       threshold: 20,
     },
     {
-      color: '#034566',
-      threshold: 30,
+      color: '#3389c4',
+      threshold: 40,
+    },
+    {
+      color: '#04537e',
+      threshold: 60,
+    },
+    {
+      color: '#06416e',
+      threshold: 80,
+    },
+    {
+      color: '#2f2657',
+      threshold: 100,
     },
   ],
 };


### PR DESCRIPTION
## Summary

I have changed thresholds and color used by the chloropleth map to beter represent the data.

## Motivation

This is usefull because it makes the data shows the cases per 100.000 more accurate for each region. That way the data is easier to interpret for users.

This fixes the issue I currently have with the used thresholds. Currently the map will not display other colors for more then 30+ cases. But a lot of regions are at 60+ or even 100+. If this is not implemented this information is not easy to see in the map.

## Detailed design

Only changes are the thresholds and colors in two files:
- municipalThresholds.ts
- regionThresholds.ts

I have increased the number of colors in these files by one. This did not change the map size. Any more colors will make the map smaller. 

## Drawbacks

I currently do not see any drawbacks for this change.
It could be of course that not displaying above 30 is a design choice I was not aware of.

## Alternatives

Colors and thresholds could be changed.


### Governance

- [ ] Documentation is added (not relevant)
- [ ] Test cases are added or updated (not relevant)
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
