### PR TITLE
Changed tooltip styling sewers

### DIFF
--- a/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
@@ -2,6 +2,7 @@ import { scaleBand, scaleLinear, ScaleTypeToD3Scale } from '@visx/scale';
 import { ScaleBand } from 'd3-scale';
 import { useMemo } from 'react';
 import { GetTooltipCoordinates } from '../tooltip';
+import { BAR_CHART_TOOLTIP_MAX_WIDTH } from './bar-chart-graph';
 
 export interface BarChartValue {
   value: number;
@@ -57,7 +58,7 @@ function generateBarChartCoordinates(
   const spacingLabel = 10;
 
   const barsWidth = width - spacing.left - spacing.right;
-  const barsHeight = values.length * 40;
+  const barsHeight = values.length * 35;
   const height = barsHeight + spacing.top + spacing.bottom;
 
   const numTicks = 10;
@@ -75,7 +76,7 @@ function generateBarChartCoordinates(
     range: [spacing.top, height - spacing.bottom],
     round: true,
     domain: values.map(getLabel),
-    padding: 0.2,
+    padding: 0.4,
   });
 
   const createPoint = (scale: any, accessor: any) => (value: BarChartValue) =>
@@ -84,13 +85,17 @@ function generateBarChartCoordinates(
   const getBarSize = createPoint(valueScale, getValue);
   const getBarOffset = createPoint(labelScale, getLabel);
 
-  // const xPoint = (value: BarChartValue) => xScale(getValue(value));
-  // const yPoint = (value: BarChartValue) => yScale(getLabel(value));
+  function getTooltipCoordinates(value: BarChartValue, event: any) {
+    const labelScaleStep = labelScale.step();
 
-  function getTooltipCoordinates(value: BarChartValue) {
-    const left = getBarSize(value) ?? 0 + spacing.left;
-    const top = getBarOffset(value) ?? 0 + spacing.top;
+    // Calculate the tooltip centered to the bar
+    const top = (getBarOffset(value) ?? 0) + ((labelScaleStep * labelScale.paddingOuter() / 2)) - labelScaleStep;
 
+    // Calculate if the tooltip is inside of the window size and if event target exists 
+    const left = event && event.target.getBoundingClientRect().right + BAR_CHART_TOOLTIP_MAX_WIDTH <= window.innerWidth 
+      ? (getBarSize(value) ?? 0) + spacing.left + spacingLabel
+      : spacing.left + spacingLabel
+    
     return { left, top };
   }
 

--- a/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
@@ -89,8 +89,11 @@ function generateBarChartCoordinates(
     const labelScaleStep = labelScale.step();
     const paddingBottom = (labelScaleStep * labelScale.paddingOuter() / 2);
 
-    // Set the offset first, than calculate the padding on the bottom side and substract it with 1 full step to align
-    // Since the tooltip is placed right under the bar the padding calculation needs to be done
+    /**
+    * Set the offset first, than calculate the padding on the bottom side and substract it with 1 full step to align 
+    * Since the tooltip is placed right under the bar the padding calculation needs to be done
+    */ 
+
     const top = getBarOffset(value) + paddingBottom - labelScaleStep;
 
     // Calculate if the tooltip is inside of the window size and if event target exists 

--- a/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
@@ -85,14 +85,16 @@ function generateBarChartCoordinates(
   const getBarSize = createPoint(valueScale, getValue);
   const getBarOffset = createPoint(labelScale, getLabel);
 
-  function getTooltipCoordinates(value: BarChartValue, event: any) {
+  function getTooltipCoordinates(value: BarChartValue) {
     const labelScaleStep = labelScale.step();
+    const paddingBottom = (labelScaleStep * labelScale.paddingOuter() / 2);
 
-    // Calculate the tooltip centered to the bar
-    const top = (getBarOffset(value) ?? 0) + ((labelScaleStep * labelScale.paddingOuter() / 2)) - labelScaleStep;
+    // Set the offset first, than calculate the padding on the bottom side and substract it with 1 full step to align
+    // Since the tooltip is placed right under the bar the padding calculation needs to be done
+    const top = getBarOffset(value) + paddingBottom - labelScaleStep;
 
     // Calculate if the tooltip is inside of the window size and if event target exists 
-    const left = event && event.target.getBoundingClientRect().right + BAR_CHART_TOOLTIP_MAX_WIDTH <= window.innerWidth 
+    const left = barsWidth - getBarSize(value) >= BAR_CHART_TOOLTIP_MAX_WIDTH 
       ? (getBarSize(value) ?? 0) + spacing.left + spacingLabel
       : spacing.left + spacingLabel
     

--- a/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
@@ -148,7 +148,6 @@ const StyledHoverBar = styled(Bar)(
     fill: 'transparent',
     // transparent stroke is to capture mouse movements in between bars for the tooltip
     stroke: 'transparent',
-    strokeWidth: 12,
 
     [`${StyledGroup}:hover &`]: {
       fill: 'lightBlue',

--- a/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
@@ -9,6 +9,8 @@ import styled from 'styled-components';
 import theme, { colors } from '~/style/theme';
 import { BarChartCoordinates, BarChartValue } from './bar-chart-coordinates';
 
+export const BAR_CHART_TOOLTIP_MAX_WIDTH = 200;
+
 interface BarChartGraphProps {
   coordinates: BarChartCoordinates;
   onMouseMoveBar: (value: BarChartValue, event: MouseEvent<SVGElement>) => void;
@@ -92,17 +94,26 @@ export function BarChartGraph({
 
       {values.map((value, index) => {
         return (
-          <Group key={index}>
+          <StyledGroup key={index}>
             <Text
               textAnchor="end"
               verticalAnchor="middle"
-              y={getBarOffset(value) ?? 0 + labelScale.bandwidth() / 2}
+              y={(getBarOffset(value) ?? 0) + labelScale.bandwidth() / 2}
               x={spacing.left - spacingLabel}
               fill={colors.annotation}
               fontSize={theme.fontSizes[0]}
             >
               {getLabel(value)}
             </Text>
+
+            {/* This bar takes all width to display the background color on hover */}
+            <StyledHoverBar
+              x={spacing.left}
+              y={getBarOffset(value) ?? 0}
+              height={labelScale.bandwidth()}
+              width={barsWidth}
+            />
+            
             {/* Bar has a minimum width of 5 pixels to stay visible / clickable */}
             <Bar
               x={spacing.left}
@@ -113,7 +124,7 @@ export function BarChartGraph({
               onMouseMove={(event) => onMouseMoveBar(value, event)}
               onMouseLeave={onMouseLeaveBar}
             />
-          </Group>
+          </StyledGroup>
         );
       })}
     </StyledSvg>
@@ -127,6 +138,20 @@ const StyledSvg = styled.svg(
       fontSize: 1,
       fill: 'annotation',
       fontFamily: '"RO Sans", Calibri, sans-serif',
+    },
+  })
+);
+
+const StyledGroup = styled(Group)({});
+const StyledHoverBar = styled(Bar)(
+  css({
+    fill: 'transparent',
+    // transparent stroke is to capture mouse movements in between bars for the tooltip
+    stroke: 'transparent',
+    strokeWidth: 12,
+
+    [`${StyledGroup}:hover &`]: {
+      fill: 'lightBlue',
     },
   })
 );

--- a/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
@@ -94,7 +94,7 @@ export function BarChartGraph({
 
       {values.map((value, index) => {
         return (
-          <StyledGroup key={index}>
+          <HoverGroup key={index}>
             <Text
               textAnchor="end"
               verticalAnchor="middle"
@@ -124,7 +124,7 @@ export function BarChartGraph({
               onMouseMove={(event) => onMouseMoveBar(value, event)}
               onMouseLeave={onMouseLeaveBar}
             />
-          </StyledGroup>
+          </HoverGroup>
         );
       })}
     </StyledSvg>
@@ -142,14 +142,14 @@ const StyledSvg = styled.svg(
   })
 );
 
-const StyledGroup = styled(Group)({});
+const HoverGroup = styled(Group)({});
 const StyledHoverBar = styled(Bar)(
   css({
     fill: 'transparent',
     // transparent stroke is to capture mouse movements in between bars for the tooltip
     stroke: 'transparent',
 
-    [`${StyledGroup}:hover &`]: {
+    [`${HoverGroup}:hover &`]: {
       fill: 'lightBlue',
     },
   })

--- a/packages/app/src/components-styled/bar-chart/bar-chart.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart.tsx
@@ -50,8 +50,7 @@ export function BarChart({
           accessibilityDescription={accessibilityDescription}
         />
       </div>
-
-      <Tooltip tooltipState={tooltipState}>
+      <Tooltip tooltipState={tooltipState} tooltipArrow={'left'}>
         {tooltipState.value && (
           <BarChartTooltipContent value={tooltipState.value} />
         )}

--- a/packages/app/src/components-styled/tooltip.tsx
+++ b/packages/app/src/components-styled/tooltip.tsx
@@ -17,6 +17,7 @@ interface TooltipProps<T> {
   tooltipState: TooltipState<T>;
   width?: number;
   controls?: string;
+  tooltipArrow?: string;
 }
 
 interface TooltipState<T> {
@@ -114,6 +115,7 @@ export function Tooltip<T>({
   children,
   tooltipState,
   width,
+  tooltipArrow
 }: TooltipProps<T>) {
   return (
     <Box
@@ -136,6 +138,25 @@ export function Tooltip<T>({
         '&[aria-hidden="true"]': {
           visibility: 'hidden',
         },
+        '&::after': () => {
+          switch(tooltipArrow) {
+            case 'left':
+              return {
+                content: '""',
+                position: 'absolute',
+                transform: 'translateY(-50%)',
+                top: '50%',
+                left: '-7px',
+                zIndex: -1,
+                borderTop: '5px solid transparent',
+                borderBottom: '5px solid transparent',
+                borderRight:  '7px solid white'
+              }
+              break;
+            default:
+              return {}
+          }
+        }
       })}
     >
       {children}

--- a/packages/app/src/components-styled/tooltip.tsx
+++ b/packages/app/src/components-styled/tooltip.tsx
@@ -152,7 +152,6 @@ export function Tooltip<T>({
                 borderBottom: '5px solid transparent',
                 borderRight:  '7px solid white'
               }
-              break;
             default:
               return {}
           }

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -191,7 +191,6 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
               accessibilityDescription={
                 text.bar_chart_accessibility_description
               }
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
             />
           </ChartTile>
         )}


### PR DESCRIPTION
## Summary

Changed the tooltip on the sewers bar graph, it should not align properly and when the window is smaller it goes to the beginning of the bar. Also added a background blue hover 

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
