### PR TITLE
Remove 'last week' option for GGD charts

### DIFF
--- a/src/components/lineChart/lineChart.module.scss
+++ b/src/components/lineChart/lineChart.module.scss
@@ -3,6 +3,7 @@
 $breakpoint: 1200px;
 
 .root {
+  width: 100%;
 }
 
 .header {

--- a/src/components/lineChart/multipleLineChart.tsx
+++ b/src/components/lineChart/multipleLineChart.tsx
@@ -8,8 +8,8 @@ import { assert } from '~/utils/assert';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
-import styles from './lineChart.module.scss';
 import { Value } from './lineChartWithWeekTooltip';
+import styles from './lineChart.module.scss';
 
 type LineConfig = {
   color: string;
@@ -177,9 +177,17 @@ function getChartOptions(
       },
     })),
     legend: {
-      align: 'left',
+      itemWidth: 300,
+      reversed: true,
+      itemHoverStyle: {
+        color: '#666',
+      },
       itemStyle: {
+        color: '#666',
+        cursor: 'pointer',
+        fontSize: '12px',
         fontWeight: 'normal',
+        textOverflow: 'ellipsis',
       },
     },
     plotOptions: {

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -246,6 +246,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
 
       <KpiSection>
         <LineChart
+          timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_percentage_titel}
           description={ggdText.linechart_percentage_toelichting}
           values={ggdValues.map((value) => ({
@@ -275,6 +276,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
 
       <KpiSection>
         <MultipleLineChart
+          timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_totaltests_titel}
           description={ggdText.linechart_totaltests_toelichting}
           values={[

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -203,6 +203,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
 
       <KpiSection>
         <LineChart
+          timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_percentage_titel}
           description={ggdText.linechart_percentage_toelichting}
           values={ggdValues.map((value) => ({
@@ -234,6 +235,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
 
       <KpiSection>
         <MultipleLineChart
+          timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_totaltests_titel}
           description={ggdText.linechart_totaltests_toelichting}
           values={[


### PR DESCRIPTION
## Summary

As the PR title states, removed this option from the national and region pages.

## Motivation

Bug report

## Detailed design

Nothing to mention, except that I gave the section for the linechart a width of 100% because after removing the option the headers didn't align properly anymore.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
