### PR TITLE
VR hospital null values workaround

### DIFF
--- a/schema/regional/results_per_region.json
+++ b/schema/regional/results_per_region.json
@@ -19,12 +19,12 @@
         "vrcode": { "type": "string", "equalsRootProperty": "code" },
         "total_reported_increase_per_region": { "type": "number" },
         "infected_total_counts_per_region": { "type": "number" },
-        "hospital_total_counts_per_region": { "type": "number" },
+        "hospital_total_counts_per_region": { "type": ["number", "null"], "nullable": true },
         "active_clusters": { "type": ["number", "null"], "nullable": true },
         "cluster_average": { "type": ["number", "null"], "nullable": true },
         "infected_increase_per_region": { "type": "number" },
-        "hospital_increase_per_region": { "type": "number" },
-        "hospital_moving_avg_per_region": { "type": "number" },
+        "hospital_increase_per_region": { "type": ["number", "null"], "nullable": true },
+        "hospital_moving_avg_per_region": { "type": ["number", "null"], "nullable": true },
         "date_of_insertion_unix": { "type": "integer" }
       }
     }

--- a/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { isFilled } from 'ts-is-present';
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { ContentHeader } from '~/components-styled/content-header';
@@ -20,6 +21,7 @@ import {
   getSafetyRegionStaticProps,
   ISafetyRegionData,
 } from '~/static-props/safetyregion-data';
+import { getLastFilledValue } from '~/utils/get-last-filled-value';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
 const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
@@ -28,7 +30,7 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
   const { data, safetyRegionName } = props;
   const router = useRouter();
 
-  const lastValue = data.results_per_region.last_value;
+  const lastValue = getLastFilledValue(data, 'results_per_region');
 
   const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
@@ -85,10 +87,12 @@ const IntakeHospital: FCWithLayout<ISafetyRegionData> = (props) => {
           metadata={{ source: text.bronnen.rivm }}
           title={text.linechart_titel}
           description={text.linechart_description}
-          values={data.results_per_region.values.map((value) => ({
-            value: value.hospital_moving_avg_per_region,
-            date: value.date_of_report_unix,
-          }))}
+          values={data.results_per_region.values
+            .filter((x) => isFilled(x.hospital_moving_avg_per_region))
+            .map((value) => ({
+              value: value.hospital_moving_avg_per_region,
+              date: value.date_of_report_unix,
+            }))}
         />
       )}
 

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -652,12 +652,12 @@ export interface RegionaalValue {
   vrcode: string;
   total_reported_increase_per_region: number;
   infected_total_counts_per_region: number;
-  hospital_total_counts_per_region: number;
+  hospital_total_counts_per_region: number | null;
   active_clusters?: number | null;
   cluster_average?: number | null;
   infected_increase_per_region: number;
-  hospital_increase_per_region: number;
-  hospital_moving_avg_per_region: number;
+  hospital_increase_per_region: number | null;
+  hospital_moving_avg_per_region: number | null;
   date_of_insertion_unix: number;
 }
 export interface RegionalGgd {

--- a/src/utils/get-last-filled-value.ts
+++ b/src/utils/get-last-filled-value.ts
@@ -1,0 +1,50 @@
+import { every, get } from 'lodash';
+import { isFilled } from 'ts-is-present';
+import { MetricKeys } from '~/components/choropleth/shared';
+import { assert } from './assert';
+
+/**
+ * This function attempts to get the lastValue but then checks whether all
+ * properties contain values that are non-null. If null values are detected then
+ * we iterate over the values array, starting with the most recent values, and
+ * return the first value that is completely filled.
+ *
+ * If no value is found an exception is thrown.
+ */
+export function getLastFilledValue<T>(
+  data: T,
+  metricName: ValueOf<MetricKeys<T>>
+) {
+  const lastValue = get(data, [
+    (metricName as unknown) as string,
+    'last_value',
+  ]);
+
+  if (hasAllPropertiesFilled(lastValue)) {
+    return lastValue;
+  }
+
+  // console.log('+++ get last full item from values array');
+  const values = get(data, [(metricName as unknown) as string, 'values']);
+
+  assert(values, `Unable to find ${metricName}.values[]`);
+
+  /**
+   * Start iterating over the most recent values. Do not mutate because it will
+   * flip the charts x-axis.
+   */
+  const reversedValues = [...values].reverse() as Record<string, unknown>[];
+
+  for (const value of reversedValues) {
+    if (hasAllPropertiesFilled(value)) {
+      return value;
+    }
+  }
+  throw new Error(
+    `Failed to find full non-null object for ${metricName}.values[]}`
+  );
+}
+
+function hasAllPropertiesFilled(x: Record<string, unknown>) {
+  return every(Object.values(x), isFilled);
+}


### PR DESCRIPTION
## Summary

This PR provides a workaround for filtering values with null in the VR hospital data. Historically we take a different approach where we define/fill a new schema only for getting the last non-null values like `reproduction_index_last_known_average`. 

Because of the time constraints, this PR takes a different approach, and instead, when confronted with null values, it looks up the last non-null value from the values array.