### PR TITLE
Clean up Sanity for the first release

### DIFF
--- a/packages/cms/desk-structure.js
+++ b/packages/cms/desk-structure.js
@@ -14,37 +14,37 @@ import ColorblindPreview from "./previews/colorblind-filter/ColorblindPreview";
 import { assemblePreviewUrl } from "./previews/assemblePreviewUrl";
 
 // Build up the root of the preview URL
-const remoteURL = process.env.SANITY_STUDIO_PREVIEW_SERVER;
-const localURL = "http://localhost:3000";
-const previewURL =
-  window.location.hostname === "localhost" ? localURL : remoteURL;
+// const remoteURL = process.env.SANITY_STUDIO_PREVIEW_SERVER;
+// const localURL = "http://localhost:3000";
+// const previewURL =
+//   window.location.hostname === "localhost" ? localURL : remoteURL;
 
-const WebPreview = ({ options, displayed }) => {
-  const url = assemblePreviewUrl({ displayed, options });
+// const WebPreview = ({ options, displayed }) => {
+//   const url = assemblePreviewUrl({ displayed, options });
 
-  return (
-    <iframe
-      style={{
-        margin: 0,
-        padding: 0,
-      }}
-      width="100%"
-      height="99%"
-      src={url}
-      frameBorder={0}
-    />
-  );
-};
+//   return (
+//     <iframe
+//       style={{
+//         margin: 0,
+//         padding: 0,
+//       }}
+//       width="100%"
+//       height="99%"
+//       src={url}
+//       frameBorder={0}
+//     />
+//   );
+// };
 
-const IFrameMobilePreview = ({ options, displayed }) => {
-  const url = assemblePreviewUrl({ displayed, options });
+// const IFrameMobilePreview = ({ options, displayed }) => {
+//   const url = assemblePreviewUrl({ displayed, options });
 
-  return (
-    <SanityMobilePreview>
-      <iframe src={url} frameBorder={0} width="100%" height="100%" />
-    </SanityMobilePreview>
-  );
-};
+//   return (
+//     <SanityMobilePreview>
+//       <iframe src={url} frameBorder={0} width="100%" height="100%" />
+//     </SanityMobilePreview>
+//   );
+// };
 
 // hiddenDocTypes will filter out all of the content models
 // we expose through other sections in the CMS.
