### PR TITLE
Fix choropleth size

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,11 +16,6 @@ module.exports = {
   moduleNameMapper: {
     '\\.svg': '<rootDir>/__mocks__/svgrMock.js',
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
-    '^~/assets(.*)$': '<rootDir>/src/assets$1',
-    '^~/components(.*)$': '<rootDir>/src/components$1',
-    '^~/locale(.*)$': '<rootDir>/src/locale$1',
-    '^~/data(.*)$': '<rootDir>/src/data$1',
-    '^~/utils(.*)$': '<rootDir>/src/utils$1',
-    '^~/static-props(.*)$': '<rootDir>/src/static-props$1',
+    '^~/(.*)$': '<rootDir>/src/$1',
   },
 };

--- a/src/components-styled/choropleth-tile.tsx
+++ b/src/components-styled/choropleth-tile.tsx
@@ -40,7 +40,7 @@ export function ChoroplethTile<T>({
   children,
 }: ChoroplethTileProps) {
   const breakpoints = useBreakpoints();
-  const legendComponent = legend && (
+  const legendaComponent = legend && (
     <ChoroplethLegenda items={legend.items} title={legend.title} />
   );
 
@@ -62,9 +62,9 @@ export function ChoroplethTile<T>({
                 </Box>
               )}
             </Box>
-            {legendComponent && breakpoints.lg && (
+            {legendaComponent && breakpoints.lg && (
               <Box display="flex" flexDirection="row" alignItems="flex-center">
-                {legendComponent}
+                {legendaComponent}
               </Box>
             )}
           </div>
@@ -72,9 +72,9 @@ export function ChoroplethTile<T>({
         <Box flex={{ lg: 1 }}>
           <div>{children}</div>
 
-          {legendComponent && !breakpoints.lg && (
+          {legendaComponent && !breakpoints.lg && (
             <Box display="flex" justifyContent="center">
-              {legendComponent}
+              {legendaComponent}
             </Box>
           )}
         </Box>

--- a/src/components-styled/choropleth-tile.tsx
+++ b/src/components-styled/choropleth-tile.tsx
@@ -2,6 +2,7 @@ import {
   ChoroplethLegenda,
   ILegendaItem,
 } from '~/components/choropleth/legenda/ChoroplethLegenda';
+import { useBreakpoints } from '~/utils/useBreakpoints';
 import { Box } from './base';
 import {
   ChartRegionControls,
@@ -22,7 +23,7 @@ interface DataProps {
 
 interface ChoroplethTileProps extends DataProps {
   title: string;
-  description?: string;
+  description?: string | React.ReactNode;
   onChangeControls?: (v: RegionControlOption) => void;
   children: React.ReactNode;
   legend?: {
@@ -38,36 +39,46 @@ export function ChoroplethTile<T>({
   legend,
   children,
 }: ChoroplethTileProps) {
+  const breakpoints = useBreakpoints();
+  const legendComponent = legend && (
+    <ChoroplethLegenda items={legend.items} title={legend.title} />
+  );
+
   return (
-    <Tile
-      mb={4}
-      ml={{ _: -4, sm: 0 }}
-      mr={{ _: -4, sm: 0 }}
-      display={{ _: 'flex', lg: 'grid' }}
-      gridTemplateColumns={'1fr 1fr'}
-      gridTemplateRows={'auto auto 1fr auto'}
-      gridTemplateAreas={`'w w' 'a c' 'b c' 'd c'`}
-    >
-      <Box gridArea="a" mb={[0, 2]}>
-        <Heading level={3}>{title}</Heading>
-        {description && <Text>{description}</Text>}
-        {onChangeControls && (
-          <Box display="flex" justifyContent="flex-start">
-            <ChartRegionControls onChange={onChangeControls} />
-          </Box>
-        )}
-      </Box>
-      <Box gridArea="c">{children}</Box>
-      {legend && (
-        <Box
-          gridArea="b"
-          display="flex"
-          flexDirection="column"
-          alignItems={{ _: 'center', lg: 'flex-start' }}
-        >
-          <ChoroplethLegenda items={legend.items} title={legend.title} />
+    <Tile mb={4} ml={{ _: -4, sm: 0 }} mr={{ _: -4, sm: 0 }}>
+      <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
+        <Box flex={{ lg: 1 }}>
+          <div>
+            <Box mb={[0, 2]}>
+              <Heading level={3}>{title}</Heading>
+              {typeof description === 'string' ? (
+                <Text>{description}</Text>
+              ) : (
+                description
+              )}
+              {onChangeControls && (
+                <Box display="flex" justifyContent="flex-start">
+                  <ChartRegionControls onChange={onChangeControls} />
+                </Box>
+              )}
+            </Box>
+            {legendComponent && breakpoints.lg && (
+              <Box display="flex" flexDirection="row" alignItems="flex-center">
+                {legendComponent}
+              </Box>
+            )}
+          </div>
         </Box>
-      )}
+        <Box flex={{ lg: 1 }}>
+          <div>{children}</div>
+
+          {legendComponent && !breakpoints.lg && (
+            <Box display="flex" justifyContent="center">
+              {legendComponent}
+            </Box>
+          )}
+        </Box>
+      </Box>
     </Tile>
   );
 }

--- a/src/pages-tests/veiligheidsregio/[code]/positief-geteste.mensen.test.js
+++ b/src/pages-tests/veiligheidsregio/[code]/positief-geteste.mensen.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render } from '~/test-utils/render';
 
 import PositiefGetesteMensen from '../../../pages/veiligheidsregio/[code]/positief-geteste-mensen';
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,8 +4,6 @@ import path from 'path';
 import { useState } from 'react';
 import ExternalLink from '~/assets/external-link.svg';
 import Notification from '~/assets/notification.svg';
-import { ChartRegionControls } from '~/components-styled/chart-region-controls';
-import { ChoroplethLegenda } from '~/components/choropleth/legenda/ChoroplethLegenda';
 import { useSafetyRegionLegendaData } from '~/components/choropleth/legenda/hooks/useSafetyRegionLegendaData';
 import { MunicipalityChoropleth } from '~/components/choropleth/MunicipalityChoropleth';
 import { SafetyRegionChoropleth } from '~/components/choropleth/SafetyRegionChoropleth';
@@ -24,6 +22,8 @@ import styles from './index.module.scss';
 import { EscalationMapLegenda } from './veiligheidsregio';
 import { assert } from '~/utils/assert';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { ChoroplethTile } from '~/components-styled/choropleth-tile';
+import css from '@styled-system/css';
 
 interface StaticProps {
   props: INationalHomepageData;
@@ -65,7 +65,10 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
         title={text.laatste_ontwikkelingen.title}
         as="h2"
       />
-      <article className={`${styles.notification} metric-article`}>
+      <article
+        className={styles.notification}
+        css={css({ mb: 4, ml: [-4, null, 0], mr: [-4, null, 0] })}
+      >
         <div className={styles.textgroup}>
           <h3 className={styles.header}>{text.notificatie.titel}</h3>
           <p>
@@ -86,65 +89,55 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
         </a>
       </article>
 
-      <article className="metric-article layout-choropleth">
-        <div className="choropleth-header">
-          <h2>{text.veiligheidsregio_index.selecteer_titel}</h2>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: text.veiligheidsregio_index.selecteer_toelichting,
-            }}
+      <ChoroplethTile
+        title={text.veiligheidsregio_index.selecteer_titel}
+        description={
+          <>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: text.veiligheidsregio_index.selecteer_toelichting,
+              }}
+            />
+            <EscalationMapLegenda text={text} />
+          </>
+        }
+      >
+        <SafetyRegionChoropleth
+          metricName="escalation_levels"
+          metricValueName="escalation_level"
+          onSelect={createSelectRegionHandler(router)}
+          tooltipContent={escalationTooltip(router)}
+        />
+      </ChoroplethTile>
+
+      <ChoroplethTile
+        title={text.positief_geteste_personen.map_titel}
+        description={text.positief_geteste_personen.map_toelichting}
+        onChangeControls={setSelectedMap}
+        legend={
+          legendItems // this data value should probably not be optional
+            ? {
+                title: text.positief_geteste_personen.chloropleth_legenda.titel,
+                items: legendItems,
+              }
+            : undefined
+        }
+      >
+        {selectedMap === 'municipal' && (
+          <MunicipalityChoropleth
+            metricName="positive_tested_people"
+            tooltipContent={createPositiveTestedPeopleMunicipalTooltip(router)}
+            onSelect={createSelectMunicipalHandler(router)}
           />
-          <EscalationMapLegenda text={text} />
-        </div>
-        <div className="choropleth-chart">
+        )}
+        {selectedMap === 'region' && (
           <SafetyRegionChoropleth
-            metricName="escalation_levels"
-            metricValueName="escalation_level"
+            metricName="positive_tested_people"
+            tooltipContent={createPositiveTestedPeopleRegionalTooltip(router)}
             onSelect={createSelectRegionHandler(router)}
-            tooltipContent={escalationTooltip(router)}
           />
-        </div>
-      </article>
-
-      <article className="metric-article layout-choropleth">
-        <div className="choropleth-header">
-          <h3>{text.positief_geteste_personen.map_titel}</h3>
-          <p>{text.positief_geteste_personen.map_toelichting}</p>
-          <div className="choropleth-controls">
-            <ChartRegionControls
-              onChange={(val: 'region' | 'municipal') => setSelectedMap(val)}
-            />
-          </div>
-        </div>
-
-        <div className="choropleth-chart">
-          {selectedMap === 'municipal' && (
-            <MunicipalityChoropleth
-              metricName="positive_tested_people"
-              tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-                router
-              )}
-              onSelect={createSelectMunicipalHandler(router)}
-            />
-          )}
-          {selectedMap === 'region' && (
-            <SafetyRegionChoropleth
-              metricName="positive_tested_people"
-              tooltipContent={createPositiveTestedPeopleRegionalTooltip(router)}
-              onSelect={createSelectRegionHandler(router)}
-            />
-          )}
-        </div>
-
-        <div className="choropleth-legend">
-          {legendItems && (
-            <ChoroplethLegenda
-              items={legendItems}
-              title={text.positief_geteste_personen.chloropleth_legenda.titel}
-            />
-          )}
-        </div>
-      </article>
+        )}
+      </ChoroplethTile>
     </>
   );
 };

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -70,11 +70,11 @@ breakpoints.lg = breakpoints[3];
 breakpoints.xl = breakpoints[4];
 
 const mediaQueries = {
-  xs: `@media screen and (min-width: ${breakpoints[0]})`,
-  sm: `@media screen and (min-width: ${breakpoints[1]})`,
-  md: `@media screen and (min-width: ${breakpoints[2]})`,
-  lg: `@media screen and (min-width: ${breakpoints[3]})`,
-  xl: `@media screen and (min-width: ${breakpoints[4]})`,
+  xs: `screen and (min-width: ${breakpoints[0]})`,
+  sm: `screen and (min-width: ${breakpoints[1]})`,
+  md: `screen and (min-width: ${breakpoints[2]})`,
+  lg: `screen and (min-width: ${breakpoints[3]})`,
+  xl: `screen and (min-width: ${breakpoints[4]})`,
 };
 
 type TMediaQueries = typeof mediaQueries;
@@ -109,3 +109,11 @@ const theme: TDashboardTheme = {
 };
 
 export default theme;
+
+/**
+ * Tell styled-components the shape of our theme
+ */
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends TDashboardTheme {}
+}

--- a/src/test-utils/render.tsx
+++ b/src/test-utils/render.tsx
@@ -1,0 +1,13 @@
+import { render as testingLibraryRender } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import theme from '~/style/theme';
+
+/**
+ * Our components might depend on things like context providers. Here's where
+ * we can add these.
+ */
+export function render(app: React.ReactElement) {
+  return testingLibraryRender(
+    <ThemeProvider theme={theme}>{app}</ThemeProvider>
+  );
+}

--- a/src/utils/useBreakpoints.ts
+++ b/src/utils/useBreakpoints.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { useMediaQuery } from './useMediaQuery';
+
+export function useBreakpoints() {
+  const { mediaQueries } = useTheme();
+  const xs = useMediaQuery(mediaQueries.xs);
+  const sm = useMediaQuery(mediaQueries.sm);
+  const md = useMediaQuery(mediaQueries.md);
+  const lg = useMediaQuery(mediaQueries.lg);
+  const xl = useMediaQuery(mediaQueries.xl);
+
+  return React.useMemo(
+    () => ({
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+    }),
+    [xs, sm, md, lg, xl]
+  );
+}


### PR DESCRIPTION
## Summary

The rendering of the choropleth was off in both IE11 as other browsers. We're moving from scss to styled-components, but the latter [won't prefix grid-related css properties for IE11](https://github.com/thysultan/stylis.js/issues/51). One of the possible fixes is to use flexbox instead of grid, which this PR will implement.

Besides the above, the following has been picked up:
- Introduce a `useBreakpoints` hook
- Use the new `ChoroplethTile` component on the app's landing page
- Fix the theme's `mediaQueries` collection, it shouldn't include the `@media` for correct usage with `window.matchMedia`
- Fix jest test-run by providing a ThemeProvider during tests