### PR TITLE
Hide choropleth tooltip on touch outside

### DIFF
--- a/src/components/choropleth/choropleth.tsx
+++ b/src/components/choropleth/choropleth.tsx
@@ -4,6 +4,7 @@ import { Mercator } from '@vx/geo';
 import { Feature, FeatureCollection, Geometry, MultiPolygon } from 'geojson';
 import { memo, MutableRefObject, ReactNode, useRef, useState } from 'react';
 import { useIsTouchDevice } from '~/utils/use-is-touch-device';
+import { useOnClickOutside } from '~/utils/use-on-click-outside';
 import { TCombinedChartDimensions } from './hooks/use-chart-dimensions';
 import { Tooltip } from './tooltips/tooltipContainer';
 
@@ -79,9 +80,14 @@ export function Choropleth<T1, T2, T3>({
 }: TProps<T1, T2, T3>) {
   const [tooltip, setTooltip] = useState<TooltipSettings>();
   const isTouch = useIsTouchDevice();
+  const ref = useRef<HTMLDivElement>(null);
+  useOnClickOutside(ref, () => setTooltip(undefined));
+
   return (
     <>
-      <ChoroplethMap {...props} setTooltip={setTooltip} />
+      <div ref={ref}>
+        <ChoroplethMap {...props} setTooltip={setTooltip} />
+      </div>
 
       {tooltip && (
         <div style={{ pointerEvents: isTouch ? 'all' : 'none' }}>
@@ -207,15 +213,7 @@ function MercatorGroup<G extends Geometry, P>(props: MercatorGroupProps<G, P>) {
   const { data, fitSize, render } = props;
 
   return (
-    <Mercator
-      /**
-       * @TODO It looks like there are some discrepancies between types coming
-       * from geojson and d3-geo.
-       * Our data uses geojson, the Mercator component depends on d3-geo.
-       */
-      data={data}
-      fitSize={fitSize}
-    >
+    <Mercator data={data} fitSize={fitSize}>
       {({ features }) => (
         <g data-cy="choropleth-features">
           {features.map(

--- a/src/utils/use-on-click-outside.ts
+++ b/src/utils/use-on-click-outside.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+export function useOnClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T>,
+  handler: (event: MouseEvent | TouchEvent) => void
+) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    function listener(event: MouseEvent | TouchEvent) {
+      // Do nothing if clicking ref's element or descendent elements
+      if (
+        !ref.current ||
+        (event.target !== null && ref.current.contains(event.target as Node))
+      ) {
+        return;
+      }
+
+      handlerRef.current(event);
+    }
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}

--- a/src/utils/use-on-click-outside.ts
+++ b/src/utils/use-on-click-outside.ts
@@ -27,5 +27,5 @@ export function useOnClickOutside<T extends HTMLElement>(
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler]);
+  }, [ref]);
 }


### PR DESCRIPTION
## Summary

Hide the choropleth tooltip when there's a touch or click registered which did not bubble up from within the choropleth.

## Motivation

On touch devices the choropleth tooltip wouldn't hide itself when a user clicked somewhere outside of the choropleth.

## Detailed design

There's a new hook `useOnClickOutside` which accepts a callback and a html-element reference. It will listen for clicks on document level and trigger the callback when the event's target lives outside this reference.

## Drawbacks

This implementation might break if we decide to render tooltips inside a portal.