@@ -69,68 +69,68 @@ export default () =>
   S.list()
     .title("Content")
     .items([
-      S.listItem()
-        .title("Instellingen")
-        .schemaType("siteSettings")
-        .icon(GoSettings)
-        .child(
-          S.editor()
-            .schemaType("siteSettings")
-            .title("Site instellingen")
-            .documentId("siteSettings")
-        ),
+      // S.listItem()
+      //   .title("Instellingen")
+      //   .schemaType("siteSettings")
+      //   .icon(GoSettings)
+      //   .child(
+      //     S.editor()
+      //       .schemaType("siteSettings")
+      //       .title("Site instellingen")
+      //       .documentId("siteSettings")
+      //   ),
 
-      S.listItem()
-        .title("Over dit dashboard")
-        .schemaType("overDitDashboard")
-        .icon(GrCircleInformation)
-        .child(
-          S.editor()
-            .title("Over dit dashboard")
-            .schemaType("overDitDashboard")
-            .documentId("overDitDashboard")
-            .views([
-              S.view.form(),
-              S.view
-                .component(WebPreview)
-                .options({ previewURL: `${previewURL}/over` })
-                .title("Web"),
-              S.view
-                .component(IFrameMobilePreview)
-                .options({ previewURL: `${previewURL}/over` })
-                .title("Mobile"),
-              S.view
-                .component(ColorblindPreview)
-                .options({ previewURL: `${previewURL}/over` })
-                .title("Color Blindness"),
-            ])
-        ),
+      // S.listItem()
+      //   .title("Over dit dashboard")
+      //   .schemaType("overDitDashboard")
+      //   .icon(GrCircleInformation)
+      //   .child(
+      //     S.editor()
+      //       .title("Over dit dashboard")
+      //       .schemaType("overDitDashboard")
+      //       .documentId("overDitDashboard")
+      //       .views([
+      //         S.view.form(),
+      //         S.view
+      //           .component(WebPreview)
+      //           .options({ previewURL: `${previewURL}/over` })
+      //           .title("Web"),
+      //         S.view
+      //           .component(IFrameMobilePreview)
+      //           .options({ previewURL: `${previewURL}/over` })
+      //           .title("Mobile"),
+      //         S.view
+      //           .component(ColorblindPreview)
+      //           .options({ previewURL: `${previewURL}/over` })
+      //           .title("Color Blindness"),
+      //       ])
+      //   ),
 
-      S.listItem()
-        .title("Over de risiconiveaus")
-        .schemaType("overRisicoNiveaus")
-        .icon(BsMap)
-        .child(
-          S.editor()
-            .title("Over de risiconiveaus")
-            .schemaType("overRisicoNiveaus")
-            .documentId("overRisicoNiveaus")
-            .views([
-              S.view.form(),
-              S.view
-                .component(WebPreview)
-                .options({ previewURL: `${previewURL}/over-risiconiveaus` })
-                .title("Web"),
-              S.view
-                .component(IFrameMobilePreview)
-                .options({ previewURL: `${previewURL}/over-risiconiveaus` })
-                .title("Mobile"),
-              S.view
-                .component(ColorblindPreview)
-                .options({ previewURL: `${previewURL}/over-risiconiveaus` })
-                .title("Color Blindness"),
-            ])
-        ),
+      // S.listItem()
+      //   .title("Over de risiconiveaus")
+      //   .schemaType("overRisicoNiveaus")
+      //   .icon(BsMap)
+      //   .child(
+      //     S.editor()
+      //       .title("Over de risiconiveaus")
+      //       .schemaType("overRisicoNiveaus")
+      //       .documentId("overRisicoNiveaus")
+      //       .views([
+      //         S.view.form(),
+      //         S.view
+      //           .component(WebPreview)
+      //           .options({ previewURL: `${previewURL}/over-risiconiveaus` })
+      //           .title("Web"),
+      //         S.view
+      //           .component(IFrameMobilePreview)
+      //           .options({ previewURL: `${previewURL}/over-risiconiveaus` })
+      //           .title("Mobile"),
+      //         S.view
+      //           .component(ColorblindPreview)
+      //           .options({ previewURL: `${previewURL}/over-risiconiveaus` })
+      //           .title("Color Blindness"),
+      //       ])
+      //   ),
 
       S.listItem()
         .title("Veelgestelde vragen")
@@ -143,46 +143,46 @@ export default () =>
             .documentId("veelgesteldeVragen")
             .views([
               S.view.form(),
-              S.view
-                .component(WebPreview)
-                .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
-                .title("Web"),
-              S.view
-                .component(IFrameMobilePreview)
-                .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
-                .title("Mobile"),
-              S.view
-                .component(ColorblindPreview)
-                .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
-                .title("Color Blindness"),
+              // S.view
+              //   .component(WebPreview)
+              //   .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
+              //   .title("Web"),
+              // S.view
+              //   .component(IFrameMobilePreview)
+              //   .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
+              //   .title("Mobile"),
+              // S.view
+              //   .component(ColorblindPreview)
+              //   .options({ previewURL: `${previewURL}/veelgestelde-vragen` })
+              //   .title("Color Blindness"),
             ])
         ),
 
-      S.listItem()
-        .title("Cijferverantwoording")
-        .schemaType("cijferVerantwoording")
-        .icon(BsCardChecklist)
-        .child(
-          S.editor()
-            .title("Cijferverantwoording")
-            .schemaType("cijferVerantwoording")
-            .documentId("cijferVerantwoording")
-            .views([
-              S.view.form(),
-              S.view
-                .component(WebPreview)
-                .title("Web")
-                .options({ previewURL: `${previewURL}/verantwoording` }),
-              S.view
-                .component(IFrameMobilePreview)
-                .options({ previewURL: `${previewURL}/verantwoording` })
-                .title("Mobile"),
-              S.view
-                .component(ColorblindPreview)
-                .options({ previewURL: `${previewURL}/verantwoording` })
-                .title("Color Blindness"),
-            ])
-        ),
+      // S.listItem()
+      //   .title("Cijferverantwoording")
+      //   .schemaType("cijferVerantwoording")
+      //   .icon(BsCardChecklist)
+      //   .child(
+      //     S.editor()
+      //       .title("Cijferverantwoording")
+      //       .schemaType("cijferVerantwoording")
+      //       .documentId("cijferVerantwoording")
+      //       .views([
+      //         S.view.form(),
+      //         S.view
+      //           .component(WebPreview)
+      //           .title("Web")
+      //           .options({ previewURL: `${previewURL}/verantwoording` }),
+      //         S.view
+      //           .component(IFrameMobilePreview)
+      //           .options({ previewURL: `${previewURL}/verantwoording` })
+      //           .title("Mobile"),
+      //         S.view
+      //           .component(ColorblindPreview)
+      //           .options({ previewURL: `${previewURL}/verantwoording` })
+      //           .title("Color Blindness"),
+      //       ])
+      //   ),
 
       // Add a visual divider (optional)
       S.divider(),

--- a/packages/cms/schemas/locale/locale-block.js
+++ b/packages/cms/schemas/locale/locale-block.js
@@ -18,8 +18,6 @@ export default {
     title: lang.title,
     name: lang.id,
     type: "array",
-    validation: (Rule) => Rule.required(),
-
     of: [{ type: "block" }],
     fieldset: lang.isDefault ? null : "translations",
   })),

