### PR TITLE
Hospital schemas unify snowball

### DIFF
--- a/src/components/choropleth/hooks/use-municipality-data.ts
+++ b/src/components/choropleth/hooks/use-municipality-data.ts
@@ -1,10 +1,6 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import {
-  Municipalities,
-  MunicipalitiesHospitalAdmissions,
-  MunicipalitiesPositiveTestedPeople,
-} from '~/types/data';
+import { Municipalities } from '~/types/data';
 import { assert } from '~/utils/assert';
 import {
   MunicipalGeoJSON,
@@ -12,6 +8,7 @@ import {
   TMunicipalityMetricName,
   TMunicipalityMetricType,
 } from '../shared';
+import set from 'lodash/set';
 
 /**
  * This hook takes a metric name, extracts the associated data from the json/municipalities.json
@@ -28,58 +25,68 @@ import {
  * @param featureCollection
  */
 
-export function useMunicipalityData(
-  metricName: TMunicipalityMetricName | undefined,
+type MunicipalitiesMetricValue = {
+  gmcode: string;
+  [key: string]: unknown;
+};
+
+export function useMunicipalityNavigationData(
   featureCollection: MunicipalGeoJSON
 ) {
   const { data: municipalities } = useSWR<Municipalities>(
     '/json/MUNICIPALITIES.json'
   );
 
-  const items =
-    metricName && municipalities ? municipalities[metricName] : undefined;
+  assert(municipalities, 'Missing municipalities data');
+
+  const propertyData = featureCollection.features.reduce(
+    (acc, feature) => set(acc, feature.properties.gemcode, feature.properties),
+    {} as Record<string, MunicipalityProperties>
+  );
+
+  return (id: string) => propertyData[id];
+}
+
+export function useMunicipalityData(
+  metricName: TMunicipalityMetricName,
+  featureCollection: MunicipalGeoJSON
+) {
+  const { data: municipalities } = useSWR<Municipalities>(
+    '/json/MUNICIPALITIES.json'
+  );
+
+  assert(municipalities, 'Missing municipalities data');
+
+  const propertyData = featureCollection.features.reduce(
+    (acc, feature) => set(acc, feature.properties.gemcode, feature.properties),
+    {} as Record<string, MunicipalityProperties>
+  );
+
+  const values = municipalities[metricName];
 
   return useMemo(() => {
-    const propertyData = featureCollection.features.reduce((aggr, feature) => {
-      aggr[feature.properties.gemcode] = feature.properties;
-      return aggr;
-    }, {} as Record<string, MunicipalityProperties>);
-
     /**
-     * cast items[] to any[] because of https://github.com/microsoft/TypeScript/issues/36390
+     * Cast values to unknown because of https://github.com/microsoft/TypeScript/issues/36390
      **/
-    const mergedData = (items as any[])?.reduce<{
-      [key: string]: TMunicipalityMetricType & { value: number };
-    }>(
-      (
-        aggr,
-        item:
-          | MunicipalitiesHospitalAdmissions
-          | MunicipalitiesPositiveTestedPeople
-      ) => {
-        assert(metricName, 'metricName is defined');
+    const mergedData = ((values as unknown) as Array<
+      MunicipalitiesMetricValue
+    >).reduce((acc, value) => {
+      const feature = featureCollection.features.find(
+        (feat) => feat.properties.gemcode === value.gmcode
+      );
 
-        const feature = featureCollection.features.find(
-          (feat) => feat.properties.gemcode === item.gmcode
-        );
+      return set(acc, value.gmcode, {
+        ...value,
+        ...feature?.properties,
+        value: value[metricName],
+      });
+    }, {} as Record<string, TMunicipalityMetricType & { value: unknown }>);
 
-        aggr[item.gmcode] = {
-          ...item,
-          ...feature?.properties,
-          value: (item as any)[metricName],
-        };
-        return aggr;
-      },
-      {}
-    );
-
-    const hasData = mergedData
-      ? Boolean(Object.keys(mergedData).length)
-      : false;
+    const hasData = Object.keys(mergedData).length > 0;
 
     const getData = (id: string) =>
       mergedData ? mergedData[id] : propertyData[id];
 
     return [getData, hasData] as const;
-  }, [items, metricName, featureCollection]);
+  }, [values, metricName, featureCollection]);
 }

