### PR TITLE
Create MessageTile component

### DIFF
--- a/src/components-styled/message-tile.tsx
+++ b/src/components-styled/message-tile.tsx
@@ -1,0 +1,62 @@
+import css from '@styled-system/css';
+import styled from 'styled-components';
+import { Box } from './base';
+import { Tile } from './layout';
+
+interface MessageTileProps {
+  children: React.ReactNode;
+}
+
+export function MessageTile({ children }: MessageTileProps) {
+  return (
+    <Tile
+      css={css({
+        pb: 4,
+        mb: 4,
+        mx: [-4, null, 0],
+        backgroundColor: '#FFF4B9',
+        borderLeft: '9px solid #FFd600',
+      })}
+    >
+      <Box display="flex" alignItems="flex-start">
+        <Box mr={3} flexShrink={0}>
+          <WarningIcon />
+        </Box>
+        <Box maxWidth={450} css={css({ p: { m: 0 } })}>
+          {children}
+        </Box>
+      </Box>
+    </Tile>
+  );
+}
+
+function WarningIcon() {
+  return (
+    <Svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M23.99 29.776c-1.012 0-1.537.72-1.537 1.641 0 1.04.566 1.6 1.557 1.6 1.011 0 1.537-.7 1.537-1.6 0-1.06-.566-1.64-1.557-1.64zM25.223 29.042l-2.468.063v-9.47l2.701-.232-.233 6.42v3.219z"
+        fill="#000"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M41.722 36.015L25.584 8.973A2.003 2.003 0 0023.862 8h-.008a2.005 2.005 0 00-1.722.985L6.27 36.028a1.962 1.962 0 00-.003 1.98A2.004 2.004 0 008 39h32c.718 0 1.38-.38 1.737-.998a1.96 1.96 0 00-.015-1.987zm-30.249-.972l12.404-21.147 12.62 21.147H11.473z"
+      />
+    </Svg>
+  );
+}
+
+const Svg = styled.svg(
+  css({
+    width: 40,
+    height: 40,
+    fill: 'black',
+    display: 'block',
+  })
+);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -623,7 +623,8 @@
     "select_municipality": "Select a municipality",
     "select_region_municipality_legend": "Select a municipality:",
     "select_region_type_legend": "Show numbers from:",
-    "your_municipality": "Municipality"
+    "your_municipality": "Municipality",
+    "belangrijk_bericht": ""
   },
   "common": {
     "metadata": {
@@ -884,7 +885,8 @@
     "metadata": {
       "title": "Level of risk per safety region | Dashboard Coronavirus | Government.nl",
       "description": "Overview of the level of risk per safety region in the Netherlands."
-    }
+    },
+    "belangrijk_bericht": ""
   },
   "gemeente_index": {
     "selecteer_titel": "Select your municipality",

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -623,7 +623,8 @@
     "select_municipality": "Selecteer een gemeente",
     "select_region_municipality_legend": "Selecteer een gemeente:",
     "select_region_type_legend": "Toon cijfers van:",
-    "your_municipality": "Gemeente"
+    "your_municipality": "Gemeente",
+    "belangrijk_bericht": ""
   },
   "common": {
     "metadata": {
@@ -884,7 +885,8 @@
     "metadata": {
       "title": "Risiconiveaus per veiligheidsregio | Dashboard Coronavirus | Rijksoverheid.nl",
       "description": "Overzicht van het huidige risiconiveau per veiligheidsregio in Nederland."
-    }
+    },
+    "belangrijk_bericht": ""
   },
   "gemeente_index": {
     "selecteer_titel": "Selecteer een gemeente",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,7 @@ import { EscalationMapLegenda } from './veiligheidsregio';
 import { assert } from '~/utils/assert';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
+import { MessageTile } from '~/components-styled/message-tile';
 import css from '@styled-system/css';
 
 interface StaticProps {
@@ -88,6 +89,16 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
           <span>{text.notificatie.link.text}</span>
         </a>
       </article>
+
+      {text.regionaal_index.belangrijk_bericht && (
+        <MessageTile>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: text.regionaal_index.belangrijk_bericht,
+            }}
+          />
+        </MessageTile>
+      )}
 
       <ChoroplethTile
         title={text.veiligheidsregio_index.selecteer_titel}
@@ -179,13 +190,19 @@ const getEscalationCounts = (
 };
 
 export async function getStaticProps(): Promise<StaticProps> {
-  const text = (await import('../locale/index')).default;
+  const text = { ...(await import('../locale/index')).default };
 
-  const serializedContent = MDToHTMLString(
-    text.veiligheidsregio_index.selecteer_toelichting
-  );
+  text.regionaal_index = {
+    ...text.regionaal_index,
+    belangrijk_bericht: MDToHTMLString(text.regionaal_index.belangrijk_bericht),
+  };
 
-  text.veiligheidsregio_index.selecteer_toelichting = serializedContent;
+  text.veiligheidsregio_index = {
+    ...text.veiligheidsregio_index,
+    selecteer_toelichting: MDToHTMLString(
+      text.veiligheidsregio_index.selecteer_toelichting
+    ),
+  };
 
   const filePath = path.join(process.cwd(), 'public', 'json', 'NL.json');
   const fileContents = fs.readFileSync(filePath, 'utf8');

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -14,6 +14,7 @@ import styles from '~/components/choropleth/tooltips/tooltip.module.scss';
 import { FCWithLayout } from '~/components/layout';
 import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
 import { SEOHead } from '~/components/seoHead';
+import { MessageTile } from '~/components-styled/message-tile';
 import { TALLLanguages } from '~/locale/index';
 import { MDToHTMLString } from '~/utils/MDToHTMLString';
 
@@ -68,6 +69,17 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
         title={text.veiligheidsregio_index.metadata.title}
         description={text.veiligheidsregio_index.metadata.description}
       />
+
+      {text.veiligheidsregio_index.belangrijk_bericht && (
+        <MessageTile>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: text.veiligheidsregio_index.belangrijk_bericht,
+            }}
+          />
+        </MessageTile>
+      )}
+
       <article className="index-article layout-choropleth">
         <div className="choropleth-header">
           <h2>{text.veiligheidsregio_index.selecteer_titel}</h2>
@@ -107,13 +119,17 @@ interface StaticProps {
 }
 
 export async function getStaticProps(): Promise<{ props: StaticProps }> {
-  const text = (await import('../../locale/index')).default;
+  const text = { ...(await import('../../locale/index')).default };
 
-  const serializedContent = MDToHTMLString(
-    text.veiligheidsregio_index.selecteer_toelichting
-  );
-
-  text.veiligheidsregio_index.selecteer_toelichting = serializedContent;
+  text.veiligheidsregio_index = {
+    ...text.veiligheidsregio_index,
+    selecteer_toelichting: MDToHTMLString(
+      text.veiligheidsregio_index.selecteer_toelichting
+    ),
+    belangrijk_bericht: MDToHTMLString(
+      text.veiligheidsregio_index.belangrijk_bericht
+    ),
+  };
 
   const filePath = path.join(process.cwd(), 'public', 'json', 'NL.json');
   const fileContents = fs.readFileSync(filePath, 'utf8');


### PR DESCRIPTION
This hotfix implements the `<MessageTile />` component.

Two translation keys can enable the message on the homepage and/or the VR index page:
- `regionaal_index.belangrijk_bericht`
- `veiligheidsregio_index.belangrijk_bericht`

I've inlined the warning SVG to minimize impact on both master as develop.

It's a draft PR until its clear whether this should be a hotfix in master or a normal PR.