### PR TITLE
Restriction schema simplification

### DIFF
--- a/schema/national/__index.json
+++ b/schema/national/__index.json
@@ -95,6 +95,9 @@
     },
     "nursing_home": {
       "$ref": "nursing_home.json"
+    },
+    "restrictions": {
+      "$ref": "restrictions.json"
     }
   }
 }

--- a/schema/national/restrictions.json
+++ b/schema/national/restrictions.json
@@ -1,25 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "title": "restrictions",
+  "title": "national_restrictions",
   "additionalProperties": false,
-  "required": ["last_generated", "proto_name", "name", "code", "values"],
+  "required": ["vrcode", "values"],
   "properties": {
-    "last_generated": {
-      "type": "string"
-    },
-    "proto_name": {
-      "type": "string",
-      "const": "RESTRICTIONS"
-    },
-    "name": {
-      "type": "string",
-      "const": { "$data": "1/proto_name" }
-    },
-    "code": {
-      "type": "string",
-      "const": { "$data": "1/proto_name" }
-    },
+    "vrcode": { "type": "string", "equalsRootProperty": "code" },
     "values": {
       "type": "array",
       "items": {
@@ -29,7 +15,7 @@
   },
   "definitions": {
     "value": {
-      "title": "restrictions_value",
+      "title": "national_restriction_value",
       "additionalProperties": false,
       "required": [
         "restriction_id",
@@ -45,7 +31,7 @@
         },
         "target_region": {
           "type": "string",
-          "enum": ["nl", "vr"]
+          "const": "nl"
         },
         "escalation_level": {
           "type": "number",

--- a/schema/regional/restrictions.json
+++ b/schema/regional/restrictions.json
@@ -9,8 +9,57 @@
     "values": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^[0-9]+_[a-z_]+_[0-9]+$"
+        "$ref": "#/definitions/value"
+      }
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "regional_restriction_value",
+      "additionalProperties": false,
+      "required": [
+        "restriction_id",
+        "target_region",
+        "escalation_level",
+        "category_id",
+        "restriction_order"
+      ],
+      "properties": {
+        "restriction_id": {
+          "type": "string",
+          "validRestrictionId": true
+        },
+        "target_region": {
+          "type": "string",
+          "enum": ["nl", "vr"]
+        },
+        "escalation_level": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "category_id": {
+          "type": "string",
+          "enum": [
+            "er_op_uit",
+            "bezoek",
+            "samenkomst",
+            "huwelijk",
+            "verpleeghuis",
+            "horeca",
+            "sport",
+            "reizen_binnenland",
+            "ov",
+            "uitvaart",
+            "onderwijs",
+            "werk",
+            "winkels",
+            "alcohol"
+          ]
+        },
+        "restriction_order": {
+          "type": "number"
+        }
       }
     }
   }

--- a/src/tools/validator/schema-information.ts
+++ b/src/tools/validator/schema-information.ts
@@ -40,11 +40,6 @@ export const schemaInformation: Record<string, SchemaInfo> = {
     basePath: localeBasePath,
     customValidations: [validatePlaceholders],
   },
-  restrictions: {
-    files: ['RESTRICTIONS.json'],
-    basePath: jsonBasePath,
-    optional: true,
-  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Simplified restrictions by placing them directly under regional and national. No more lookups.

## Motivation

Simpler === better

## Detailed design

The separate restrictions schema for a single file that would contain all the restrictions was removed. In favor of having the specific restriction items directly in the regional and national files.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
