### PR TITLE
Cache the render callback of the ChartAxes component

### DIFF
--- a/packages/app/src/components-styled/line-chart/index.tsx
+++ b/packages/app/src/components-styled/line-chart/index.tsx
@@ -256,7 +256,27 @@ export function LineChart<T extends Value>({
     [bisect, trendsList, linesConfig, toggleHoverElements]
   );
 
-  const trendType = hideFill ? 'line' : 'area';
+  const renderAxes = useCallback(
+    (x: ChartScales) => (
+      <>
+        {trendsList.map((trend, index) => (
+          <>
+            <Trend
+              key={index}
+              trend={trend}
+              type={hideFill ? 'line' : 'area'}
+              style={linesConfig[index].style}
+              xScale={x.xScale}
+              yScale={x.yScale}
+              color={linesConfig[index].color}
+              onHover={handleHover}
+            />
+          </>
+        ))}
+      </>
+    ),
+    [handleHover, linesConfig, hideFill, trendsList]
+  );
 
   if (!xDomain) {
     return null;
@@ -286,24 +306,7 @@ export function LineChart<T extends Value>({
           onHover={handleHover}
           benchmark={benchmark}
         >
-          {(renderProps) => (
-            <>
-              {trendsList.map((trend, index) => (
-                <>
-                  <Trend
-                    key={index}
-                    trend={trend}
-                    type={trendType}
-                    style={linesConfig[index].style}
-                    xScale={renderProps.xScale}
-                    yScale={renderProps.yScale}
-                    color={linesConfig[index].color}
-                    onHover={handleHover}
-                  />
-                </>
-              ))}
-            </>
-          )}
+          {renderAxes}
         </ChartAxes>
 
         {isDefined(tooltipData) && (


### PR DESCRIPTION
## Summary

Prevent unnecessary re-renders of the chart axes.