### PR TITLE
Fix NL sewer line chart tooltip by applying generics

### DIFF
--- a/src/components-styled/line-chart-tile.tsx
+++ b/src/components-styled/line-chart-tile.tsx
@@ -1,23 +1,23 @@
 // Props type needs to be imported from lineChart directly because charts only works with
 // default export.
-import LineChart, { LineChartProps } from '~/components/lineChart';
+import LineChart, { LineChartProps, Value } from '~/components/lineChart';
 import locale from '~/locale/index';
 import { Spacer } from './base';
 import { ExternalLink } from './external-link';
 import { Tile } from './layout';
 import { Text } from './typography';
 
-interface LineChartTileProps extends LineChartProps {
+interface LineChartTileProps<T> extends LineChartProps<T> {
   sourcedFrom?: {
     text: string;
     href: string;
   };
 }
 
-export function LineChartTile({
+export function LineChartTile<T extends Value>({
   sourcedFrom,
   ...chartProps
-}: LineChartTileProps) {
+}: LineChartTileProps<T>) {
   return (
     <Tile
       /**

--- a/src/components/lineChart/index.tsx
+++ b/src/components/lineChart/index.tsx
@@ -16,21 +16,21 @@ export type Value = {
 
 const SIGNAALWAARDE_Z_INDEX = 5;
 
-export interface LineChartProps {
+export interface LineChartProps<T> {
   title: string;
   description?: string;
-  values: Value[];
+  values: T[];
   signaalwaarde?: number;
   timeframeOptions?: TimeframeOption[];
-  formatTooltip?: (x: number, y: number) => string;
+  formatTooltip?: (value: T) => string;
   formatYAxis?: (y: number) => string;
   showFill?: boolean;
 }
 
-function getChartOptions(
-  values: Value[],
+function getChartOptions<T extends Value>(
+  values: T[],
   signaalwaarde?: number,
-  formatTooltip?: (x: number, y: number) => string,
+  formatTooltip?: (value: T) => string,
   formatYAxis?: (y: number) => string,
   showFill?: boolean
 ) {
@@ -79,7 +79,7 @@ function getChartOptions(
       borderRadius: 0,
       formatter: function (): string {
         if (formatTooltip) {
-          return formatTooltip(this.x, this.y);
+          return formatTooltip(values[this.point.index]);
         }
         return `${formatDateFromSeconds(this.x)}: ${formatNumber(this.y)}`;
       },
@@ -183,7 +183,7 @@ function getChartOptions(
   return options;
 }
 
-export default function LineChart({
+export default function LineChart<T extends Value>({
   title,
   description,
   values,
@@ -192,16 +192,16 @@ export default function LineChart({
   formatTooltip,
   formatYAxis,
   showFill = true,
-}: LineChartProps) {
+}: LineChartProps<T>) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>('5weeks');
 
   const chartOptions = useMemo(() => {
-    const filteredValues = getFilteredValues<Value>(
+    const filteredValues = getFilteredValues<T>(
       values,
       timeframe,
-      (value: Value) => value.date * 1000
+      (value: T) => value.date * 1000
     );
-    return getChartOptions(
+    return getChartOptions<T>(
       filteredValues,
       signaalwaarde,
       formatTooltip,

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -9,8 +9,16 @@ import { getNationalLayout } from '~/components/layout/NationalLayout';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
+import { formatDateFromSeconds } from '~/utils/formatDate';
+import { formatNumber } from '~/utils/formatNumber';
 
 const text = siteText.rioolwater_metingen;
+
+interface LineChartValue {
+  value: number;
+  date: number;
+  week: { start: number; end: number };
+}
 
 const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
   const sewerAverages = data.rioolwater_metingen;
@@ -58,11 +66,23 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
       <LineChartTile
         title={text.linechart_titel}
         timeframeOptions={['all', '5weeks']}
-        values={sewerAverages.values.map((value) => ({
-          value: Number(value.average),
-          date: value.week_unix,
-          week: { start: value.week_start_unix, end: value.week_end_unix },
-        }))}
+        values={sewerAverages.values.map(
+          (value) =>
+            ({
+              value: Number(value.average),
+              date: value.week_unix,
+              week: { start: value.week_start_unix, end: value.week_end_unix },
+            } as LineChartValue)
+        )}
+        formatTooltip={(x) => {
+          return `<strong>${formatDateFromSeconds(
+            x.week.start,
+            'short'
+          )} - ${formatDateFromSeconds(
+            x.week.end,
+            'short'
+          )}:</strong> ${formatNumber(x.value)}`;
+        }}
       />
     </>
   );


### PR DESCRIPTION
Show week range in NL sewer tooltip. Instead of creating a new LineChart just for displaying a different tooltip I used TS generics to solve the problem.