### PR TITLE
Fix IE11 development build errors and some layout issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,29 +55,6 @@ const nextConfig = {
       })
     );
 
-    // if (!dev) {
-    //   // Move Preact into the framework chunk instead of duplicating in routes:
-    //   const splitChunks =
-    //     config.optimization && config.optimization.splitChunks;
-    //   if (splitChunks) {
-    //     const cacheGroups = splitChunks.cacheGroups;
-    //     const test = /[\\/]node_modules[\\/](preact|preact-render-to-string|preact-context-provider)[\\/]/;
-    //     if (cacheGroups.framework) {
-    //       cacheGroups.preact = Object.assign({}, cacheGroups.framework, {
-    //         test,
-    //       });
-    //       // if you want to merge the 2 small commons+framework chunks:
-    //       cacheGroups.commons.name = 'framework';
-    //     } else {
-    //       cacheGroups.preact = { name: 'commons', chunks: 'all', test };
-    //     }
-    //   }
-
-    //   // Install webpack aliases:
-    //   const aliases = config.resolve.alias || (config.resolve.alias = {});
-    //   aliases.react = aliases['react-dom'] = 'preact/compat';
-    // }
-
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "resolutions": {
-    "@types/lodash": "4.14.159"
+    "@types/lodash": "4.14.159",
+    "//": "d3-scale v3 is not compatible with IE11",
+    "d3-scale": "2.2.2"
   },
   "dependencies": {
     "@formatjs/intl-datetimeformat": "^2.6.7",

--- a/src/components-styled/difference-indicator.tsx
+++ b/src/components-styled/difference-indicator.tsx
@@ -129,7 +129,6 @@ type SpanProps = SpaceProps & ColorProps & TypographyProps;
 
 const Span = styled.span<SpanProps>(compose(color, space, typography));
 const IconContainer = styled(Span)(
-  compose(color, space, typography),
   css({
     svg: {
       mr: 1,

--- a/src/components-styled/difference-indicator.tsx
+++ b/src/components-styled/difference-indicator.tsx
@@ -41,9 +41,9 @@ function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
   if (difference > 0) {
     return (
       <Container>
-        <Span color="red">
+        <IconContainer color="red">
           <IconUp />
-        </Span>
+        </IconContainer>
       </Container>
     );
   }
@@ -51,18 +51,18 @@ function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
   if (difference < 0) {
     return (
       <Container>
-        <Span color="data.primary">
+        <IconContainer color="data.primary">
           <IconDown />
-        </Span>
+        </IconContainer>
       </Container>
     );
   }
 
   return (
     <Container>
-      <Span color="lightGray">
+      <IconContainer color="lightGray">
         <IconGelijk />
-      </Span>
+      </IconContainer>
     </Container>
   );
 }
@@ -82,9 +82,9 @@ function renderTileIndicator(
 
     return (
       <Container>
-        <Span color="red">
+        <IconContainer color="red">
           <IconUp />
-        </Span>
+        </IconContainer>
         <Span fontWeight="bold" mr="0.3em">
           {differenceFormattedString} {splitText[0]}
         </Span>
@@ -100,9 +100,9 @@ function renderTileIndicator(
 
     return (
       <Container>
-        <Span color="data.primary">
+        <IconContainer color="data.primary">
           <IconDown />
-        </Span>
+        </IconContainer>
         <Span fontWeight="bold" mr="0.3em">
           {differenceFormattedString} {splitText[0]}
         </Span>
@@ -115,9 +115,9 @@ function renderTileIndicator(
 
   return (
     <Container>
-      <Span color="lightGray">
+      <IconContainer color="lightGray">
         <IconGelijk />
-      </Span>
+      </IconContainer>
       <Span>
         {text.gelijk} <TimespanText date={old_date_of_report_unix} />
       </Span>
@@ -128,6 +128,16 @@ function renderTileIndicator(
 type SpanProps = SpaceProps & ColorProps & TypographyProps;
 
 const Span = styled.span<SpanProps>(compose(color, space, typography));
+const IconContainer = styled(Span)(
+  compose(color, space, typography),
+  css({
+    svg: {
+      mr: 1,
+      width: '19px',
+      height: '19px',
+    },
+  })
+);
 
 const Container = styled.div(
   css({

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -1,5 +1,12 @@
 @import './variables.scss';
 
+main {
+  /**
+   * IE11 does not support the main tag, the following line makes it styleable
+   */
+  display: block;
+}
+
 .container {
   display: flex;
   flex-direction: column-reverse;

--- a/src/utils/use-on-click-outside.ts
+++ b/src/utils/use-on-click-outside.ts
@@ -11,9 +11,17 @@ export function useOnClickOutside<T extends RefObject<Element>>(
     const refs = Array.isArray(ref) ? ref : [ref];
 
     function listener(event: MouseEvent | TouchEvent) {
-      const clickedInsideRef = refs.find((ref) =>
-        ref.current?.contains(event.target as Node)
-      );
+      const clickedInsideRef = refs.find((ref) => {
+        let el = ref.current as Node | null;
+        /**
+         * IE11 does not support `.contains` on SVG elements. We'll traverse the
+         * DOM to find the first parent which does support that method.
+         */
+        while (el && !el.contains && el !== document.body) {
+          el = el.parentNode;
+        }
+        el?.contains(event.target as Node);
+      });
 
       if (!clickedInsideRef) {
         handlerRef.current(event);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,11 +4443,6 @@ d3-array@1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-d3-array@^2.3.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
-  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
-
 d3-collection@1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
@@ -4458,20 +4453,10 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
 d3-format@1:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
   integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
-
-"d3-format@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
-  integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
 
 d3-geo@^1.11.3:
   version "1.12.1"
@@ -4487,13 +4472,6 @@ d3-interpolate@1, d3-interpolate@^1.4.0:
   dependencies:
     d3-color "1"
 
-"d3-interpolate@1.2.0 - 2":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
-  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
-  dependencies:
-    d3-color "1 - 2"
-
 d3-path@1, d3-path@^1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
@@ -4504,7 +4482,7 @@ d3-random@^1.0.3:
   resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
   integrity sha512-6AK5BNpIFqP+cx/sreKzNjWbwZQCSUatxq+pPRmFIQaWuoD+NrbVWw7YWpHiXpCQ/NanKdtGDuB+VQcZDaEmYQ==
 
-d3-scale@2.2.2:
+d3-scale@2.2.2, d3-scale@^3.0.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.2.2.tgz#4e880e0b2745acaaddd3ede26a9e908a9e17b81f"
   integrity sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==
@@ -4515,17 +4493,6 @@ d3-scale@2.2.2:
     d3-interpolate "1"
     d3-time "1"
     d3-time-format "2"
-
-d3-scale@^3.0.1:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.3.tgz#be380f57f1f61d4ff2e6cbb65a40593a51649cfd"
-  integrity sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==
-  dependencies:
-    d3-array "^2.3.0"
-    d3-format "1 - 2"
-    d3-interpolate "1.2.0 - 2"
-    d3-time "1 - 2"
-    d3-time-format "2 - 3"
 
 d3-shape@^1.0.6, d3-shape@^1.2.0:
   version "1.3.7"
@@ -4541,22 +4508,10 @@ d3-time-format@2:
   dependencies:
     d3-time "1"
 
-"d3-time-format@2 - 3":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-3.0.0.tgz#df8056c83659e01f20ac5da5fdeae7c08d5f1bb6"
-  integrity sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==
-  dependencies:
-    d3-time "1 - 2"
-
 d3-time@1, d3-time@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
-
-"d3-time@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
-  integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
 
 d@1, d@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
- Fixed some IE11 runtime errors during development mode of next. It looks like the `d3-scale` package was the one throwing roet in the food: v3 is not compatible with IE11, which means it's likely we can expect more issues in the future since `@visx/*` is depending on v3, where we now install v2 ...
- Fixed svg size in sidebar 
- Fix an issue where `element.contains()` threw an error because IE11 does not support that method on SVG elements.