### PR TITLE
Dates everywhere, part two

### DIFF
--- a/src/components-styled/kpi-example-tile.tsx
+++ b/src/components-styled/kpi-example-tile.tsx
@@ -1,0 +1,71 @@
+import { Box } from './base';
+import { Text, Heading } from './typography';
+import { Tile } from './layout';
+import { MetadataProps, Metadata } from './metadata';
+
+interface Example {
+  image: string;
+  alt: string;
+  description: string;
+}
+
+interface KpiExampleProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+  metadata: MetadataProps;
+  example: Example;
+}
+
+/**
+ * A generic KPI tile which composes its value content using the children prop.
+ * Description can be both plain text and html strings.
+ */
+export function KpiExampleTile({
+  title,
+  description,
+  children,
+  metadata,
+  example,
+}: KpiExampleProps) {
+  return (
+    <Tile>
+      <Box display="flex" flexWrap="wrap">
+        <Box
+          mb={4}
+          flexGrow={0}
+          flexShrink={0}
+          flexBasis={{ _: '100%', lg: '50%' }}
+          pr={{ _: 0, lg: 4 }}
+        >
+          <Heading level={3}>{title}</Heading>
+          {children}
+          {description && (
+            <Text
+              as="div"
+              dangerouslySetInnerHTML={{
+                __html: description,
+              }}
+            />
+          )}
+        </Box>
+        <Box
+          flexGrow={0}
+          flexShrink={0}
+          flexBasis={{ _: '100%', lg: '50%' }}
+          pl={{ _: 0, lg: 4 }}
+        >
+          <img
+            width={315}
+            height={100}
+            loading="lazy"
+            src={example.image}
+            alt={example.alt}
+          />
+          <p>{example.description}</p>
+        </Box>
+      </Box>
+      <Metadata {...metadata} />
+    </Tile>
+  );
+}

--- a/src/components-styled/kpi-with-illustration-tile.tsx
+++ b/src/components-styled/kpi-with-illustration-tile.tsx
@@ -3,31 +3,31 @@ import { Text, Heading } from './typography';
 import { Tile } from './layout';
 import { MetadataProps, Metadata } from './metadata';
 
