### PR TITLE
Sidebar menu order

### DIFF
--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -128,8 +128,12 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
         />
       </Head>
       <div
-        className={`municipality-layout has-menu-${
-          isMainRoute ? 'and-content-opened' : isMenuOpen ? 'opened' : 'closed'
+        className={`municipality-layout ${
+          isMainRoute
+            ? 'has-menu-and-content-opened'
+            : isMenuOpen
+            ? 'has-menu-and-opened'
+            : 'has-menu-and-closed'
         }`}
       >
         <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>
@@ -161,7 +165,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                   </p>
                 )}
               </div>
-              <h2>{siteText.nationaal_layout.headings.medisch}</h2>
+              <h2>{siteText.nationaal_layout.headings.besmettingen}</h2>
               <ul>
                 <li>
                   <Link
@@ -189,7 +193,10 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                     </a>
                   </Link>
                 </li>
+              </ul>
 
+              <h2>{siteText.nationaal_layout.headings.ziekenhuizen}</h2>
+              <ul>
                 <li>
                   <Link
                     href="/gemeente/[code]/ziekenhuis-opnames"
@@ -218,7 +225,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                 </li>
               </ul>
 
-              <h2>{siteText.nationaal_layout.headings.overig}</h2>
+              <h2>{siteText.nationaal_layout.headings.vroege_signalen}</h2>
               <ul>
                 <li>
                   {sewerWaterBarScaleData ? (

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -165,7 +165,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                   </p>
                 )}
               </div>
-              <h2>{siteText.nationaal_layout.headings.besmettingen}</h2>
+              <h2>{siteText.gemeente_layout.headings.besmettingen}</h2>
               <ul>
                 <li>
                   <Link
@@ -195,7 +195,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                 </li>
               </ul>
 
-              <h2>{siteText.nationaal_layout.headings.ziekenhuizen}</h2>
+              <h2>{siteText.gemeente_layout.headings.ziekenhuizen}</h2>
               <ul>
                 <li>
                   <Link
@@ -225,7 +225,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                 </li>
               </ul>
 
-              <h2>{siteText.nationaal_layout.headings.vroege_signalen}</h2>
+              <h2>{siteText.gemeente_layout.headings.vroege_signalen}</h2>
               <ul>
                 <li>
                   {sewerWaterBarScaleData ? (

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -132,8 +132,8 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
           isMainRoute
             ? 'has-menu-and-content-opened'
             : isMenuOpen
-            ? 'has-menu-and-opened'
-            : 'has-menu-and-closed'
+            ? 'has-menu-opened'
+            : 'has-menu-closed'
         }`}
       >
         <Link href="/gemeente/[code]" as={`/gemeente/${code}`}>

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -97,8 +97,8 @@ function NationalLayout(props: NationalLayoutProps) {
       </Head>
 
       <div
-        className={`national-layout has-menu-${
-          isMenuOpen ? 'opened' : 'closed'
+        className={`national-layout ${
+          isMenuOpen ? 'has-menu-opened' : 'has-menu-closed'
         }`}
       >
         <Link href="/landelijk">
@@ -111,7 +111,7 @@ function NationalLayout(props: NationalLayoutProps) {
         </Link>
         <aside className="national-aside">
           <nav aria-label="metric navigation">
-            <h2>{siteText.nationaal_layout.headings.laatste}</h2>
+            <h2>{siteText.nationaal_layout.headings.algemeen}</h2>
             <ul className="last-developments">
               <li>
                 <Link href="/">

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -71,7 +71,8 @@ function NationalLayout(props: NationalLayoutProps) {
   const { isMenuOpen, openMenu } = useMenuState(isMainRoute);
 
   // remove focus after navigation
-  const blur = (evt: any) => evt.currentTarget.blur();
+  const blur = (evt: React.MouseEvent<HTMLAnchorElement>) =>
+    evt.currentTarget.blur();
 
   function getClassName(path: string) {
     return router.pathname === path
@@ -127,7 +128,7 @@ function NationalLayout(props: NationalLayoutProps) {
                 </Link>
               </li>
             </ul>
-            <h2>{siteText.nationaal_layout.headings.medisch}</h2>
+            <h2>{siteText.nationaal_layout.headings.besmettingen}</h2>
             <ul>
               <li>
                 <Link href="/landelijk/positief-geteste-mensen">
@@ -149,6 +150,27 @@ function NationalLayout(props: NationalLayoutProps) {
                         data={data.infected_people_delta_normalized}
                         showAxis={false}
                         showValue={false}
+                      />
+                    </span>
+                  </a>
+                </Link>
+              </li>
+
+              <li>
+                <Link href="/landelijk/besmettelijke-mensen">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/besmettelijke-mensen')}
+                  >
+                    <TitleWithIcon
+                      Icon={Ziektegolf}
+                      title={siteText.besmettelijke_personen.titel_sidebar}
+                    />
+                    <span>
+                      <InfectiousPeopleMetric
+                        data={
+                          data.infectious_people_last_known_average?.last_value
+                        }
                       />
                     </span>
                   </a>
@@ -180,28 +202,11 @@ function NationalLayout(props: NationalLayoutProps) {
                   </a>
                 </Link>
               </li>
+            </ul>
 
-              <li>
-                <Link href="/landelijk/besmettelijke-mensen">
-                  <a
-                    onClick={blur}
-                    className={getClassName('/landelijk/besmettelijke-mensen')}
-                  >
-                    <TitleWithIcon
-                      Icon={Ziektegolf}
-                      title={siteText.besmettelijke_personen.titel_sidebar}
-                    />
-                    <span>
-                      <InfectiousPeopleMetric
-                        data={
-                          data.infectious_people_last_known_average?.last_value
-                        }
-                      />
-                    </span>
-                  </a>
-                </Link>
-              </li>
+            <h2>{siteText.nationaal_layout.headings.ziekenhuizen}</h2>
 
+            <ul>
               <li>
                 <Link href="/landelijk/ziekenhuis-opnames">
                   <a
@@ -253,48 +258,8 @@ function NationalLayout(props: NationalLayoutProps) {
               </li>
             </ul>
 
-            <h2>{siteText.nationaal_layout.headings.overig}</h2>
-            <ul>
-              <li>
-                <Link href="/landelijk/verdenkingen-huisartsen">
-                  <a
-                    onClick={blur}
-                    className={getClassName(
-                      '/landelijk/verdenkingen-huisartsen'
-                    )}
-                  >
-                    <TitleWithIcon
-                      Icon={Arts}
-                      title={siteText.verdenkingen_huisartsen.titel_sidebar}
-                    />
-                    <span>
-                      <SuspectedPatientsMetric
-                        data={data.verdenkingen_huisartsen.last_value}
-                      />
-                    </span>
-                  </a>
-                </Link>
-              </li>
+            <h2>{siteText.nationaal_layout.headings.verpleeghuizen}</h2>
 
-              <li>
-                <Link href="/landelijk/rioolwater">
-                  <a
-                    onClick={blur}
-                    className={getClassName('/landelijk/rioolwater')}
-                  >
-                    <TitleWithIcon
-                      Icon={RioolwaterMonitoring}
-                      title={siteText.rioolwater_metingen.titel_sidebar}
-                    />
-                    <span>
-                      <SewerWaterMetric data={data.sewer} />
-                    </span>
-                  </a>
-                </Link>
-              </li>
-            </ul>
-
-            <h2>{siteText.nationaal_layout.headings.verpleeghuis}</h2>
             <ul>
               <li>
                 <Link href="/landelijk/verpleeghuis-positief-geteste-personen">
@@ -357,6 +322,48 @@ function NationalLayout(props: NationalLayoutProps) {
                       <NursingHomeDeathsMetric
                         data={data.nursing_home.last_value}
                       />
+                    </span>
+                  </a>
+                </Link>
+              </li>
+            </ul>
+
+            <h2>{siteText.nationaal_layout.headings.vroege_signalen}</h2>
+
+            <ul>
+              <li>
+                <Link href="/landelijk/verdenkingen-huisartsen">
+                  <a
+                    onClick={blur}
+                    className={getClassName(
+                      '/landelijk/verdenkingen-huisartsen'
+                    )}
+                  >
+                    <TitleWithIcon
+                      Icon={Arts}
+                      title={siteText.verdenkingen_huisartsen.titel_sidebar}
+                    />
+                    <span>
+                      <SuspectedPatientsMetric
+                        data={data.verdenkingen_huisartsen.last_value}
+                      />
+                    </span>
+                  </a>
+                </Link>
+              </li>
+
+              <li>
+                <Link href="/landelijk/rioolwater">
+                  <a
+                    onClick={blur}
+                    className={getClassName('/landelijk/rioolwater')}
+                  >
+                    <TitleWithIcon
+                      Icon={RioolwaterMonitoring}
+                      title={siteText.rioolwater_metingen.titel_sidebar}
+                    />
+                    <span>
+                      <SewerWaterMetric data={data.sewer} />
                     </span>
                   </a>
                 </Link>

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -63,7 +63,7 @@ type TSafetyRegion = {
 function SafetyRegionLayout(
   props: ISafetyRegionData & { children: React.ReactNode }
 ) {
-  const { children, data } = props;
+  const { children, data, safetyRegionName } = props;
 
   const router = useRouter();
   const isLargeScreen = useMediaQuery('(min-width: 1000px)', true);
@@ -118,8 +118,12 @@ function SafetyRegionLayout(
       </Head>
 
       <div
-        className={`safety-region-layout  has-menu-${
-          isMainRoute ? 'and-content-opened' : isMenuOpen ? 'opened' : 'closed'
+        className={`safety-region-layout ${
+          isMainRoute
+            ? 'has-menu-and-content-opened'
+            : isMenuOpen
+            ? 'has-menu-opened'
+            : 'has-menu-closed'
         }`}
       >
         <Link href="/veiligheidsregio/[code]" as={`/veiligheidsregio/${code}`}>
@@ -137,8 +141,8 @@ function SafetyRegionLayout(
 
           {showMetricLinks && (
             <nav aria-label="metric navigation">
-              <h2>{siteText.veiligheidsregio_layout.headings.medisch}</h2>
-
+              <h2>{safetyRegionName}</h2>
+              <h2>{siteText.veiligheidsregio_layout.headings.besmettingen}</h2>
               <ul>
                 <li>
                   <Link
@@ -171,7 +175,9 @@ function SafetyRegionLayout(
                     </a>
                   </Link>
                 </li>
-
+              </ul>
+              <h2>{siteText.veiligheidsregio_layout.headings.ziekenhuizen}</h2>
+              <ul>
                 <li>
                   <Link
                     href="/veiligheidsregio/[code]/ziekenhuis-opnames"
@@ -197,38 +203,9 @@ function SafetyRegionLayout(
                   </Link>
                 </li>
               </ul>
-
-              <h2>{siteText.veiligheidsregio_layout.headings.overig}</h2>
-              <ul>
-                <li>
-                  <Link
-                    href="/veiligheidsregio/[code]/rioolwater"
-                    as={`/veiligheidsregio/${code}/rioolwater`}
-                  >
-                    <a
-                      onClick={blur}
-                      className={getClassName(
-                        `/veiligheidsregio/[code]/rioolwater`
-                      )}
-                    >
-                      <TitleWithIcon
-                        Icon={RioolwaterMonitoring}
-                        title={
-                          siteText.veiligheidsregio_rioolwater_metingen
-                            .titel_sidebar
-                        }
-                      />
-                      <span>
-                        <SewerWaterMetric
-                          data={getSewerWaterBarScaleData(data)}
-                        />
-                      </span>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
-
-              <h2>{siteText.veiligheidsregio_layout.headings.verpleeghuis}</h2>
+              <h2>
+                {siteText.veiligheidsregio_layout.headings.verpleeghuizen}
+              </h2>
               <ul>
                 <li>
                   <Link
@@ -299,6 +276,39 @@ function SafetyRegionLayout(
                       <span>
                         <NursingHomeDeathsMetric
                           data={data.nursing_home.last_value}
+                        />
+                      </span>
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+
+              <h2>
+                {siteText.veiligheidsregio_layout.headings.vroege_signalen}
+              </h2>
+
+              <ul>
+                <li>
+                  <Link
+                    href="/veiligheidsregio/[code]/rioolwater"
+                    as={`/veiligheidsregio/${code}/rioolwater`}
+                  >
+                    <a
+                      onClick={blur}
+                      className={getClassName(
+                        `/veiligheidsregio/[code]/rioolwater`
+                      )}
+                    >
+                      <TitleWithIcon
+                        Icon={RioolwaterMonitoring}
+                        title={
+                          siteText.veiligheidsregio_rioolwater_metingen
+                            .titel_sidebar
+                        }
+                      />
+                      <span>
+                        <SewerWaterMetric
+                          data={getSewerWaterBarScaleData(data)}
                         />
                       </span>
                     </a>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -661,7 +661,7 @@
       "ziekenhuizen": "[@TODO] Ziekenhuizen",
       "verpleeghuizen": "[@TODO] Verpleeghuizen",
       "vroege_signalen": "[@TODO] Vroege signalen",
-      "gedrag": "Gedrag"
+      "gedrag": "[@TODO] Gedrag"
     }
   },
   "veiligheidsregio_layout": {
@@ -671,6 +671,13 @@
       "verpleeghuizen": "[@TODO] Verpleeghuizen",
       "vroege_signalen": "[@TODO] Vroege signalen",
       "gedrag" :"[@TODO] gedrag"
+    }
+  },
+  "gemeente_layout": {
+    "headings": {
+      "besmettingen": "[@TODO] Besmettingen",
+      "ziekenhuizen": "[@TODO] Ziekenhuizen",
+      "vroege_signalen": "[@TODO] Vroege signalen"
     }
   },
   "veiligheidsregio_metadata": {
@@ -917,13 +924,6 @@
       "titel": "Legend"
     },
     "valid_from": "Valid from {{validFrom}}"
-  },
-  "gemeente_layout": {
-    "headings": {
-      "medisch": "Medical indicators",
-      "overig": "Early warning",
-      "verpleeghuis": "Nursing homes"
-    }
   },
   "positief_geteste_personen_ggd": {
     "titel": "Percentage confirmed cases by GGD",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -656,18 +656,21 @@
   },
   "nationaal_layout": {
     "headings": {
-      "laatste": "Latest developments",
-      "besmettingen": "[@todo] Besmettingen",
-      "ziekenhuizen": "[@todo] Ziekenhuizen",
-      "verpleeghuizen": "[@todo] Verpleeghuizen",
-      "vroege_signalen": "[@todo] Vroege signalen"
+      "algemeen": "[@TODO] Algemeen",
+      "besmettingen": "[@TODO] Besmettingen",
+      "ziekenhuizen": "[@TODO] Ziekenhuizen",
+      "verpleeghuizen": "[@TODO] Verpleeghuizen",
+      "vroege_signalen": "[@TODO] Vroege signalen",
+      "gedrag": "Gedrag"
     }
   },
   "veiligheidsregio_layout": {
     "headings": {
-      "medisch": "Medical indicators",
-      "overig": "Other indicators",
-      "verpleeghuis": "Nursing homes"
+      "besmettingen": "[@TODO] Besmettingen",
+      "ziekenhuizen": "[@TODO] Ziekenhuizen",
+      "verpleeghuizen": "[@TODO] Verpleeghuizen",
+      "vroege_signalen": "[@TODO] Vroege signalen",
+      "gedrag" :"[@TODO] gedrag"
     }
   },
   "veiligheidsregio_metadata": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -656,10 +656,11 @@
   },
   "nationaal_layout": {
     "headings": {
-      "medisch": "Medical indicators",
-      "overig": "Early indicators",
-      "verpleeghuis": "Nursing homes",
-      "laatste": "Latest developments"
+      "laatste": "Latest developments",
+      "besmettingen": "[@todo] Besmettingen",
+      "ziekenhuizen": "[@todo] Ziekenhuizen",
+      "verpleeghuizen": "[@todo] Verpleeghuizen",
+      "vroege_signalen": "[@todo] Vroege signalen"
     }
   },
   "veiligheidsregio_layout": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -656,10 +656,12 @@
   },
   "nationaal_layout": {
     "headings": {
-      "medisch": "Medische indicatoren",
-      "overig": "Vroegsignalering",
-      "verpleeghuis": "Verpleeghuiszorg",
-      "laatste": "Laatste ontwikkelingen"
+      "laatste": "Laatste ontwikkelingen",
+
+      "besmettingen": "Besmettingen",
+      "ziekenhuizen": "Ziekenhuizen",
+      "verpleeghuizen": "Verpleeghuizen",
+      "vroege_signalen": "Vroege signalen"
     }
   },
   "veiligheidsregio_layout": {

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -673,6 +673,13 @@
       "gedrag" :"Gedrag"
     }
   },
+  "gemeente_layout": {
+    "headings": {
+      "besmettingen": "Besmettingen",
+      "ziekenhuizen": "Ziekenhuizen",
+      "vroege_signalen": "Vroege signalen"
+    }
+  },
   "veiligheidsregio_metadata": {
     "title": "Regionaal Dashboard Coronavirus COVID-19 | Rijksoverheid.nl",
     "description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
@@ -917,13 +924,6 @@
       "titel": "Legenda"
     },
     "valid_from": "Geldig vanaf {{validFrom}}"
-  },
-  "gemeente_layout": {
-    "headings": {
-      "medisch": "Medische indicatoren",
-      "overig": "Vroegsignalering",
-      "verpleeghuis": "Verpleeghuiszorg"
-    }
   },
   "positief_geteste_personen_ggd": {
     "titel": "Percentage positief geteste personen via GGD teststraten",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -656,19 +656,21 @@
   },
   "nationaal_layout": {
     "headings": {
-      "laatste": "Laatste ontwikkelingen",
-
+      "algemeen": "Algemeen",
       "besmettingen": "Besmettingen",
       "ziekenhuizen": "Ziekenhuizen",
-      "verpleeghuizen": "Verpleeghuizen",
-      "vroege_signalen": "Vroege signalen"
+      "verpleeghuizen": "Verpleeghuiszorg",
+      "vroege_signalen": "Vroege signalen",
+      "gedrag": "Gedrag"
     }
   },
   "veiligheidsregio_layout": {
     "headings": {
-      "medisch": "Medische indicatoren",
-      "overig": "Vroegsignalering",
-      "verpleeghuis": "Verpleeghuiszorg"
+      "besmettingen": "Besmettingen",
+      "ziekenhuizen": "Ziekenhuizen",
+      "verpleeghuizen": "Verpleeghuiszorg",
+      "vroege_signalen": "Vroege signalen",
+      "gedrag" :"Gedrag"
     }
   },
   "veiligheidsregio_metadata": {

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -45,7 +45,7 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
         })}
       />
       <ContentHeader
