### PR TITLE
Topic/actueel sans sidebar

### DIFF
--- a/src/pages/gemeente/[code]/actueel.tsx
+++ b/src/pages/gemeente/[code]/actueel.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { Tile } from '~/components-styled/layout';
+import { MaxWidth } from '~/components-styled/max-width';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout } from '~/components/layout';
-import { getMunicipalityLayout } from '~/components/layout/MunicipalityLayout';
+import { FCWithLayout, getLayoutWithMetadata } from '~/components/layout';
 import { TALLLanguages } from '~/locale/';
 import { EscalationMapLegenda } from '~/pages/veiligheidsregio';
 import {
@@ -21,7 +21,7 @@ const MunicipalityActueel: FCWithLayout<ActueelData> = (data) => {
   const { text } = data;
 
   return (
-    <>
+    <MaxWidth>
       <Tile>De actuele situatie in {data.municipalityName}</Tile>
       <Tile>Artikelen</Tile>
       <ChoroplethTile
@@ -44,11 +44,13 @@ const MunicipalityActueel: FCWithLayout<ActueelData> = (data) => {
           tooltipContent={escalationTooltip(createSelectRegionHandler(router))}
         />
       </ChoroplethTile>
-    </>
+    </MaxWidth>
   );
 };
 
-MunicipalityActueel.getLayout = getMunicipalityLayout();
+/** @TODO Fill metadata / adjust layout */
+const metadata = {};
+MunicipalityActueel.getLayout = getLayoutWithMetadata(metadata);
 
 export const getStaticProps = getMunicipalityData();
 export const getStaticPaths = getMunicipalityPaths();

--- a/src/pages/gemeente/[code]/actueel.tsx
+++ b/src/pages/gemeente/[code]/actueel.tsx
@@ -49,7 +49,9 @@ const MunicipalityActueel: FCWithLayout<ActueelData> = (data) => {
 };
 
 /** @TODO Fill metadata / adjust layout */
-const metadata = {};
+const metadata = {
+  title: '',
+};
 MunicipalityActueel.getLayout = getLayoutWithMetadata(metadata);
 
 export const getStaticProps = getMunicipalityData();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,11 +3,11 @@ import { useRouter } from 'next/router';
 import path from 'path';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { Tile } from '~/components-styled/layout';
+import { MaxWidth } from '~/components-styled/max-width';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout } from '~/components/layout';
-import { getNationalLayout } from '~/components/layout/NationalLayout';
+import { FCWithLayout, getLayoutWithMetadata } from '~/components/layout';
 import { TALLLanguages } from '~/locale/';
 import { National } from '~/types/data';
 import { parseMarkdownInLocale } from '~/utils/parse-markdown-in-locale';
@@ -28,7 +28,7 @@ const Home: FCWithLayout<IHomeData> = (data) => {
   const { text } = data;
 
   return (
-    <>
+    <MaxWidth>
       <Tile>De actuele situatie in Nederland</Tile>
       <Tile>Artikelen</Tile>
       <ChoroplethTile
@@ -53,11 +53,13 @@ const Home: FCWithLayout<IHomeData> = (data) => {
           )}
         />
       </ChoroplethTile>
-    </>
+    </MaxWidth>
   );
 };
 
-Home.getLayout = getNationalLayout;
+/** @TODO Fill metadata / adjust layout */
+const metadata = {};
+Home.getLayout = getLayoutWithMetadata(metadata);
 
 export async function getStaticProps(): Promise<StaticProps> {
   const text = parseMarkdownInLocale((await import('../locale/index')).default);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -58,7 +58,9 @@ const Home: FCWithLayout<IHomeData> = (data) => {
 };
 
 /** @TODO Fill metadata / adjust layout */
-const metadata = {};
+const metadata = {
+  title: '',
+};
 Home.getLayout = getLayoutWithMetadata(metadata);
 
 export async function getStaticProps(): Promise<StaticProps> {

--- a/src/pages/veiligheidsregio/[code]/actueel.tsx
+++ b/src/pages/veiligheidsregio/[code]/actueel.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { Tile } from '~/components-styled/layout';
+import { MaxWidth } from '~/components-styled/max-width';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout } from '~/components/layout';
-import { getSafetyRegionLayout } from '~/components/layout/SafetyRegionLayout';
+import { FCWithLayout, getLayoutWithMetadata } from '~/components/layout';
 import { TALLLanguages } from '~/locale/';
 import {
   getSafetyRegionStaticProps,
@@ -21,7 +21,7 @@ const SafetyRegionActueel: FCWithLayout<ActueelData> = (data) => {
   const { text } = data;
 
   return (
-    <>
+    <MaxWidth>
       <Tile>De actuele situatie in {data.safetyRegionName}</Tile>
       <Tile>Artikelen</Tile>
       <ChoroplethTile
@@ -44,11 +44,13 @@ const SafetyRegionActueel: FCWithLayout<ActueelData> = (data) => {
           tooltipContent={escalationTooltip(createSelectRegionHandler(router))}
         />
       </ChoroplethTile>
-    </>
+    </MaxWidth>
   );
 };
 
-SafetyRegionActueel.getLayout = getSafetyRegionLayout();
+/** @TODO Fill metadata / adjust layout */
+const metadata = {};
+SafetyRegionActueel.getLayout = getLayoutWithMetadata(metadata);
 
 export const getStaticProps = getSafetyRegionStaticProps;
 export const getStaticPaths = getSafetyRegionPaths();

--- a/src/pages/veiligheidsregio/[code]/actueel.tsx
+++ b/src/pages/veiligheidsregio/[code]/actueel.tsx
@@ -49,7 +49,9 @@ const SafetyRegionActueel: FCWithLayout<ActueelData> = (data) => {
 };
 
 /** @TODO Fill metadata / adjust layout */
-const metadata = {};
+const metadata = {
+  title: '',
+};
 SafetyRegionActueel.getLayout = getLayoutWithMetadata(metadata);
 
 export const getStaticProps = getSafetyRegionStaticProps;


### PR DESCRIPTION
## Summary

Removes the sidebar on Actueel pages.

## Detailed design

* This is just a quick way to do this, we could opt for a dedicated layout if needed later on.
* Added a Todo to fill the Metadata, or when using a layout we can provide it using the SEOHead component.
