### PR TITLE
Fix no js mode

### DIFF
--- a/packages/app/public/init.js
+++ b/packages/app/public/init.js
@@ -1,0 +1,3 @@
+try {
+  window.document.documentElement.classList.remove('has-no-js');
+} catch(err) {/** */};

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -38,11 +38,6 @@ export default function App(props: AppPropsWithLayout) {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `try { window.document.documentElement.classList.remove('has-no-js'); } catch(err) {};`,
-        }}
-      />
       {pageWithLayout}
     </ThemeProvider>
   );

--- a/packages/app/src/pages/_document.tsx
+++ b/packages/app/src/pages/_document.tsx
@@ -44,7 +44,7 @@ class MyDocument extends Document {
     return (
       <Html lang={locale} className="has-no-js">
         <Head>
-          <script src="/init.js" />
+          <script src="/init.js" async />
         </Head>
         <body>
           <Main />

--- a/packages/app/src/pages/_document.tsx
+++ b/packages/app/src/pages/_document.tsx
@@ -43,7 +43,9 @@ class MyDocument extends Document {
 
     return (
       <Html lang={locale} className="has-no-js">
-        <Head />
+        <Head>
+          <script src="/init.js" />
+        </Head>
         <body>
           <Main />
 


### PR DESCRIPTION
## Summary

Initially the html tag has a `has-no-js` classname which is ASAP removed with javascript. This line of code was added inside an inline script tag, but our TAP environments have CSP directives which block inline script execution.
A fix is to move this code to a separate file instead of running inline script. In order to run this as fast as possible it's loaded at the top of our head with an async prop to prevent a blocking ui.