-        category={siteText.gemeente_layout.headings.medisch}
+        category={siteText.gemeente_layout.headings.besmettingen}
         title={replaceVariablesInText(text.titel, {
           municipality: municipalityName,
         })}

--- a/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/src/pages/gemeente/[code]/rioolwater.tsx
@@ -59,7 +59,7 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
       />
 
       <ContentHeader_weekRangeHack
-        category={siteText.gemeente_layout.headings.overig}
+        category={siteText.gemeente_layout.headings.vroege_signalen}
         title={replaceVariablesInText(text.titel, {
           municipality: municipalityName,
         })}

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -43,7 +43,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         })}
       />
       <ContentHeader
-        category={siteText.gemeente_layout.headings.medisch}
+        category={siteText.gemeente_layout.headings.ziekenhuizen}
         title={replaceVariablesInText(text.titel, {
           municipality: municipalityName,
         })}

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -26,7 +26,7 @@ const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.medisch}
+        category={siteText.nationaal_layout.headings.besmettingen}
         title={text.title}
         Icon={Ziektegolf}
         subtitle={text.toelichting_pagina}

--- a/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/src/pages/landelijk/intensive-care-opnames.tsx
@@ -28,7 +28,7 @@ const IntakeIntensiveCare: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader_sourcesHack
-        category={siteText.nationaal_layout.headings.medisch}
+        category={siteText.nationaal_layout.headings.ziekenhuizen}
         title={text.titel}
         Icon={Arts}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -72,7 +72,7 @@ const PositivelyTestedPeople: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.medisch}
