### PR TITLE
Ensure schema validation will catch empty escalation_levels

### DIFF
--- a/schema/regions/__index.json
+++ b/schema/regions/__index.json
@@ -34,6 +34,7 @@
     },
     "hospital_admissions": {
       "type": "array",
+      "minItems": 25,
       "maxItems": 25,
       "items": {
         "$ref": "hospital_admissions.json"


### PR DESCRIPTION
The `escalation_levels` in `REGIONS.json` is currently an empty array, this change will catch those mistakes during data validation.