### PR TITLE
Update e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "download": "yarn workspace @corona-dashboard/app download",
     "start": "yarn workspace @corona-dashboard/app start",
     "validate-json": "yarn workspace @corona-dashboard/cli validate-json",
-    "validate-single": "yarn workspace @corona-dashboard/cli validate-single"
+    "validate-single": "yarn workspace @corona-dashboard/cli validate-single",
+    "e2e": "yarn workspace @corona-dashboard/app e2e"
   },
   "workspaces": {
     "packages": [

--- a/packages/app/cypress/integration/landelijk/positief-geteste-mensen.spec.ts
+++ b/packages/app/cypress/integration/landelijk/positief-geteste-mensen.spec.ts
@@ -1,5 +1,6 @@
 import { NationalContext } from 'cypress/integration/types';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
+import { getLastFilledValue } from '~/utils/get-last-filled-value';
 
 context('Landelijk - Positief geteste mensen', () => {
   before(() => {
@@ -7,8 +8,12 @@ context('Landelijk - Positief geteste mensen', () => {
   });
 
   it('Should show the correct KPI values', function (this: NationalContext) {
-    const infectedTotalLastValue = this.nationalData.tested_overall.last_value;
-    const ggdLastValue = this.nationalData.ggd.last_value;
+    const infectedTotalLastValue = getLastFilledValue(
+      this.nationalData.tested_overall
+    );
+    const ggdLastValue = getLastFilledValue(
+      this.nationalData.tested_ggd_average
+    );
 
     const kpiTestInfo = {
       infected: formatNumber(infectedTotalLastValue.infected),

--- a/packages/app/cypress/support/commands.ts
+++ b/packages/app/cypress/support/commands.ts
@@ -24,6 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+import { sortNationalTimeSeriesInDataInPlace } from '~/static-props/data-sorting';
 import { Municipal, National, Regionaal } from '~/types/data';
 
 // Must be declared global to be detected by typescript (allows import/export)
@@ -113,6 +114,9 @@ Cypress.Commands.add('beforeNationalTests', (pageName: string) => {
   cy.swallowResizeObserverError();
 
   cy.fixture<National>('NL.json')
+    .then((nationalData) => {
+      sortNationalTimeSeriesInDataInPlace(nationalData);
+    })
     .as('nationalData')
     .visit(`/landelijk/${pageName}`);
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,7 +76,7 @@
     "babel-plugin-styled-components": "^1.11.1",
     "chalk": "^4.1.0",
     "cross-env": "^7.0.3",
-    "cypress": "^6.1.0",
+    "cypress": "^6.2.1",
     "download": "^8.0.0",
     "download-cli": "^1.1.1",
     "eslint": "^7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5138,9 +5138,10 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
-cypress@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.0.tgz#1a8a7dd5bd08db3064551a9f12072963cc9337bf"
+cypress@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.1.tgz#27d5fbcf008c698c390fdb0c03441804176d06c4"
+  integrity sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
## Summary

Some tests were failing due to name changes in the schemas. Others failed because the national data fixture wasn't being sorted like in the app. Also upgraded to the latest version of Cypress.

## Motivation

Working tests are better than failing tests.

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