+        category={siteText.nationaal_layout.headings.besmettingen}
         title={text.titel}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -26,7 +26,7 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.medisch}
+        category={siteText.nationaal_layout.headings.besmettingen}
         title={text.titel}
         Icon={Repro}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -32,7 +32,7 @@ const SewerWater: FCWithLayout<INationalData> = ({ data }) => {
         description={text.metadata.description}
       />
       <ContentHeader_weekRangeHack
-        category={siteText.gemeente_layout.headings.overig}
+        category={siteText.nationaal_layout.headings.vroege_signalen}
         title={text.titel}
         Icon={RioolwaterMonitoring}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -31,7 +31,7 @@ const SuspectedPatients: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.gemeente_layout.headings.overig}
+        category={siteText.nationaal_layout.headings.vroege_signalen}
         title={text.titel}
         Icon={Arts}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/landelijk/verpleeghuis-besmette-locaties.tsx
@@ -35,7 +35,7 @@ const NursingHomeInfectedLocations: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.verpleeghuis}
+        category={siteText.nationaal_layout.headings.verpleeghuizen}
         title={text.titel}
         Icon={Locatie}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -19,7 +19,7 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = ({ data }) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.verpleeghuis}
+        category={siteText.nationaal_layout.headings.verpleeghuizen}
         title={text.titel}
         Icon={Getest}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -21,7 +21,7 @@ const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader
