### PR TITLE
Age demographic QA fixes

### DIFF
--- a/src/components-styled/tooltip.tsx
+++ b/src/components-styled/tooltip.tsx
@@ -39,7 +39,7 @@ export function useTooltip<T>({
   const [isVisible, setIsVisible] = useState(false);
   const [coordinates, setCoordinates] = useState<TooltipCoordinates>();
   const [value, setValue] = useState<T>();
-  const [keyboardValueIndex, setKeyboardValueIndex] = useState<undefined>();
+  const [keyboardValueIndex, setKeyboardValueIndex] = useState<number>();
 
   const timer = useRef(-1);
 

--- a/src/components-styled/tooltip.tsx
+++ b/src/components-styled/tooltip.tsx
@@ -39,7 +39,7 @@ export function useTooltip<T>({
   const [isVisible, setIsVisible] = useState(false);
   const [coordinates, setCoordinates] = useState<TooltipCoordinates>();
   const [value, setValue] = useState<T>();
-  const [keyboardValueIndex, setKeyboardValueIndex] = useState(0);
+  const [keyboardValueIndex, setKeyboardValueIndex] = useState<undefined>();
 
   const timer = useRef(-1);
 

--- a/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
+++ b/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
@@ -59,7 +59,6 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
       ageGroupPercentagePoint,
       infectedPercentagePoint,
       ageGroupRangePoint,
-      isSmallScreen,
       margin,
       values,
       ageGroupRange,
@@ -87,7 +86,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           x={width / 2 - ageRangeAxisWidth / 2}
           fill="black"
           fontWeight="bold"
-          fontSize={isSmallScreen ? '1rem' : '1.2rem'}
+          fontSize={xMax < 300 ? '1rem' : '1.2rem'}
           width={xMax + margin.left}
         >
           {text.graph.age_group_percentage_title}
@@ -99,7 +98,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           x={width / 2 + ageRangeAxisWidth / 2}
           fill="black"
           fontWeight="bold"
-          fontSize={isSmallScreen ? '1rem' : '1.2rem'}
+          fontSize={xMax < 300 ? '1rem' : '1.2rem'}
           width={xMax + margin.right}
         >
           {text.graph.infected_percentage_title}

--- a/src/utils/use-element-size.ts
+++ b/src/utils/use-element-size.ts
@@ -14,7 +14,7 @@ export function useElementSize<T extends HTMLElement>(
   useEffect(() => {
     const debounceHandleResize = debounce(handleResize, 60);
 
-    handleResize();
+    requestAnimationFrame(handleResize);
     window.addEventListener('resize', debounceHandleResize);
 
     return () => window.removeEventListener('resize', debounceHandleResize);


### PR DESCRIPTION
## Summary

Age demographic QA fixes

## Detailed design

Fixes:
* tooltip started at index 1, not at index 0.
* alignment/size of headers was off
* `aria-live` works again when going through the content with a screenreader on (the fix was to calculate the size after a `requestAnimationFrame` since `ref` was not defined on init)