### PR TITLE
Calibrate sewer choropleth legenda

### DIFF
--- a/src/components-styled/choropleth-legenda.tsx
+++ b/src/components-styled/choropleth-legenda.tsx
@@ -41,7 +41,6 @@ const Item = styled.li(
 const LegendaItemBox = styled(Box)(
   css({
     width: '100%',
-    maxWidth: 60,
     height: '10px',
     flexGrow: 0,
     flexShrink: 0,
@@ -54,13 +53,13 @@ export function ChoroplethLegenda(props: ChoroplethLegendaProps) {
   const { items, title } = props;
 
   return (
-    <Box width="100%" maxWidth={300}>
+    <Box width="100%" maxWidth={400}>
       {title && <h4>{title}</h4>}
       <List aria-label="legend">
         {items.map((item) => (
           <Item key={item.color}>
             <LegendaItemBox backgroundColor={item.color} />
-            <div>{item.label}</div>
+            <Box p={1}>{item.label}</Box>
           </Item>
         ))}
       </List>

--- a/src/components/choropleth/region-thresholds.ts
+++ b/src/components/choropleth/region-thresholds.ts
@@ -109,23 +109,23 @@ const sewerThresholds: ChoroplethThresholds = {
     },
     {
       color: colors.data.scale.blue[1],
-      threshold: 5,
-    },
-    {
-      color: colors.data.scale.blue[2],
       threshold: 50,
     },
     {
+      color: colors.data.scale.blue[2],
+      threshold: 250,
+    },
+    {
       color: colors.data.scale.blue[3],
-      threshold: 100,
+      threshold: 500,
     },
     {
       color: colors.data.scale.blue[4],
-      threshold: 150,
+      threshold: 750,
     },
     {
       color: colors.data.scale.blue[5],
-      threshold: 200,
+      threshold: 1000,
     },
   ],
 };


### PR DESCRIPTION
It's time to calibrate the sewer choropleth legenda.

The story on our backlog states that it should come with a copy update to alert users that it has been recalibrated. This extra message should be visible for one week.

My question is whether we should change that copy in this PR, or will that be managed using localize?