-        category={siteText.nationaal_layout.headings.verpleeghuis}
+        category={siteText.nationaal_layout.headings.verpleeghuizen}
         title={text.titel}
         Icon={CoronaVirus}
         subtitle={text.pagina_toelichting}

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -44,7 +44,7 @@ const IntakeHospital: FCWithLayout<INationalData> = (props) => {
         description={text.metadata.description}
       />
       <ContentHeader_sourcesHack
-        category={siteText.nationaal_layout.headings.medisch}
+        category={siteText.nationaal_layout.headings.ziekenhuizen}
         title={text.titel}
         Icon={Ziekenhuis}
         subtitle={text.pagina_toelichting}

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -60,7 +60,7 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
         })}
       />
       <ContentHeader
-        category={siteText.veiligheidsregio_layout.headings.medisch}
+        category={siteText.veiligheidsregio_layout.headings.besmettingen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -70,7 +70,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
         })}
       />
       <ContentHeader_weekRangeHack
-        category={siteText.veiligheidsregio_layout.headings.overig}
+        category={siteText.veiligheidsregio_layout.headings.vroege_signalen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-besmette-locaties.tsx
@@ -42,7 +42,7 @@ const NursingHomeInfectedLocations: FCWithLayout<ISafetyRegionData> = (
         })}
       />
       <ContentHeader
-        category={siteText.veiligheidsregio_layout.headings.verpleeghuis}
+        category={siteText.veiligheidsregio_layout.headings.verpleeghuizen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
@@ -31,7 +31,7 @@ const NursingHomeInfectedPeople: FCWithLayout<ISafetyRegionData> = ({
         })}
       />
       <ContentHeader
-        category={siteText.veiligheidsregio_layout.headings.verpleeghuis}
+        category={siteText.veiligheidsregio_layout.headings.verpleeghuizen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
@@ -33,7 +33,7 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
         })}
       />
       <ContentHeader
-        category={siteText.veiligheidsregio_layout.headings.verpleeghuis}
+        category={siteText.veiligheidsregio_layout.headings.verpleeghuizen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -47,7 +47,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
         })}
       />
       <ContentHeader
-        category={siteText.veiligheidsregio_layout.headings.medisch}
+        category={siteText.veiligheidsregio_layout.headings.ziekenhuizen}
         title={replaceVariablesInText(text.titel, {
           safetyRegion: safetyRegionName,
         })}


### PR DESCRIPTION
## In this PR:
- Reorder sidebar menu items
- Use correct translation keys (e.g. `gemeente` menu was depending on translation values of `landelijk`)