--- a/src/components/choropleth/legenda/utils.ts
+++ b/src/components/choropleth/legenda/utils.ts
@@ -3,14 +3,14 @@ import { ChoroplethThresholdsValue } from '../shared';
 export function getDataThresholds<T>(
   thresholdData: T,
   metricName: keyof T,
-  metricNameValue?: string
+  metricProperty?: string
 ) {
-  // Even if a metricNameValue is passed in, there's not necessarily
+  // Even if a metricProperty is passed in, there's not necessarily
   // a threshold defined for this. In that case we fall back to the threshold
   // that exists for the metric name.
   const thresholdInfo =
-    (metricNameValue
-      ? (thresholdData[metricName] as any)[metricNameValue]
+    (metricProperty
+      ? (thresholdData[metricName] as any)[metricProperty]
       : thresholdData[metricName]) ?? thresholdData[metricName];
 
   return thresholdInfo as ChoroplethThresholdsValue[];

--- a/src/components/choropleth/legenda/utils.ts
+++ b/src/components/choropleth/legenda/utils.ts
@@ -1,6 +1,6 @@
 import { ChoroplethThresholdsValue } from '../shared';
 import get from 'lodash/get';
-import { assert } from 'console';
+import { assert } from '~/utils/assert';
 
 export function getDataThresholds<T>(
   thresholdData: T,

--- a/src/components/choropleth/legenda/utils.ts
+++ b/src/components/choropleth/legenda/utils.ts
@@ -1,17 +1,20 @@
 import { ChoroplethThresholdsValue } from '../shared';
+import get from 'lodash/get';
+import { assert } from 'console';
 
 export function getDataThresholds<T>(
   thresholdData: T,
   metricName: keyof T,
   metricProperty?: string
 ) {
-  // Even if a metricProperty is passed in, there's not necessarily
-  // a threshold defined for this. In that case we fall back to the threshold
-  // that exists for the metric name.
-  const thresholdInfo =
-    (metricProperty
-      ? (thresholdData[metricName] as any)[metricProperty]
-      : thresholdData[metricName]) ?? thresholdData[metricName];
+  const thresholds = metricProperty
+    ? get(thresholdData, [metricName, metricProperty])
+    : thresholdData[metricName];
 
-  return thresholdInfo as ChoroplethThresholdsValue[];
+  assert(
+    thresholds,
+    `No thresholds are defined for ${metricName} ${metricProperty ?? ''}`
+  );
+
+  return thresholds as ChoroplethThresholdsValue[];
 }

--- a/src/components/choropleth/legenda/utils.ts
+++ b/src/components/choropleth/legenda/utils.ts
@@ -1,20 +1,17 @@
-import { regionThresholds } from '~/components/choropleth/region-thresholds';
-import { ChoroplethThresholdsValue, TRegionMetricName } from '../shared';
+import { ChoroplethThresholdsValue } from '../shared';
 
-export function getSelectedThreshold(
-  metricName?: TRegionMetricName,
-  metricValueName?: string
+export function getDataThresholds<T>(
+  thresholdData: T,
+  metricName: keyof T,
+  metricNameValue?: string
 ) {
-  if (!metricName) {
-    return;
-  }
-  // Even if a metricValueName is passed in, there's not necessarily
+  // Even if a metricNameValue is passed in, there's not necessarily
   // a threshold defined for this. In that case we fall back to the threshold
   // that exists for the metric name.
   const thresholdInfo =
-    (metricValueName
-      ? (regionThresholds as any)?.[metricName]?.[metricValueName]
-      : regionThresholds[metricName]) ?? regionThresholds[metricName];
+    (metricNameValue
+      ? (thresholdData[metricName] as any)[metricNameValue]
+      : thresholdData[metricName]) ?? thresholdData[metricName];
 
   return thresholdInfo as ChoroplethThresholdsValue[];
 }

--- a/src/components/choropleth/municipal-thresholds.ts
+++ b/src/components/choropleth/municipal-thresholds.ts
@@ -53,5 +53,7 @@ const hospitalAdmissionsThresholds: ChoroplethThresholdsValue[] = [
 
 export const municipalThresholds = {
   positive_tested_people: positiveTestedThresholds,
-  hospital_admissions: hospitalAdmissionsThresholds,
+  hospital: {
+    admissions_moving_average: hospitalAdmissionsThresholds,
+  },
 } as const;

--- a/src/components/choropleth/municipality-choropleth.tsx
+++ b/src/components/choropleth/municipality-choropleth.tsx
@@ -17,7 +17,7 @@ import { countryGeo, municipalGeo, regionGeo } from './topology';
 
 type MunicipalityChoroplethProps<T> = {
   metricName: TMunicipalityMetricName;
-  metricNameValue?: string;
+  metricProperty?: string;
   selected?: string;
   highlightSelection?: boolean;
   onSelect?: (context: MunicipalityProperties) => void;
@@ -45,7 +45,7 @@ export function MunicipalityChoropleth<T>(
   const {
     selected,
     metricName,
-    metricNameValue,
+    metricProperty,
     onSelect,
     tooltipContent,
     highlightSelection = true,
@@ -56,14 +56,18 @@ export function MunicipalityChoropleth<T>(
 
   const [boundingbox] = useMunicipalityBoundingbox(regionGeo, selected);
 
-  const [getData, hasData] = useMunicipalityData(metricName, municipalGeo);
+  const [getData, hasData] = useMunicipalityData(
+    municipalGeo,
+    metricName,
+    metricProperty
+  );
 
   const safetyRegionMunicipalCodes = useRegionMunicipalities(selected);
 
   const thresholdValues = getDataThresholds(
     municipalThresholds,
     metricName,
-    metricNameValue
+    metricProperty
   );
 
   const getFillColor = useChoroplethColorScale(getData, thresholdValues);

--- a/src/components/choropleth/municipality-choropleth.tsx
+++ b/src/components/choropleth/municipality-choropleth.tsx
@@ -24,7 +24,6 @@ type MunicipalityChoroplethProps<T> = {
   tooltipContent?: (
     context: MunicipalityProperties & { value: T }
   ) => ReactNode;
-  isSelectorMap?: boolean;
 };
 
 /**
@@ -49,7 +48,6 @@ export function MunicipalityChoropleth<T>(
     onSelect,
     tooltipContent,
     highlightSelection = true,
-    isSelectorMap,
   } = props;
 
   const [ref, dimensions] = useChartDimensions<HTMLDivElement>(1.2);
@@ -90,9 +88,7 @@ export function MunicipalityChoropleth<T>(
           d={path}
           fill={hasData && fill ? fill : '#fff'}
           stroke={
-            isSelectorMap
-              ? '#01689b'
-              : selected
+            selected
               ? /**
                  * If `selected` eq true, the map is zoomed in on a VR. Render
                  * white strokes when we're rendering a municipality inside this
@@ -107,7 +103,7 @@ export function MunicipalityChoropleth<T>(
         />
       );
     },
-    [getFillColor, hasData, safetyRegionMunicipalCodes, selected, isSelectorMap]
+    [getFillColor, hasData, safetyRegionMunicipalCodes, selected]
   );
 
   const hoverCallback = useCallback(
@@ -127,19 +123,12 @@ export function MunicipalityChoropleth<T>(
           id={gemcode}
           key={gemcode}
           d={path}
-          stroke={isSelectorMap ? '#01689b' : isSelected ? '#000' : undefined}
+          stroke={isSelected ? '#000' : undefined}
           strokeWidth={isSelected ? 3 : undefined}
-          fill={isSelectorMap ? '#01689b' : undefined}
         />
       );
     },
-    [
-      selected,
-      highlightSelection,
-      safetyRegionMunicipalCodes,
-      hasData,
-      isSelectorMap,
-    ]
+    [selected, highlightSelection, safetyRegionMunicipalCodes, hasData]
   );
 
   const onClick = (id: string) => {
@@ -161,7 +150,7 @@ export function MunicipalityChoropleth<T>(
     <div ref={ref} css={css({ bg: 'transparent', position: 'relative' })}>
       <Choropleth
         featureCollection={municipalGeo}
-        hovers={hasData || isSelectorMap ? municipalGeo : undefined}
+        hovers={hasData ? municipalGeo : undefined}
         boundingBox={boundingbox || countryGeo}
         dimensions={dimensions}
         featureCallback={featureCallback}

--- a/src/components/choropleth/municipality-choropleth.tsx
+++ b/src/components/choropleth/municipality-choropleth.tsx
@@ -9,17 +9,21 @@ import {
   useMunicipalityData,
   useRegionMunicipalities,
 } from './hooks';
+import { getDataThresholds } from './legenda/utils';
 import { municipalThresholds } from './municipal-thresholds';
 import { Path } from './path';
 import { MunicipalityProperties, TMunicipalityMetricName } from './shared';
 import { countryGeo, municipalGeo, regionGeo } from './topology';
 
-export type TProps = {
-  metricName?: TMunicipalityMetricName;
+type MunicipalityChoroplethProps<T> = {
+  metricName: TMunicipalityMetricName;
+  metricNameValue?: string;
   selected?: string;
   highlightSelection?: boolean;
   onSelect?: (context: MunicipalityProperties) => void;
-  tooltipContent?: (context: MunicipalityProperties) => ReactNode;
+  tooltipContent?: (
+    context: MunicipalityProperties & { value: T }
+  ) => ReactNode;
   isSelectorMap?: boolean;
 };
 
@@ -35,10 +39,13 @@ export type TProps = {
  *
  * @param props
  */
-export function MunicipalityChoropleth(props: TProps) {
+export function MunicipalityChoropleth<T>(
+  props: MunicipalityChoroplethProps<T>
+) {
   const {
     selected,
     metricName,
+    metricNameValue,
     onSelect,
     tooltipContent,
     highlightSelection = true,
@@ -53,9 +60,11 @@ export function MunicipalityChoropleth(props: TProps) {
 
   const safetyRegionMunicipalCodes = useRegionMunicipalities(selected);
 
-  const thresholdValues = metricName
-    ? municipalThresholds[metricName]
-    : undefined;
+  const thresholdValues = getDataThresholds(
+    municipalThresholds,
+    metricName,
+    metricNameValue
+  );
 
   const getFillColor = useChoroplethColorScale(getData, thresholdValues);
 

--- a/src/components/choropleth/municipality-navigation-map.tsx
+++ b/src/components/choropleth/municipality-navigation-map.tsx
@@ -12,7 +12,6 @@ type MunicipalityNavigationMapProps<T> = {
   tooltipContent?: (
     context: MunicipalityProperties & { value: T }
   ) => ReactNode;
-  isSelectorMap?: boolean;
 };
 
 /**

--- a/src/components/choropleth/municipality-navigation-map.tsx
+++ b/src/components/choropleth/municipality-navigation-map.tsx
@@ -1,0 +1,98 @@
+import css from '@styled-system/css';
+import { Feature, MultiPolygon } from 'geojson';
+import { ReactNode } from 'react';
+import { Choropleth } from './choropleth';
+import { useChartDimensions, useMunicipalityNavigationData } from './hooks';
+import { Path } from './path';
+import { MunicipalityProperties } from './shared';
+import { countryGeo, municipalGeo } from './topology';
+
+type MunicipalityNavigationMapProps<T> = {
+  onSelect?: (context: MunicipalityProperties) => void;
+  tooltipContent?: (
+    context: MunicipalityProperties & { value: T }
+  ) => ReactNode;
+  isSelectorMap?: boolean;
+};
+
+/**
+ * This component renders a map of the Netherlands with the outlines of all the
+ * municipalities but contains no data. It can be used for navigating at GM
+ * index page.
+ */
+export function MunicipalityNavigationMap<T>(
+  props: MunicipalityNavigationMapProps<T>
+) {
+  const { onSelect, tooltipContent } = props;
+
+  const [ref, dimensions] = useChartDimensions<HTMLDivElement>(1.2);
+
+  const getData = useMunicipalityNavigationData(municipalGeo);
+
+  const featureCallback = (
+    feature: Feature<MultiPolygon, MunicipalityProperties>,
+    path: string,
+    _index: number
+  ) => {
+    const { gemcode } = feature.properties;
+
+    return (
+      <Path
+        key={gemcode}
+        id={gemcode}
+        d={path}
+        fill={'#fff'}
+        stroke={'#01689b'}
+        strokeWidth={0.5}
+      />
+    );
+  };
+
+  const hoverCallback = (
+    feature: Feature<MultiPolygon, MunicipalityProperties>,
+    path: string
+  ) => {
+    const { gemcode } = feature.properties;
+
+    return (
+      <Path
+        hoverable
+        id={gemcode}
+        key={gemcode}
+        d={path}
+        stroke={'#01689b'}
+        fill={'#01689b'}
+      />
+    );
+  };
+
+  const onClick = (id: string) => {
+    if (onSelect) {
+      const data = getData(id);
+      onSelect(data as any);
+    }
+  };
+
+  const getTooltipContent = (id: string) => {
+    if (tooltipContent) {
+      const data = getData(id);
+      return tooltipContent(data as any);
+    }
+    return null;
+  };
+
+  return (
+    <div ref={ref} css={css({ bg: 'transparent', position: 'relative' })}>
+      <Choropleth
+        featureCollection={municipalGeo}
+        hovers={municipalGeo}
+        boundingBox={countryGeo}
+        dimensions={dimensions}
+        featureCallback={featureCallback}
+        hoverCallback={hoverCallback}
+        onPathClick={onClick}
+        getTooltipContent={getTooltipContent}
+      />
+    </div>
+  );
+}

--- a/src/components/choropleth/region-thresholds.ts
+++ b/src/components/choropleth/region-thresholds.ts
@@ -154,7 +154,9 @@ const behaviorThresholds: ChoroplethThresholdsValue[] = [
 
 export const regionThresholds = {
   positive_tested_people: positiveTestedThresholds,
-  hospital_admissions: hospitalAdmissionsThresholds,
+  hospital: {
+    admissions_moving_avarage: hospitalAdmissionsThresholds,
+  },
   escalation_levels: escalationThresholds,
   nursing_home: {
     infected_locations_percentage: nursingHomeInfectedLocationsPercentageThresholds,

--- a/src/components/choropleth/region-thresholds.ts
+++ b/src/components/choropleth/region-thresholds.ts
@@ -155,7 +155,7 @@ const behaviorThresholds: ChoroplethThresholdsValue[] = [
 export const regionThresholds = {
   positive_tested_people: positiveTestedThresholds,
   hospital: {
-    admissions_moving_avarage: hospitalAdmissionsThresholds,
+    admissions_moving_average: hospitalAdmissionsThresholds,
   },
   escalation_levels: escalationThresholds,
   nursing_home: {

--- a/src/components/choropleth/safety-region-choropleth.tsx
+++ b/src/components/choropleth/safety-region-choropleth.tsx
@@ -16,7 +16,7 @@ import { countryGeo, regionGeo } from './topology';
 
 type SafetyRegionChoroplethProps<T> = {
   metricName: TRegionMetricName;
-  metricNameValue?: string;
+  metricProperty?: string;
   selected?: string;
   highlightSelection?: boolean;
   onSelect?: (context: SafetyRegionProperties) => void;
@@ -32,7 +32,7 @@ type SafetyRegionChoroplethProps<T> = {
  *
  * The metricName specifies which exact metric is visualized. The color scale is calculated using
  * the specified metric and the given gradient.
- * An optional metricNameValue can be provided as well, when the metric key isn't the same name
+ * An optional metricProperty can be provided as well, when the metric key isn't the same name
  * as the actual value name. Most of the time they are the same:
  * e.g. hospital_admissions.hospital_admissions
  *
@@ -47,7 +47,7 @@ export function SafetyRegionChoropleth<T>(
     selected,
     highlightSelection = true,
     metricName,
-    metricNameValue,
+    metricProperty,
     onSelect,
     tooltipContent,
   } = props;
@@ -57,15 +57,15 @@ export function SafetyRegionChoropleth<T>(
   const boundingBox = useSafetyRegionBoundingbox(regionGeo, selected);
 
   const [getData, hasData] = useSafetyRegionData(
-    metricName,
     regionGeo,
-    metricNameValue
+    metricName,
+    metricProperty
   );
 
   const selectedThreshold = getDataThresholds(
     regionThresholds,
     metricName,
-    metricNameValue
+    metricProperty
   );
 
   const DEFAULT_FILL = 'white';

--- a/src/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip.tsx
+++ b/src/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip.tsx
@@ -3,10 +3,13 @@ import { ReactNode } from 'react';
 import { MunicipalityProperties } from '~/components/choropleth/shared';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltipContent';
+import { MunicipalHospitalValue } from '~/types/data';
 
 export const createMunicipalHospitalAdmissionsTooltip = (
   router: NextRouter
-) => (context: MunicipalityProperties & { value?: number }): ReactNode => {
+) => (
+  context: MunicipalityProperties & { value: MunicipalHospitalValue }
+): ReactNode => {
   const handler = createSelectMunicipalHandler(router);
 
   const onSelect = (event: any) => {
@@ -15,10 +18,8 @@ export const createMunicipalHospitalAdmissionsTooltip = (
   };
 
   return (
-    context && (
-      <TooltipContent title={context.gemnaam} onSelect={onSelect}>
-        <strong>{context.value !== undefined ? context.value : '-'}</strong>
-      </TooltipContent>
-    )
+    <TooltipContent title={context.gemnaam} onSelect={onSelect}>
+      <strong>{context.value.admissions_moving_average}</strong>
+    </TooltipContent>
   );
 };

--- a/src/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip.tsx
+++ b/src/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip.tsx
@@ -7,7 +7,7 @@ import { createSelectRegionHandler } from '../../select-handlers/create-select-r
 import { SafetyRegionProperties } from '../../shared';
 
 export const createInfectedLocationsRegionalTooltip = (router: NextRouter) => (
-  context: RegionsNursingHome & SafetyRegionProperties
+  context: SafetyRegionProperties & { value: RegionsNursingHome }
 ): ReactNode => {
   const handler = createSelectRegionHandler(router);
 
@@ -21,8 +21,8 @@ export const createInfectedLocationsRegionalTooltip = (router: NextRouter) => (
       <TooltipContent title={context.vrname} onSelect={onSelect}>
         <strong>
           {`${formatPercentage(
-            context.infected_locations_percentage
-          )}% (${formatNumber(context.infected_locations_total)})`}
+            context.value.infected_locations_percentage
+          )}% (${formatNumber(context.value.infected_locations_total)})`}
         </strong>
       </TooltipContent>
     )

--- a/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
+++ b/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
@@ -13,12 +13,11 @@ export const createPositiveTestedPeopleRegionalTooltip = (
 ) => (
   context: SafetyRegionProperties & {
     value: number;
-    total_positive_tested_people: number;
   }
 ): ReactNode => {
   const handler = createSelectRegionHandler(router);
 
-  const { vrname, value, total_positive_tested_people } = context;
+  const { vrname, value } = context;
 
   const onSelect = (event: any) => {
     event.stopPropagation();
@@ -31,7 +30,7 @@ export const createPositiveTestedPeopleRegionalTooltip = (
         <p className="info-value">{formatNumber(value)} per 100.000</p>
         <p className="info-total">
           {replaceVariablesInText(text.positive_tested_people, {
-            totalPositiveTestedPeople: `${total_positive_tested_people}`,
+            totalPositiveTestedPeople: `${value}`,
           })}
         </p>
       </TooltipContent>

--- a/src/components/choropleth/tooltips/region/create-region-hospital-admissions-tooltip.tsx
+++ b/src/components/choropleth/tooltips/region/create-region-hospital-admissions-tooltip.tsx
@@ -3,10 +3,11 @@ import { ReactNode } from 'react';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { SafetyRegionProperties } from '~/components/choropleth/shared';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltipContent';
+import { RegionalHospitalValue } from '~/types/data';
 import { formatNumber } from '~/utils/formatNumber';
 
 export const createRegionHospitalAdmissionsTooltip = (router: NextRouter) => (
-  context: SafetyRegionProperties & { value: number }
+  context: SafetyRegionProperties & { value: RegionalHospitalValue }
 ): ReactNode => {
   const handler = createSelectRegionHandler(router);
 
@@ -18,7 +19,7 @@ export const createRegionHospitalAdmissionsTooltip = (router: NextRouter) => (
   return (
     context && (
       <TooltipContent title={context.vrname} onSelect={onSelect}>
-        <strong>{formatNumber(context.value)}</strong>
+        <strong>{formatNumber(context.value.admissions_moving_average)}</strong>
       </TooltipContent>
     )
   );

--- a/src/components/choropleth/tooltips/region/create-sewer-regional-tooltip.tsx
+++ b/src/components/choropleth/tooltips/region/create-sewer-regional-tooltip.tsx
@@ -10,7 +10,7 @@ import { SafetyRegionProperties } from '../../shared';
 const text = siteText.rioolwater_metingen;
 
 export const createSewerRegionalTooltip = (router: NextRouter) => (
-  context: RegionalSewerValue & SafetyRegionProperties
+  context: SafetyRegionProperties & { value: RegionalSewerValue }
 ): ReactNode => {
   const handler = createSelectRegionHandler(router);
 
@@ -24,7 +24,7 @@ export const createSewerRegionalTooltip = (router: NextRouter) => (
       <TooltipContent title={context.vrname} onSelect={onSelect}>
         <p className="info-value">
           {`${replaceVariablesInText(text.map_tooltip_value, {
-            value: formatNumber(context.average),
+            value: formatNumber(context.value.average),
           })}`}
         </p>
         <p className="info-total">{text.map_tooltip}</p>

--- a/src/components/gemeente/intake-hospital-barscale.tsx
+++ b/src/components/gemeente/intake-hospital-barscale.tsx
@@ -1,11 +1,11 @@
 import { BarScale } from '~/components/barScale';
-import { MunicipalHospitalAdmissions } from '~/types/data.d';
+import { MunicipalHospital } from '~/types/data.d';
 
 import siteText from '~/locale/index';
 const text = siteText.gemeente_ziekenhuisopnames_per_dag;
 
 export function IntakeHospitalBarScale(props: {
-  data: MunicipalHospitalAdmissions | undefined;
+  data: MunicipalHospital | undefined;
   showAxis: boolean;
 }) {
   const { data, showAxis } = props;
@@ -17,7 +17,7 @@ export function IntakeHospitalBarScale(props: {
       min={0}
       max={100}
       screenReaderText={text.screen_reader_graph_content}
-      value={data.last_value.moving_average_hospital}
+      value={data.last_value.admissions_moving_average}
       id="opnames"
       rangeKey="moving_average_hospital"
       gradient={[

--- a/src/components/gemeente/intake-hospital-metric.tsx
+++ b/src/components/gemeente/intake-hospital-metric.tsx
@@ -9,9 +9,8 @@ const text = siteText.common.metricKPI;
 const title = siteText.gemeente_ziekenhuisopnames_per_dag.titel_kpi;
 
 export function IntakeHospitalMetric({ data }: { data: Municipal }) {
-  const lastValue = data.hospital_admissions.last_value;
-  const difference =
-    data.difference.hospital_admissions__moving_average_hospital;
+  const lastValue = data.hospital.last_value;
+  const difference = data.difference.hospital__admissions_moving_average;
 
   const description = replaceVariablesInText(text.dateOfReport, {
     dateOfReport: formatDateFromSeconds(
@@ -23,7 +22,7 @@ export function IntakeHospitalMetric({ data }: { data: Municipal }) {
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(lastValue.moving_average_hospital)}
+      absolute={formatNumber(lastValue.admissions_moving_average)}
       description={description}
       difference={difference}
     />

--- a/src/components/landelijk/intake-hospital-barscale.tsx
+++ b/src/components/landelijk/intake-hospital-barscale.tsx
@@ -13,9 +13,8 @@ export function IntakeHospitalBarScale(props: {
 }) {
   const { data, showAxis, showValue } = props;
 
-  const lastValue = data.intake_hospital_ma.last_value;
-  const difference =
-    data.difference.intake_hospital_ma__moving_average_hospital;
+  const lastValue = data.hospital.last_value;
+  const difference = data.difference.hospital__admissions_moving_average;
 
   return (
     <Box spacing={2}>
@@ -24,7 +23,7 @@ export function IntakeHospitalBarScale(props: {
         max={100}
         signaalwaarde={40}
         screenReaderText={text.barscale_screenreader_text}
-        value={lastValue.moving_average_hospital}
+        value={lastValue.admissions_moving_average}
         id="opnames"
         rangeKey="moving_average_hospital"
         gradient={[

--- a/src/components/landelijk/intake-hospital-metric.tsx
+++ b/src/components/landelijk/intake-hospital-metric.tsx
@@ -9,9 +9,8 @@ const text = siteText.common.metricKPI;
 const title = siteText.ziekenhuisopnames_per_dag.titel_kpi;
 
 export function IntakeHospitalMetric({ data }: { data: National }) {
-  const lastValue = data.intake_hospital_ma.last_value;
-  const difference =
-    data.difference.intake_hospital_ma__moving_average_hospital;
+  const lastValue = data.hospital.last_value;
+  const difference = data.difference.hospital__admissions_moving_average;
 
   const description = replaceVariablesInText(text.dateOfReport, {
     dateOfReport: formatDateFromSeconds(
@@ -23,7 +22,7 @@ export function IntakeHospitalMetric({ data }: { data: National }) {
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(lastValue.moving_average_hospital)}
+      absolute={formatNumber(lastValue.admissions_moving_average)}
       description={description}
       difference={difference}
     />

--- a/src/components/veiligheidsregio/intake-hospital-barscale.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-barscale.tsx
@@ -1,14 +1,13 @@
 import { BarScale } from '~/components/barScale';
-import { ResultsPerRegion } from '~/types/data.d';
+import { Regionaal } from '~/types/data.d';
 import siteText from '~/locale/index';
 
 export function IntakeHospitalBarScale(props: {
-  data: ResultsPerRegion | undefined;
+  data: Regionaal;
   showAxis: boolean;
 }) {
   const { data, showAxis } = props;
-
-  if (!data) return null;
+  const lastValue = data.hospital.last_value;
 
   const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
 
@@ -17,7 +16,7 @@ export function IntakeHospitalBarScale(props: {
       min={0}
       max={100}
       screenReaderText={text.barscale_screenreader_text}
-      value={data.last_value.hospital_moving_avg_per_region}
+      value={lastValue.admissions_moving_average}
       id="opnames"
       rangeKey="hospital_moving_avg_per_region"
       gradient={[

--- a/src/components/veiligheidsregio/intake-hospital-metric.tsx
+++ b/src/components/veiligheidsregio/intake-hospital-metric.tsx
@@ -9,9 +9,8 @@ const text = siteText.common.metricKPI;
 const title = siteText.veiligheidsregio_ziekenhuisopnames_per_dag.titel_kpi;
 
 export function IntakeHospitalMetric({ data }: { data: Regionaal }) {
-  const lastValue = data.results_per_region.last_value;
-  const difference =
-    data.difference.results_per_region__hospital_moving_avg_per_region;
+  const lastValue = data.hospital.last_value;
+  const difference = data.difference.hospital__admissions_moving_average;
 
   const description = replaceVariablesInText(text.dateOfReport, {
     dateOfReport: formatDateFromSeconds(
@@ -23,7 +22,7 @@ export function IntakeHospitalMetric({ data }: { data: Regionaal }) {
   return (
     <MetricKPI
       title={title}
-      absolute={formatNumber(lastValue.hospital_moving_avg_per_region)}
+      absolute={formatNumber(lastValue.admissions_moving_average)}
       description={description}
       difference={difference}
     />

--- a/src/pages-tests/gemeente/[code]/ziekenhuis-opnames.test.tsx
+++ b/src/pages-tests/gemeente/[code]/ziekenhuis-opnames.test.tsx
@@ -25,7 +25,7 @@ describe('Municipal page: IntakeHospital', () => {
     testKpiValue(
       container,
       'moving_average_hospital',
-      formatNumber(data.hospital_admissions.last_value.moving_average_hospital)
+      formatNumber(data.hospital.last_value.admissions_moving_average)
     );
   });
 });

--- a/src/pages-tests/landelijk/ziekenhuis-opnames.test.tsx
+++ b/src/pages-tests/landelijk/ziekenhuis-opnames.test.tsx
@@ -21,7 +21,7 @@ describe('National page: IntakeHospital', () => {
     testKpiValue(
       container,
       'covid_occupied',
-      formatNumber(data.hospital_beds_occupied.last_value.covid_occupied)
+      formatNumber(data.hospital.last_value.beds_occupied_covid)
     );
   });
 });

--- a/src/pages-tests/veiligheidsregio/[code]/ziekenhuis-opnames.test.tsx
+++ b/src/pages-tests/veiligheidsregio/[code]/ziekenhuis-opnames.test.tsx
@@ -25,9 +25,7 @@ describe('Regional page: NursingHomeCare', () => {
     testKpiValue(
       container,
       'hospital_moving_avg_per_region',
-      formatNumber(
-        data.results_per_region.last_value.hospital_moving_avg_per_region
-      )
+      formatNumber(data.hospital.last_value.admissions_moving_average)
     );
   });
 });

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -28,7 +28,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
   const { data, municipalityName } = props;
   const router = useRouter();
 
-  const hospitalAdmissions = data.hospital_admissions;
+  const lastValue = data.hospital.last_value;
 
   return (
     <>
@@ -50,9 +50,8 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateInfo: hospitalAdmissions.last_value.date_of_report_unix,
-          dateOfInsertionUnix:
-            hospitalAdmissions.last_value.date_of_insertion_unix,
+          dateInfo: lastValue.date_of_report_unix,
+          dateOfInsertionUnix: lastValue.date_of_insertion_unix,
           dataSources: [text.bronnen.rivm],
         }}
         reference={text.reference}
@@ -64,21 +63,19 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{
-            date: hospitalAdmissions.last_value.date_of_report_unix,
+            date: lastValue.date_of_report_unix,
             source: text.bronnen.rivm,
           }}
         >
           <KpiValue
             data-cy="moving_average_hospital"
-            absolute={hospitalAdmissions.last_value.moving_average_hospital}
-            difference={
-              data.difference.hospital_admissions__moving_average_hospital
-            }
+            absolute={lastValue.admissions_moving_average}
+            difference={data.difference.hospital__admissions_moving_average}
           />
         </KpiTile>
       </TwoKpiSection>
 
-      {hospitalAdmissions && (
+      {lastValue && (
         <ChartTileWithTimeframe
           showDataWarning
           title={text.linechart_titel}
@@ -88,8 +85,8 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           {(timeframe) => (
             <LineChart
               timeframe={timeframe}
-              values={hospitalAdmissions.values.map((value) => ({
-                value: value.moving_average_hospital,
+              values={data.hospital.values.map((value) => ({
+                value: value.admissions_moving_average,
                 date: value.date_of_report_unix,
               }))}
             />
@@ -103,18 +100,19 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
           municipality: municipalityName,
         })}
         metadata={{
-          date: hospitalAdmissions.last_value.date_of_report_unix,
+          date: lastValue.date_of_report_unix,
           source: text.bronnen.rivm,
         }}
         description={text.map_toelichting}
         legend={{
           title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
-          thresholds: municipalThresholds.hospital_admissions,
+          thresholds: municipalThresholds.hospital.admissions_moving_average,
         }}
       >
         <MunicipalityChoropleth
           selected={data.code}
-          metricName="hospital_admissions"
+          metricName="hospital"
+          metricNameValue="admissions_moving_average"
           tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
           onSelect={createSelectMunicipalHandler(router, 'ziekenhuis-opnames')}
         />

--- a/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -112,7 +112,7 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
         <MunicipalityChoropleth
           selected={data.code}
           metricName="hospital"
-          metricNameValue="admissions_moving_average"
+          metricProperty="admissions_moving_average"
           tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
           onSelect={createSelectMunicipalHandler(router, 'ziekenhuis-opnames')}
         />

--- a/src/pages/gemeente/index.tsx
+++ b/src/pages/gemeente/index.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { ReactNode } from 'react';
-import { MunicipalityChoropleth } from '~/components/choropleth/municipality-choropleth';
+import { MunicipalityNavigationMap } from '~/components/choropleth/municipality-navigation-map';
 import {
   createSelectMunicipalHandler,
   MunicipalitySelectionHandler,
@@ -59,8 +59,7 @@ const Municipality: FCWithLayout<any> = () => {
           <p>{text.gemeente_index.selecteer_toelichting}</p>
         </div>
         <div className="map-container">
-          <MunicipalityChoropleth
-            isSelectorMap
+          <MunicipalityNavigationMap
             tooltipContent={tooltipContent(onSelectMunicipal)}
             onSelect={createSelectMunicipalHandler(
               router,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,7 +113,7 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
       >
         <SafetyRegionChoropleth
           metricName="escalation_levels"
-          metricNameValue="escalation_level"
+          metricProperty="escalation_level"
           onSelect={createSelectRegionHandler(router)}
           tooltipContent={escalationTooltip(router)}
         />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,7 +113,7 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
       >
         <SafetyRegionChoropleth
           metricName="escalation_levels"
-          metricValueName="escalation_level"
+          metricNameValue="escalation_level"
           onSelect={createSelectRegionHandler(router)}
           tooltipContent={escalationTooltip(router)}
         />

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -129,7 +129,7 @@ const SewerWater: FCWithLayout<NationalPageProps> = ({ data }) => {
       >
         <SafetyRegionChoropleth
           metricName="sewer"
-          metricNameValue="average"
+          metricProperty="average"
           tooltipContent={createSewerRegionalTooltip(router)}
           onSelect={createSelectRegionHandler(router, 'rioolwater')}
         />

--- a/src/pages/landelijk/rioolwater.tsx
+++ b/src/pages/landelijk/rioolwater.tsx
@@ -129,7 +129,7 @@ const SewerWater: FCWithLayout<NationalPageProps> = ({ data }) => {
       >
         <SafetyRegionChoropleth
           metricName="sewer"
-          metricValueName="average"
+          metricNameValue="average"
           tooltipContent={createSewerRegionalTooltip(router)}
           onSelect={createSelectRegionHandler(router, 'rioolwater')}
         />

--- a/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -144,7 +144,7 @@ const NursingHomeCare: FCWithLayout<NationalPageProps> = (props) => {
       >
         <SafetyRegionChoropleth
           metricName="nursing_home"
-          metricValueName="infected_locations_percentage"
+          metricNameValue="infected_locations_percentage"
           tooltipContent={createInfectedLocationsRegionalTooltip(router)}
           onSelect={createSelectRegionHandler(router, 'verpleeghuiszorg')}
         />

--- a/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -144,7 +144,7 @@ const NursingHomeCare: FCWithLayout<NationalPageProps> = (props) => {
       >
         <SafetyRegionChoropleth
           metricName="nursing_home"
-          metricNameValue="infected_locations_percentage"
+          metricProperty="infected_locations_percentage"
           tooltipContent={createInfectedLocationsRegionalTooltip(router)}
           onSelect={createSelectRegionHandler(router, 'verpleeghuiszorg')}
         />

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -34,8 +34,8 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
   );
   const router = useRouter();
 
-  const dataIntake = data.intake_hospital_ma;
-  const dataBeds = data.hospital_beds_occupied;
+  const dataHospital = data.hospital;
+  const lastValue = dataHospital.last_value;
 
   return (
     <>
@@ -50,8 +50,8 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateInfo: dataIntake.last_value.date_of_report_unix,
-          dateOfInsertionUnix: dataIntake.last_value.date_of_insertion_unix,
+          dateInfo: lastValue.date_of_report_unix,
+          dateOfInsertionUnix: lastValue.date_of_insertion_unix,
           dataSources: [text.bronnen.nice, text.bronnen.lnaz],
         }}
         reference={text.reference}
@@ -63,7 +63,7 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{
-            date: dataIntake.last_value.date_of_report_unix,
+            date: lastValue.date_of_report_unix,
             source: text.bronnen.nice,
           }}
         >
@@ -78,13 +78,13 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
           title={text.kpi_bedbezetting.title}
           description={text.kpi_bedbezetting.description}
           metadata={{
-            date: dataIntake.last_value.date_of_report_unix,
+            date: lastValue.date_of_report_unix,
             source: text.bronnen.lnaz,
           }}
         >
           <KpiValue
             data-cy="covid_occupied"
-            absolute={dataBeds.last_value.covid_occupied}
+            absolute={lastValue.beds_occupied_covid}
           />
         </KpiTile>
       </TwoKpiSection>
@@ -92,7 +92,7 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
       <LineChartTile
         title={text.linechart_titel}
         description={text.linechart_description}
-        values={dataIntake.values.map((value: any) => ({
+        values={dataHospital.values.map((value: any) => ({
           value: value.moving_average_hospital,
           date: value.date_of_report_unix,
         }))}
@@ -105,8 +105,8 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
       <LineChartTile
         title={text.chart_bedbezetting.title}
         description={text.chart_bedbezetting.description}
-        values={dataBeds.values.map((value) => ({
-          value: value.covid_occupied,
+        values={dataHospital.values.map((value) => ({
+          value: value.beds_occupied_covid,
           date: value.date_of_report_unix,
         }))}
         metadata={{
@@ -119,18 +119,19 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         description={text.map_toelichting}
         onChangeControls={setSelectedMap}
         legend={{
-          thresholds: regionThresholds.hospital_admissions,
+          thresholds: regionThresholds.hospital.admissions_moving_avarage,
           title: text.chloropleth_legenda.titel,
         }}
         metadata={{
-          date: dataIntake.last_value.date_of_report_unix,
+          date: lastValue.date_of_report_unix,
           source: text.bronnen.nice,
         }}
         showDataWarning
       >
         {selectedMap === 'municipal' && (
           <MunicipalityChoropleth
-            metricName="hospital_admissions"
+            metricName="hospital"
+            metricNameValue="admissions_moving_average"
             tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
             onSelect={createSelectMunicipalHandler(
               router,
@@ -140,7 +141,8 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         )}
         {selectedMap === 'region' && (
           <SafetyRegionChoropleth
-            metricName="hospital_admissions"
+            metricName="hospital"
+            metricNameValue="admissions_moving_average"
             tooltipContent={createRegionHospitalAdmissionsTooltip(router)}
             onSelect={createSelectRegionHandler(router, 'ziekenhuis-opnames')}
           />

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -131,7 +131,7 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         {selectedMap === 'municipal' && (
           <MunicipalityChoropleth
             metricName="hospital"
-            metricNameValue="admissions_moving_average"
+            metricProperty="admissions_moving_average"
             tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
             onSelect={createSelectMunicipalHandler(
               router,
@@ -142,7 +142,7 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         {selectedMap === 'region' && (
           <SafetyRegionChoropleth
             metricName="hospital"
-            metricNameValue="admissions_moving_average"
+            metricProperty="admissions_moving_average"
             tooltipContent={createRegionHospitalAdmissionsTooltip(router)}
             onSelect={createSelectRegionHandler(router, 'ziekenhuis-opnames')}
           />

--- a/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -119,7 +119,7 @@ const IntakeHospital: FCWithLayout<NationalPageProps> = (props) => {
         description={text.map_toelichting}
         onChangeControls={setSelectedMap}
         legend={{
-          thresholds: regionThresholds.hospital.admissions_moving_avarage,
+          thresholds: regionThresholds.hospital.admissions_moving_average,
           title: text.chloropleth_legenda.titel,
         }}
         metadata={{

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -109,7 +109,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           selected={selectedMunicipalCode}
           highlightSelection={false}
           metricName="hospital"
-          metricNameValue="admissions_moving_average"
+          metricProperty="admissions_moving_average"
           tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
           onSelect={createSelectMunicipalHandler(router, 'ziekenhuis-opnames')}
         />

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -28,7 +28,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data, safetyRegionName } = props;
   const router = useRouter();
 
-  const resultsPerRegion = data.results_per_region;
+  const lastValue = data.hospital.last_value;
 
   const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
@@ -52,9 +52,8 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
         subtitle={text.pagina_toelichting}
         metadata={{
           datumsText: text.datums,
-          dateInfo: resultsPerRegion.last_value.date_of_report_unix,
-          dateOfInsertionUnix:
-            resultsPerRegion.last_value.date_of_insertion_unix,
+          dateInfo: lastValue.date_of_report_unix,
+          dateOfInsertionUnix: lastValue.date_of_insertion_unix,
           dataSources: [text.bronnen.rivm],
         }}
         reference={text.reference}
@@ -66,30 +65,26 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           title={text.barscale_titel}
           description={text.extra_uitleg}
           metadata={{
-            date: resultsPerRegion.last_value.date_of_report_unix,
+            date: lastValue.date_of_report_unix,
             source: text.bronnen.rivm,
           }}
         >
           <KpiValue
             data-cy="hospital_moving_avg_per_region"
-            absolute={
-              resultsPerRegion.last_value.hospital_moving_avg_per_region
-            }
-            difference={
-              data.difference.results_per_region__hospital_moving_avg_per_region
-            }
+            absolute={lastValue.admissions_moving_average}
+            difference={data.difference.hospital__admissions_moving_average}
           />
         </KpiTile>
       </TwoKpiSection>
 
-      {resultsPerRegion && (
+      {lastValue && (
         <LineChartTile
           showDataWarning
           metadata={{ source: text.bronnen.rivm }}
           title={text.linechart_titel}
           description={text.linechart_description}
-          values={resultsPerRegion.values.map((value: any) => ({
-            value: value.hospital_moving_avg_per_region,
+          values={data.hospital.values.map((value) => ({
+            value: value.admissions_moving_average,
             date: value.date_of_report_unix,
           }))}
         />
@@ -102,18 +97,19 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
         })}
         description={text.map_toelichting}
         legend={{
-          thresholds: municipalThresholds.hospital_admissions,
+          thresholds: municipalThresholds.hospital.admissions_moving_average,
           title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
         }}
         metadata={{
-          date: resultsPerRegion.last_value.date_of_report_unix,
+          date: lastValue.date_of_report_unix,
           source: text.bronnen.rivm,
         }}
       >
         <MunicipalityChoropleth
           selected={selectedMunicipalCode}
           highlightSelection={false}
-          metricName="hospital_admissions"
+          metricName="hospital"
+          metricNameValue="admissions_moving_average"
           tooltipContent={createMunicipalHospitalAdmissionsTooltip(router)}
           onSelect={createSelectMunicipalHandler(router, 'ziekenhuis-opnames')}
         />

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -83,7 +83,7 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
         <div className="choropleth-chart">
           <SafetyRegionChoropleth
             metricName="escalation_levels"
-            metricNameValue="escalation_level"
+            metricProperty="escalation_level"
             onSelect={createSelectRegionHandler(router)}
             tooltipContent={escalationTooltip(router)}
           />

--- a/src/pages/veiligheidsregio/index.tsx
+++ b/src/pages/veiligheidsregio/index.tsx
@@ -83,7 +83,7 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
         <div className="choropleth-chart">
           <SafetyRegionChoropleth
             metricName="escalation_levels"
-            metricValueName="escalation_level"
+            metricNameValue="escalation_level"
             onSelect={createSelectRegionHandler(router)}
             tooltipContent={escalationTooltip(router)}
           />


### PR DESCRIPTION
## Summary

This PR was aimed at altering the code to match the schema updates in #1042. Then it turned out I couldn't use a nested property on the GM level because the required changes for this type of structure were only made to VR at the time. While working on this I started defining stricter types, and things snowballed from there.

I decided to create a separate navigation map component for the GM index page, because the fact that it was used with and without data greatly complicated the code and the type definitions involved.

I also changed the way tooltips get served data. Previously a value was set on the "value" property, but also the value was spread across the context container. This PR changes it so that the value for the tooltip is always found on the value named property.