-interface Example {
+interface Illustration {
   image: string;
   alt: string;
   description: string;
 }
 
-interface KpiExampleProps {
+interface KpiWithIllustrationProps {
   title: string;
   description?: string;
   children: React.ReactNode;
   metadata: MetadataProps;
-  example: Example;
+  illustration: Illustration;
 }
 
 /**
  * A generic KPI tile which composes its value content using the children prop.
  * Description can be both plain text and html strings.
  */
-export function KpiExampleTile({
+export function KpiWithIllustrationTile({
   title,
   description,
   children,
   metadata,
-  example,
-}: KpiExampleProps) {
+  illustration,
+}: KpiWithIllustrationProps) {
   return (
     <Tile>
       <Box display="flex" flexWrap="wrap">
@@ -36,7 +36,7 @@ export function KpiExampleTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
-          pr={{ _: 0, lg: 4 }}
+          pr={{ lg: 4 }}
         >
           <Heading level={3}>{title}</Heading>
           {children}
@@ -53,16 +53,16 @@ export function KpiExampleTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
-          pl={{ _: 0, lg: 4 }}
+          pl={{ lg: 4 }}
         >
           <img
             width={315}
             height={100}
             loading="lazy"
-            src={example.image}
-            alt={example.alt}
+            src={illustration.image}
+            alt={illustration.alt}
           />
-          <p>{example.description}</p>
+          <p>{illustration.description}</p>
         </Box>
       </Box>
       <Metadata {...metadata} />

--- a/src/components-styled/metadata.tsx
+++ b/src/components-styled/metadata.tsx
@@ -6,27 +6,40 @@ import { Text } from './typography';
 import { Box } from './base';
 
 export interface MetadataProps {
-  date?: number;
+  date?: number | [number, number];
   source?: {
     text: string;
     href: string;
   };
 }
 
-export function Metadata(metadata: MetadataProps) {
+function formatMetadataDate(date: number | [number, number]): string {
+  if (typeof date === 'number') {
+    return replaceVariablesInText(locale.common.metadata.date, {
+      date: formatDateFromSeconds(date, 'weekday-medium'),
+    });
+  }
+
+  return replaceVariablesInText(
+    'Waarde vannneh : {{dateFrom}} TOOO {{dateTo}}',
+    {
+      dateFrom: formatDateFromSeconds(date[0], 'weekday-medium'),
+      dateTo: formatDateFromSeconds(date[1], 'weekday-medium'),
+    }
+  );
+}
+
+export function Metadata({ date, source }: MetadataProps) {
+  const dateString = date ? formatMetadataDate(date) : null;
   return (
     <Box as="footer" mt={3}>
       <Text color="annotation" fontSize={1}>
-        {metadata.date
-          ? replaceVariablesInText(locale.common.metadata.date, {
-              date: formatDateFromSeconds(metadata.date, 'weekday-medium'),
-            })
-          : null}
-        {metadata.date && metadata.source ? ' · ' : null}
-        {metadata.source ? (
+        {dateString}
+        {dateString && source ? ' · ' : null}
+        {source ? (
           <>
             {locale.common.metadata.source}
-            {': '} <ExternalLink {...metadata.source} />
+            {': '} <ExternalLink {...source} />
           </>
         ) : null}
       </Text>

--- a/src/components-styled/metadata.tsx
+++ b/src/components-styled/metadata.tsx
@@ -20,19 +20,16 @@ function formatMetadataDate(date: number | [number, number]): string {
     });
   }
 
-  return replaceVariablesInText(
-    'Waarde vannneh : {{dateFrom}} TOOO {{dateTo}}',
-    {
-      dateFrom: formatDateFromSeconds(date[0], 'weekday-medium'),
-      dateTo: formatDateFromSeconds(date[1], 'weekday-medium'),
-    }
-  );
+  return replaceVariablesInText(locale.common.metadata.dateFromTo, {
+    dateFrom: formatDateFromSeconds(date[0], 'weekday-medium'),
+    dateTo: formatDateFromSeconds(date[1], 'weekday-medium'),
+  });
 }
 
 export function Metadata({ date, source }: MetadataProps) {
   const dateString = date ? formatMetadataDate(date) : null;
   return (
-    <Box as="footer" mt={3}>
+    <Box as="footer" mt={3} gridArea="metadata">
       <Text color="annotation" fontSize={1}>
         {dateString}
         {dateString && source ? ' · ' : null}

--- a/src/components/gemeente/intake-hospital-metric.tsx
+++ b/src/components/gemeente/intake-hospital-metric.tsx
@@ -16,7 +16,7 @@ export function IntakeHospitalMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/gemeente/positively-tested-people-metric.tsx
+++ b/src/components/gemeente/positively-tested-people-metric.tsx
@@ -17,7 +17,7 @@ export function PositivelyTestedPeopleMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/landelijk/infectious-people-metric.tsx
+++ b/src/components/landelijk/infectious-people-metric.tsx
@@ -16,7 +16,7 @@ export function InfectiousPeopleMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/landelijk/intake-hospital-metric.tsx
+++ b/src/components/landelijk/intake-hospital-metric.tsx
@@ -17,7 +17,7 @@ export function IntakeHospitalMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/landelijk/intake-intensive-care-metric.tsx
+++ b/src/components/landelijk/intake-intensive-care-metric.tsx
@@ -17,7 +17,7 @@ export function IntakeIntensiveCareMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/landelijk/positive-tested-people-metric.tsx
+++ b/src/components/landelijk/positive-tested-people-metric.tsx
@@ -17,7 +17,7 @@ export function PositiveTestedPeopleMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/landelijk/reproduction-index-metric.tsx
+++ b/src/components/landelijk/reproduction-index-metric.tsx
@@ -17,7 +17,7 @@ export function ReproductionIndexMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/components/veiligheidsregio/positive-tested-people-metric.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-metric.tsx
@@ -17,7 +17,7 @@ export function PositivelyTestedPeopleMetric(props: {
   if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data?.date_of_report_unix, 'relative'),
+    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'relative'),
   });
 
   return (

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -628,7 +628,8 @@
   "common": {
     "metadata": {
       "source": "Source",
-      "date": ""
+      "date": "Waarde van {{date}}",
+      "dateFromTo": "Waarde van {{dateFrom}} tot {{dateTo}}"
     },
     "barScale": {
       "signaalwaarde": "Alert value"

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -628,7 +628,8 @@
   "common": {
     "metadata": {
       "source": "Bron",
-      "date": "Waarde van {{date}}"
+      "date": "Waarde van {{date}}",
+      "dateFromTo": "Waarde van {{dateFrom}} tot {{dateTo}}"
     },
     "barScale": {
       "signaalwaarde": "Signaalwaarde"

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -53,9 +53,9 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: positivelyTestedPeople?.last_value?.date_of_report_unix,
+          dateUnix: positivelyTestedPeople.last_value.date_of_report_unix,
           dateInsertedUnix:
-            positivelyTestedPeople?.last_value?.date_of_insertion_unix,
+            positivelyTestedPeople.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -65,7 +65,7 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
           title={text.barscale_titel}
           data-cy="infected_daily_increase"
           metadata={{
-            date: positivelyTestedPeople?.last_value?.date_of_report_unix,
+            date: positivelyTestedPeople.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -79,7 +79,7 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
         <KpiTile
           title={text.kpi_titel}
           metadata={{
-            date: positivelyTestedPeople?.last_value?.date_of_report_unix,
+            date: positivelyTestedPeople.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -100,7 +100,6 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
             date: value.date_of_report_unix,
           }))}
           metadata={{
-            date: positivelyTestedPeople?.last_value?.date_of_report_unix,
             source: text.bron,
           }}
         />
@@ -136,7 +135,7 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
           )}
         </div>
         <Metadata
-          date={positivelyTestedPeople?.last_value?.date_of_report_unix}
+          date={positivelyTestedPeople.last_value.date_of_report_unix}
           source={text.bron}
         />
       </article>

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -80,7 +80,10 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
             title={text.barscale_titel}
             description={text.extra_uitleg}
             metadata={{
-              date: sewerAverages.last_value.week_end_unix,
+              date: [
+                sewerAverages.last_value.week_start_unix,
+                sewerAverages.last_value.week_end_unix,
+              ],
               source: text.bron,
             }}
           >
@@ -98,7 +101,10 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
             `<p style="color:#595959">${text.rwzi_abbrev}</p>`
           }
           metadata={{
-            date: sewerAverages.last_value.week_end_unix,
+            date: [
+              sewerAverages.last_value.week_start_unix,
+              sewerAverages.last_value.week_end_unix,
+            ],
             source: text.bron,
           }}
         >
@@ -138,7 +144,10 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
             valueAnnotation={siteText.waarde_annotaties.riool_normalized}
           />
           <Metadata
-            date={sewerAverages.last_value.week_end_unix}
+            date={[
+              sewerAverages.last_value.week_start_unix,
+              sewerAverages.last_value.week_end_unix,
+            ]}
             source={text.bron}
           />
         </article>

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -121,10 +121,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
             valueAnnotation={siteText.waarde_annotaties.riool_normalized}
           />
         )}
-        <Metadata
-          date={sewerAverages.last_value.week_end_unix}
-          source={text.bron}
-        />
+        <Metadata source={text.bron} />
       </article>
 
       {barChartData && (

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -92,10 +92,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
               date: value.date_of_report_unix,
             }))}
           />
-          <Metadata
-            date={hospitalAdmissions.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
 

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -51,9 +51,9 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: hospitalAdmissions?.last_value?.date_of_report_unix,
+          dateUnix: hospitalAdmissions.last_value.date_of_report_unix,
           dateInsertedUnix:
-            hospitalAdmissions?.last_value?.date_of_insertion_unix,
+            hospitalAdmissions.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -76,7 +76,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         </div>
 
         <Metadata
-          date={hospitalAdmissions?.last_value?.date_of_report_unix}
+          date={hospitalAdmissions.last_value.date_of_report_unix}
           source={text.bron}
         />
       </article>
@@ -93,7 +93,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
             }))}
           />
           <Metadata
-            date={hospitalAdmissions?.last_value?.date_of_report_unix}
+            date={hospitalAdmissions.last_value.date_of_report_unix}
             source={text.bron}
           />
         </article>
@@ -135,7 +135,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           )}
         </div>
         <Metadata
