### PR TITLE
Toe en afname indicators continued

### DIFF
--- a/schema/municipal/__index.json
+++ b/schema/municipal/__index.json
@@ -9,7 +9,8 @@
     "name",
     "code",
     "hospital_admissions",
-    "positive_tested_people"
+    "positive_tested_people",
+    "difference"
   ],
   "properties": {
     "last_generated": {

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -12,7 +12,8 @@
     "nursing_home",
     "sewer",
     "sewer_per_installation",
-    "behavior"
+    "behavior",
+    "difference"
   ],
   "additionalProperties": false,
   "properties": {

--- a/src/components-styled/difference-indicator.tsx
+++ b/src/components-styled/difference-indicator.tsx
@@ -122,7 +122,6 @@ const Container = styled.div(
     whiteSpace: 'nowrap',
     display: 'inline-block',
     fontSize: 1,
-    position: 'relative',
     svg: {
       mr: 1,
       width: '1em',

--- a/src/components-styled/metric-kpi.tsx
+++ b/src/components-styled/metric-kpi.tsx
@@ -60,7 +60,7 @@ export function MetricKPI(props: IProps) {
           </InlineText>
         )}
 
-        {difference && (
+        {isDefined(difference) && (
           <Box as="span" fontSize={3} display="flex" alignItems="center">
             <DifferenceIndicator value={difference} isContextSidebar={true} />
           </Box>

--- a/src/components-styled/metric-kpi.tsx
+++ b/src/components-styled/metric-kpi.tsx
@@ -1,6 +1,9 @@
 import { ValueAnnotation } from '~/components-styled/value-annotation';
+import { DifferenceDecimal, DifferenceInteger } from '~/types/data';
 import { Box } from './base';
-import { Heading, Text } from './typography';
+import { DifferenceIndicator } from './difference-indicator';
+import { Heading, InlineText } from './typography';
+import { isDefined } from 'ts-is-present';
 
 type IProps = {
   title: string;
@@ -8,10 +11,18 @@ type IProps = {
   percentage?: string;
   description?: string;
   valueAnnotation?: string;
+  difference?: DifferenceDecimal | DifferenceInteger;
 };
 
 export function MetricKPI(props: IProps) {
-  const { absolute, percentage, title, description, valueAnnotation } = props;
+  const {
+    absolute,
+    percentage,
+    title,
+    description,
+    valueAnnotation,
+    difference,
+  } = props;
 
   return (
     <Box width="100%" minHeight="4rem">
@@ -24,31 +35,50 @@ export function MetricKPI(props: IProps) {
       >
         {title}
       </Heading>
-      <Box display="flex" alignItems="center">
-        <Text display="inline-block" fontSize={3} fontWeight="bold" margin="0">
-          {absolute}
-        </Text>
-        {percentage !== undefined && (
-          <Text
-            display="inline-block"
+      <Box display="flex" alignItems="center" justifyContent="flex-start">
+        {isDefined(absolute) && (
+          <InlineText
+            as="span"
             fontSize={3}
             fontWeight="bold"
             margin="0"
-            marginLeft={1}
+            marginRight={1}
+          >
+            {absolute}
+          </InlineText>
+        )}
+
+        {isDefined(percentage) && (
+          <InlineText
+            as="span"
+            fontSize={3}
+            fontWeight="bold"
+            margin="0"
+            marginRight={1}
           >
             ({percentage}%)
-          </Text>
+          </InlineText>
         )}
-        <Text
-          display="inline-block"
-          margin="0"
-          marginLeft={3}
-          color="annotation"
-          fontSize={1}
-        >
-          {description}
-        </Text>
+
+        {difference && (
+          <Box as="span" fontSize={3} display="flex" alignItems="center">
+            <DifferenceIndicator value={difference} isContextSidebar={true} />
+          </Box>
+        )}
+
+        {isDefined(description) && (
+          <InlineText
+            display="inline-block"
+            margin="0"
+            color="annotation"
+            fontSize={1}
+            marginLeft={2}
+          >
+            {description}
+          </InlineText>
+        )}
       </Box>
+
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}
     </Box>
   );

--- a/src/components-styled/metric-kpi.tsx
+++ b/src/components-styled/metric-kpi.tsx
@@ -37,25 +37,13 @@ export function MetricKPI(props: IProps) {
       </Heading>
       <Box display="flex" alignItems="center" justifyContent="flex-start">
         {isDefined(absolute) && (
-          <InlineText
-            as="span"
-            fontSize={3}
-            fontWeight="bold"
-            margin="0"
-            marginRight={1}
-          >
+          <InlineText fontSize={3} fontWeight="bold" margin="0" marginRight={1}>
             {absolute}
           </InlineText>
         )}
 
         {isDefined(percentage) && (
-          <InlineText
-            as="span"
-            fontSize={3}
-            fontWeight="bold"
-            margin="0"
-            marginRight={1}
-          >
+          <InlineText fontSize={3} fontWeight="bold" margin="0" marginRight={1}>
             ({percentage}%)
           </InlineText>
         )}

--- a/src/components-styled/typography/text.tsx
+++ b/src/components-styled/typography/text.tsx
@@ -26,6 +26,10 @@ export const Text = styled.p<TextProps>(
   compose(margin, padding, typography, color)
 );
 
+export const InlineText = styled.span<TextProps>(
+  compose(margin, padding, typography, color)
+);
+
 /**
  * By setting defaultProps we can set themed defaults for the text component to
  * match what normally would be the default body text styling.

--- a/src/components/gemeente/intake-hospital-metric.tsx
+++ b/src/components/gemeente/intake-hospital-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { HospitalAdmissionsLastValue } from '~/types/data.d';
+import { Municipal } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,24 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.gemeente_ziekenhuisopnames_per_dag.titel_kpi;
 
-export function IntakeHospitalMetric(props: {
-  data: HospitalAdmissionsLastValue | undefined;
-}) {
-  const { data } = props;
-
-  if (data === undefined) return null;
+export function IntakeHospitalMetric({ data }: { data: Municipal }) {
+  const lastValue = data.hospital_admissions.last_value;
+  const difference =
+    data.difference.hospital_admissions__moving_average_hospital;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.moving_average_hospital)}
+      absolute={formatNumber(lastValue.moving_average_hospital)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/gemeente/positively-tested-people-metric.tsx
+++ b/src/components/gemeente/positively-tested-people-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { PositiveTestedPeopleLastValue } from '~/types/data.d';
+import { Municipal } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,24 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.gemeente_positief_geteste_personen.titel_kpi;
 
-export function PositivelyTestedPeopleMetric(props: {
-  data: PositiveTestedPeopleLastValue | undefined;
-}) {
-  const { data } = props;
-
-  if (data === undefined) return null;
+export function PositivelyTestedPeopleMetric({ data }: { data: Municipal }) {
+  const lastValue = data.positive_tested_people.last_value;
+  const difference =
+    data.difference.positive_tested_people__infected_daily_total;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.infected_daily_total)}
+      absolute={formatNumber(lastValue.infected_daily_total)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/landelijk/intake-hospital-metric.tsx
+++ b/src/components/landelijk/intake-hospital-metric.tsx
@@ -8,8 +8,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.ziekenhuisopnames_per_dag.titel_kpi;
 
-export function IntakeHospitalMetric(props: { data: National }) {
-  const { data } = props;
+export function IntakeHospitalMetric({ data }: { data: National }) {
   const lastValue = data.intake_hospital_ma.last_value;
   const difference =
     data.difference.intake_hospital_ma__moving_average_hospital;

--- a/src/components/landelijk/intake-hospital-metric.tsx
+++ b/src/components/landelijk/intake-hospital-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { IntakeHospitalMaLastValue } from '~/types/data.d';
+import { National } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,25 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.ziekenhuisopnames_per_dag.titel_kpi;
 
-export function IntakeHospitalMetric(props: {
-  data: IntakeHospitalMaLastValue | undefined;
-}) {
+export function IntakeHospitalMetric(props: { data: National }) {
   const { data } = props;
-
-  if (data === undefined) return null;
+  const lastValue = data.intake_hospital_ma.last_value;
+  const difference =
+    data.difference.intake_hospital_ma__moving_average_hospital;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.moving_average_hospital)}
+      absolute={formatNumber(lastValue.moving_average_hospital)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/landelijk/intake-intensive-care-metric.tsx
+++ b/src/components/landelijk/intake-intensive-care-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { IntakeIntensivecareMaLastValue } from '~/types/data.d';
+import { National } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,24 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.ic_opnames_per_dag.titel_kpi;
 
-export function IntakeIntensiveCareMetric(props: {
-  data: IntakeIntensivecareMaLastValue | undefined;
-}) {
+export function IntakeIntensiveCareMetric(props: { data: National }) {
   const { data } = props;
-
-  if (data === undefined) return null;
+  const lastValue = data.intake_intensivecare_ma.last_value;
+  const difference = data.difference.intake_intensivecare_ma__moving_average_ic;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.moving_average_ic)}
+      absolute={formatNumber(lastValue.moving_average_ic)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/landelijk/positive-tested-people-metric.tsx
+++ b/src/components/landelijk/positive-tested-people-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { NationalInfectedPeopleTotalValue } from '~/types/data.d';
+import { National } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,31 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.positief_geteste_personen.titel_kpi;
 
-export function PositiveTestedPeopleMetric(props: {
-  data: NationalInfectedPeopleTotalValue | undefined;
-}) {
+/**
+ * @TODO refactor / replace this with better abstraction
+ */
+export function PositiveTestedPeopleMetric(props: { data: National }) {
   const { data } = props;
 
-  if (data === undefined) return null;
+  const lastValue = data.infected_people_total.last_value;
+  const difference =
+    data.difference.infected_people_total__infected_daily_total;
+
+  // if (data === undefined) return null;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.infected_daily_total)}
+      absolute={formatNumber(lastValue.infected_daily_total)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/landelijk/positive-tested-people-metric.tsx
+++ b/src/components/landelijk/positive-tested-people-metric.tsx
@@ -13,8 +13,6 @@ export function PositiveTestedPeopleMetric({ data }: { data: National }) {
   const difference =
     data.difference.infected_people_total__infected_daily_total;
 
-  // if (data === undefined) return null;
-
   const description = replaceVariablesInText(text.dateOfReport, {
     dateOfReport: formatDateFromSeconds(
       lastValue.date_of_report_unix,

--- a/src/components/landelijk/positive-tested-people-metric.tsx
+++ b/src/components/landelijk/positive-tested-people-metric.tsx
@@ -8,12 +8,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.positief_geteste_personen.titel_kpi;
 
-/**
- * @TODO refactor / replace this with better abstraction
- */
-export function PositiveTestedPeopleMetric(props: { data: National }) {
-  const { data } = props;
-
+export function PositiveTestedPeopleMetric({ data }: { data: National }) {
   const lastValue = data.infected_people_total.last_value;
   const difference =
     data.difference.infected_people_total__infected_daily_total;

--- a/src/components/layout/MunicipalityLayout.tsx
+++ b/src/components/layout/MunicipalityLayout.tsx
@@ -173,10 +173,8 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                             .titel_sidebar
                         }
                       />
-                      <span>
-                        <PositivelyTestedPeopleMetric
-                          data={data?.positive_tested_people.last_value}
-                        />
+                      <span className="metric-wrapper">
+                        <PositivelyTestedPeopleMetric data={data} />
                       </span>
                     </a>
                   </Link>
@@ -200,10 +198,8 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                             .titel_sidebar
                         }
                       />
-                      <span>
-                        <IntakeHospitalMetric
-                          data={data?.hospital_admissions.last_value}
-                        />
+                      <span className="metric-wrapper">
+                        <IntakeHospitalMetric data={data} />
                       </span>
                     </a>
                   </Link>
@@ -225,7 +221,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                             siteText.gemeente_rioolwater_metingen.titel_sidebar
                           }
                         />
-                        <span>
+                        <span className="metric-wrapper">
                           <SewerWaterMetric data={sewerWaterBarScaleData} />
                         </span>
                       </a>

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -224,9 +224,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       title={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
                     />
                     <span className="metric-wrapper">
-                      <IntakeHospitalMetric
-                        data={data.intake_hospital_ma.last_value}
-                      />
+                      <IntakeHospitalMetric data={data} />
                       <IntakeHospitalBarScale
                         data={data.intake_hospital_ma}
                         showAxis={false}
@@ -250,9 +248,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       title={siteText.ic_opnames_per_dag.titel_sidebar}
                     />
                     <span className="metric-wrapper">
-                      <IntakeIntensiveCareMetric
-                        data={data.intake_intensivecare_ma.last_value}
-                      />
+                      <IntakeIntensiveCareMetric data={data} />
                       <IntakeIntensiveCareBarscale
                         data={data.intake_intensivecare_ma}
                         showAxis={false}

--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -46,7 +46,6 @@ export function getNationalLayout(
       {...siteText.nationaal_metadata}
       lastGenerated={pageProps.lastGenerated}
     >
-      {/* {console.log('XXXXX', pageProps.data.difference)} */}
       <NationalLayout {...pageProps}>{page}</NationalLayout>
     </Layout>
   );
@@ -152,9 +151,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       title={siteText.positief_geteste_personen.titel_sidebar}
                     />
                     <span className="metric-wrapper">
-                      <PositiveTestedPeopleMetric
-                        data={data.infected_people_total.last_value}
-                      />
+                      <PositiveTestedPeopleMetric data={data} />
                       <PositiveTestedPeopleBarScale
                         data={data.infected_people_delta_normalized}
                         showAxis={false}
@@ -175,7 +172,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       icon={<Ziektegolf />}
                       title={siteText.besmettelijke_personen.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <InfectiousPeopleMetric
                         data={
                           data.infectious_people_last_known_average?.last_value
@@ -282,7 +279,7 @@ function NationalLayout(props: NationalLayoutProps) {
                         siteText.verpleeghuis_besmette_locaties.titel_sidebar
                       }
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <NursingHomeInfectedPeopleMetric
                         data={data.nursing_home.last_value}
                       />
@@ -307,7 +304,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       icon={<Arts />}
                       title={siteText.verdenkingen_huisartsen.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <SuspectedPatientsMetric
                         data={data.verdenkingen_huisartsen.last_value}
                       />
@@ -326,7 +323,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       icon={<RioolwaterMonitoring />}
                       title={siteText.rioolwater_metingen.titel_sidebar}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <SewerWaterMetric data={data.sewer} />
                     </span>
                   </a>
@@ -345,7 +342,7 @@ function NationalLayout(props: NationalLayoutProps) {
                       icon={<Gedrag />}
                       title={siteText.nl_gedrag.sidebar.titel}
                     />
-                    <span>
+                    <span className="metric-wrapper">
                       <BehaviorMetric data={data.behavior} />
                     </span>
                   </a>

--- a/src/components/layout/SafetyRegionLayout.tsx
+++ b/src/components/layout/SafetyRegionLayout.tsx
@@ -155,9 +155,7 @@ function SafetyRegionLayout(
                         }
                       />
                       <span className="metric-wrapper">
-                        <PositivelyTestedPeopleMetric
-                          data={data.results_per_region.last_value}
-                        />
+                        <PositivelyTestedPeopleMetric data={data} />
                         <PositivelyTestedPeopleBarScale
                           data={data.results_per_region}
                           showAxis={false}
@@ -185,8 +183,8 @@ function SafetyRegionLayout(
                             .titel_sidebar
                         }
                       />
-                      <span>
-                        <IntakeHospitalMetric data={data.results_per_region} />
+                      <span className="metric-wrapper">
+                        <IntakeHospitalMetric data={data} />
                       </span>
                     </a>
                   </Link>
@@ -212,7 +210,7 @@ function SafetyRegionLayout(
                             .titel_sidebar
                         }
                       />
-                      <span>
+                      <span className="metric-wrapper">
                         <NursingHomeInfectedPeopleMetric
                           data={data.nursing_home.last_value}
                         />
@@ -242,7 +240,7 @@ function SafetyRegionLayout(
                             .titel_sidebar
                         }
                       />
-                      <span>
+                      <span className="metric-wrapper">
                         <SewerWaterMetric
                           data={getSewerWaterBarScaleData(data)}
                         />
@@ -265,7 +263,7 @@ function SafetyRegionLayout(
                         icon={<Gedrag />}
                         title={siteText.nl_gedrag.sidebar.titel}
                       />
-                      <span>
+                      <span className="metric-wrapper">
                         <BehaviorMetric data={data.behavior} />
                       </span>
                     </a>

--- a/src/components/veiligheidsregio/intake-hospital-metric.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-metric.tsx
@@ -8,8 +8,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.veiligheidsregio_ziekenhuisopnames_per_dag.titel_kpi;
 
-export function IntakeHospitalMetric(props: { data: Regionaal }) {
-  const { data } = props;
+export function IntakeHospitalMetric({ data }: { data: Regionaal }) {
   const lastValue = data.results_per_region.last_value;
   const difference =
     data.difference.results_per_region__hospital_moving_avg_per_region;

--- a/src/components/veiligheidsregio/intake-hospital-metric.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { ResultsPerRegion } from '~/types/data.d';
+import { Regionaal } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,16 +8,15 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.veiligheidsregio_ziekenhuisopnames_per_dag.titel_kpi;
 
-export function IntakeHospitalMetric(props: {
-  data: ResultsPerRegion | undefined;
-}) {
+export function IntakeHospitalMetric(props: { data: Regionaal }) {
   const { data } = props;
-
-  if (data === undefined) return null;
+  const lastValue = data.results_per_region.last_value;
+  const difference =
+    data.difference.results_per_region__hospital_moving_avg_per_region;
 
   const description = replaceVariablesInText(text.dateOfReport, {
     dateOfReport: formatDateFromSeconds(
-      data?.last_value.date_of_report_unix,
+      lastValue.date_of_report_unix,
       'medium'
     ),
   });
@@ -25,8 +24,9 @@ export function IntakeHospitalMetric(props: {
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.last_value.hospital_moving_avg_per_region)}
+      absolute={formatNumber(lastValue.hospital_moving_avg_per_region)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/veiligheidsregio/positive-tested-people-metric.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-metric.tsx
@@ -1,6 +1,6 @@
 import { MetricKPI } from '~/components-styled/metric-kpi';
 import siteText from '~/locale/index';
-import { RegionaalValue } from '~/types/data.d';
+import { Regionaal } from '~/types/data.d';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
@@ -8,22 +8,25 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.gemeente_positief_geteste_personen.titel_kpi;
 
-export function PositivelyTestedPeopleMetric(props: {
-  data: RegionaalValue | undefined;
-}) {
+export function PositivelyTestedPeopleMetric(props: { data: Regionaal }) {
   const { data } = props;
-
-  if (data === undefined) return null;
+  const lastValue = data.results_per_region.last_value;
+  const difference =
+    data.difference.results_per_region__total_reported_increase_per_region;
 
   const description = replaceVariablesInText(text.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_of_report_unix, 'medium'),
+    dateOfReport: formatDateFromSeconds(
+      lastValue.date_of_report_unix,
+      'medium'
+    ),
   });
 
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(data.total_reported_increase_per_region)}
+      absolute={formatNumber(lastValue.total_reported_increase_per_region)}
       description={description}
+      difference={difference}
     />
   );
 }

--- a/src/components/veiligheidsregio/positive-tested-people-metric.tsx
+++ b/src/components/veiligheidsregio/positive-tested-people-metric.tsx
@@ -8,8 +8,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 const text = siteText.common.metricKPI;
 const title = siteText.gemeente_positief_geteste_personen.titel_kpi;
 
-export function PositivelyTestedPeopleMetric(props: { data: Regionaal }) {
-  const { data } = props;
+export function PositivelyTestedPeopleMetric({ data }: { data: Regionaal }) {
   const lastValue = data.results_per_region.last_value;
   const difference =
     data.difference.results_per_region__total_reported_increase_per_region;

--- a/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -85,6 +85,9 @@ const PositivelyTestedPeople: FCWithLayout<IMunicipalityData> = (props) => {
           <KpiValue
             data-cy="infected_daily_total"
             absolute={positivelyTestedPeople.last_value.infected_daily_total}
+            difference={
+              data.difference.positive_tested_people__infected_daily_total
+            }
           />
           <Text>{text.kpi_toelichting}</Text>
         </KpiTile>

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -89,7 +89,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           {(timeframe) => (
             <LineChart
               timeframe={timeframe}
-              values={hospitalAdmissions.values.map((value: any) => ({
+              values={hospitalAdmissions.values.map((value) => ({
                 value: value.moving_average_hospital,
                 date: value.date_of_report_unix,
               }))}

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -72,6 +72,9 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         >
           <KpiValue
             absolute={hospitalAdmissions.last_value.moving_average_hospital}
+            difference={
+              data.difference.hospital_admissions__moving_average_hospital
+            }
           />
         </KpiTile>
       </TwoKpiSection>
@@ -84,15 +87,13 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           metadata={{ source: text.bron }}
         >
           {(timeframe) => (
-            <>
-              <LineChart
-                timeframe={timeframe}
-                values={hospitalAdmissions.values.map((value: any) => ({
-                  value: value.moving_average_hospital,
-                  date: value.date_of_report_unix,
-                }))}
-              />
-            </>
+            <LineChart
+              timeframe={timeframe}
+              values={hospitalAdmissions.values.map((value: any) => ({
+                value: value.moving_average_hospital,
+                date: value.date_of_report_unix,
+              }))}
+            />
           )}
         </ChartTileWithTimeframe>
       )}

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -102,6 +102,10 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
             absolute={Math.round(
               resultsPerRegion.last_value.total_reported_increase_per_region
             )}
+            difference={
+              data.difference
+                .results_per_region__total_reported_increase_per_region
+            }
           />
           <Text>{text.kpi_toelichting}</Text>
           <Box>

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -75,6 +75,9 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
             absolute={
               resultsPerRegion.last_value.hospital_moving_avg_per_region
             }
+            difference={
+              data.difference.results_per_region__hospital_moving_avg_per_region
+            }
           />
         </KpiTile>
       </TwoKpiSection>

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -353,8 +353,13 @@
       }
     }
   }
+}
 
-  .metric-wrapper > div:not(:first-child) {
+.metric-wrapper {
+  display: block;
+  margin: 0 2.5rem;
+
+  & > div:not(:first-child) {
     height: 3.5rem;
     margin-top: -1.25em;
   }
@@ -403,11 +408,6 @@ a.metric-link {
     position: absolute;
     right: 1em;
     top: 1.35em;
-  }
-
-  span {
-    display: block;
-    margin: 0 2.5rem;
   }
 
   &.last-developments-link {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -93,6 +93,7 @@ export const colors = {
   lightGray: '#dfdfdf',
   annotation: '#595959',
   notification: '#cd005a',
+  red: '#F35363',
 
   data: {
     primary: '#007BC7',

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -10,7 +10,7 @@ export interface Municipal {
   proto_name: string;
   name: string;
   code: string;
-  difference?: MunicipalDifference;
+  difference: MunicipalDifference;
   hospital_admissions: MunicipalHospitalAdmissions;
   positive_tested_people: MunicipalPositiveTestedPeople;
   sewer?: MunicipalSewer;
@@ -525,7 +525,7 @@ export interface Regionaal {
   proto_name: string;
   name: string;
   code: string;
-  difference?: RegionalDifference;
+  difference: RegionalDifference;
   sewer: RegionalSewer;
   sewer_per_installation: RegionalSewerPerInstallation;
   results_per_region: ResultsPerRegion;


### PR DESCRIPTION
This is a continuation of #987 because adding the indicators to the sidebar required some other structural changes and since the other PR was already reviewed and also quite large, this makes it a little easier to follow maybe.

The NaN in the screenshot is a result of a missing timestamp property in the differences data.

<img width="1499" alt="Screenshot 2020-11-23 at 19 40 20" src="https://user-images.githubusercontent.com/71320230/100001728-d926bf80-2dc3-11eb-9848-b547f24d7bf5.png">
