### PR TITLE
Remove behavior table rows if data is not available

### DIFF
--- a/src/domain/behavior/behavior-table-tile.tsx
+++ b/src/domain/behavior/behavior-table-tile.tsx
@@ -1,6 +1,7 @@
 import css from '@styled-system/css';
 import { useState } from 'react';
 import styled from 'styled-components';
+import { isDefined, isPresent } from 'ts-is-present';
 import { Box } from '~/components-styled/base';
 import { Tile } from '~/components-styled/layout';
 import { PercentageBar } from '~/components-styled/percentage-bar';
@@ -32,8 +33,8 @@ interface BehaviorTileProps {
 interface BehaviorFormatted {
   id: BehaviorIdentifier;
   description: string;
-  percentage: number | undefined;
-  trend: BehaviorTrendType | undefined;
+  percentage: number;
+  trend: BehaviorTrendType;
 }
 
 const HeaderCell = styled.th(
@@ -59,24 +60,28 @@ function formatBehaviorType(
   behavior: BehaviorValue,
   type: BehaviorType
 ): BehaviorFormatted[] {
-  return behaviorIdentifiers.map((identifier) => {
-    const percentage = behavior[
-      `${identifier}_${type}` as keyof BehaviorValue
-    ] as number | null;
-    const trend = (behavior[
-      `${identifier}_${type}_trend` as keyof BehaviorValue
-    ] ?? undefined) as BehaviorTrendType | null;
+  return behaviorIdentifiers
+    .map((identifier) => {
+      const percentage = behavior[
+        `${identifier}_${type}` as keyof BehaviorValue
+      ] as number | null;
+      const trend = (behavior[
+        `${identifier}_${type}_trend` as keyof BehaviorValue
+      ] ?? undefined) as BehaviorTrendType | null;
 
-    return {
-      id: identifier,
-      description: siteText.gedrag_onderwerpen[identifier],
-      percentage: percentage ?? undefined,
-      trend: trend ?? undefined,
-    };
-  });
+      return isPresent(percentage) && isPresent(trend)
+        ? {
+            id: identifier,
+            description: siteText.gedrag_onderwerpen[identifier],
+            percentage,
+            trend,
+          }
+        : undefined;
+    })
+    .filter(isDefined);
 }
 
-/* Sort lists of formatted compliance and support behaviours */
+/* Sort lists of formatted compliance and support behaviors */
 function sortBehavior(
   compliance: BehaviorFormatted[],
   support: BehaviorFormatted[]
@@ -175,29 +180,31 @@ export function BehaviorTableTile({
             {(behaviorType === 'compliance'
               ? sortedCompliance
               : sortedSupport
-            ).map((behavior) => (
-              <tr key={behavior.id}>
-                <Cell>{formatPercentage(behavior.percentage ?? 0)}%</Cell>
-                <Cell
-                  color={
-                    behaviorType === 'compliance'
-                      ? 'data.primary'
-                      : 'data.secondary'
-                  }
-                >
-                  <PercentageBar percentage={behavior.percentage ?? 0} />
-                </Cell>
-                <Cell>
-                  <Box minWidth={32}>
-                    <BehaviorIcon name={behavior.id} />
-                  </Box>
-                </Cell>
-                <Cell>{behavior.description}</Cell>
-                <Cell>
-                  <BehaviorTrend trend={behavior.trend} />
-                </Cell>
-              </tr>
-            ))}
+            ).map((behavior) =>
+              isDefined(behavior.percentage) ? (
+                <tr key={behavior.id}>
+                  <Cell>{formatPercentage(behavior.percentage)}%</Cell>
+                  <Cell
+                    color={
+                      behaviorType === 'compliance'
+                        ? 'data.primary'
+                        : 'data.secondary'
+                    }
+                  >
+                    <PercentageBar percentage={behavior.percentage} />
+                  </Cell>
+                  <Cell>
+                    <Box minWidth={32}>
+                      <BehaviorIcon name={behavior.id} />
+                    </Box>
+                  </Cell>
+                  <Cell>{behavior.description}</Cell>
+                  <Cell>
+                    <BehaviorTrend trend={behavior.trend} />
+                  </Cell>
+                </tr>
+              ) : null
+            )}
           </tbody>
         </table>
       </div>

--- a/src/domain/behavior/behavior-table-tile.tsx
+++ b/src/domain/behavior/behavior-table-tile.tsx
@@ -34,7 +34,7 @@ interface BehaviorFormatted {
   id: BehaviorIdentifier;
   description: string;
   percentage: number;
-  trend: BehaviorTrendType;
+  trend?: BehaviorTrendType;
 }
 
 const HeaderCell = styled.th(
@@ -69,12 +69,12 @@ function formatBehaviorType(
         `${identifier}_${type}_trend` as keyof BehaviorValue
       ] ?? undefined) as BehaviorTrendType | null;
 
-      return isPresent(percentage) && isPresent(trend)
+      return isPresent(percentage) /* && isPresent(trend) */
         ? {
             id: identifier,
             description: siteText.gedrag_onderwerpen[identifier],
             percentage,
-            trend,
+            trend: trend || undefined,
           }
         : undefined;
     })
@@ -180,31 +180,29 @@ export function BehaviorTableTile({
             {(behaviorType === 'compliance'
               ? sortedCompliance
               : sortedSupport
-            ).map((behavior) =>
-              isDefined(behavior.percentage) ? (
-                <tr key={behavior.id}>
-                  <Cell>{formatPercentage(behavior.percentage)}%</Cell>
-                  <Cell
-                    color={
-                      behaviorType === 'compliance'
-                        ? 'data.primary'
-                        : 'data.secondary'
-                    }
-                  >
-                    <PercentageBar percentage={behavior.percentage} />
-                  </Cell>
-                  <Cell>
-                    <Box minWidth={32}>
-                      <BehaviorIcon name={behavior.id} />
-                    </Box>
-                  </Cell>
-                  <Cell>{behavior.description}</Cell>
-                  <Cell>
-                    <BehaviorTrend trend={behavior.trend} />
-                  </Cell>
-                </tr>
-              ) : null
-            )}
+            ).map((behavior) => (
+              <tr key={behavior.id}>
+                <Cell>{formatPercentage(behavior.percentage)}%</Cell>
+                <Cell
+                  color={
+                    behaviorType === 'compliance'
+                      ? 'data.primary'
+                      : 'data.secondary'
+                  }
+                >
+                  <PercentageBar percentage={behavior.percentage} />
+                </Cell>
+                <Cell>
+                  <Box minWidth={32}>
+                    <BehaviorIcon name={behavior.id} />
+                  </Box>
+                </Cell>
+                <Cell>{behavior.description}</Cell>
+                <Cell>
+                  <BehaviorTrend trend={behavior.trend} />
+                </Cell>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/src/domain/behavior/behavior-table-tile.tsx
+++ b/src/domain/behavior/behavior-table-tile.tsx
@@ -69,7 +69,7 @@ function formatBehaviorType(
         `${identifier}_${type}_trend` as keyof BehaviorValue
       ] ?? undefined) as BehaviorTrendType | null;
 
-      return isPresent(percentage) /* && isPresent(trend) */
+      return isPresent(percentage)
         ? {
             id: identifier,
             description: siteText.gedrag_onderwerpen[identifier],


### PR DESCRIPTION
At regional level 3 properties were removed from behavior, and the table should not render those rows.