### PR TITLE
Implement differences in standardized way

### DIFF
--- a/schema/municipal/__difference.json
+++ b/schema/municipal/__difference.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "municipal_difference",
+  "type": "object",
+  "properties": {
+    "positive_tested_people__infected_daily_increase": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "positive_tested_people__infected_daily_total": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "hospital_admissions__moving_average_hospital": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "sewer__average": {
+      "$ref": "#/definitions/diff_integer"
+    }
+  },
+  "required": [
+    "positive_tested_people__infected_daily_increase",
+    "positive_tested_people__infected_daily_total",
+    "hospital_admissions__moving_average_hospital",
+    "sewer__average"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "diff_integer": {
+      "title": "municipal_difference_integer",
+      "type": "object",
+      "properties": {
+        "old_value": {
+          "type": "integer"
+        },
+        "difference": {
+          "type": "integer"
+        },
+        "old_date_of_report_unix": {
+          "type": "integer"
+        }
+      },
+      "required": ["old_value", "difference", "old_date_of_report_unix"],
+      "additionalProperties": false
+    },
+    "diff_decimal": {
+      "title": "municipal_difference_decimal",
+      "type": "object",
+      "properties": {
+        "old_value": {
+          "type": "number"
+        },
+        "difference": {
+          "type": "number"
+        },
+        "old_date_of_report_unix": {
+          "type": "number"
+        }
+      },
+      "required": ["old_value", "difference", "old_date_of_report_unix"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/municipal/__difference.json
+++ b/schema/municipal/__difference.json
@@ -10,7 +10,7 @@
       "$ref": "#/definitions/diff_integer"
     },
     "hospital_admissions__moving_average_hospital": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "sewer__average": {
       "$ref": "#/definitions/diff_integer"

--- a/schema/municipal/__index.json
+++ b/schema/municipal/__index.json
@@ -27,6 +27,9 @@
       "type": "string",
       "const": { "$data": "1/proto_name" }
     },
+    "difference": {
+      "$ref": "__difference.json"
+    },
     "hospital_admissions": {
       "$ref": "hospital_admissions.json"
     },

--- a/schema/national/__difference.json
+++ b/schema/national/__difference.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "national_differences",
+  "type": "object",
+  "properties": {
+    "huisarts_verdenkingen__incidentie": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "huisarts_verdenkingen__geschat_aantal": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "infected_people_total__infected_daily_total": {
+      "$ref": "#/definitions/diff_integer"
+    }
+  },
+  "required": ["huisarts_verdenkingen"],
+  "additionalProperties": false,
+  "definitions": {
+    "diff_integer": {
+      "title": "national_diff_integer",
+      "type": "object",
+      "properties": {
+        "old_value": {
+          "type": "integer"
+        },
+        "difference": {
+          "type": "integer"
+        },
+        "old_date_of_report_unix": {
+          "type": "integer"
+        }
+      },
+      "required": ["old_value", "difference", "old_date_of_report_unix"],
+      "additionalProperties": false
+    },
+    "diff_decimal": {
+      "title": "national_diff_decimal",
+      "type": "object",
+      "properties": {
+        "old_value": {
+          "type": "number"
+        },
+        "difference": {
+          "type": "number"
+        },
+        "old_date_of_report_unix": {
+          "type": "number"
+        }
+      },
+      "required": ["old_value", "difference", "old_date_of_report_unix"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/national/__difference.json
+++ b/schema/national/__difference.json
@@ -22,13 +22,13 @@
       "$ref": "#/definitions/diff_integer"
     },
     "intake_hospital_ma__moving_average_hospital": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "hospital_beds_occupied__covid_occupied": {
       "$ref": "#/definitions/diff_integer"
     },
     "intake_intensivecare_ma__moving_average_ic": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "intensive_care_beds_occupied__covid_occupied": {
       "$ref": "#/definitions/diff_integer"

--- a/schema/national/__difference.json
+++ b/schema/national/__difference.json
@@ -9,7 +9,7 @@
     "infected_people_total__infected_daily_total": {
       "$ref": "#/definitions/diff_integer"
     },
-    "ggd__infected": {
+    "ggd__tested_total": {
       "$ref": "#/definitions/diff_integer"
     },
     "ggd__infected_percentage": {
@@ -55,7 +55,7 @@
   "required": [
     "infected_people_delta_normalized__infected_daily_increase",
     "infected_people_total__infected_daily_total",
-    "ggd__infected",
+    "ggd__tested_total",
     "ggd__infected_percentage",
     "reproduction_index_last_known_average__reproduction_index_avg",
     "infectious_people_count_normalized__infectious_avg_normalized",

--- a/schema/national/__difference.json
+++ b/schema/national/__difference.json
@@ -13,7 +13,7 @@
       "$ref": "#/definitions/diff_integer"
     }
   },
-  "required": ["huisarts_verdenkingen"],
+  "required": ["huisarts_verdenkingen__incidentie", "huisarts_verdenkingen__geschat_aantal", "infected_people_total__infected_daily_total"],
   "additionalProperties": false,
   "definitions": {
     "diff_integer": {

--- a/schema/national/__difference.json
+++ b/schema/national/__difference.json
@@ -1,15 +1,54 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "national_differences",
+  "title": "national_difference",
   "type": "object",
   "properties": {
-    "huisarts_verdenkingen__incidentie": {
+    "infected_people_delta_normalized__infected_daily_increase": {
       "$ref": "#/definitions/diff_integer"
+    },
+    "infected_people_total__infected_daily_total": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "ggd__infected": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "ggd__infected_percentage": {
+      "$ref": "#/definitions/diff_decimal"
+    },
+    "reproduction_index_last_known_average__reproduction_index_avg": {
+      "$ref": "#/definitions/diff_decimal"
+    },
+    "infectious_people_count_normalized__infectious_avg_normalized": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "intake_hospital_ma__moving_average_hospital": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "hospital_beds_occupied__covid_occupied": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "intake_intensivecare_ma__moving_average_ic": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "intensive_care_beds_occupied__covid_occupied": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "huisarts_verdenkingen__incidentie": {
+      "$ref": "#/definitions/diff_decimal"
     },
     "huisarts_verdenkingen__geschat_aantal": {
       "$ref": "#/definitions/diff_integer"
     },
-    "infected_people_total__infected_daily_total": {
+    "sewer__average": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "nursing_home__newly_infected_people": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "nursing_home__infected_locations_total": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "nursing_home__deceased_daily": {
       "$ref": "#/definitions/diff_integer"
     }
   },
@@ -17,7 +56,7 @@
   "additionalProperties": false,
   "definitions": {
     "diff_integer": {
-      "title": "national_diff_integer",
+      "title": "national_difference_integer",
       "type": "object",
       "properties": {
         "old_value": {
@@ -34,7 +73,7 @@
       "additionalProperties": false
     },
     "diff_decimal": {
-      "title": "national_diff_decimal",
+      "title": "national_difference_decimal",
       "type": "object",
       "properties": {
         "old_value": {

--- a/schema/national/__index.json
+++ b/schema/national/__index.json
@@ -7,6 +7,7 @@
     "proto_name",
     "name",
     "code",
+    "difference",
     "verdenkingen_huisartsen",
     "intake_hospital_ma",
     "infectious_people_count",
@@ -42,6 +43,9 @@
     "code": {
       "type": "string",
       "const": { "$data": "1/proto_name" }
+    },
+    "difference": {
+      "$ref": "__difference.json"
     },
     "verdenkingen_huisartsen": {
       "$ref": "verdenkingen_huisartsen.json"

--- a/schema/national/infected_people_total.json
+++ b/schema/national/infected_people_total.json
@@ -12,9 +12,6 @@
     },
     "last_value": {
       "$ref": "#/definitions/value"
-    },
-    "last_value_difference": {
-      "$ref": "#/definitions/value_difference"
     }
   },
   "required": ["values", "last_value"],
@@ -38,28 +35,6 @@
         "infected_daily_total",
         "date_of_report_unix",
         "date_of_insertion_unix"
-      ],
-      "additionalProperties": false
-    },
-    "value_difference": {
-      "title": "national_infected_people_total_value_difference",
-      "type": "object",
-      "properties": {
-        "infected_daily_total_old": {
-          "type": "integer"
-        },
-        "infected_daily_total_difference": {
-          "type": "integer"
-        },
-
-        "date_of_report_unix_old": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "infected_daily_total_old",
-        "infected_daily_total_difference",
-        "date_of_report_unix_old"
       ],
       "additionalProperties": false
     }

--- a/schema/national/verdenkingen_huisartsen.json
+++ b/schema/national/verdenkingen_huisartsen.json
@@ -11,9 +11,6 @@
     },
     "last_value": {
       "$ref": "#/definitions/value"
-    },
-    "last_value_difference": {
-      "$ref": "#/definitions/value_difference"
     }
   },
   "required": ["values", "last_value"],
@@ -49,35 +46,6 @@
         "incidentie",
         "geschat_aantal",
         "date_of_insertion_unix"
-      ],
-      "additionalProperties": false
-    },
-    "value_difference": {
-      "title": "national_huisarts_verdenkingen_value_difference",
-      "type": "object",
-      "properties": {
-        "incidentie_old": {
-          "type": "integer"
-        },
-        "incidentie_difference": {
-          "type": "integer"
-        },
-        "geschat_aantal_old": {
-          "type": "integer"
-        },
-        "geschat_aantal_difference": {
-          "type": "integer"
-        },
-        "date_of_report_unix_old": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "incidentie_old",
-        "incidentie_difference",
-        "geschat_aantal_old",
-        "geschat_aantal_difference",
-        "date_of_report_unix_old"
       ],
       "additionalProperties": false
     }

--- a/schema/regional/__difference.json
+++ b/schema/regional/__difference.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "national_difference",
+  "title": "regional_difference",
   "type": "object",
   "properties": {
-    "infected_people_delta_normalized__infected_daily_increase": {
-      "$ref": "#/definitions/diff_decimal"
+    "results_per_region__infected_increase_per_region": {
+      "$ref": "#/definitions/diff_integer"
     },
-    "infected_people_total__infected_daily_total": {
+    "results_per_region__total_reported_increase_per_region": {
       "$ref": "#/definitions/diff_integer"
     },
     "ggd__infected": {
@@ -15,28 +15,10 @@
     "ggd__infected_percentage": {
       "$ref": "#/definitions/diff_decimal"
     },
-    "reproduction_index_last_known_average__reproduction_index_avg": {
-      "$ref": "#/definitions/diff_decimal"
-    },
-    "infectious_people_count_normalized__infectious_avg_normalized": {
+    "results_per_region__hospital_moving_avg_per_region": {
       "$ref": "#/definitions/diff_integer"
     },
-    "intake_hospital_ma__moving_average_hospital": {
-      "$ref": "#/definitions/diff_integer"
-    },
-    "hospital_beds_occupied__covid_occupied": {
-      "$ref": "#/definitions/diff_integer"
-    },
-    "intake_intensivecare_ma__moving_average_ic": {
-      "$ref": "#/definitions/diff_integer"
-    },
-    "intensive_care_beds_occupied__covid_occupied": {
-      "$ref": "#/definitions/diff_integer"
-    },
-    "huisarts_verdenkingen__incidentie": {
-      "$ref": "#/definitions/diff_decimal"
-    },
-    "huisarts_verdenkingen__geschat_aantal": {
+    "results_per_region__hospital_total_counts_per_region": {
       "$ref": "#/definitions/diff_integer"
     },
     "sewer__average": {
@@ -53,18 +35,12 @@
     }
   },
   "required": [
-    "infected_people_delta_normalized__infected_daily_increase",
-    "infected_people_total__infected_daily_total",
+    "results_per_region__infected_increase_per_region",
+    "results_per_region__total_reported_increase_per_region",
     "ggd__infected",
     "ggd__infected_percentage",
-    "reproduction_index_last_known_average__reproduction_index_avg",
-    "infectious_people_count_normalized__infectious_avg_normalized",
-    "intake_hospital_ma__moving_average_hospital",
-    "hospital_beds_occupied__covid_occupied",
-    "intake_intensivecare_ma__moving_average_ic",
-    "intensive_care_beds_occupied__covid_occupied",
-    "huisarts_verdenkingen__incidentie",
-    "huisarts_verdenkingen__geschat_aantal",
+    "results_per_region__hospital_moving_avg_per_region",
+    "results_per_region__hospital_total_counts_per_region",
     "sewer__average",
     "nursing_home__newly_infected_people",
     "nursing_home__infected_locations_total",
@@ -73,7 +49,7 @@
   "additionalProperties": false,
   "definitions": {
     "diff_integer": {
-      "title": "national_difference_integer",
+      "title": "regional_difference_integer",
       "type": "object",
       "properties": {
         "old_value": {
@@ -90,7 +66,7 @@
       "additionalProperties": false
     },
     "diff_decimal": {
-      "title": "national_difference_decimal",
+      "title": "regional_difference_decimal",
       "type": "object",
       "properties": {
         "old_value": {

--- a/schema/regional/__difference.json
+++ b/schema/regional/__difference.json
@@ -9,7 +9,7 @@
     "results_per_region__total_reported_increase_per_region": {
       "$ref": "#/definitions/diff_integer"
     },
-    "ggd__infected": {
+    "ggd__tested_total": {
       "$ref": "#/definitions/diff_integer"
     },
     "ggd__infected_percentage": {
@@ -37,7 +37,7 @@
   "required": [
     "results_per_region__infected_increase_per_region",
     "results_per_region__total_reported_increase_per_region",
-    "ggd__infected",
+    "ggd__tested_total",
     "ggd__infected_percentage",
     "results_per_region__hospital_moving_avg_per_region",
     "results_per_region__hospital_total_counts_per_region",

--- a/schema/regional/__difference.json
+++ b/schema/regional/__difference.json
@@ -16,7 +16,7 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "results_per_region__hospital_moving_avg_per_region": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "results_per_region__hospital_total_counts_per_region": {
       "$ref": "#/definitions/diff_integer"

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -31,6 +31,9 @@
       "type": "string",
       "const": { "$data": "1/proto_name" }
     },
+    "difference": {
+      "$ref": "__difference.json"
+    },
     "sewer": {
       "$ref": "sewer.json"
     },

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -11,8 +11,8 @@ export interface Municipal {
   name: string;
   code: string;
   difference?: MunicipalDifference;
-  hospital_admissions: HospitalAdmissions;
-  positive_tested_people: PositiveTestedPeople;
+  hospital_admissions: MunicipalHospitalAdmissions;
+  positive_tested_people: MunicipalPositiveTestedPeople;
   sewer?: MunicipalSewer;
   sewer_per_installation?: MunicipalSewerPerInstallation;
 }
@@ -27,7 +27,7 @@ export interface MunicipalDifferenceInteger {
   difference: number;
   old_date_of_report_unix: number;
 }
-export interface HospitalAdmissions {
+export interface MunicipalHospitalAdmissions {
   values: HospitalAdmissionsLastValue[];
   last_value: HospitalAdmissionsLastValue;
 }
@@ -38,7 +38,7 @@ export interface HospitalAdmissionsLastValue {
   moving_average_hospital: number;
   date_of_insertion_unix: number;
 }
-export interface PositiveTestedPeople {
+export interface MunicipalPositiveTestedPeople {
   values: PositiveTestedPeopleLastValue[];
   last_value: PositiveTestedPeopleLastValue;
 }
@@ -88,17 +88,17 @@ export interface Municipalities {
   proto_name: "MUNICIPALITIES";
   name: string;
   code: string;
-  hospital_admissions: HospitalAdmissions[];
-  positive_tested_people: PositiveTestedPeople[];
+  hospital_admissions: MunicipalitiesHospitalAdmissions[];
+  positive_tested_people: MunicipalitiesPositiveTestedPeople[];
   deceased: Deceased[];
 }
-export interface HospitalAdmissions {
+export interface MunicipalitiesHospitalAdmissions {
   date_of_report_unix: number;
   gmcode: string;
   hospital_admissions: number;
   date_of_insertion_unix: number;
 }
-export interface PositiveTestedPeople {
+export interface MunicipalitiesPositiveTestedPeople {
   date_of_report_unix: number;
   gmcode: string;
   positive_tested_people: number;
@@ -137,6 +137,7 @@ export interface National {
   ggd: NationalGgd;
   nursing_home: NationalNursingHome;
   restrictions?: NationalRestrictions;
+  behavior: NationalBehavior;
 }
 export interface NationalDifference {
   infected_people_delta_normalized__infected_daily_increase: NationalDifferenceDecimal;
@@ -388,6 +389,56 @@ export interface NationalRestrictionValue {
   restriction_order: number;
   valid_from_unix: number;
 }
+export interface NationalBehavior {
+  values: NationalBehaviorValue[];
+  last_value: NationalBehaviorValue;
+}
+export interface NationalBehaviorValue {
+  number_of_participants: number;
+  wash_hands_compliance: number | null;
+  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
+  keep_distance_compliance: number | null;
+  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
+  work_from_home_compliance: number | null;
+  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_compliance: number | null;
+  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_compliance: number | null;
+  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_compliance: number | null;
+  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_compliance: number | null;
+  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_compliance: number | null;
+  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_compliance: number | null;
+  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
+  max_visitors_compliance: number | null;
+  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
+  wash_hands_support: number | null;
+  wash_hands_support_trend: ("up" | "down" | "equal") | null;
+  keep_distance_support: number | null;
+  keep_distance_support_trend: ("up" | "down" | "equal") | null;
+  work_from_home_support: number | null;
+  work_from_home_support_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_support: number | null;
+  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_support: number | null;
+  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_support: number | null;
+  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_support: number | null;
+  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_support?: number | null;
+  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_support: number | null;
+  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
+  max_visitors_support: number | null;
+  max_visitors_support_trend: ("up" | "down" | "equal") | null;
+  week_start_unix: number;
+  week_end_unix: number;
+  date_of_insertion_unix: number;
+}
 
 export interface Ranges {
   last_generated: string;
@@ -472,6 +523,7 @@ export interface Regionaal {
   ggd: RegionalGgd;
   nursing_home: RegionalNursingHome;
   restrictions?: RegionalRestrictions;
+  behavior: RegionalBehavior;
 }
 export interface RegionalDifference {
   results_per_region__infected_increase_per_region: RegionalDifferenceInteger;
@@ -599,6 +651,57 @@ export interface RegionalRestrictionValue {
   restriction_order: number;
   valid_from_unix: number;
 }
+export interface RegionalBehavior {
+  values: RegionalBehaviorValue[];
+  last_value: RegionalBehaviorValue;
+}
+export interface RegionalBehaviorValue {
+  number_of_participants: number;
+  wash_hands_compliance: number | null;
+  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
+  keep_distance_compliance: number | null;
+  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
+  work_from_home_compliance: number | null;
+  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_compliance: number | null;
+  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_compliance: number | null;
+  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_compliance: number | null;
+  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_compliance: number | null;
+  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_compliance: number | null;
+  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_compliance: number | null;
+  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
+  max_visitors_compliance: number | null;
+  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
+  wash_hands_support: number | null;
+  wash_hands_support_trend: ("up" | "down" | "equal") | null;
+  keep_distance_support: number | null;
+  keep_distance_support_trend: ("up" | "down" | "equal") | null;
+  work_from_home_support: number | null;
+  work_from_home_support_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_support: number | null;
+  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_support: number | null;
+  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_support: number | null;
+  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_support: number | null;
+  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_support?: number | null;
+  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_support: number | null;
+  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
+  max_visitors_support: number | null;
+  max_visitors_support_trend: ("up" | "down" | "equal") | null;
+  week_start_unix: number;
+  week_end_unix: number;
+  date_of_insertion_unix: number;
+  vrcode: string;
+}
 
 export interface Regions {
   last_generated: string;
@@ -611,6 +714,7 @@ export interface Regions {
   escalation_levels: EscalationLevels[];
   nursing_home: RegionsNursingHome[];
   sewer: RegionsSewer[];
+  behavior: RegionsBehavior[];
 }
 export interface RegionHospitalAdmissions {
   date_of_report_unix: number;
@@ -655,5 +759,52 @@ export interface RegionsSewer {
   vrcode: string;
   average: number;
   total_installation_count: number;
+  date_of_insertion_unix: number;
+}
+export interface RegionsBehavior {
+  vrcode: string;
+  number_of_participants: number;
+  wash_hands_compliance: number | null;
+  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
+  keep_distance_compliance: number | null;
+  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
+  work_from_home_compliance: number | null;
+  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_compliance: number | null;
+  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_compliance: number | null;
+  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_compliance: number | null;
+  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_compliance: number | null;
+  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_compliance: number | null;
+  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_compliance: number | null;
+  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
+  max_visitors_compliance: number | null;
+  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
+  wash_hands_support: number | null;
+  wash_hands_support_trend: ("up" | "down" | "equal") | null;
+  keep_distance_support: number | null;
+  keep_distance_support_trend: ("up" | "down" | "equal") | null;
+  work_from_home_support: number | null;
+  work_from_home_support_trend: ("up" | "down" | "equal") | null;
+  avoid_crowds_support: number | null;
+  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_support: number | null;
+  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
+  symptoms_get_tested_support: number | null;
+  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_indoors_support: number | null;
+  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
+  wear_mask_public_transport_support?: number | null;
+  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
+  sneeze_cough_elbow_support: number | null;
+  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
+  max_visitors_support: number | null;
+  max_visitors_support_trend: ("up" | "down" | "equal") | null;
+  week_start_unix: number;
+  week_end_unix: number;
   date_of_insertion_unix: number;
 }

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -141,7 +141,7 @@ export interface National {
 export interface NationalDifference {
   infected_people_delta_normalized__infected_daily_increase: NationalDifferenceDecimal;
   infected_people_total__infected_daily_total: NationalDifferenceInteger;
-  ggd__infected: NationalDifferenceInteger;
+  ggd__tested_total: NationalDifferenceInteger;
   ggd__infected_percentage: NationalDifferenceDecimal;
   reproduction_index_last_known_average__reproduction_index_avg: NationalDifferenceDecimal;
   infectious_people_count_normalized__infectious_avg_normalized: NationalDifferenceInteger;
@@ -476,7 +476,7 @@ export interface Regionaal {
 export interface RegionalDifference {
   results_per_region__infected_increase_per_region: RegionalDifferenceInteger;
   results_per_region__total_reported_increase_per_region: RegionalDifferenceInteger;
-  ggd__infected: RegionalDifferenceInteger;
+  ggd__tested_total: RegionalDifferenceInteger;
   ggd__infected_percentage: RegionalDifferenceDecimal;
   results_per_region__hospital_moving_avg_per_region: RegionalDifferenceInteger;
   results_per_region__hospital_total_counts_per_region: RegionalDifferenceInteger;

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -10,12 +10,24 @@ export interface Municipal {
   proto_name: string;
   name: string;
   code: string;
-  hospital_admissions: MunicipalHospitalAdmissions;
-  positive_tested_people: MunicipalPositiveTestedPeople;
+  difference?: MunicipalDifference;
+  hospital_admissions: HospitalAdmissions;
+  positive_tested_people: PositiveTestedPeople;
   sewer?: MunicipalSewer;
   sewer_per_installation?: MunicipalSewerPerInstallation;
 }
-export interface MunicipalHospitalAdmissions {
+export interface MunicipalDifference {
+  positive_tested_people__infected_daily_increase: MunicipalDifferenceInteger;
+  positive_tested_people__infected_daily_total: MunicipalDifferenceInteger;
+  hospital_admissions__moving_average_hospital: MunicipalDifferenceInteger;
+  sewer__average: MunicipalDifferenceInteger;
+}
+export interface MunicipalDifferenceInteger {
+  old_value: number;
+  difference: number;
+  old_date_of_report_unix: number;
+}
+export interface HospitalAdmissions {
   values: HospitalAdmissionsLastValue[];
   last_value: HospitalAdmissionsLastValue;
 }
@@ -26,7 +38,7 @@ export interface HospitalAdmissionsLastValue {
   moving_average_hospital: number;
   date_of_insertion_unix: number;
 }
-export interface MunicipalPositiveTestedPeople {
+export interface PositiveTestedPeople {
   values: PositiveTestedPeopleLastValue[];
   last_value: PositiveTestedPeopleLastValue;
 }
@@ -76,17 +88,17 @@ export interface Municipalities {
   proto_name: "MUNICIPALITIES";
   name: string;
   code: string;
-  hospital_admissions: MunicipalitiesHospitalAdmissions[];
-  positive_tested_people: MunicipalitiesPositiveTestedPeople[];
+  hospital_admissions: HospitalAdmissions[];
+  positive_tested_people: PositiveTestedPeople[];
   deceased: Deceased[];
 }
-export interface MunicipalitiesHospitalAdmissions {
+export interface HospitalAdmissions {
   date_of_report_unix: number;
   gmcode: string;
   hospital_admissions: number;
   date_of_insertion_unix: number;
 }
-export interface MunicipalitiesPositiveTestedPeople {
+export interface PositiveTestedPeople {
   date_of_report_unix: number;
   gmcode: string;
   positive_tested_people: number;
@@ -105,6 +117,7 @@ export interface National {
   proto_name: "NL";
   name: string;
   code: string;
+  difference: NationalDifference;
   verdenkingen_huisartsen: NationalHuisartsVerdenkingen;
   intake_hospital_ma: IntakeHospitalMa;
   infectious_people_count: InfectiousPeopleCount;
@@ -124,12 +137,38 @@ export interface National {
   ggd: NationalGgd;
   nursing_home: NationalNursingHome;
   restrictions?: NationalRestrictions;
-  behavior: NationalBehavior;
+}
+export interface NationalDifference {
+  infected_people_delta_normalized__infected_daily_increase: NationalDifferenceDecimal;
+  infected_people_total__infected_daily_total: NationalDifferenceInteger;
+  ggd__infected: NationalDifferenceInteger;
+  ggd__infected_percentage: NationalDifferenceDecimal;
+  reproduction_index_last_known_average__reproduction_index_avg: NationalDifferenceDecimal;
+  infectious_people_count_normalized__infectious_avg_normalized: NationalDifferenceInteger;
+  intake_hospital_ma__moving_average_hospital: NationalDifferenceInteger;
+  hospital_beds_occupied__covid_occupied: NationalDifferenceInteger;
+  intake_intensivecare_ma__moving_average_ic: NationalDifferenceInteger;
+  intensive_care_beds_occupied__covid_occupied: NationalDifferenceInteger;
+  huisarts_verdenkingen__incidentie: NationalDifferenceDecimal;
+  huisarts_verdenkingen__geschat_aantal: NationalDifferenceInteger;
+  sewer__average: NationalDifferenceInteger;
+  nursing_home__newly_infected_people: NationalDifferenceInteger;
+  nursing_home__infected_locations_total: NationalDifferenceInteger;
+  nursing_home__deceased_daily: NationalDifferenceInteger;
+}
+export interface NationalDifferenceDecimal {
+  old_value: number;
+  difference: number;
+  old_date_of_report_unix: number;
+}
+export interface NationalDifferenceInteger {
+  old_value: number;
+  difference: number;
+  old_date_of_report_unix: number;
 }
 export interface NationalHuisartsVerdenkingen {
   values: NationalHuisartsVerdenkingenValue[];
   last_value: NationalHuisartsVerdenkingenValue;
-  last_value_difference?: NationalHuisartsVerdenkingenValueDifference;
 }
 export interface NationalHuisartsVerdenkingenValue {
   week_unix: number;
@@ -138,13 +177,6 @@ export interface NationalHuisartsVerdenkingenValue {
   incidentie: number;
   geschat_aantal: number;
   date_of_insertion_unix: number;
-}
-export interface NationalHuisartsVerdenkingenValueDifference {
-  incidentie_old: number;
-  incidentie_difference: number;
-  geschat_aantal_old: number;
-  geschat_aantal_difference: number;
-  date_of_report_unix_old: number;
 }
 export interface IntakeHospitalMa {
   values: IntakeHospitalMaLastValue[];
@@ -199,17 +231,11 @@ export interface InfectedPeopleClustersLastValue {
 export interface NationalInfectedPeopleTotal {
   values: NationalInfectedPeopleTotalValue[];
   last_value: NationalInfectedPeopleTotalValue;
-  last_value_difference?: NationalInfectedPeopleTotalValueDifference;
 }
 export interface NationalInfectedPeopleTotalValue {
   infected_daily_total: number;
   date_of_report_unix: number;
   date_of_insertion_unix: number;
-}
-export interface NationalInfectedPeopleTotalValueDifference {
-  infected_daily_total_old: number;
-  infected_daily_total_difference: number;
-  date_of_report_unix_old: number;
 }
 export interface InfectedPeopleDeltaNormalized {
   values: InfectedPeopleDeltaNormalizedLastValue[];
@@ -362,56 +388,6 @@ export interface NationalRestrictionValue {
   restriction_order: number;
   valid_from_unix: number;
 }
-export interface NationalBehavior {
-  values: NationalBehaviorValue[];
-  last_value: NationalBehaviorValue;
-}
-export interface NationalBehaviorValue {
-  number_of_participants: number;
-  wash_hands_compliance: number | null;
-  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
-  keep_distance_compliance: number | null;
-  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
-  work_from_home_compliance: number | null;
-  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_compliance: number | null;
-  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_compliance: number | null;
-  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_compliance: number | null;
-  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_compliance: number | null;
-  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_compliance: number | null;
-  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_compliance: number | null;
-  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
-  max_visitors_compliance: number | null;
-  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
-  wash_hands_support: number | null;
-  wash_hands_support_trend: ("up" | "down" | "equal") | null;
-  keep_distance_support: number | null;
-  keep_distance_support_trend: ("up" | "down" | "equal") | null;
-  work_from_home_support: number | null;
-  work_from_home_support_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_support: number | null;
-  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_support: number | null;
-  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_support: number | null;
-  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_support: number | null;
-  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_support?: number | null;
-  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_support: number | null;
-  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
-  max_visitors_support: number | null;
-  max_visitors_support_trend: ("up" | "down" | "equal") | null;
-  week_start_unix: number;
-  week_end_unix: number;
-  date_of_insertion_unix: number;
-}
 
 export interface Ranges {
   last_generated: string;
@@ -489,13 +465,35 @@ export interface Regionaal {
   proto_name: string;
   name: string;
   code: string;
+  difference?: RegionalDifference;
   sewer: RegionalSewer;
   sewer_per_installation: RegionalSewerPerInstallation;
   results_per_region: ResultsPerRegion;
   ggd: RegionalGgd;
   nursing_home: RegionalNursingHome;
   restrictions?: RegionalRestrictions;
-  behavior: RegionalBehavior;
+}
+export interface RegionalDifference {
+  results_per_region__infected_increase_per_region: RegionalDifferenceInteger;
+  results_per_region__total_reported_increase_per_region: RegionalDifferenceInteger;
+  ggd__infected: RegionalDifferenceInteger;
+  ggd__infected_percentage: RegionalDifferenceDecimal;
+  results_per_region__hospital_moving_avg_per_region: RegionalDifferenceInteger;
+  results_per_region__hospital_total_counts_per_region: RegionalDifferenceInteger;
+  sewer__average: RegionalDifferenceInteger;
+  nursing_home__newly_infected_people: RegionalDifferenceInteger;
+  nursing_home__infected_locations_total: RegionalDifferenceInteger;
+  nursing_home__deceased_daily: RegionalDifferenceInteger;
+}
+export interface RegionalDifferenceInteger {
+  old_value: number;
+  difference: number;
+  old_date_of_report_unix: number;
+}
+export interface RegionalDifferenceDecimal {
+  old_value: number;
+  difference: number;
+  old_date_of_report_unix: number;
 }
 export interface RegionalSewer {
   values: RegionalSewerValue[];
@@ -601,57 +599,6 @@ export interface RegionalRestrictionValue {
   restriction_order: number;
   valid_from_unix: number;
 }
-export interface RegionalBehavior {
-  values: RegionalBehaviorValue[];
-  last_value: RegionalBehaviorValue;
-}
-export interface RegionalBehaviorValue {
-  number_of_participants: number;
-  wash_hands_compliance: number | null;
-  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
-  keep_distance_compliance: number | null;
-  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
-  work_from_home_compliance: number | null;
-  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_compliance: number | null;
-  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_compliance: number | null;
-  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_compliance: number | null;
-  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_compliance: number | null;
-  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_compliance: number | null;
-  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_compliance: number | null;
-  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
-  max_visitors_compliance: number | null;
-  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
-  wash_hands_support: number | null;
-  wash_hands_support_trend: ("up" | "down" | "equal") | null;
-  keep_distance_support: number | null;
-  keep_distance_support_trend: ("up" | "down" | "equal") | null;
-  work_from_home_support: number | null;
-  work_from_home_support_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_support: number | null;
-  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_support: number | null;
-  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_support: number | null;
-  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_support: number | null;
-  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_support?: number | null;
-  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_support: number | null;
-  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
-  max_visitors_support: number | null;
-  max_visitors_support_trend: ("up" | "down" | "equal") | null;
-  week_start_unix: number;
-  week_end_unix: number;
-  date_of_insertion_unix: number;
-  vrcode: string;
-}
 
 export interface Regions {
   last_generated: string;
@@ -664,7 +611,6 @@ export interface Regions {
   escalation_levels: EscalationLevels[];
   nursing_home: RegionsNursingHome[];
   sewer: RegionsSewer[];
-  behavior: RegionsBehavior[];
 }
 export interface RegionHospitalAdmissions {
   date_of_report_unix: number;
@@ -709,52 +655,5 @@ export interface RegionsSewer {
   vrcode: string;
   average: number;
   total_installation_count: number;
-  date_of_insertion_unix: number;
-}
-export interface RegionsBehavior {
-  vrcode: string;
-  number_of_participants: number;
-  wash_hands_compliance: number | null;
-  wash_hands_compliance_trend: ("up" | "down" | "equal") | null;
-  keep_distance_compliance: number | null;
-  keep_distance_compliance_trend: ("up" | "down" | "equal") | null;
-  work_from_home_compliance: number | null;
-  work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_compliance: number | null;
-  avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_compliance: number | null;
-  symptoms_stay_home_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_compliance: number | null;
-  symptoms_get_tested_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_compliance: number | null;
-  wear_mask_public_indoors_compliance_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_compliance: number | null;
-  wear_mask_public_transport_compliance_trend: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_compliance: number | null;
-  sneeze_cough_elbow_compliance_trend: ("up" | "down" | "equal") | null;
-  max_visitors_compliance: number | null;
-  max_visitors_compliance_trend: ("up" | "down" | "equal") | null;
-  wash_hands_support: number | null;
-  wash_hands_support_trend: ("up" | "down" | "equal") | null;
-  keep_distance_support: number | null;
-  keep_distance_support_trend: ("up" | "down" | "equal") | null;
-  work_from_home_support: number | null;
-  work_from_home_support_trend: ("up" | "down" | "equal") | null;
-  avoid_crowds_support: number | null;
-  avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_support: number | null;
-  symptoms_stay_home_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_get_tested_support: number | null;
-  symptoms_get_tested_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_indoors_support: number | null;
-  wear_mask_public_indoors_support_trend: ("up" | "down" | "equal") | null;
-  wear_mask_public_transport_support?: number | null;
-  wear_mask_public_transport_support_trend?: ("up" | "down" | "equal") | null;
-  sneeze_cough_elbow_support: number | null;
-  sneeze_cough_elbow_support_trend: ("up" | "down" | "equal") | null;
-  max_visitors_support: number | null;
-  max_visitors_support_trend: ("up" | "down" | "equal") | null;
-  week_start_unix: number;
-  week_end_unix: number;
   date_of_insertion_unix: number;
 }


### PR DESCRIPTION
A proposal to define property differences in a standardized manner. Things to note:

- Every level (NL/VR/GM) gets its own differences file named __difference.json. This file holds differences for any property in the data. 
- Each property uses a standardized definition for either integer or decimal value.
- The file + property names are concatenated so we can have a flat structure. For example the difference for `national/huisarts_verdenkingen.json` => property `incidentie` will live in `national/__difference.json` => property `huisarts_verdenkingen__incidentie`. Note the double underscore to make a distinction between data context and property in the concatenation.

The aim of this setup is to define differences with the least effort for both backend and frontend while also avoiding code duplication.
