### PR TITLE
Land on maatregelen when selecting a VR from the index page

### DIFF
--- a/packages/app/src/components/choropleth/select-handlers/create-select-region-handler.ts
+++ b/packages/app/src/components/choropleth/select-handlers/create-select-region-handler.ts
@@ -6,13 +6,9 @@ export type RegionSelectionHandler = (context: SafetyRegionProperties) => void;
 
 export function createSelectRegionHandler(
   router: NextRouter,
-  pageName: RegioPageName = 'positief-geteste-mensen'
+  pageName: RegioPageName
 ): RegionSelectionHandler {
   return (context: SafetyRegionProperties) => {
-    if (!context) {
-      return;
-    }
-
     router.push(`/veiligheidsregio/${context.vrcode}/${pageName}`);
   };
 }

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -151,9 +151,12 @@ const Home: FCWithLayout<INationalHomepageData> = (props) => {
             metricName="tested_overall"
             metricProperty="infected_per_100k"
             tooltipContent={createPositiveTestedPeopleRegionalTooltip(
-              createSelectRegionHandler(router)
+              createSelectRegionHandler(router, 'positief-geteste-mensen')
             )}
-            onSelect={createSelectRegionHandler(router)}
+            onSelect={createSelectRegionHandler(
+              router,
+              'positief-geteste-mensen'
+            )}
           />
         )}
       </ChoroplethTile>

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -204,9 +204,12 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
               metricName="tested_overall"
               metricProperty="infected_per_100k"
               tooltipContent={createPositiveTestedPeopleRegionalTooltip(
-                createSelectRegionHandler(router)
+                createSelectRegionHandler(router, 'positief-geteste-mensen')
               )}
-              onSelect={createSelectRegionHandler(router)}
+              onSelect={createSelectRegionHandler(
+                router,
+                'positief-geteste-mensen'
+              )}
             />
           )}
         </ChoroplethTile>

--- a/packages/app/src/pages/veiligheidsregio/index.tsx
+++ b/packages/app/src/pages/veiligheidsregio/index.tsx
@@ -99,9 +99,9 @@ const SafetyRegion: FCWithLayout<any> = (props) => {
           <SafetyRegionChoropleth
             metricName="escalation_levels"
             metricProperty="escalation_level"
-            onSelect={createSelectRegionHandler(router)}
+            onSelect={createSelectRegionHandler(router, 'maatregelen')}
             tooltipContent={escalationTooltip(
-              createSelectRegionHandler(router)
+              createSelectRegionHandler(router, 'maatregelen')
             )}
           />
         </ChoroplethTile>


### PR DESCRIPTION
## Summary

This PR makes you land on "maatregelen" when selecting a VR. I have removed the default page name, because I think it obfuscates more than it helps. Also by removing it, it more clearly exposes what could be refactored, since the same function is called twice to create the props of the choropleth.