### PR TITLE
Fix critital issue with behavior line chart

### DIFF
--- a/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -106,6 +106,11 @@ export function BehaviorLineChartTile({
       <Spacer mb={3} />
 
       <BehaviorLineChart
+        /**
+         * setting this key is a very aggresive fix for an unknown critital
+         * issue which only happens with a production build.
+         */
+        key={type + currentId}
         values={behaviorIdentifierWithData.map(({ valueKey, label }) =>
           (values as NationalBehaviorValue[])
             .map((value) =>

--- a/src/domain/behavior/components/behavior-line-chart.tsx
+++ b/src/domain/behavior/components/behavior-line-chart.tsx
@@ -138,6 +138,7 @@ function getChartOptions<T>(values: Value[][], linesConfig: LineConfig<T>[]) {
       const { id, isSelected, onClick } = linesConfig[index];
 
       return {
+        animation: false,
         type: 'line',
         showInLegend: false,
 


### PR DESCRIPTION
This PR will fix an issue with the behavior line chart. The entire app would free when changing the highlighted behavior, this only happened with a production build.

I was unable to find the root cause of this error but a hard remount of the chart will prevent the issue from happening.