### PR TITLE
Improve choropleth UI and performance

### DIFF
--- a/src/components/choropleth/choropleth.tsx
+++ b/src/components/choropleth/choropleth.tsx
@@ -5,7 +5,9 @@ import { Feature, FeatureCollection, Geometry, MultiPolygon } from 'geojson';
 import { memo, MutableRefObject, ReactNode, useRef, useState } from 'react';
 import { useIsTouchDevice } from '~/utils/use-is-touch-device';
 import { TCombinedChartDimensions } from './hooks/use-chart-dimensions';
+import { Path } from './path';
 import { Tooltip } from './tooltips/tooltipContainer';
+import { countryGeo } from './topology';
 
 export type TooltipSettings = {
   left: number;
@@ -23,9 +25,6 @@ export type TProps<T1, T2, T3> = {
   // This is the main feature collection that displays the features that will
   // be colored in as part of the choropleth
   featureCollection: FeatureCollection<MultiPolygon, T1>;
-  // These are features that are used as an overlay, overlays have no interactions
-  // they are simply there to beautify the map or emphasize certain parts.
-  overlays: FeatureCollection<MultiPolygon, T2>;
   // These are features that are used as as the hover features, these are
   // typically activated when the user mouse overs them.
   hovers?: FeatureCollection<MultiPolygon, T3>;
@@ -38,13 +37,6 @@ export type TProps<T1, T2, T3> = {
   // This will usually return a <path/> element.
   featureCallback: (
     feature: Feature<MultiPolygon, T1>,
-    path: string,
-    index: number
-  ) => ReactNode;
-  // This callback is invoked for each of the features in the overlays property.
-  // This will usually return a <path/> element.
-  overlayCallback: (
-    feature: Feature<MultiPolygon, T2>,
     path: string,
     index: number
   ) => ReactNode;
@@ -65,7 +57,7 @@ export type TProps<T1, T2, T3> = {
 
 /**
  * Generic choropleth component that takes featurecollection that is considered the data layer
- * and another that is considered the overlay layer.
+ * and another that is considered the interactive hover layer.
  * It implements a click and mouseover/mouseout system where the value that is assigned to the
  * data-id attribute of a path is propagated to the injected onPatchClick and getTooltipContent
  * callbacks.
@@ -98,6 +90,8 @@ export function Choropleth<T1, T2, T3>({
   );
 }
 
+type FitSize = [[number, number], any];
+
 type ChoroplethMapProps<T1, T2, T3> = Omit<
   TProps<T1, T2, T3>,
   'getTooltipContent'
@@ -110,12 +104,10 @@ const ChoroplethMap: <T1, T2, T3>(
 ) => JSX.Element | null = memo((props) => {
   const {
     featureCollection,
-    overlays,
     hovers,
     boundingBox,
     dimensions,
     featureCallback,
-    overlayCallback,
     hoverCallback,
     onPathClick,
     setTooltip,
@@ -134,10 +126,7 @@ const ChoroplethMap: <T1, T2, T3>(
     boundedHeight,
   } = dimensions;
 
-  const sizeToFit: [[number, number], any] = [
-    [boundedWidth, boundedHeight],
-    boundingBox,
-  ];
+  const fitSize: FitSize = [[boundedWidth, boundedHeight], boundingBox];
 
   return (
     <>
@@ -171,20 +160,16 @@ const ChoroplethMap: <T1, T2, T3>(
           <MercatorGroup
             data={featureCollection.features}
             render={featureCallback}
-            fitSize={sizeToFit}
+            fitSize={fitSize}
           />
 
-          <MercatorGroup
-            data={overlays.features}
-            render={overlayCallback}
-            fitSize={sizeToFit}
-          />
+          <Country fitSize={fitSize} />
 
           {hovers && (
             <MercatorGroup
               data={hovers.features}
               render={hoverCallback}
-              fitSize={sizeToFit}
+              fitSize={fitSize}
             />
           )}
         </g>
@@ -193,6 +178,20 @@ const ChoroplethMap: <T1, T2, T3>(
   );
 });
 
+function Country({ fitSize }: { fitSize: FitSize }) {
+  return (
+    <g css={css({ pointerEvents: 'none' })}>
+      <MercatorGroup
+        data={countryGeo.features}
+        render={(_, path, index) => (
+          <Path key={index} d={path} stroke="#c4c4c4" strokeWidth={0.5} />
+        )}
+        fitSize={fitSize}
+      />
+    </g>
+  );
+}
+
 interface MercatorGroupProps<G extends Geometry, P> {
   data: Feature<G, P>[];
   render: (
@@ -200,7 +199,7 @@ interface MercatorGroupProps<G extends Geometry, P> {
     path: string,
     index: number
   ) => React.ReactNode;
-  fitSize: [[number, number], any];
+  fitSize: FitSize;
 }
 
 function MercatorGroup<G extends Geometry, P>(props: MercatorGroupProps<G, P>) {

--- a/src/components/choropleth/safety-region-choropleth.tsx
+++ b/src/components/choropleth/safety-region-choropleth.tsx
@@ -1,5 +1,5 @@
 import css from '@styled-system/css';
-import { Feature, GeoJsonProperties, MultiPolygon } from 'geojson';
+import { Feature, MultiPolygon } from 'geojson';
 import { ReactNode, useCallback } from 'react';
 import { Regions } from '~/types/data';
 import { Choropleth } from './choropleth';
@@ -40,8 +40,6 @@ export type TProps<
  *
  * When a selected region code is specified, the map will zoom in on the safety region.
  *
- * As an overlay the country outlines are shown.
- *
  * @param props
  */
 export function SafetyRegionChoropleth<
@@ -71,37 +69,31 @@ export function SafetyRegionChoropleth<
 
   const selectedThreshold = getSelectedThreshold(metricName, metricValueName);
 
+  const DEFAULT_FILL = 'white';
   const getFillColor = useChoroplethColorScale(
     getData,
-    selectedThreshold?.thresholds
+    selectedThreshold?.thresholds,
+    DEFAULT_FILL
   );
 
   const featureCallback = useCallback(
     (feature: Feature<MultiPolygon, SafetyRegionProperties>, path: string) => {
       const { vrcode } = feature.properties;
-      const fill = getFillColor(vrcode);
-
+      const fill =
+        hasData && getFillColor(vrcode) ? getFillColor(vrcode) : DEFAULT_FILL;
       return (
         <Path
           key={vrcode}
           id={vrcode}
           d={path}
-          fill={hasData && fill ? fill : '#fff'}
-          stroke="#fff"
+          fill={fill}
+          stroke={fill === DEFAULT_FILL ? '#c4c4c4' : '#fff'}
           strokeWidth={1}
         />
       );
     },
     [getFillColor, hasData]
   );
-
-  const overlayCallback = (
-    _feature: Feature<MultiPolygon, GeoJsonProperties>,
-    path: string,
-    index: number
-  ) => {
-    return <Path key={index} d={path} stroke="#c4c4c4" strokeWidth={1} />;
-  };
 
   const hoverCallback = useCallback(
     (feature: Feature<MultiPolygon, SafetyRegionProperties>, path: string) => {
@@ -141,12 +133,10 @@ export function SafetyRegionChoropleth<
     <div ref={ref} css={css({ position: 'relative', bg: 'transparent' })}>
       <Choropleth
         featureCollection={regionGeo}
-        overlays={countryGeo}
         hovers={hasData ? regionGeo : undefined}
         boundingBox={boundingBox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}
-        overlayCallback={overlayCallback}
         hoverCallback={hoverCallback}
         onPathClick={onClick}
         getTooltipContent={getTooltipContent}


### PR DESCRIPTION
## Summary

This PR removed the need of the `overlay` collection on choropleths. The main purpose of that layer was to render stuff like the afsluitdijk. These things are part of the country geo data and I've moved those features to the choropleth itself - it will always be rendered.

![image](https://user-images.githubusercontent.com/73584448/99790259-208f2080-2b24-11eb-9303-a019acb7f5f0.png)

![image](https://user-images.githubusercontent.com/73584448/99790270-25ec6b00-2b24-11eb-8f11-b898e1196ded.png)

![image](https://user-images.githubusercontent.com/73584448/99790284-2c7ae280-2b24-11eb-9461-fb92f1875475.png)

![image](https://user-images.githubusercontent.com/73584448/99790316-356bb400-2b24-11eb-8495-e5944ebbae00.png)

![image](https://user-images.githubusercontent.com/73584448/99790231-1836e580-2b24-11eb-9033-7e530c5261df.png)

![image](https://user-images.githubusercontent.com/73584448/99790200-10774100-2b24-11eb-9fbb-08174549d53a.png)

![image](https://user-images.githubusercontent.com/73584448/99790330-3bfa2b80-2b24-11eb-8e93-e51b98594afc.png)
