### PR TITLE
Add difference value to decreased variant

### DIFF
--- a/src/components-styled/difference-indicator.tsx
+++ b/src/components-styled/difference-indicator.tsx
@@ -9,9 +9,9 @@ import {
   typography,
   TypographyProps,
 } from 'styled-system';
+import IconGelijk from '~/assets/gelijk.svg';
 import IconUp from '~/assets/pijl-omhoog.svg';
 import IconDown from '~/assets/pijl-omlaag.svg';
-import IconGelijk from '~/assets/gelijk.svg';
 import siteText from '~/locale/index';
 import { DifferenceDecimal, DifferenceInteger } from '~/types/data';
 
@@ -100,7 +100,7 @@ function renderTileIndicator(value: DifferenceDecimal | DifferenceInteger) {
           <IconDown />
         </Span>
         <Span fontWeight="bold" mr="0.3em">
-          {splitText[0]}
+          {`${Math.abs(difference)} ${splitText[0]}`}
         </Span>
         <Span>{`${splitText[1]} ${timespanText}`}</Span>
       </Container>


### PR DESCRIPTION
## Summary

The difference component didn't show the actual value in the case of a decreased difference. This fixes that.

## Motivation

Bug report

## Detailed design

Add Math.abs(difference) to the output

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
