### PR TITLE
Fix page header icons on disability pages

### DIFF
--- a/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import CoronaVirus from '~/assets/coronavirus.svg';
+import Gehandicaptenzorg from '~/assets/gehandicapte-zorg.svg';
 import Locatie from '~/assets/locaties.svg';
-import Verpleeghuiszorg from '~/assets/verpleeghuiszorg.svg';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
@@ -47,7 +47,7 @@ const DisabilityCare: FCWithLayout<NationalPageProps> = (props) => {
           siteText.verpleeghuis_positief_geteste_personen.titel_sidebar
         }
         title={positiveTestedPeopleText.titel}
-        icon={<Verpleeghuiszorg />}
+        icon={<Gehandicaptenzorg />}
         subtitle={positiveTestedPeopleText.pagina_toelichting}
         metadata={{
           datumsText: positiveTestedPeopleText.datums,

--- a/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -1,6 +1,6 @@
 import CoronaVirus from '~/assets/coronavirus.svg';
+import Gehandicaptenzorg from '~/assets/gehandicapte-zorg.svg';
 import Locatie from '~/assets/locaties.svg';
-import Verpleeghuiszorg from '~/assets/verpleeghuiszorg.svg';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
@@ -49,7 +49,7 @@ const DisabilityCare: FCWithLayout<ISafetyRegionData> = (props) => {
         title={replaceVariablesInText(positiveTestPeopleText.titel, {
           safetyRegion: safetyRegionName,
         })}
-        icon={<Verpleeghuiszorg />}
+        icon={<Gehandicaptenzorg />}
         subtitle={replaceVariablesInText(
           positiveTestPeopleText.pagina_toelichting,
           {


### PR DESCRIPTION
## Summary

The disability pages were showing the wrong icon, this PR fixes that situation

## Motivation

Bug report

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
