### PR TITLE
Styling adjustments for 1 KPI tile on a row

### DIFF
--- a/src/components-styled/kpi-tile.tsx
+++ b/src/components-styled/kpi-tile.tsx
@@ -1,13 +1,15 @@
 import { Box, Spacer } from './base';
-import { Text, Heading } from './typography';
+import { Heading } from './typography';
 import { Tile } from './layout';
 import { MetadataProps, Metadata } from './metadata';
+import { DataWarning } from '~/components/dataWarning';
 
 interface KpiTileProps {
   title: string;
   description?: string;
   children: React.ReactNode;
   metadata: MetadataProps;
+  dataWarning?: boolean /* TODO: remove this temporary attribute when it is not used anymore */;
 }
 
 /**
@@ -19,14 +21,18 @@ export function KpiTile({
   description,
   children,
   metadata,
+  dataWarning,
 }: KpiTileProps) {
   return (
     <Tile height="100%">
+      {dataWarning && <DataWarning />}
       <Heading level={3}>{title}</Heading>
       <Box>{children}</Box>
       {description && (
-        <Text
+        <Box
           as="div"
+          maxWidth="400px"
+          mt="3"
           dangerouslySetInnerHTML={{
             __html: description,
           }}

--- a/src/components-styled/kpi-tile.tsx
+++ b/src/components-styled/kpi-tile.tsx
@@ -9,7 +9,7 @@ interface KpiTileProps {
   description?: string;
   children: React.ReactNode;
   metadata: MetadataProps;
-  dataWarning?: boolean /* TODO: remove this temporary attribute when it is not used anymore */;
+  showDataWarning?: boolean /* TODO: remove this temporary attribute when it is not used anymore */;
 }
 
 /**
@@ -21,18 +21,20 @@ export function KpiTile({
   description,
   children,
   metadata,
-  dataWarning,
+  showDataWarning,
 }: KpiTileProps) {
   return (
     <Tile height="100%">
-      {dataWarning && <DataWarning />}
+      {showDataWarning && <DataWarning />}
       <Heading level={3}>{title}</Heading>
       <Box>{children}</Box>
       {description && (
         <Box
           as="div"
           maxWidth="400px"
-          mt="3"
+          mt={3}
+          fontSize={2}
+          lineHeight={2}
           dangerouslySetInnerHTML={{
             __html: description,
           }}

--- a/src/components-styled/two-kpi-section.tsx
+++ b/src/components-styled/two-kpi-section.tsx
@@ -36,10 +36,14 @@ export function TwoKpiSection({ children, ...props }: TwoKpiSectionProps) {
       mr={{ _: -4, sm: 0 }}
       {...(props as any)}
     >
-      <Box flex="1 1 50%" mr={{ lg: 3 }} mb={{ _: 4, lg: 0 }}>
+      <Box flex={`1 1 ${childrenCount === 2 ? 50 : 100}%`} mb={{ _: 4, lg: 0 }}>
         {childrenArray[0]}
       </Box>
-      <Box flex="1 1 50%">{childrenArray[1]}</Box>
+      {childrenArray[1] && (
+        <Box flex="1 1 50%" ml={{ lg: 3 }}>
+          {childrenArray[1]}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components-styled/two-kpi-section.tsx
+++ b/src/components-styled/two-kpi-section.tsx
@@ -14,6 +14,7 @@ export function TwoKpiSection({ children, ...props }: TwoKpiSectionProps) {
     `TwoKpiSection can only have 1 or 2 children, but received ${childrenCount}`
   );
 
+  const hasTwoChildren = childrenCount === 2;
   const childrenArray = React.Children.toArray(children);
 
   return (
@@ -36,10 +37,10 @@ export function TwoKpiSection({ children, ...props }: TwoKpiSectionProps) {
       mr={{ _: -4, sm: 0 }}
       {...(props as any)}
     >
-      <Box flex={`1 1 ${childrenCount === 2 ? 50 : 100}%`} mb={{ _: 4, lg: 0 }}>
+      <Box flex={`1 1 ${hasTwoChildren ? 50 : 100}%`} mb={{ _: 4, lg: 0 }}>
         {childrenArray[0]}
       </Box>
-      {childrenArray[1] && (
+      {hasTwoChildren && (
         <Box flex="1 1 50%" ml={{ lg: 3 }}>
           {childrenArray[1]}
         </Box>

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -18,9 +18,11 @@ import {
   IMunicipalityData,
 } from '~/static-props/municipality-data';
 import { MunicipalHospitalAdmissions } from '~/types/data.d';
-import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Metadata } from '~/components-styled/metadata';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiValue } from '~/components-styled/kpi-value';
+import { KpiTile } from '~/components-styled/kpi-tile';
 
 const text = siteText.gemeente_ziekenhuisopnames_per_dag;
 
@@ -58,28 +60,21 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         }}
       />
 
-      <article className="metric-article layout-two-column-two-row">
-        <DataWarning />
-        <div className="row-item">
-          <div className="column-item column-item-extra-margin">
-            <h3>{text.barscale_titel}</h3>
-            <p className="text-blue kpi" data-cy="infected_daily_total">
-              {formatNumber(
-                hospitalAdmissions.last_value.moving_average_hospital
-              )}
-            </p>
-          </div>
-
-          <div className="column-item column-item-extra-margin">
-            <p>{text.extra_uitleg}</p>
-          </div>
-        </div>
-
-        <Metadata
-          date={hospitalAdmissions.last_value.date_of_report_unix}
-          source={text.bron}
-        />
-      </article>
+      <TwoKpiSection>
+        <KpiTile
+          dataWarning
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: hospitalAdmissions.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue
+            absolute={hospitalAdmissions.last_value.moving_average_hospital}
+          />
+        </KpiTile>
+      </TwoKpiSection>
 
       {hospitalAdmissions && (
         <article className="metric-article">

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -62,7 +62,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
 
       <TwoKpiSection>
         <KpiTile
-          dataWarning
+          showDataWarning
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{

--- a/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -8,7 +8,9 @@ import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
 import { Metadata } from '~/components-styled/metadata';
-import { formatNumber } from '~/utils/formatNumber';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.besmettelijke_personen;
 
@@ -40,54 +42,23 @@ const InfectiousPeople: FCWithLayout<INationalData> = (props) => {
         }}
       />
 
-      {/*
-        @TODO make this replace the code below. Maybe extend TwoKpiSection so that
-        it renders the KPI full-width if there is only one child.
-
-        Discuss with design. https://trello.com/c/gnDOKkZ2/780-regressie-gemiddeld-aantal-besmettelijke-mensen-per-100k
-
       <TwoKpiSection>
-        {infectiousPeopleLastKnownAverage && (
-          <KpiTile
-            title={text.cijfer_titel}
-            description={text.cijfer_toelichting}
-            metadata={{
-              date:
-                infectiousPeopleLastKnownAverage.last_value.date_of_report_unix,
-              source: text.bron,
-            }}
-          >
-            <KpiValue
-              absolute={
-                infectiousPeopleLastKnownAverage.last_value.infectious_avg
-              }
-            />
-          </KpiTile>
-        )}
-      </TwoKpiSection>
-
-      */}
-
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.cijfer_titel}</h3>
-          <p className="text-blue kpi" data-cy="infected_daily_total">
-            {formatNumber(
+        <KpiTile
+          title={text.cijfer_titel}
+          description={text.cijfer_toelichting}
+          metadata={{
+            date:
+              infectiousPeopleLastKnownAverage.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue
+            absolute={
               infectiousPeopleLastKnownAverage.last_value.infectious_avg
-            )}
-          </p>
-          <Metadata
-            date={
-              infectiousPeopleLastKnownAverage.last_value.date_of_report_unix
             }
-            source={text.bron}
           />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.cijfer_toelichting}</p>
-        </div>
-      </article>
+        </KpiTile>
+      </TwoKpiSection>
 
       {count?.values && (
         <article className="metric-article">

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -11,6 +11,7 @@ import getNlData, { INationalData } from '~/static-props/nl-data';
 import { Metadata } from '~/components-styled/metadata';
 import { Text } from '~/components-styled/typography';
 import { KpiWithIllustrationTile } from '~/components-styled/kpi-with-illustration-tile';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 
 const text = siteText.reproductiegetal;
 
@@ -39,21 +40,26 @@ const ReproductionIndex: FCWithLayout<INationalData> = (props) => {
         }}
       />
 
-      <KpiWithIllustrationTile
-        title={text.barscale_titel}
-        metadata={{
-          date: lastKnownValidData.last_value.date_of_report_unix,
-          source: text.bron,
-        }}
-        illustration={{
-          image: '/images/reproductie-explainer.svg',
-          alt: text.reproductie_explainer_alt,
-          description: text.extra_uitleg,
-        }}
-      >
-        <ReproductionIndexBarScale data={lastKnownValidData} showAxis={true} />
-        <Text>{text.barscale_toelichting}</Text>
-      </KpiWithIllustrationTile>
+      <TwoKpiSection>
+        <KpiWithIllustrationTile
+          title={text.barscale_titel}
+          metadata={{
+            date: lastKnownValidData.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+          illustration={{
+            image: '/images/reproductie-explainer.svg',
+            alt: text.reproductie_explainer_alt,
+            description: text.extra_uitleg,
+          }}
+        >
+          <ReproductionIndexBarScale
+            data={lastKnownValidData}
+            showAxis={true}
+          />
+          <Text>{text.barscale_toelichting}</Text>
+        </KpiWithIllustrationTile>
+      </TwoKpiSection>
 
       {data.reproduction_index.values && (
         <article className="metric-article">

--- a/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/landelijk/verpleeghuis-positief-geteste-personen.tsx
@@ -6,8 +6,10 @@ import { getNationalLayout } from '~/components/layout/NationalLayout';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
-import { formatNumber } from '~/utils/formatNumber';
 import { Metadata } from '~/components-styled/metadata';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.verpleeghuis_positief_geteste_personen;
 
@@ -31,22 +33,21 @@ const NursingHomeInfectedPeople: FCWithLayout<INationalData> = ({ data }) => {
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <p className="text-blue kpi" data-cy="infected_daily_total">
-            {formatNumber(data.nursing_home.last_value.newly_infected_people)}
-          </p>
-          <Metadata
-            date={data.nursing_home.last_value.date_of_report_unix}
-            source={text.bron}
+      <TwoKpiSection>
+        <KpiTile
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: data.nursing_home.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue
+            data-cy="infected_daily_total"
+            absolute={data.nursing_home.last_value.newly_infected_people}
           />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
+        </KpiTile>
+      </TwoKpiSection>
 
       <article className="metric-article">
         <LineChart

--- a/src/pages/landelijk/verpleeghuis-sterfte.tsx
+++ b/src/pages/landelijk/verpleeghuis-sterfte.tsx
@@ -6,8 +6,10 @@ import { getNationalLayout } from '~/components/layout/NationalLayout';
 import { SEOHead } from '~/components/seoHead';
 import siteText from '~/locale/index';
 import getNlData, { INationalData } from '~/static-props/nl-data';
-import { formatNumber } from '~/utils/formatNumber';
 import { Metadata } from '~/components-styled/metadata';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.verpleeghuis_oversterfte;
 
@@ -33,24 +35,18 @@ const NursingHomeDeaths: FCWithLayout<INationalData> = (props) => {
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <p>
-            <span className="text-blue kpi" data-cy="infected_daily_total">
-              {formatNumber(data.last_value.deceased_daily)}
-            </span>
-          </p>
-          <Metadata
-            date={data.last_value.date_of_report_unix}
-            source={text.bron}
-          />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
+      <TwoKpiSection>
+        <KpiTile
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: data.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue absolute={data.last_value.deceased_daily} />
+        </KpiTile>
+      </TwoKpiSection>
 
       {data && (
         <article className="metric-article">

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-positief-geteste-personen.tsx
@@ -10,9 +10,11 @@ import {
   getSafetyRegionPaths,
   ISafetyRegionData,
 } from '~/static-props/safetyregion-data';
-import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Metadata } from '~/components-styled/metadata';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.veiligheidsregio_verpleeghuis_positief_geteste_personen;
 
@@ -47,22 +49,21 @@ const NursingHomeInfectedPeople: FCWithLayout<ISafetyRegionData> = ({
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <p className="text-blue kpi" data-cy="infected_daily_total">
-            {formatNumber(data.nursing_home.last_value.newly_infected_people)}
-          </p>
-          <Metadata
-            date={data.nursing_home.last_value.date_of_report_unix}
-            source={text.bron}
+      <TwoKpiSection>
+        <KpiTile
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: data.nursing_home.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue
+            data-cy="infected_daily_total"
+            absolute={data.nursing_home.last_value.newly_infected_people}
           />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
+        </KpiTile>
+      </TwoKpiSection>
 
       <article className="metric-article">
         <LineChart

--- a/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
+++ b/src/pages/veiligheidsregio/[code]/verpleeghuis-sterfte.tsx
@@ -11,9 +11,11 @@ import {
   ISafetyRegionData,
 } from '~/static-props/safetyregion-data';
 import { RegionalNursingHome } from '~/types/data.d';
-import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Metadata } from '~/components-styled/metadata';
+import { KpiValue } from '~/components-styled/kpi-value';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 
 const text = siteText.veiligheidsregio_verpleeghuis_oversterfte;
 
@@ -47,22 +49,18 @@ const NursingHomeDeaths: FCWithLayout<ISafetyRegionData> = (props) => {
         }}
       />
 
-      <article className="metric-article layout-two-column">
-        <div className="column-item column-item-extra-margin">
-          <h3>{text.barscale_titel}</h3>
-          <p className="text-blue kpi" data-cy="infected_daily_total">
-            {formatNumber(data?.last_value.deceased_daily)}
-          </p>
-          <Metadata
-            date={data.last_value.date_of_report_unix}
-            source={text.bron}
-          />
-        </div>
-
-        <div className="column-item column-item-extra-margin">
-          <p>{text.extra_uitleg}</p>
-        </div>
-      </article>
+      <TwoKpiSection>
+        <KpiTile
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: data.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue absolute={data.last_value.deceased_daily} />
+        </KpiTile>
+      </TwoKpiSection>
 
       {data && (
         <article className="metric-article">

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -65,7 +65,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
 
       <TwoKpiSection>
         <KpiTile
-          dataWarning
+          showDataWarning
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -19,9 +19,11 @@ import {
   ISafetyRegionData,
 } from '~/static-props/safetyregion-data';
 import { ResultsPerRegion } from '~/types/data.d';
-import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Metadata } from '~/components-styled/metadata';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { KpiTile } from '~/components-styled/kpi-tile';
+import { KpiValue } from '~/components-styled/kpi-value';
 
 const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
 
@@ -60,27 +62,24 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           dataSource: text.bron,
         }}
       />
-      <article className="metric-article layout-two-column-two-row">
-        <DataWarning />
-        <div className="row-item">
-          <div className="column-item column-item-extra-margin">
-            <h3>{text.barscale_titel}</h3>
-            <p className="text-blue kpi" data-cy="infected_daily_total">
-              {formatNumber(
-                resultsPerRegion.last_value.hospital_moving_avg_per_region
-              )}
-            </p>
-          </div>
 
-          <div className="column-item column-item-extra-margin">
-            <p>{text.extra_uitleg}</p>
-          </div>
-        </div>
-        <Metadata
-          date={resultsPerRegion.last_value.date_of_report_unix}
-          source={text.bron}
-        />
-      </article>
+      <TwoKpiSection>
+        <KpiTile
+          dataWarning
+          title={text.barscale_titel}
+          description={text.extra_uitleg}
+          metadata={{
+            date: resultsPerRegion.last_value.date_of_report_unix,
+            source: text.bron,
+          }}
+        >
+          <KpiValue
+            absolute={
+              resultsPerRegion.last_value.hospital_moving_avg_per_region
+            }
+          />
+        </KpiTile>
+      </TwoKpiSection>
 
       {resultsPerRegion && (
         <article className="metric-article">


### PR DESCRIPTION
## Summary

Adjust TwoKpiSection/Tile components to display 1 Tile with the new design.

## Detailed design

* Use Tiles on all leftover pages that were previously blocked.
* Apply new layout when 1 Tile is used in TwoKpiSection: full width, description with a max width of 1 column (400px).
* Fix padding issue with reproduction number tile along the way.
* Add (temporary) `dataWarning` attribute to the Tile so we can use the new design on the Ziekenhuis-tiles as well.

## Unresolved questions

* Should we rename _TwoKpiSection_ to something different, now that it is optimized for 1 or 2 Kpi Tiles?