-          date={hospitalAdmissions?.last_value?.date_of_report_unix}
+          date={hospitalAdmissions.last_value.date_of_report_unix}
           source={text.bron}
         />
       </article>

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -76,6 +76,12 @@ const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
               infectiousPeopleLastKnownAverage.last_value.infectious_avg
             )}
           </p>
+          <Metadata
+            date={
+              infectiousPeopleLastKnownAverage.last_value.date_of_report_unix
+            }
+            source={text.bron}
+          />
         </div>
 
         <div className="column-item column-item-extra-margin">
@@ -101,10 +107,7 @@ const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
             <li className="blue">{text.legenda_line}</li>
             <li className="gray square">{text.legenda_marge}</li>
           </Legenda>
-          <Metadata
-            date={count.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
     </>

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -102,7 +102,7 @@ const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
             <li className="gray square">{text.legenda_marge}</li>
           </Legenda>
           <Metadata
-            date={count?.last_value?.date_of_report_unix}
+            date={count.last_value.date_of_report_unix}
             source={text.bron}
           />
         </article>

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -76,7 +76,6 @@ const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
         }))}
         signaalwaarde={10}
         metadata={{
-          date: dataIntake.last_value.date_of_report_unix,
           source: text.bronnen.nice,
         }}
       />
@@ -89,7 +88,6 @@ const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
           date: value.date_of_report_unix,
         }))}
         metadata={{
-          date: dataBeds.last_value.date_of_report_unix,
           source: text.bronnen.lnaz,
         }}
       />

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -237,7 +237,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         <KpiTile
           title={ggdText.totaal_getest_week_titel}
           metadata={{
-            date: ggdLastValue.week_end_unix,
+            date: [ggdLastValue.week_start_unix, ggdLastValue.week_end_unix],
             source: ggdText.bron,
           }}
         >
