### PR TITLE
Fix click-through for choropleth tooltips

### DIFF
--- a/src/utils/use-on-click-outside.ts
+++ b/src/utils/use-on-click-outside.ts
@@ -20,7 +20,8 @@ export function useOnClickOutside<T extends RefObject<Element>>(
         while (el && !el.contains && el !== document.body) {
           el = el.parentNode;
         }
-        el?.contains(event.target as Node);
+
+        return el?.contains(event.target as Node);
       });
 
       if (!clickedInsideRef) {


### PR DESCRIPTION
## Summary

The click through on the chorpleth tooltips no longer worked on mobile. This fixes the issue. 

## Motivation

Bug report

## Detailed design

Added a missing 'return' in a find method...

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
