### PR TITLE
Fix escalation map tooltip text

### DIFF
--- a/src/components/choropleth/tooltips/region/escalation-tooltip.tsx
+++ b/src/components/choropleth/tooltips/region/escalation-tooltip.tsx
@@ -26,6 +26,13 @@ export const escalationTooltip = (selectHandler: RegionSelectionHandler) => {
       { titel: string; valid_from: string }
     >)[level];
 
+    const validFromText = replaceVariablesInText(
+      text.escalatie_niveau.valid_from,
+      {
+        validFrom: formatDateFromSeconds(context.valid_from_unix, 'short'),
+      }
+    );
+
     return (
       <TooltipContent title={context.vrname} onSelect={onSelect}>
         <div className={styles.escalationInfo}>
@@ -35,12 +42,7 @@ export const escalationTooltip = (selectHandler: RegionSelectionHandler) => {
           <div>
             <strong>{escalationText.titel}</strong>
             <br />
-            {replaceVariablesInText(escalationText.valid_from, {
-              validFrom: formatDateFromSeconds(
-                context.valid_from_unix,
-                'short'
-              ),
-            })}
+            {validFromText}
           </div>
         </div>
       </TooltipContent>

--- a/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -26,10 +26,10 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<ISafetyRegionData> = (props) => {
     <>
       <SEOHead
         title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
+          safetyRegion: safetyRegionName,
         })}
         description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
+          safetyRegion: safetyRegionName,
         })}
       />
 

--- a/src/utils/__tests__/replaceKpisInText.spec.ts
+++ b/src/utils/__tests__/replaceKpisInText.spec.ts
@@ -1,12 +1,6 @@
 import { replaceKpisInText } from '../replaceKpisInText';
 
 describe('Util: replaceKpisInText', () => {
-  it('Should embed nothing if there are no KPIs', () => {
-    expect(replaceKpisInText('Example text string', [])).toMatchInlineSnapshot(
-      `"Example text string"`
-    );
-  });
-
   it('Should embed KPI if there is one', () => {
     expect(
       replaceKpisInText('Example text {{foo}}', [
@@ -31,10 +25,11 @@ describe('Util: replaceKpisInText', () => {
     ).toMatchInlineSnapshot(`"Example text"`);
   });
 
-  it('Should use empty string if KPI is not provided', () => {
-    expect(replaceKpisInText('Example text {{zap}}', [])).toMatchInlineSnapshot(
-      `"Example text "`
-    );
+  it('Should throw error if KPI is not provided', () => {
+    const testFunc = () => {
+      replaceKpisInText('Example text {{zap}}', []);
+    };
+    expect(testFunc).toThrow(Error);
   });
 
   it('Should replace multiple KPIs', () => {

--- a/src/utils/__tests__/replaceVariablesInText.spec.ts
+++ b/src/utils/__tests__/replaceVariablesInText.spec.ts
@@ -1,25 +1,6 @@
 import { replaceVariablesInText } from '../replaceVariablesInText';
 
 describe('Util: replaceVariablesInText', () => {
-  it('Should return the translation string if no variables are present', () => {
-    expect(
-      replaceVariablesInText('Example translation string')
-    ).toMatchInlineSnapshot(`"Example translation string"`);
-  });
-
-  it('Should remove any curly bracket variables if no variables (or no variable with that key) is supplied and replace them with an empty string.', () => {
-    expect(
-      replaceVariablesInText('Example translation {{variableName}} string')
-    ).toMatchInlineSnapshot(`"Example translation  string"`);
-
-    expect(
-      replaceVariablesInText(
-        'Example translation with {{firstKey}} and {{secondKey}}',
-        { firstKey: 'one' }
-      )
-    ).toMatchInlineSnapshot(`"Example translation with one and "`);
-  });
-
   it('Should replace variables inside curly brackets with the variables supplied', () => {
     expect(
       replaceVariablesInText('Example translation {{keyOne}} {{keyTwo}}.', {
@@ -42,11 +23,14 @@ describe('Util: replaceVariablesInText', () => {
 
   it('Should leave curly brackets in place if they are not closed.', () => {
     expect(
-      replaceVariablesInText('Example translation {{')
+      replaceVariablesInText('Example translation {{', {})
     ).toMatchInlineSnapshot(`"Example translation {{"`);
   });
 
-  it('Should return an empty string if no translation string is supplied', () => {
-    expect(replaceVariablesInText()).toMatchInlineSnapshot(`""`);
+  it('Should throw error if no translation string is supplied', () => {
+    const testFunc = () => {
+      replaceVariablesInText('', {});
+    };
+    expect(testFunc).toThrow(Error);
   });
 });

--- a/src/utils/replaceVariablesInText.ts
+++ b/src/utils/replaceVariablesInText.ts
@@ -1,3 +1,5 @@
+import { assert } from './assert';
+
 const curlyBracketRegex = /\{\{(.+?)\}\}/g;
 
 /**
@@ -17,10 +19,13 @@ const curlyBracketRegex = /\{\{(.+?)\}\}/g;
  */
 
 export function replaceVariablesInText(
-  translation?: string | undefined | null,
+  translation?: string,
   variables?: { [key: string]: string | number | undefined }
 ): string {
-  if (!translation) return '';
+  assert(
+    translation,
+    'translation placeholder text is not defined, perhaps a missing locale key?'
+  );
 
   return translation.replace(curlyBracketRegex, (_string, variableName) => {
     /**

--- a/src/utils/replaceVariablesInText.ts
+++ b/src/utils/replaceVariablesInText.ts
@@ -19,8 +19,8 @@ const curlyBracketRegex = /\{\{(.+?)\}\}/g;
  */
 
 export function replaceVariablesInText(
-  translation?: string,
-  variables?: { [key: string]: string | number | undefined }
+  translation: string,
+  variables: { [key: string]: string | number | undefined }
 ): string {
   assert(
     translation,
@@ -28,12 +28,12 @@ export function replaceVariablesInText(
   );
 
   return translation.replace(curlyBracketRegex, (_string, variableName) => {
-    /**
-     * @TODO Why are we replacing variables with empty strings? It feels like
-     * these cases should be reported somewhere.
-     */
-    if (!variables) return '';
-
-    return (variables[variableName.trim()] ?? '').toString();
+    const trimmedName = variableName.trim();
+    if (trimmedName in variables) {
+      return (variables[variableName.trim()] ?? '').toString();
+    }
+    throw new Error(
+      `Placeholder name ${trimmedName} was not defined in the given variables`
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fix correct rendering of valid from date in the escalation choropleth tooltip. (It went missing)

## Motivation

Bug report

## Detailed design

The reason why this text disappeared was an invalid locale value was given to the replaceVariablesInText method which silently swallowed this and just returned an empty string. I've changed the implementation now and added an assert for this value.
In the future, the build or e2e tests will break when this happens again.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
