### PR TITLE
Prevent rendering SewerWaterMetric when value is undefined

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -214,7 +214,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
               <h2>{siteText.nationaal_layout.headings.overig}</h2>
               <ul>
                 <li>
-                  {sewerWaterBarScaleData ? (
+                  {sewerWaterBarScaleData.value !== undefined ? (
                     <Link
                       href="/gemeente/[code]/rioolwater"
                       as={`/gemeente/${code}/rioolwater`}

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -74,7 +74,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
       />
 
       <TwoKpiSection>
-        {barScaleData?.value !== undefined && (
+        {barScaleData.value !== undefined && (
           <KpiTile title={text.barscale_titel} description={text.extra_uitleg}>
             <KpiValue absolute={barScaleData.value} />
           </KpiTile>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,6 +2,7 @@ import '@formatjs/intl-getcanonicallocales/polyfill';
 import '@formatjs/intl-datetimeformat/polyfill';
 import '@formatjs/intl-datetimeformat/locale-data/en';
 import '@formatjs/intl-datetimeformat/locale-data/nl';
+import { assert } from '~/utils/assert';
 
 // Adding the Europe/Amsterdam time zone manually since its the only being used.
 // The data was pulled from the @formatjs/add-golden-ts.js file.
@@ -68,11 +69,14 @@ export function formatDateFromSeconds(
   seconds: number,
   style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
 ): string {
+  assert(!isNaN(seconds), 'seconds is NaN');
+
   /**
    * JavaScript uses milliseconds since EPOCH, therefore the value
    * formatted by the format() function needs to be multiplied by 1000
    * to format to an accurate dateTime
    */
+
   const milliseconds = seconds * 1000;
 
   return formatDateFromMilliseconds(milliseconds, style);
@@ -82,6 +86,8 @@ export function formatDateFromMilliseconds(
   milliseconds: number,
   style?: 'long' | 'medium' | 'short' | 'relative' | 'iso' | 'axis'
 ): string {
+  assert(!isNaN(milliseconds), 'milliseconds is NaN');
+
   if (style === 'iso') return new Date(milliseconds).toISOString(); // '2020-07-23T10:01:16.000Z'
   if (style === 'long') return Long.format(milliseconds); // '23 juli 2020 om 12:01'
   if (style === 'medium') return Medium.format(milliseconds); // '23 juli 2020'


### PR DESCRIPTION
This PR will fix an issue where an `undefined` value is converted to `NaN` using `Number(undefined)`. Our app doesn't handle this type very well.