### PR TITLE
Make positive tested choropleth tooltip show decimal values

### DIFF
--- a/packages/app/src/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltipContent';
 import siteText from '~/locale/index';
 import { MunicipalitiesTestedOverall } from '~/types/data';
-import { formatNumber } from '~/utils/formatNumber';
+import { formatPercentage } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { MunicipalitySelectionHandler } from '../../select-handlers/create-select-municipal-handler';
 import { MunicipalityProperties } from '../../shared';
@@ -25,7 +25,7 @@ export const createPositiveTestedPeopleMunicipalTooltip = (
   return (
     <TooltipContent title={gemnaam} onSelect={onSelect}>
       <p className="info-value">
-        {formatNumber(infected_per_100k)} per 100.000
+        {formatPercentage(infected_per_100k)} per 100.000
       </p>
       <p className="info-total">
         {replaceVariablesInText(text.positive_tested_people, {

--- a/packages/app/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltipContent';
 import siteText from '~/locale/index';
 import { RegionsTestedOverall } from '~/types/data';
-import { formatNumber } from '~/utils/formatNumber';
+import { formatPercentage } from '~/utils/formatNumber';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { RegionSelectionHandler } from '../../select-handlers/create-select-region-handler';
 import { SafetyRegionProperties } from '../../shared';
@@ -21,7 +21,7 @@ export const createPositiveTestedPeopleRegionalTooltip = (
   return (
     <TooltipContent title={vrname} onSelect={onSelect}>
       <p className="info-value">
-        {formatNumber(infected_per_100k)} per 100.000
+        {formatPercentage(infected_per_100k)} per 100.000
       </p>
       <p className="info-total">
         {replaceVariablesInText(text.positive_tested_people, {


### PR DESCRIPTION
## Summary

This allows for decimal values to be visible in the positive tested people choropleth tooltip for VR and GM. However GM data is currently not supplied with decimal values it seems, but that is out of the scope of this PR and will be addressed separately with BE.

Also `formatPercentage` should probably be renamed to something like `formatDecimal`, but then it would be wise to also rename `formatNumber` to `formatInteger` or something. I have left this for another day.