### PR TITLE
Reproduction layout ie11

### DIFF
--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -13,6 +13,7 @@ import {
   Text,
 } from '~/components-styled/typography';
 import { Link } from '~/utils/link';
+import { asResponsiveArray } from '~/style/utils';
 import { Box } from '../base';
 
 /*
@@ -82,13 +83,13 @@ const ReferenceBox = styled(Box)(
   css({
     maxWidth: '30em',
     marginRight: 3,
-    flex: [null, null, null, '1 1 60%'],
+    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 60%' })
   })
 );
 
 const MetadataBox = styled(Box)(
   css({
-    flex: [null, null, null, '1 1 40%'],
+    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 40%' })
   })
 );
 

--- a/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
+++ b/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
@@ -36,7 +36,7 @@ export function KpiWithIllustrationTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
-          flex={1}
+          flex={{ lg: 1 }}
           pr={{ lg: 4 }}
         >
           <Heading level={3}>{title}</Heading>
@@ -54,7 +54,7 @@ export function KpiWithIllustrationTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
-          flex={1}
+          flex={{ lg: 1 }}
           pl={{ lg: 4 }}
         >
           <img

--- a/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
+++ b/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
@@ -36,6 +36,7 @@ export function KpiWithIllustrationTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
+          flex={1}
           pr={{ lg: 4 }}
         >
           <Heading level={3}>{title}</Heading>
@@ -53,6 +54,7 @@ export function KpiWithIllustrationTile({
           flexGrow={0}
           flexShrink={0}
           flexBasis={{ _: '100%', lg: '50%' }}
+          flex={1}
           pl={{ lg: 4 }}
         >
           <img

--- a/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
+++ b/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
@@ -33,10 +33,7 @@ export function KpiWithIllustrationTile({
       <Box display="flex" flexWrap="wrap">
         <Box
           mb={4}
-          flexGrow={0}
-          flexShrink={0}
-          flexBasis={{ _: '100%', lg: '50%' }}
-          flex={{ lg: 1 }}
+          flex={{ _: '0 0 100%', lg: '1'}}
           pr={{ lg: 4 }}
         >
           <Heading level={3}>{title}</Heading>
@@ -51,10 +48,7 @@ export function KpiWithIllustrationTile({
           )}
         </Box>
         <Box
-          flexGrow={0}
-          flexShrink={0}
-          flexBasis={{ _: '100%', lg: '50%' }}
-          flex={{ lg: 1 }}
+          flex={{ _: '0 0 100%', lg: '1'}}
           pl={{ lg: 4 }}
         >
           <img


### PR DESCRIPTION
## Summary

De header flexbox column issues opgelost op IE11
Flexbox probleem bij de KPI with illustration til opgelost.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
