### PR TITLE
Fix yDomain calculcation for line chart

### DIFF
--- a/packages/app/src/components-styled/line-chart/index.tsx
+++ b/packages/app/src/components-styled/line-chart/index.tsx
@@ -9,6 +9,7 @@ import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { TimeframeOption } from '~/utils/timeframe';
 import { Chart, defaultMargin } from './components/chart';
+import { Tooltip } from './components/tooltip';
 import {
   calculateYMax,
   getTrendData,
@@ -18,7 +19,6 @@ import {
   Value,
   WeeklyValue,
 } from './helpers';
-import { Tooltip } from './components/tooltip';
 
 const dateToValue = (d: Date) => d.valueOf() / 1000;
 const formatXAxis = (date: Date) =>
@@ -95,8 +95,8 @@ export function LineChart<T extends Value>({
   }, [trendData]);
 
   const yDomain = useMemo(
-    () => [0, calculateYMax(values, metricProperties, signaalwaarde)],
-    [values, metricProperties, signaalwaarde]
+    () => [0, calculateYMax(trendData, metricProperties, signaalwaarde)],
+    [trendData, metricProperties, signaalwaarde]
   );
 
   const handleHover = useCallback(


### PR DESCRIPTION
## Summary

The max values were calculated using the entire dataset, instead of the timeframe filtered set

## Motivation

Bug fix

## Detailed design

The fix was simply to pass the `trendData` value instead of the `values` to the `calculateYMax()` function.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