--- a/packages/cms/schemas/locale/locale-block.js
+++ b/packages/cms/schemas/locale/locale-block.js
@@ -7,18 +7,18 @@ export default {
   name: "localeBlock",
   type: "object",
   title: "Locale Block Content",
-  fieldsets: [
-    {
-      title: "Vertalingen",
-      name: "translations",
-      options: { collapsible: true },
-    },
-  ],
+  // fieldsets: [
+  //   {
+  //     title: "Vertalingen",
+  //     name: "translations",
+  //     options: { collapsible: true },
+  //   },
+  // ],
   fields: supportedLanguages.map((lang) => ({
     title: lang.title,
     name: lang.id,
     type: "array",
     of: [{ type: "block" }],
-    fieldset: lang.isDefault ? null : "translations",
+    // fieldset: lang.isDefault ? null : "translations",
   })),
 };

--- a/packages/cms/schemas/locale/locale-string.js
+++ b/packages/cms/schemas/locale/locale-string.js
@@ -7,17 +7,17 @@ export default {
   name: "localeString",
   type: "object",
   title: "Locale String Content",
-  fieldsets: [
-    {
-      title: "Vertalingen",
-      name: "translations",
-      options: { collapsible: true },
-    },
-  ],
+  // fieldsets: [
+  //   {
+  //     title: "Vertalingen",
+  //     name: "translations",
+  //     options: { collapsible: true },
+  //   },
+  // ],
   fields: supportedLanguages.map((lang) => ({
     title: lang.title,
     name: lang.id,
     type: "string",
-    fieldset: lang.isDefault ? null : "translations",
+    // fieldset: lang.isDefault ? null : "translations",
   })),
 };

--- a/packages/cms/schemas/locale/locale-string.js
+++ b/packages/cms/schemas/locale/locale-string.js
@@ -18,7 +18,6 @@ export default {
     title: lang.title,
     name: lang.id,
     type: "string",
-    validation: (Rule) => Rule.required(),
     fieldset: lang.isDefault ? null : "translations",
   })),
 };

--- a/packages/cms/schemas/schema.js
+++ b/packages/cms/schemas/schema.js
@@ -6,15 +6,15 @@ import schemaTypes from "all:part:@sanity/base/schema-type";
 
 // documents are items that are published/queriable
 // some of these are 'singletons' but that's not enforced by the API
-import siteSettings from "./documents/siteSettings";
-import laatsteOntwikkelingen from "./documents/laatste-ontwikkelingen";
+// import siteSettings from "./documents/siteSettings";
+// import laatsteOntwikkelingen from "./documents/laatste-ontwikkelingen";
 import veelgesteldeVragen from "./documents/veelgestelde-vragen";
-import cijferVerantwoording from "./documents/cijfer-verantwoording";
-import overDitDashboard from "./documents/over-dit-dashboard";
-import overRisicoNiveaus from "./documents/over-risico-niveaus";
+// import cijferVerantwoording from "./documents/cijfer-verantwoording";
+// import overDitDashboard from "./documents/over-dit-dashboard";
+// import overRisicoNiveaus from "./documents/over-risico-niveaus";
 
 //objects are building blocks, but not queryable in itself
-import openGraph from "./objects/open-graph";
+// import openGraph from "./objects/open-graph";
 import collapsible from "./objects/collapsible";
 
 // These 2 locale helpers are technically objects too, but we keep them grouped here
@@ -30,14 +30,14 @@ export default createSchema({
   // to the ones provided by any plugins that are installed
   types: schemaTypes.concat([
     //documents
-    siteSettings,
-    laatsteOntwikkelingen,
+    // siteSettings,
+    // laatsteOntwikkelingen,
     veelgesteldeVragen,
-    cijferVerantwoording,
-    overDitDashboard,
-    overRisicoNiveaus,
+    // cijferVerantwoording,
+    // overDitDashboard,
+    // overRisicoNiveaus,
     //objects
-    openGraph,
+    // openGraph,
     collapsible,
     //locale helpers
     localeString,


### PR DESCRIPTION
## Summary

We're going to use Sanity soon. We've already configured some schemas's and documents, but we're planning a soft-launch with only 1 feature integration (the FAQ page). This PR hides all things that are not related to the FAQ page, so content managers don't fill in documents that are not called by the front-end yet.


## How

By out commenting stuff. In an ideal world we'd use feature flags, but this is good enough for now.

## Motivation

Trial out Sanity with a small set of features.
Test the integration and deploy flow.
Keep an eye on resource limits.