### PR TITLE
Simplify jest config

### DIFF
--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -1,22 +1,10 @@
 module.exports = {
-  preset: 'ts-jest',
-  collectCoverageFrom: [
-    '**/*.{js,jsx,ts,tsx}',
-    '!**/*.d.ts',
-    '!**/node_modules/**',
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.+(ts|tsx|js)',
+    '**/?(*.)+(spec|test).+(ts|tsx|js)',
   ],
-  setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/out', '/cypress'],
   transform: {
-    '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/node_modules/babel-jest',
-  },
-  transformIgnorePatterns: [
-    '/node_modules/',
-    '^.+\\.module\\.(css|sass|scss)$',
-  ],
-  moduleNameMapper: {
-    '\\.svg': '<rootDir>/__mocks__/svgrMock.js',
-    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
-    '^~/(.*)$': '<rootDir>/src/$1',
+    '^.+\\.(ts|tsx)$': 'ts-jest',
   },
 };

--- a/packages/app/src/components/comboBox/index.tsx
+++ b/packages/app/src/components/comboBox/index.tsx
@@ -116,9 +116,9 @@ function useSearchedOptions<Option extends TOption>(
   options: Option[]
 ): Option[] {
   const throttledTerm = useThrottle(term, 100);
-  const sortByName = (a: Option, b: Option) => a.name.localeCompare(b.name);
-
   return useMemo(() => {
+    const sortByName = (a: Option, b: Option) => a.name.localeCompare(b.name);
+
     if (throttledTerm.trim() === '') return options.sort(sortByName);
 
     return matchSorter(options, throttledTerm.trim(), {


### PR DESCRIPTION
## Summary

The current Jest config wasn't working with the monorepo. I copied a much simpler config from a previous monorepo project and things seem to "just work". 
