### PR TITLE
Topic/ui tweaks

### DIFF
--- a/src/components-styled/chart-time-controls.tsx
+++ b/src/components-styled/chart-time-controls.tsx
@@ -10,8 +10,8 @@ interface ChartTimeControlsProps {
 
 export function ChartTimeControls(props: ChartTimeControlsProps) {
   const {
-    timeframe,
     onChange,
+    timeframe,
     timeframeOptions = ['all', '5weeks', 'week'],
   } = props;
 

--- a/src/components-styled/choropleth-legenda.tsx
+++ b/src/components-styled/choropleth-legenda.tsx
@@ -14,15 +14,17 @@ export type ChoroplethLegendaProps = {
 
 const List = styled.ul(
   css({
+    width: '100%',
     marginTop: 0,
     paddingLeft: 0,
     listStyle: 'none',
-    display: 'inline-flex',
+    display: 'flex',
   })
 );
 
 const Item = styled.li(
   css({
+    flex: 1,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
@@ -38,7 +40,8 @@ const Item = styled.li(
 
 const LegendaItemBox = styled(Box)(
   css({
-    width: ['50px', null, '60px'],
+    width: '100%',
+    maxWidth: 60,
     height: '10px',
     flexGrow: 0,
     flexShrink: 0,
@@ -51,7 +54,7 @@ export function ChoroplethLegenda(props: ChoroplethLegendaProps) {
   const { items, title } = props;
 
   return (
-    <Box>
+    <Box width="100%" maxWidth={300}>
       <h4>{title}</h4>
       <List aria-label="legend">
         {items.map((item) => (

--- a/src/components-styled/choropleth-tile.tsx
+++ b/src/components-styled/choropleth-tile.tsx
@@ -50,7 +50,7 @@ export function ChoroplethTile<T>({
   return (
     <Tile mb={4} ml={{ _: -4, sm: 0 }} mr={{ _: -4, sm: 0 }}>
       <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
-        <Box flex={{ lg: 1 }}>
+        <Box mb={3} flex={{ lg: 1 }}>
           <div>
             <Box mb={[0, 2]}>
               <Heading level={3}>{title}</Heading>

--- a/src/components-styled/radio-group.tsx
+++ b/src/components-styled/radio-group.tsx
@@ -32,6 +32,7 @@ const StyledLabel = styled.label(
     borderStyle: 'solid',
     borderColor: 'button',
     borderWidth: '1px 0 1px 1px',
+    whiteSpace: 'nowrap',
 
     '&:last-child': {
       borderRightWidth: '1px',

--- a/src/components/choropleth/path.tsx
+++ b/src/components/choropleth/path.tsx
@@ -43,14 +43,17 @@ const StyledPath = styled.path<{ hoverable?: boolean }>(
     x.hoverable &&
     css({
       cursor: 'pointer',
-      fill: 'none',
+      fill: 'transparent',
       stroke: x.stroke ?? 'transparent',
       strokeWidth: x.strokeWidth ?? 0,
       pointerEvents: 'all',
-
+      transitionProperty: 'fill, stroke, stroke-width',
+      transitionDuration: '90ms',
+      transitionTimingFunction: 'ease-out',
       '&:hover': {
+        transitionDuration: '0ms',
         fill: x.fill ?? 'none',
-        stroke: x.stroke ?? '#000',
+        stroke: x.stroke ?? '#222',
         strokeWidth: x.strokeWidth ?? 2,
       },
     })

--- a/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -30,6 +30,7 @@ import { Metadata } from '~/components-styled/metadata';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
+import css from '@styled-system/css';
 
 const text = siteText.veiligheidsregio_rioolwater_metingen;
 
@@ -126,7 +127,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
 
       <article className="metric-article">
         <div className="metric-article-header">
-          <h3>{text.linechart_titel}</h3>
+          <h3 css={css({ mr: 3, flex: 1 })}>{text.linechart_titel}</h3>
           <ChartTimeControls
             timeframeOptions={['all', '5weeks']}
             timeframe={timeframe}


### PR DESCRIPTION
## Summary
- Prevent text wrapping in radio buttons
- Fix choropleth render issue on narrow devices (it would break out of its container)
- Add tiny margin between an instance of title and chart time controls
- Add tiny fade-out animation to choropleth path hover