### PR TITLE
Remove difference indicator for reproductiegetal

### DIFF
--- a/src/components/layout/NationalLayout.tsx
+++ b/src/components/layout/NationalLayout.tsx
@@ -230,7 +230,6 @@ function NationalLayout(props: NationalLayoutProps) {
                           metricName="reproduction_index_last_known_average"
                           metricProperty="reproduction_index_avg"
                           localeTextKey="reproductiegetal"
-                          differenceKey="reproduction_index_last_known_average__reproduction_index_avg"
                           showBarScale={true}
                         />
                       </a>

--- a/src/pages/landelijk/reproductiegetal.tsx
+++ b/src/pages/landelijk/reproductiegetal.tsx
@@ -63,7 +63,6 @@ const ReproductionIndex: FCWithLayout<NationalPageProps> = (props) => {
             metricName="reproduction_index_last_known_average"
             metricProperty="reproduction_index_avg"
             localeTextKey="reproductiegetal"
-            differenceKey="reproduction_index_last_known_average__reproduction_index_avg"
           />
           <Text>{text.barscale_toelichting}</Text>
         </KpiWithIllustrationTile>


### PR DESCRIPTION
The title says it all. The current values are correct but too confusing.