### PR TITLE
Fix build error

### DIFF
--- a/src/components-styled/sidebar-metric/sidebar-metric.tsx
+++ b/src/components-styled/sidebar-metric/sidebar-metric.tsx
@@ -1,14 +1,14 @@
-import { assert } from '~/utils/assert';
 import { get } from 'lodash';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components-styled/base';
+import { MetricKeys } from '~/components/choropleth/shared';
+import siteText, { TALLLanguages } from '~/locale/index';
+import { DataScope, getMetricConfig } from '~/metric-config';
+import { assert } from '~/utils/assert';
+import { formatDateFromSeconds } from '~/utils/formatDate';
+import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { SidebarBarScale } from './sidebar-barscale';
 import { SidebarKpiValue } from './sidebar-kpi-value';
-import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
-import { formatDateFromSeconds } from '~/utils/formatDate';
-import siteText, { TALLLanguages } from '~/locale/index';
-import { getMetricConfig, DataScope } from '~/metric-config';
-import { MetricKeys } from '~/components/choropleth/shared';
 
 interface SidebarMetricProps<T extends { difference: unknown }> {
   scope: DataScope;
@@ -71,10 +71,10 @@ export function SidebarMetric<T extends { difference: unknown }>({
    * we support both but kpi_titel has precedence.
    */
   const title =
-    get(siteText, [localeTextKey, 'kpi_titel']) ||
+    get(siteText, [localeTextKey, 'kpi_titel']) ??
     get(siteText, [localeTextKey, 'titel_kpi']);
 
-  assert(title, `Missing title at ${localeTextKey}.kpi_titel`);
+  assert(title !== undefined, `Missing title at ${localeTextKey}.kpi_titel`);
 
   const description = config.isWeeklyData
     ? replaceVariablesInText(commonText.dateRangeOfReport, {


### PR DESCRIPTION
## Summary

The build was failing for the English site, this PR fixes that.

## Motivation

Bug

## Detailed design

The sidebar metric retrieved its title like this:
```
  const title =
    get(siteText, [localeTextKey, 'kpi_titel']) ||
    get(siteText, [localeTextKey, 'titel_kpi']);
```

Which would fall back to the second get in the case of an empty string and therefore would end up being undefined.
Changing it to this:
```
  const title =
    get(siteText, [localeTextKey, 'kpi_titel']) ??
    get(siteText, [localeTextKey, 'titel_kpi']);
```
Will allow an empty string, the assert on the title now checks for `title !== undefined` as well, otherwise it'll still error on empty strings.

## Drawbacks

Why should we _not_ do this? Please consider:

- implementation cost, both in term of code size and complexity
- maintenance cost, how complex is the solution and how prone to change is it?
- integration of this feature with other existing and planned features

There are tradeoffs to choosing any path. Attempt to identify them here.

## Alternatives

What other designs have been considered? What is the impact of not doing this?

## Unresolved questions

Optional, but suggested for bigger features. What parts of the design are still
TBD or not implemented? How will you deal with that in the future?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
