### PR TITLE
Add regional choropleth for sewerwater data

### DIFF
--- a/src/components/choropleth/regionThresholds.ts
+++ b/src/components/choropleth/regionThresholds.ts
@@ -138,39 +138,31 @@ const nursingHomeInfectedLocationsPercentageThresholds: ChoroplethThresholds = {
   ],
 };
 
-/**
- * @TODO set correct threshold colors and levels. This is a placeholder so that
- * the code compiles.
- */
 const sewerThresholds: ChoroplethThresholds = {
   thresholds: [
     {
-      color: '#FFFFFF',
+      color: '#C0E8FC',
       threshold: 0,
     },
     {
-      color: '#C0E8FC',
-      threshold: 1,
+      color: '#8BD1FF',
+      threshold: 5,
     },
     {
-      color: '#87CBF8',
-      threshold: 3,
+      color: '#61B6ED',
+      threshold: 50,
     },
     {
-      color: '#5DAFE4',
-      threshold: 7,
+      color: '#3597D4',
+      threshold: 100,
     },
     {
-      color: '#3391CC',
-      threshold: 11,
-    },
-    {
-      color: '#0579B3',
-      threshold: 21,
+      color: '#046899',
+      threshold: 150,
     },
     {
       color: '#034566',
-      threshold: 30,
+      threshold: 200,
     },
   ],
 };

--- a/src/components/choropleth/tooltips/region/createSewerRegionalTooltip.tsx
+++ b/src/components/choropleth/tooltips/region/createSewerRegionalTooltip.tsx
@@ -1,0 +1,32 @@
+import { NextRouter } from 'next/router';
+import { ReactNode } from 'react';
+import { TooltipContent } from '~/components/choropleth/tooltips/tooltipContent';
+import { RegionalSewerValue } from '~/types/data';
+import { formatNumber } from '~/utils/formatNumber';
+import { createSelectRegionHandler } from '../../selectHandlers/createSelectRegionHandler';
+import { SafetyRegionProperties } from '../../shared';
+import siteText from '~/locale/index';
+import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+
+const text = siteText.rioolwater_metingen;
+
+export const createSewerRegionalTooltip = (router: NextRouter) => (
+  context: RegionalSewerValue & SafetyRegionProperties
+): ReactNode => {
+  const handler = createSelectRegionHandler(router);
+
+  const onSelect = (event: any) => {
+    event.stopPropagation();
+    handler(context);
+  };
+
+  return (
+    context && (
+      <TooltipContent title={context.vrname} onSelect={onSelect}>
+        <strong>{`${replaceVariablesInText(text.map_tooltip, {
+          value: formatNumber(context.average),
+        })}`}</strong>
+      </TooltipContent>
+    )
+  );
+};

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -414,7 +414,11 @@
     "titel_kpi": "Average number of coronavirus particles per 100,000 inhabitants found in wastewater in the Netherlands corrected for quantity",
     "total_installation_count_titel": "Number of measurement locations",
     "total_installation_count_description": "Weekly number of sewage water treatment plants that have reported at least one measurement. The weekly average is calculated by taking the average of all measurements at these locations. This number can vary each week because not all measurements are successful.",
-    "rwzi_abbrev": ""
+    "rwzi_abbrev": "",
+    "map_titel": "Average number of virus particles in one milliliter of sewage water per region",
+    "map_toelichting": "",
+    "legenda_titel": "Legend",
+    "map_tooltip": "{{value}} billion particles per 100.000"
   },
   "notfound_titel": {
     "text": "Something went wrong"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -414,7 +414,11 @@
     "titel_kpi": "Gemiddelde aantal virusdeeltjes per 100.000 inwoners in rioolwater in Nederland omgerekend naar dagelijks hoeveelheid rioolwater",
     "total_installation_count_titel": "Aantal meetlocaties",
     "total_installation_count_description": "Wekelijks aantal rioolwaterzuiveringsinstallaties die minimaal één keer een meting hebben gerapporteerd. Het weekgemiddelde wordt berekend door het gemiddelde te nemen van alle metingen op deze locaties. Per week kan dit aantal variëren omdat niet alle metingen altijd lukken.",
-    "rwzi_abbrev": ""
+    "rwzi_abbrev": "",
+    "map_titel": "Gemiddeld aantal virusdeeltjes per 100.000 inwoners in rioolwater per gemeente",
+    "map_toelichting": "",
+    "legenda_titel": "Legenda",
+    "map_tooltip": "{{value}} miljard deeltjes per 100.000 inwoners"
   },
   "notfound_titel": {
     "text": "Er is iets misgegaan"

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -36,13 +36,14 @@ import {
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
+import { RegionControlOption } from '~/components-styled/chart-region-controls';
 
 const text = siteText.positief_geteste_personen;
 const ggdText = siteText.positief_geteste_personen_ggd;
 
 const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
   const { data } = props;
-  const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
+  const [selectedMap, setSelectedMap] = useState<RegionControlOption>(
     'municipal'
   );
   const router = useRouter();

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -1,4 +1,5 @@
 import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
+import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
@@ -11,11 +12,18 @@ import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
+import { SafetyRegionChoropleth } from '~/components/choropleth/SafetyRegionChoropleth';
+import { createSelectRegionHandler } from '~/components/choropleth/selectHandlers/createSelectRegionHandler';
+import { useRouter } from 'next/router';
+import { useSafetyRegionLegendaData } from '~/components/choropleth/legenda/hooks/useSafetyRegionLegendaData';
+import { createSewerRegionalTooltip } from '~/components/choropleth/tooltips/region/createSewerRegionalTooltip';
 
 const text = siteText.rioolwater_metingen;
 
 const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
   const sewerAverages = data.sewer;
+  const router = useRouter();
+  const legendItems = useSafetyRegionLegendaData('sewer');
 
   return (
     <>
@@ -76,6 +84,26 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
         }}
         valueAnnotation={siteText.waarde_annotaties.riool_normalized}
       />
+
+      <ChoroplethTile
+        title={text.map_titel}
+        description={text.map_toelichting}
+        legend={
+          legendItems // this data value should probably not be optional
+            ? {
+                title: text.legenda_titel,
+                items: legendItems,
+              }
+            : undefined
+        }
+      >
+        <SafetyRegionChoropleth
+          metricName="sewer"
+          metricValueName="average"
+          tooltipContent={createSewerRegionalTooltip(router)}
+          onSelect={createSelectRegionHandler(router)}
+        />
+      </ChoroplethTile>
     </>
   );
 };


### PR DESCRIPTION
## Summary

This adds a choropleth to the national sewerwater page that shows the viral particles per 100k people for all the regions.

## Motivation

Feature request

## Detailed design

Just a standard implementation od the choropleth with new threshold data specific to sewer water and a tooltip handler.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
