### PR TITLE
Filter partial values in page bar scale

### DIFF
--- a/packages/app/src/components-styled/page-barscale.tsx
+++ b/packages/app/src/components-styled/page-barscale.tsx
@@ -4,7 +4,12 @@ import { BarScale } from '~/components/barScale';
 import { MetricKeys } from '~/components/choropleth/shared';
 import siteText, { TALLLanguages } from '~/locale/index';
 import { assert } from '~/utils/assert';
-import { DataScope, getMetricConfig } from '../metric-config';
+import { getLastFilledValue } from '~/utils/get-last-filled-value';
+import {
+  DataScope,
+  getMetricConfig,
+  metricContainsPartialData,
+} from '../metric-config';
 import { Box } from './base';
 import { DifferenceIndicator } from './difference-indicator';
 
@@ -32,10 +37,17 @@ export function PageBarScale<T>({
   differenceKey,
 }: PageBarScaleProps<T>) {
   const text = siteText[localeTextKey] as Record<string, string>;
-  const lastValue = get(data, [
-    (metricName as unknown) as string,
-    'last_value',
-  ]);
+
+  /**
+   * @TODO this is still a bit messy due to improper typing. Not sure how to
+   * fix this easily. The getLastFilledValue function is not strongly typed on
+   * a certain metric but here we don't have that type as input.
+   */
+  const lastValue = metricContainsPartialData((metricName as unknown) as string)
+    ? // @ts-ignore
+      (getLastFilledValue(data[metricName]) as data[metricName])
+    : get(data, [(metricName as unknown) as string, 'last_value']);
+
   const propertyValue = lastValue && lastValue[metricProperty];
 
   /**


### PR DESCRIPTION
## Summary

We don't get filtered null value data supplied separately anymore, as a result, different locations (like metric tiles) that grab their data directly need to be made aware to filter partial data for certain metrics. Otherwise, their value will be null and they might display "-".

 