### PR TITLE
Correct colors in sewerwater scatter chart legend

### DIFF
--- a/packages/app/src/assets/line.svg
+++ b/packages/app/src/assets/line.svg
@@ -1,3 +1,3 @@
 <svg focusable="false" width="12" height="6" stroke="currentColor" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 0 l12 0" stroke="currentColor" stroke-width="6" />
+<path d="M0 0 l12 0" stroke="currentColor" fill="currentColor" stroke-width="6" />
 </svg>

--- a/packages/app/src/components/lineChart/sewer-water-chart.tsx
+++ b/packages/app/src/components/lineChart/sewer-water-chart.tsx
@@ -55,8 +55,8 @@ export function SewerWaterChart<T extends SewerPerInstallationBaseValue>(
               .map((serie) => (
                 <LegendItem key={serie.name}>
                   <LegendMarker>
-                    {serie.type === 'scatter' && <Dot fill={serie.color} />}
-                    {serie.type === 'line' && <Line stroke={serie.color} />}
+                    {serie.type === 'scatter' && <Dot color={serie.color} />}
+                    {serie.type === 'line' && <Line color={serie.color} />}
                   </LegendMarker>
                   <div>{serie.description}</div>
                 </LegendItem>


### PR DESCRIPTION
## Summary

This fixes the colors of the dots and lines in the legend for the sewerwater scatter chart.

## Motivation

Bug report

## Detailed design

Correctly set color prop instead of fill on the svg elements.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