@@ -247,7 +247,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         <KpiTile
           title={ggdText.positief_getest_week_titel}
           metadata={{
-            date: ggdLastValue.week_end_unix,
+            date: [ggdLastValue.week_start_unix, ggdLastValue.week_end_unix],
             source: ggdText.bron,
           }}
         >

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -78,8 +78,8 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: delta?.last_value?.date_of_report_unix,
-          dateInsertedUnix: delta?.last_value?.date_of_insertion_unix,
+          dateUnix: delta.last_value.date_of_report_unix,
+          dateInsertedUnix: delta.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -89,7 +89,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           title={text.barscale_titel}
           data-cy="infected_daily_increase"
           metadata={{
-            date: delta?.last_value?.date_of_report_unix,
+            date: delta.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -102,7 +102,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         <KpiTile
           title={text.kpi_titel}
           metadata={{
-            date: delta?.last_value?.date_of_report_unix,
+            date: delta.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -138,7 +138,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         data-cy="chloropleths"
         title={text.map_titel}
         metadata={{
-          date: delta?.last_value?.date_of_report_unix,
+          date: delta.last_value.date_of_report_unix,
           source: text.bron,
         }}
         description={text.map_toelichting}
@@ -188,7 +188,6 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           date: value.date_of_report_unix,
         }))}
         metadata={{
-          date: delta?.last_value?.date_of_report_unix,
           source: text.bron,
         }}
       />
@@ -215,7 +214,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           />
         </Box>
         <Metadata
-          date={delta?.last_value?.date_of_report_unix}
+          date={delta.last_value.date_of_report_unix}
           source={text.bron}
         />
       </KpiSection>
@@ -307,7 +306,6 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           return `${formatPercentage(y)}%`;
         }}
         metadata={{
-          date: ggdLastValue.week_end_unix,
           source: ggdText.bron,
         }}
       />
@@ -344,7 +342,6 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
           },
         ]}
         metadata={{
-          date: ggdLastValue.week_end_unix,
           source: ggdText.bron,
         }}
       />

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -9,6 +9,8 @@ import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { Metadata } from '~/components-styled/metadata';
+import { Text } from '~/components-styled/typography';
+import { KpiExampleTile } from '~/components-styled/kpi-example-tile';
 
 const text = siteText.reproductiegetal;
 
