### PR TITLE
Use infectious_people__estimate as difference key

### DIFF
--- a/packages/app/schema/national/__difference.json
+++ b/packages/app/schema/national/__difference.json
@@ -21,8 +21,8 @@
     "tested_ggd_average__infected_percentage": {
       "$ref": "#/definitions/diff_decimal"
     },
-    "infectious_people__count_average": {
-      "$ref": "#/definitions/diff_decimal"
+    "infectious_people__estimate": {
+      "$ref": "#/definitions/diff_integer"
     },
     "hospital_nice__admissions_moving_average": {
       "$ref": "#/definitions/diff_decimal"
@@ -68,7 +68,7 @@
     "tested_ggd_average__tested_total",
     "tested_ggd_average__infected_percentage",
     "reproduction__index_average",
-    "infectious_people__count_average",
+    "infectious_people__estimate",
     "intensive_care_nice__admissions_moving_average",
     "intensive_care_lcps__beds_occupied_covid",
     "doctor__covid_symptoms_per_100k",

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -150,6 +150,7 @@ function NationalLayout(props: NationalLayoutProps) {
                     metricName="infectious_people"
                     metricProperty="estimate"
                     localeTextKey="besmettelijke_personen"
+                    differenceKey="infectious_people__estimate"
                   />
                 </MetricMenuItemLink>
 

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -63,6 +63,7 @@ const InfectiousPeople: FCWithLayout<NationalPageProps> = (props) => {
                * we can be sure that estimate exists
                */
               absolute={lastFullValue.estimate || 0}
+              difference={data.difference.infectious_people__estimate}
             />
           </KpiTile>
         </TwoKpiSection>

--- a/packages/app/src/types/data.d.ts
+++ b/packages/app/src/types/data.d.ts
@@ -133,7 +133,7 @@ export interface NationalDifference {
   tested_ggd_daily__infected_percentage: DifferenceDecimal;
   tested_ggd_average__tested_total: DifferenceInteger;
   tested_ggd_average__infected_percentage: DifferenceDecimal;
-  infectious_people__count_average: DifferenceDecimal;
+  infectious_people__estimate: DifferenceInteger;
   hospital_nice__admissions_moving_average: DifferenceDecimal;
   hospital_lcps__beds_occupied_covid: DifferenceInteger;
   intensive_care_nice__admissions_moving_average: DifferenceDecimal;


### PR DESCRIPTION
## Summary

The difference property for infectious people was not correct. This was proposed as a change but then didn't make it through the schema migration changes. So here it is again:

The current key NL difference `infectious_people__count_average` should be removed and a new value for `infectious_people__estimate` should be added to the data.