### PR TITLE
Use weekdays in all metadata in headers

### DIFF
--- a/src/components/contentHeader_sourcesHack/metadata_sourcesHack.tsx
+++ b/src/components/contentHeader_sourcesHack/metadata_sourcesHack.tsx
@@ -33,9 +33,9 @@ export function MetadataHack(props: IProps) {
     dateInsertedUnix,
   } = props;
 
-  const dateOfReport = formatDateFromSeconds(dateUnix, 'relative');
+  const dateOfReport = formatDateFromSeconds(dateUnix, 'weekday-medium');
   const dateOfInsertion = dateInsertedUnix
-    ? formatDateFromSeconds(dateInsertedUnix, 'relative')
+    ? formatDateFromSeconds(dateInsertedUnix, 'weekday-medium')
     : undefined;
 
   return (

--- a/src/components/contentHeader_weekRangeHack/metadata_weekRangeHack.tsx
+++ b/src/components/contentHeader_weekRangeHack/metadata_weekRangeHack.tsx
@@ -31,11 +31,11 @@ export function Metadata(props: IProps) {
     dateOfInsertionUnix,
   } = props;
 
-  const weekStart = formatDateFromSeconds(weekStartUnix, 'relative');
-  const weekEnd = formatDateFromSeconds(weekEndUnix, 'relative');
+  const weekStart = formatDateFromSeconds(weekStartUnix, 'weekday-medium');
+  const weekEnd = formatDateFromSeconds(weekEndUnix, 'weekday-medium');
   const dateOfInsertion = formatDateFromSeconds(
     dateOfInsertionUnix,
-    'relative'
+    'weekday-medium'
   );
 
   return (


### PR DESCRIPTION
## Summary

Applies the date format `weekday-medium` for all content headers. (It was already applied to the regular version of the `contentheader` component.)