### PR TITLE
Per 100k instead of 1000

### DIFF
--- a/schema/national/elderly_at_home.json
+++ b/schema/national/elderly_at_home.json
@@ -23,7 +23,7 @@
         "positive_tested_daily": {
           "type": "integer"
         },
-        "positive_tested_daily_permillage": {
+        "positive_tested_daily_per_100k": {
           "type": "number"
         },
         "deceased_daily": {
@@ -38,7 +38,7 @@
       },
       "required": [
         "positive_tested_daily",
-        "positive_tested_daily_permillage",
+        "positive_tested_daily_per_100k",
         "deceased_daily",
         "date_of_report_unix",
         "date_of_insertion_unix"

--- a/schema/regional/elderly_at_home.json
+++ b/schema/regional/elderly_at_home.json
@@ -23,7 +23,7 @@
         "positive_tested_daily": {
           "type": "integer"
         },
-        "positive_tested_daily_permillage": {
+        "positive_tested_daily_per_100k": {
           "type": "number"
         },
         "deceased_daily": {
@@ -42,7 +42,7 @@
       },
       "required": [
         "positive_tested_daily",
-        "positive_tested_daily_permillage",
+        "positive_tested_daily_per_100k",
         "deceased_daily",
         "date_of_report_unix",
         "date_of_insertion_unix",

--- a/schema/regions/elderly_at_home.json
+++ b/schema/regions/elderly_at_home.json
@@ -6,7 +6,7 @@
     "positive_tested_daily": {
       "type": "integer"
     },
-    "positive_tested_daily_permillage": {
+    "positive_tested_daily_per_100k": {
       "type": "number"
     },
     "deceased_daily": {
@@ -25,7 +25,7 @@
   },
   "required": [
     "positive_tested_daily",
-    "positive_tested_daily_permillage",
+    "positive_tested_daily_per_100k",
     "deceased_daily",
     "date_of_report_unix",
     "date_of_insertion_unix",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -161,8 +161,8 @@
       "kpi_daily_title": "Dagelijks nieuw gemelde besmettingen onder thuiswonende ouderen",
       "kpi_daily_description": "Dit getal laat zien van hoeveel thuiswonende ouderen gemeld is dat ze positief getest zijn en COVID-19 hebben. Een deel van de meldingen zijn positieve tests van eerdere dagen, die later zijn doorgegeven.",
 
-      "kpi_daily_permillage_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
-      "kpi_daily_permillage_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
+      "kpi_daily_per_100k_title": "Aantal dagelijks gemelde besmettingen per 100.000 thuiswonende ouderen",
+      "kpi_daily_per_100k_description": "Dit getal laat zien welke deel van de thuiswonende ouderen positief getest is op COVID-19.",
 
       "line_chart_daily_title": "Aantal dagelijks nieuwe besmette thuiswonende ouders",
 
@@ -228,8 +228,8 @@
       "kpi_daily_title": "Dagelijks nieuw gemelde besmettingen onder thuiswonende ouderen",
       "kpi_daily_description": "Dit getal laat zien van hoeveel thuiswonende ouderen gemeld is dat ze positief getest zijn en COVID-19 hebben. Een deel van de meldingen zijn positieve tests van eerdere dagen, die later zijn doorgegeven.",
 
-      "kpi_daily_permillage_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
-      "kpi_daily_permillage_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
+      "kpi_daily_per_100k_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
+      "kpi_daily_per_100k_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
 
       "line_chart_daily_title": "Aantal dagelijks nieuwe besmette thuiswonende ouders",
 

--- a/src/locale/nl.json
+++ b/src/locale/nl.json
@@ -161,8 +161,8 @@
       "kpi_daily_title": "Dagelijks nieuw gemelde besmettingen onder thuiswonende ouderen",
       "kpi_daily_description": "Dit getal laat zien van hoeveel thuiswonende ouderen gemeld is dat ze positief getest zijn en COVID-19 hebben. Een deel van de meldingen zijn positieve tests van eerdere dagen, die later zijn doorgegeven.",
 
-      "kpi_daily_permillage_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
-      "kpi_daily_permillage_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
+      "kpi_daily_per_100k_title": "Aantal dagelijks gemelde besmettingen per 100.000 thuiswonende ouderen",
+      "kpi_daily_per_100k_description": "Dit getal laat zien welke deel van de thuiswonende ouderen positief getest is op COVID-19.",
 
       "line_chart_daily_title": "Aantal dagelijks nieuwe besmette thuiswonende ouders",
 
@@ -228,8 +228,8 @@
       "kpi_daily_title": "Dagelijks nieuw gemelde besmettingen onder thuiswonende ouderen",
       "kpi_daily_description": "Dit getal laat zien van hoeveel thuiswonende ouderen gemeld is dat ze positief getest zijn en COVID-19 hebben. Een deel van de meldingen zijn positieve tests van eerdere dagen, die later zijn doorgegeven.",
 
-      "kpi_daily_permillage_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
-      "kpi_daily_permillage_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
+      "kpi_daily_per_100k_title": "Aantal dagelijks gemelde besmettingen per 1.000 thuiswonende ouderen",
+      "kpi_daily_per_100k_description": "Dit getal laat zien welke percentage van de thuiswonende ouderen positief getest is op covid-19.",
 
       "line_chart_daily_title": "Aantal dagelijks nieuwe besmette thuiswonende ouders",
 

--- a/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -62,7 +62,7 @@ const ElderlyAtHomeNationalPage: FCWithLayout<NationalPageProps> = (props) => {
           <Text>{text.section_positive_tested.kpi_daily_description}</Text>
         </KpiTile>
         <KpiTile
-          title={text.section_positive_tested.kpi_daily_permillage_title}
+          title={text.section_positive_tested.kpi_daily_per_100k_title}
           metadata={{
             date: elderlyAtHomeData.last_value.date_of_report_unix,
             source: text.section_positive_tested.bronnen.rivm,
@@ -70,11 +70,11 @@ const ElderlyAtHomeNationalPage: FCWithLayout<NationalPageProps> = (props) => {
         >
           <KpiValue
             absolute={
-              elderlyAtHomeData.last_value.positive_tested_daily_permillage
+              elderlyAtHomeData.last_value.positive_tested_daily_per_100k
             }
           />
           <Text>
-            {text.section_positive_tested.kpi_daily_permillage_description}
+            {text.section_positive_tested.kpi_daily_per_100k_description}
           </Text>
         </KpiTile>
       </TwoKpiSection>

--- a/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -69,7 +69,7 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<ISafetyRegionData> = (props) => {
           <Text>{text.section_positive_tested.kpi_daily_description}</Text>
         </KpiTile>
         <KpiTile
-          title={text.section_positive_tested.kpi_daily_permillage_title}
+          title={text.section_positive_tested.kpi_daily_per_100k_title}
           metadata={{
             date: elderlyAtHomeData.last_value.date_of_report_unix,
             source: text.section_positive_tested.bronnen.rivm,
@@ -77,11 +77,11 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<ISafetyRegionData> = (props) => {
         >
           <KpiValue
             absolute={
-              elderlyAtHomeData.last_value.positive_tested_daily_permillage
+              elderlyAtHomeData.last_value.positive_tested_daily_per_100k
             }
           />
           <Text>
-            {text.section_positive_tested.kpi_daily_permillage_description}
+            {text.section_positive_tested.kpi_daily_per_100k_description}
           </Text>
         </KpiTile>
       </TwoKpiSection>

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -455,7 +455,7 @@ export interface NationalElderlyAtHome {
 }
 export interface NationalElderlyAtHomeValue {
   positive_tested_daily: number;
-  positive_tested_daily_permillage: number;
+  positive_tested_daily_per_100k: number;
   deceased_daily: number;
   date_of_report_unix: number;
   date_of_insertion_unix: number;
@@ -732,7 +732,7 @@ export interface RegionalElderlyAtHome {
 }
 export interface RegionalElderlyAtHomeValue {
   positive_tested_daily: number;
-  positive_tested_daily_permillage: number;
+  positive_tested_daily_per_100k: number;
   deceased_daily: number;
   date_of_report_unix: number;
   date_of_insertion_unix: number;
@@ -847,7 +847,7 @@ export interface RegionsBehavior {
 }
 export interface RegionsElderlyAtHome {
   positive_tested_daily: number;
-  positive_tested_daily_permillage: number;
+  positive_tested_daily_per_100k: number;
   deceased_daily: number;
   date_of_report_unix: number;
   date_of_insertion_unix: number;


### PR DESCRIPTION
## Summary

The positive tested relative value is per 100.000 instead of per 1000.

I assumed postfixing it with `_per_100k` would be more clear than the alternatives:
- `_per_100000`
- `_per_100_000`
- `_per_cent_mille`
- `_pcm`
- `_milli_percent`

Another approach would be to postfix it with `_relative`..