### PR TITLE
Remove ggd tested absolute and only show percentage

### DIFF
--- a/src/components-styled/kpi-value.tsx
+++ b/src/components-styled/kpi-value.tsx
@@ -44,9 +44,13 @@ export function KpiValue({
 }: KpiValueProps) {
   return (
     <>
-      {isDefined(percentage) ? (
+      {isDefined(percentage) && isDefined(absolute) ? (
         <StyledValue color="data.primary" {...otherProps}>
           {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}
+        </StyledValue>
+      ) : isDefined(percentage) ? (
+        <StyledValue color="data.primary" {...otherProps}>
+          {`${formatPercentage(percentage)}%`}
         </StyledValue>
       ) : (
         <StyledValue color="data.primary" {...otherProps}>

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -286,7 +286,6 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({ data }) => {
         >
           <KpiValue
             data-cy="ggd_infected"
-            // absolute={dataGgdLastValue.infected}
             percentage={dataGgdLastValue.infected_percentage}
             difference={data.difference.ggd__infected_percentage}
           />

--- a/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -286,7 +286,7 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({ data }) => {
         >
           <KpiValue
             data-cy="ggd_infected"
-            absolute={dataGgdLastValue.infected}
+            // absolute={dataGgdLastValue.infected}
             percentage={dataGgdLastValue.infected_percentage}
             difference={data.difference.ggd__infected_percentage}
           />

--- a/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -216,7 +216,6 @@ const PostivelyTestedPeople: FCWithLayout<ISafetyRegionData> = (props) => {
           }}
         >
           <KpiValue
-            absolute={ggdData.infected}
             percentage={ggdData.infected_percentage}
             difference={data.difference.ggd__infected_percentage}
           />


### PR DESCRIPTION
## Summary

Removes the percentage suffix on absolute value kpi and only show percentage.