@@ -37,31 +39,21 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <ReproductionIndexBarScale
-            data={lastKnownValidData}
-            showAxis={true}
-          />
-          <p>{text.barscale_toelichting}</p>
-          <Metadata
-            date={lastKnownValidData.last_value.date_of_report_unix}
-            source={text.bron}
-          />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <img
-            width={315}
-            height={100}
-            loading="lazy"
-            src="/images/reproductie-explainer.svg"
-            alt={text.reproductie_explainer_alt}
-          />
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
+      <KpiExampleTile
+        title={text.barscale_titel}
+        metadata={{
+          date: lastKnownValidData.last_value.date_of_report_unix,
+          source: text.bron,
+        }}
+        example={{
+          image: '/images/reproductie-explainer.svg',
+          alt: text.reproductie_explainer_alt,
+          description: text.extra_uitleg,
+        }}
+      >
+        <ReproductionIndexBarScale data={lastKnownValidData} showAxis={true} />
+        <Text>{text.barscale_toelichting}</Text>
+      </KpiExampleTile>
 
       {data.reproduction_index.values && (
         <article className="metric-article">

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -10,7 +10,7 @@ import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { Metadata } from '~/components-styled/metadata';
 import { Text } from '~/components-styled/typography';
-import { KpiExampleTile } from '~/components-styled/kpi-example-tile';
+import { KpiWithIllustrationTile } from '~/components-styled/kpi-with-illustration-tile';
 
 const text = siteText.reproductiegetal;
 
@@ -39,13 +39,13 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
         }}
       />
 
-      <KpiExampleTile
+      <KpiWithIllustrationTile
         title={text.barscale_titel}
         metadata={{
           date: lastKnownValidData.last_value.date_of_report_unix,
           source: text.bron,
         }}
-        example={{
+        illustration={{
           image: '/images/reproductie-explainer.svg',
           alt: text.reproductie_explainer_alt,
           description: text.extra_uitleg,
@@ -53,7 +53,7 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
       >
         <ReproductionIndexBarScale data={lastKnownValidData} showAxis={true} />
         <Text>{text.barscale_toelichting}</Text>
-      </KpiExampleTile>
+      </KpiWithIllustrationTile>
 
       {data.reproduction_index.values && (
         <article className="metric-article">

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -70,10 +70,7 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
           <Legenda>
             <li className="blue">{text.legenda_r}</li>
           </Legenda>
-          <Metadata
-            date={lastKnownValidData.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
     </>

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -16,6 +16,7 @@ import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
+import { Metadata } from '~/components-styled/metadata';
 
 const text = siteText.rioolwater_metingen;
 
@@ -89,6 +90,14 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
           <p className="text-blue kpi" data-cy="infected_daily_total">
             {formatNumber(sewerAverages.last_value.average)}
           </p>
+
+          <Metadata
+            date={[
+              sewerAverages.last_value.week_start_unix,
+              sewerAverages.last_value.week_end_unix,
+            ]}
+            source={text.bron}
+          />
         </div>
 
         <div className="column-item column-item-extra-margin">
@@ -107,7 +116,6 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
           week: { start: value.week_start_unix, end: value.week_end_unix },
         }))}
         metadata={{
-          date: sewerAverages.last_value.week_end_unix,
           source: text.bron,
         }}
         formatTooltip={(x) => {
@@ -125,6 +133,13 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
       <ChoroplethTile
         title={text.map_titel}
         description={text.map_toelichting}
+        metadata={{
+          date: [
+            sewerAverages.last_value.week_start_unix,
+            sewerAverages.last_value.week_end_unix,
+          ],
+          source: text.bron,
+        }}
         legend={
           legendItems // this data value should probably not be optional
             ? {

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -57,7 +57,7 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{
-            date: sewerAverages.last_value.week_end_unix,
+            date: [sewerAverages.last_value.week_start_unix, sewerAverages.last_value.week_end_unix],
             source: text.bron,
           }}
         >
@@ -73,7 +73,7 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
             `<p style="color:#595959">${text.rwzi_abbrev}</p>`
           }
           metadata={{
-            date: sewerAverages.last_value.week_end_unix,
+            date: [sewerAverages.last_value.week_start_unix, sewerAverages.last_value.week_end_unix],
             source: text.bron,
           }}
         >

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -37,8 +37,8 @@ const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: data?.last_value?.week_unix,
-          dateInsertedUnix: data?.last_value?.date_of_insertion_unix,
+          dateUnix: data.last_value.week_unix,
+          dateInsertedUnix: data.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -80,7 +80,7 @@ const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
               },
             }))}
           />
