### PR TITLE
Fix hydration error

### DIFF
--- a/src/utils/useMediaQuery.ts
+++ b/src/utils/useMediaQuery.ts
@@ -2,19 +2,9 @@ import { useState, useEffect } from 'react';
 
 export function useMediaQuery(
   breakpoint: string,
-  initialMatches?: boolean
+  initialMatches = false
 ): boolean {
-  const [matches, setMatches] = useState(() => {
-    if (initialMatches === undefined) {
-      try {
-        return window.matchMedia(breakpoint).matches;
-      } catch (err) {
-        return false;
-      }
-    }
-
-    return initialMatches;
-  });
+  const [matches, setMatches] = useState(initialMatches);
 
   useEffect(() => {
     const mqList = window.matchMedia(breakpoint);


### PR DESCRIPTION
The initial state could be different between server and client. Therefore an error could pop up where the initial matches-state would be equal across server and client, but nonetheless should actually be different. Because the state was equal no re-render got triggered and therefore we were having weird bugs with our UI.
