### PR TITLE
Fix issue with duplicate radio group ids

### DIFF
--- a/src/components-styled/radio-group.tsx
+++ b/src/components-styled/radio-group.tsx
@@ -78,13 +78,13 @@ export function RadioGroup(props: RadioGroupProps) {
         <Fragment key={`radiogroup-${id}-input-${index}`}>
           <StyledInput
             onChange={() => onLocalChange(item.value)}
-            id={`radiogroup-${id}-${index}`}
+            id={`radiogroup-${item.value}-${id}-${index}`}
             type="radio"
             name={`radiogroup-${id}-item-${item.value}`}
             value={item.value}
             checked={selectedValue === item.value}
           />
-          <StyledLabel htmlFor={`radiogroup-${id}-${index}`}>
+          <StyledLabel htmlFor={`radiogroup-${item.value}-${id}-${index}`}>
             {item.label}
           </StyledLabel>
         </Fragment>


### PR DESCRIPTION
## Summary

I encountered an issue with the radio-group unique id not being very unique, resulting in radio-groups controlling several instances at once. This could for example be caused by the `radio-group.tsx` being part of multiple chunks (But rendered on a single page), not entirely sure if that's the case though.

A quick fix for the particular issue I ran into is to make the item's value be part of the unique id, hence this PR, but I can imagine there are some other edge-cases where the issue would pop up again.