### PR TITLE
GGD daily + average

### DIFF
--- a/schema/national/__index.json
+++ b/schema/national/__index.json
@@ -24,6 +24,7 @@
     "hospital_beds_occupied",
     "intensive_care_beds_occupied",
     "ggd",
+    "ggd_average",
     "nursing_home",
     "behavior",
     "restrictions",
@@ -102,6 +103,9 @@
     },
     "ggd": {
       "$ref": "ggd.json"
+    },
+    "ggd_average": {
+      "$ref": "ggd_average.json"
     },
     "nursing_home": {
       "$ref": "nursing_home.json"

--- a/schema/national/ggd.json
+++ b/schema/national/ggd.json
@@ -29,13 +29,7 @@
         "tested_total": {
           "type": "integer"
         },
-        "week_unix": {
-          "type": "integer"
-        },
-        "week_start_unix": {
-          "type": "integer"
-        },
-        "week_end_unix": {
+        "date_of_report_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {
@@ -46,9 +40,7 @@
         "tested_total",
         "infected_percentage",
         "infected",
-        "week_unix",
-        "week_start_unix",
-        "week_end_unix",
+        "date_of_report_unix",
         "date_of_insertion_unix"
       ],
       "additionalProperties": false

--- a/schema/national/ggd_average.json
+++ b/schema/national/ggd_average.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "regional_ggd",
+  "title": "national_ggd_average",
   "type": "object",
   "properties": {
     "values": {
@@ -17,36 +17,35 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "regional_ggd_value",
+      "title": "national_ggd_average_value",
       "type": "object",
       "properties": {
-        "infected": {
+        "infected_average": {
           "type": "integer"
         },
-        "infected_percentage": {
+        "infected_percentage_average": {
           "type": "number"
         },
-        "tested_total": {
+        "tested_total_average": {
           "type": "integer"
         },
-        "date_of_report_unix": {
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {
           "type": "integer"
-        },
-        "vrcode": {
-          "type": "string",
-          "equalsRootProperty": "code"
         }
       },
       "required": [
-        "infected",
+        "tested_total_average",
         "infected_percentage",
-        "tested_total",
-        "date_of_report_unix",
-        "date_of_insertion_unix",
-        "vrcode"
+        "infected_average",
+        "week_start_unix",
+        "week_end_unix",
+        "date_of_insertion_unix"
       ],
       "additionalProperties": false
     }

--- a/schema/regional/__index.json
+++ b/schema/regional/__index.json
@@ -9,6 +9,7 @@
     "code",
     "results_per_region",
     "ggd",
+    "ggd_average",
     "nursing_home",
     "sewer",
     "sewer_per_installation",
@@ -51,6 +52,9 @@
     },
     "ggd": {
       "$ref": "ggd.json"
+    },
+    "ggd_average": {
+      "$ref": "ggd_average.json"
     },
     "nursing_home": {
       "$ref": "nursing_home.json"

--- a/schema/regional/ggd_average.json
+++ b/schema/regional/ggd_average.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "regional_ggd",
+  "title": "regional_ggd_average",
   "type": "object",
   "properties": {
     "values": {
@@ -17,19 +17,22 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "regional_ggd_value",
+      "title": "regional_ggd_average_value",
       "type": "object",
       "properties": {
-        "infected": {
+        "infected_average": {
           "type": "integer"
         },
-        "infected_percentage": {
+        "infected_percentage_average": {
           "type": "number"
         },
-        "tested_total": {
+        "tested_total_average": {
           "type": "integer"
         },
-        "date_of_report_unix": {
+        "week_start_unix": {
+          "type": "integer"
+        },
+        "week_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {
@@ -41,10 +44,11 @@
         }
       },
       "required": [
-        "infected",
-        "infected_percentage",
-        "tested_total",
-        "date_of_report_unix",
+        "infected_average",
+        "infected_percentage_average",
+        "tested_total_average",
+        "week_start_unix",
+        "week_end_unix",
         "date_of_insertion_unix",
         "vrcode"
       ],


### PR DESCRIPTION
## Summary

GGD data will be delivered in two different sets. One calculated as moving average (over 7 days) like we have now, and the other data is reported over a single day.

Because one uses day timestamps and the other date range timestamps (week_start/week_end) I split them into two schema's, so each can have its own independent timestamps.




