### PR TITLE
Bumped the z-index of the main by 1 to prevent clipping with the sidebar

### DIFF
--- a/packages/app/src/components-styled/layout/app-content.tsx
+++ b/packages/app/src/components-styled/layout/app-content.tsx
@@ -79,7 +79,7 @@ const AppContentContainer = styled.div(
 const StyledAppContent = styled.main(
   css({
     bg: 'page',
-    zIndex: 2,
+    zIndex: 3,
     width: '100%',
     minWidth: 0,
     flexGrow: 1,


### PR DESCRIPTION
On the landelijk/positief-geteste-mensen page the AgeDemographic tooltip was clipping behind the sidebar, added more z-index.