-          <Metadata date={data.last_value.week_unix} source={text.bron} />
+          <Metadata source={text.bron} />
         </article>
       )}
     </>

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -114,10 +114,7 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
             date: value.date_of_report_unix,
           }))}
         />
-        <Metadata
-          date={data.last_value.date_of_report_unix}
-          source={text.bron}
-        />
+        <Metadata source={text.bron} />
       </article>
     </>
   );

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -56,10 +56,7 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = ({ data }) => {
             date: value.date_of_report_unix,
           }))}
         />
-        <Metadata
-          date={data.nursing_home.last_value.date_of_report_unix}
-          source={text.bron}
-        />
+        <Metadata source={text.bron} />
       </article>
     </>
   );

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -61,10 +61,7 @@ const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
               date: value.date_of_report_unix,
             }))}
           />
-          <Metadata
-            date={data.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
     </>

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -91,7 +91,6 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
         }))}
         signaalwaarde={40}
         metadata={{
-          date: dataIntake.last_value.date_of_report_unix,
           source: text.bronnen.rivm,
         }}
       />
@@ -104,7 +103,6 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
           date: value.date_of_report_unix,
         }))}
         metadata={{
-          date: dataIntake.last_value.date_of_report_unix,
           source: text.bronnen.lnaz,
         }}
       />

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -69,7 +69,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
         metadata={{
           datumsText: text.datums,
           dateUnix: resultsPerRegion.last_value.date_of_report_unix,
-          dateInsertedUnix: resultsPerRegion.last_value?.date_of_insertion_unix,
+          dateInsertedUnix: resultsPerRegion.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -134,7 +134,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           date: value.date_of_report_unix,
         }))}
         metadata={{
-          date: resultsPerRegion.last_value.date_of_report_unix,
           source: text.bron,
         }}
       />
@@ -256,7 +255,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           return `${formatPercentage(y)}%`;
         }}
         metadata={{
-          date: ggdData.week_end_unix,
           source: ggdText.bron,
         }}
       />

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -186,7 +186,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
         <KpiTile
           title={ggdText.totaal_getest_week_titel}
           metadata={{
-            date: ggdData.week_end_unix,
+            date: [ggdData.week_start_unix, ggdData.week_end_unix],
             source: ggdText.bron,
           }}
         >
@@ -196,7 +196,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
         <KpiTile
           title={ggdText.positief_getest_week_titel}
           metadata={{
-            date: ggdData.week_end_unix,
+            date: [ggdData.week_start_unix, ggdData.week_end_unix],
             source: ggdText.bron,
           }}
         >
@@ -292,7 +292,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           },
         ]}
         metadata={{
-          date: ggdData.week_end_unix,
           source: ggdText.bron,
         }}
       />

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -155,10 +155,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
           </>
         )}
 
-        <Metadata
-          date={sewerAverages.last_value.week_end_unix}
-          source={text.bron}
-        />
+        <Metadata source={text.bron} />
       </article>
 
       {barChartData && (

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -91,7 +91,10 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
             title={text.barscale_titel}
             description={text.extra_uitleg}
             metadata={{
-              date: sewerAverages.last_value.week_end_unix,
+              date: [
+                sewerAverages.last_value.week_start_unix,
+                sewerAverages.last_value.week_end_unix,
+              ],
               source: text.bron,
             }}
           >
@@ -107,7 +110,10 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
               `<p style="color:#595959">${text.rwzi_abbrev}</p>`
             }
             metadata={{
-              date: sewerAverages.last_value.week_end_unix,
+              date: [
+                sewerAverages.last_value.week_start_unix,
+                sewerAverages.last_value.week_end_unix,
+              ],
               source: text.bron,
             }}
           >
@@ -172,7 +178,10 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
             valueAnnotation={siteText.waarde_annotaties.riool_normalized}
           />
           <Metadata
-            date={sewerAverages.last_value.week_end_unix}
+            date={[
+              sewerAverages.last_value.week_start_unix,
+              sewerAverages.last_value.week_end_unix,
+            ]}
             source={text.bron}
           />
         </article>

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
@@ -50,9 +50,9 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: state?.nursing_home.last_value?.date_of_report_unix,
+          dateUnix: state.nursing_home.last_value.date_of_report_unix,
           dateInsertedUnix:
-            state?.nursing_home.last_value?.date_of_insertion_unix,
+            state.nursing_home.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -61,7 +61,7 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         <KpiTile
           title={text.kpi_titel}
           metadata={{
-            date: state?.nursing_home.last_value?.date_of_report_unix,
+            date: state.nursing_home.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -74,7 +74,7 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         <KpiTile
           title={text.barscale_titel}
           metadata={{
-            date: state?.nursing_home.last_value?.date_of_report_unix,
+            date: state.nursing_home.last_value.date_of_report_unix,
             source: text.bron,
           }}
         >
@@ -94,7 +94,6 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
             date: value.date_of_report_unix,
           }))}
           metadata={{
-            date: state?.nursing_home.last_value?.date_of_report_unix,
             source: text.bron,
           }}
         />

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
@@ -72,10 +72,7 @@ const NursingHomeInfectedPeople: FCWithLayout<ISafetyRegionData> = ({
             date: value.date_of_report_unix,
           }))}
         />
