### PR TITLE
Apply week ranges in ggd positief getest tooltips on NL and VR

### DIFF
--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -24,10 +24,6 @@ import { ContentHeader_weekRangeHack } from '~/components/contentHeader_weekRang
 import { PositiveTestedPeopleBarScale } from '~/components/landelijk/positive-tested-people-barscale';
 import { FCWithLayout } from '~/components/layout';
 import { getNationalLayout } from '~/components/layout/NationalLayout';
-import {
-  LineChart,
-  Value,
-} from '~/components/lineChart/lineChartWithWeekTooltip';
 import { MultipleLineChart } from '~/components/lineChart/multipleLineChart';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
@@ -247,35 +243,31 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         </KpiTile>
       </TwoKpiSection>
 
-      <KpiSection>
-        <LineChart
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_percentage_titel}
-          description={ggdText.linechart_percentage_toelichting}
-          values={ggdValues.map((value) => ({
-            value: value.infected_percentage,
-            date: value.week_unix,
-            week: {
-              start: value.week_start_unix,
-              end: value.week_end_unix,
-            },
-          }))}
-          tooltipFormatter={function () {
-            const { originalData }: { originalData: Value } = this.point as any;
-
-            return `<strong>${formatDateFromSeconds(
-              originalData.week.start,
-              'short'
-            )} - ${formatDateFromSeconds(
-              originalData.week.end,
-              'short'
-            )}:</strong> ${formatPercentage(this.y)}%`;
-          }}
-          formatYAxis={(y: number) => {
-            return `${formatPercentage(y)}%`;
-          }}
-        />
-      </KpiSection>
+      <LineChartTile
+        timeframeOptions={['all', '5weeks']}
+        title={ggdText.linechart_percentage_titel}
+        description={ggdText.linechart_percentage_toelichting}
+        values={ggdValues.map((value) => ({
+          value: value.infected_percentage,
+          date: value.week_unix,
+          week: {
+            start: value.week_start_unix,
+            end: value.week_end_unix,
+          },
+        }))}
+        formatTooltip={(x) => {
+          return `<strong>${formatDateFromSeconds(
+            x.week.start,
+            'short'
+          )} - ${formatDateFromSeconds(
+            x.week.end,
+            'short'
+          )}:</strong> ${formatPercentage(x.value)}%`;
+        }}
+        formatYAxis={(y: number) => {
+          return `${formatPercentage(y)}%`;
+        }}
+      />
 
       <KpiSection>
         <MultipleLineChart

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -14,12 +14,6 @@ import { formatNumber } from '~/utils/formatNumber';
 
 const text = siteText.rioolwater_metingen;
 
-interface LineChartValue {
-  value: number;
-  date: number;
-  week: { start: number; end: number };
-}
-
 const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
   const sewerAverages = data.rioolwater_metingen;
 
@@ -66,14 +60,11 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
       <LineChartTile
         title={text.linechart_titel}
         timeframeOptions={['all', '5weeks']}
-        values={sewerAverages.values.map(
-          (value) =>
-            ({
-              value: Number(value.average),
-              date: value.week_unix,
-              week: { start: value.week_start_unix, end: value.week_end_unix },
-            } as LineChartValue)
-        )}
+        values={sewerAverages.values.map((value) => ({
+          value: Number(value.average),
+          date: value.week_unix,
+          week: { start: value.week_start_unix, end: value.week_end_unix },
+        }))}
         formatTooltip={(x) => {
           return `<strong>${formatDateFromSeconds(
             x.week.start,

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -204,37 +204,31 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
         </KpiTile>
       </TwoKpiSection>
 
-      <KpiSection>
-        <LineChart
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_percentage_titel}
-          description={ggdText.linechart_percentage_toelichting}
-          values={ggdValues.map((value) => ({
-            value: value.infected_percentage,
-            date: value.week_unix,
-            week: {
-              start: value.week_start_unix,
-              end: value.week_end_unix,
-            },
-          }))}
-          tooltipFormatter={function () {
-            const { originalData } = (this.point as unknown) as {
-              originalData: Value;
-            };
-
-            return `<strong>${formatDateFromSeconds(
-              originalData.week.start,
-              'short'
-            )} - ${formatDateFromSeconds(
-              originalData.week.end,
-              'short'
-            )}:</strong> ${formatPercentage(this.y)}%`;
-          }}
-          formatYAxis={(y: number) => {
-            return `${formatPercentage(y)}%`;
-          }}
-        />
-      </KpiSection>
+      <LineChartTile
+        timeframeOptions={['all', '5weeks']}
+        title={ggdText.linechart_percentage_titel}
+        description={ggdText.linechart_percentage_toelichting}
+        values={ggdValues.map((value) => ({
+          value: value.infected_percentage,
+          date: value.week_unix,
+          week: {
+            start: value.week_start_unix,
+            end: value.week_end_unix,
+          },
+        }))}
+        formatTooltip={(x) => {
+          return `<strong>${formatDateFromSeconds(
+            x.week.start,
+            'short'
+          )} - ${formatDateFromSeconds(
+            x.week.end,
+            'short'
+          )}:</strong> ${formatPercentage(x.value)}%`;
+        }}
+        formatYAxis={(y: number) => {
+          return `${formatPercentage(y)}%`;
+        }}
+      />
 
       <KpiSection>
         <MultipleLineChart

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -18,10 +18,6 @@ import { ContentHeader } from '~/components/contentHeader';
 import { ContentHeader_weekRangeHack } from '~/components/contentHeader_weekRangeHack';
 import { FCWithLayout } from '~/components/layout';
 import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
-import {
-  LineChart,
-  Value,
-} from '~/components/lineChart/lineChartWithWeekTooltip';
 import { MultipleLineChart } from '~/components/lineChart/multipleLineChart';
 import { SEOHead } from '~/components/seoHead';
 import { PositivelyTestedPeopleBarScale } from '~/components/veiligheidsregio/positive-tested-people-barscale';


### PR DESCRIPTION
Format tooltips for GGD positief getest line charts on NL and VR to show week range.