### PR TITLE
Correct metric for hospital admissions (safety region)

### DIFF
--- a/src/components/veiligheidsregio/intake-hospital-metric.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-metric.tsx
@@ -26,7 +26,7 @@ export function IntakeHospitalMetric(props: {
   return (
     <MetricKPI
       title={title}
-      value={data.last_value.hospital_increase_per_region}
+      value={data.last_value.hospital_moving_avg_per_region}
       format={formatNumber}
       description={description}
     />

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -67,7 +67,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
             <h3>{text.barscale_titel}</h3>
             <p className="text-blue kpi" data-cy="infected_daily_total">
               {formatNumber(
-                resultsPerRegion.last_value.hospital_increase_per_region
+                resultsPerRegion.last_value.hospital_moving_avg_per_region
               )}
             </p>
           </div>


### PR DESCRIPTION
## Summary

Use the correct metric `hospital_moving_avg_per_region` in the sidebar component and the tile on Hospital Admissions 

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
