### PR TITLE
Implement new proposal for difference values

### DIFF
--- a/schema/national/infected_people_total.json
+++ b/schema/national/infected_people_total.json
@@ -12,9 +12,6 @@
     },
     "last_value": {
       "$ref": "#/definitions/value"
-    },
-    "last_value_difference": {
-      "$ref": "#/definitions/value_difference"
     }
   },
   "required": ["values", "last_value"],
@@ -27,6 +24,9 @@
         "infected_daily_total": {
           "type": "number"
         },
+        "infected_daily_total_difference": {
+          "type": "number"
+        },
         "date_of_report_unix": {
           "type": "integer"
         },
@@ -36,30 +36,9 @@
       },
       "required": [
         "infected_daily_total",
+        "infected_daily_total_difference",
         "date_of_report_unix",
         "date_of_insertion_unix"
-      ],
-      "additionalProperties": false
-    },
-    "value_difference": {
-      "title": "national_infected_people_total_value_difference",
-      "type": "object",
-      "properties": {
-        "infected_daily_total_old": {
-          "type": "integer"
-        },
-        "infected_daily_total_difference": {
-          "type": "integer"
-        },
-
-        "date_of_report_unix_old": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "infected_daily_total_old",
-        "infected_daily_total_difference",
-        "date_of_report_unix_old"
       ],
       "additionalProperties": false
     }

--- a/schema/national/verdenkingen_huisartsen.json
+++ b/schema/national/verdenkingen_huisartsen.json
@@ -11,9 +11,6 @@
     },
     "last_value": {
       "$ref": "#/definitions/value"
-    },
-    "last_value_difference": {
-      "$ref": "#/definitions/value_difference"
     }
   },
   "required": ["values", "last_value"],
@@ -35,8 +32,14 @@
         "incidentie": {
           "type": "number"
         },
+        "incidentie_difference": {
+          "type": "integer"
+        },
         "geschat_aantal": {
           "type": "number"
+        },
+        "geschat_aantal_difference": {
+          "type": "integer"
         },
         "date_of_insertion_unix": {
           "type": "integer"
@@ -47,37 +50,10 @@
         "week_start_unix",
         "week_end_unix",
         "incidentie",
-        "geschat_aantal",
-        "date_of_insertion_unix"
-      ],
-      "additionalProperties": false
-    },
-    "value_difference": {
-      "title": "national_huisarts_verdenkingen_value_difference",
-      "type": "object",
-      "properties": {
-        "incidentie_old": {
-          "type": "integer"
-        },
-        "incidentie_difference": {
-          "type": "integer"
-        },
-        "geschat_aantal_old": {
-          "type": "integer"
-        },
-        "geschat_aantal_difference": {
-          "type": "integer"
-        },
-        "date_of_report_unix_old": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "incidentie_old",
         "incidentie_difference",
-        "geschat_aantal_old",
+        "geschat_aantal",
         "geschat_aantal_difference",
-        "date_of_report_unix_old"
+        "date_of_insertion_unix"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
This proposal implements difference values differently by nesting the property directly in the value objects, instead of using a separate last_value_difference key, because the original proposal poses problems for backend implementation.