-        <Metadata
-          date={data.nursing_home.last_value.date_of_report_unix}
-          source={text.bron}
-        />
+        <Metadata source={text.bron} />
       </article>
     </>
   );

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
@@ -41,8 +41,8 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: data?.last_value?.date_of_report_unix,
-          dateInsertedUnix: data?.last_value?.date_of_insertion_unix,
+          dateUnix: data.last_value.date_of_report_unix,
+          dateInsertedUnix: data.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -54,7 +54,7 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
             {formatNumber(data?.last_value.deceased_daily)}
           </p>
           <Metadata
-            date={data?.last_value?.date_of_report_unix}
+            date={data.last_value.date_of_report_unix}
             source={text.bron}
           />
         </div>
@@ -74,7 +74,7 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
             }))}
           />
           <Metadata
-            date={data?.last_value?.date_of_report_unix}
+            date={data.last_value.date_of_report_unix}
             source={text.bron}
           />
         </article>

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
@@ -73,10 +73,7 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
               date: value.date_of_report_unix,
             }))}
           />
-          <Metadata
-            date={data.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
     </>

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -55,9 +55,8 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateUnix: resultsPerRegion?.last_value?.date_of_report_unix,
-          dateInsertedUnix:
-            resultsPerRegion?.last_value?.date_of_insertion_unix,
+          dateUnix: resultsPerRegion.last_value.date_of_report_unix,
+          dateInsertedUnix: resultsPerRegion.last_value.date_of_insertion_unix,
           dataSource: text.bron,
         }}
       />
@@ -78,7 +77,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           </div>
         </div>
         <Metadata
-          date={resultsPerRegion?.last_value?.date_of_report_unix}
+          date={resultsPerRegion.last_value.date_of_report_unix}
           source={text.bron}
         />
       </article>
@@ -95,7 +94,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
             }))}
           />
           <Metadata
-            date={resultsPerRegion?.last_value?.date_of_report_unix}
+            date={resultsPerRegion.last_value.date_of_report_unix}
             source={text.bron}
           />
         </article>
@@ -137,7 +136,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           )}
         </div>
         <Metadata
-          date={resultsPerRegion?.last_value?.date_of_report_unix}
+          date={resultsPerRegion.last_value.date_of_report_unix}
           source={text.bron}
         />
       </article>

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -93,10 +93,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
               date: value.date_of_report_unix,
             }))}
           />
-          <Metadata
-            date={resultsPerRegion.last_value.date_of_report_unix}
-            source={text.bron}
-          />
+          <Metadata source={text.bron} />
         </article>
       )}
       <article className="metric-article layout-choropleth">


### PR DESCRIPTION
## Summary

Part two of the dates everywhere task!

## Detailed design

* Removed optional chaining from all dates
* Added date ranges to metadata for sewer data and GGD data
* Removed dates from Linecharts, Areacharts, Multiplelinecharts, they are not useful there as the data is about a long range.
* Dedicated component for the KPI + Example Tile, feedback wanted regarding the use (or abuse) of styled system there.