### PR TITLE
Add support for static difference timespan labels

### DIFF
--- a/packages/app/src/components-styled/difference-indicator.tsx
+++ b/packages/app/src/components-styled/difference-indicator.tsx
@@ -31,8 +31,6 @@ interface DifferenceIndicatorProps {
 export function DifferenceIndicator(props: DifferenceIndicatorProps) {
   const { isContextSidebar, value, isDecimal, staticTimespan } = props;
 
-  // console.log('+++ staticTimespan', staticTimespan);
-
   return isContextSidebar
     ? renderSidebarIndicator(value)
     : renderTileIndicator(value, isDecimal, staticTimespan);
@@ -81,9 +79,7 @@ function renderTileIndicator(
     ? formatPercentage(Math.abs(difference))
     : formatNumber(Math.abs(difference));
 
-  const timespanTextNode = staticTimespan ? (
-    staticTimespan
-  ) : (
+  const timespanTextNode = staticTimespan ?? (
     <TimespanText date={old_date_unix} />
   );
 

--- a/packages/app/src/components-styled/difference-indicator.tsx
+++ b/packages/app/src/components-styled/difference-indicator.tsx
@@ -25,14 +25,17 @@ interface DifferenceIndicatorProps {
   value: DifferenceDecimal | DifferenceInteger;
   isContextSidebar?: boolean;
   isDecimal?: boolean;
+  staticTimespan?: string;
 }
 
 export function DifferenceIndicator(props: DifferenceIndicatorProps) {
-  const { isContextSidebar, value, isDecimal } = props;
+  const { isContextSidebar, value, isDecimal, staticTimespan } = props;
+
+  // console.log('+++ staticTimespan', staticTimespan);
 
   return isContextSidebar
     ? renderSidebarIndicator(value)
-    : renderTileIndicator(value, isDecimal);
+    : renderTileIndicator(value, isDecimal, staticTimespan);
 }
 
 function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
@@ -69,13 +72,20 @@ function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
 
 function renderTileIndicator(
   value: DifferenceDecimal | DifferenceInteger,
-  isDecimal?: boolean
+  isDecimal?: boolean,
+  staticTimespan?: string
 ) {
   const { difference, old_date_unix } = value;
 
   const differenceFormattedString = isDecimal
     ? formatPercentage(Math.abs(difference))
     : formatNumber(Math.abs(difference));
+
+  const timespanTextNode = staticTimespan ? (
+    staticTimespan
+  ) : (
+    <TimespanText date={old_date_unix} />
+  );
 
   if (difference > 0) {
     const splitText = text.toename.split(' ');
@@ -88,8 +98,9 @@ function renderTileIndicator(
         <Span fontWeight="bold" mr="0.3em">
           {differenceFormattedString} {splitText[0]}
         </Span>
+
         <Span color="annotation">
-          {splitText[1]} <TimespanText date={old_date_unix} />
+          {splitText[1]} {timespanTextNode}
         </Span>
       </Container>
     );
@@ -107,7 +118,7 @@ function renderTileIndicator(
           {differenceFormattedString} {splitText[0]}
         </Span>
         <Span>
-          {splitText[1]} <TimespanText date={old_date_unix} />
+          {splitText[1]} {timespanTextNode}
         </Span>
       </Container>
     );
@@ -119,7 +130,7 @@ function renderTileIndicator(
         <IconGelijk />
       </IconContainer>
       <Span>
-        {text.gelijk} <TimespanText date={old_date_unix} />
+        {text.gelijk} {timespanTextNode}
       </Span>
     </Container>
   );

--- a/packages/app/src/components-styled/kpi-value.tsx
+++ b/packages/app/src/components-styled/kpi-value.tsx
@@ -11,6 +11,7 @@ interface KpiValueProps {
   percentage?: number;
   valueAnnotation?: string;
   difference?: DifferenceDecimal | DifferenceInteger;
+  differenceStaticTimespan?: string;
 }
 
 /**
@@ -40,6 +41,7 @@ export function KpiValue({
   percentage,
   valueAnnotation,
   difference,
+  differenceStaticTimespan,
   ...otherProps
 }: KpiValueProps) {
   return (
@@ -57,7 +59,12 @@ export function KpiValue({
           {formatNumber(absolute)}
         </StyledValue>
       )}
-      {difference && <DifferenceIndicator value={difference} />}
+      {difference && (
+        <DifferenceIndicator
+          value={difference}
+          staticTimespan={differenceStaticTimespan}
+        />
+      )}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}
     </>
   );

--- a/packages/app/src/components-styled/page-barscale.tsx
+++ b/packages/app/src/components-styled/page-barscale.tsx
@@ -26,6 +26,7 @@ interface PageBarScaleProps<T> {
   metricName: MetricKeys<T>;
   metricProperty: string;
   differenceKey?: string;
+  differenceStaticTimespan?: string;
 }
 
 export function PageBarScale<T>({
@@ -35,6 +36,7 @@ export function PageBarScale<T>({
   metricProperty,
   localeTextKey,
   differenceKey,
+  differenceStaticTimespan,
 }: PageBarScaleProps<T>) {
   const text = siteText[localeTextKey] as Record<string, string>;
 
@@ -122,6 +124,7 @@ export function PageBarScale<T>({
         <DifferenceIndicator
           value={differenceValue}
           isDecimal={config.isDecimal}
+          staticTimespan={differenceStaticTimespan}
         />
       )}
     </Box>

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -166,6 +166,7 @@ function NationalLayout(props: NationalLayoutProps) {
                     metricProperty="index_average"
                     localeTextKey="reproductiegetal"
                     showBarScale={true}
+                    differenceKey="reproduction__index_average"
                   />
                 </MetricMenuItemLink>
 

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -824,13 +824,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1506,7 +1500,8 @@
       "week": {
         "enkelvoud": "week",
         "meervoud": "weeks"
-      }
+      },
+      "hiervoor": "before"
     }
   },
   "aria_labels": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -824,13 +824,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1506,7 +1500,8 @@
       "week": {
         "enkelvoud": "week",
         "meervoud": "weken"
-      }
+      },
+      "hiervoor": "hiervoor"
     }
   },
   "aria_labels": {

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -272,6 +272,9 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
               data-cy="ggd_tested_total"
               absolute={dataGgdAverageLastValue.tested_total}
               difference={data.difference.tested_ggd_average__tested_total}
+              differenceStaticTimespan={
+                siteText.toe_en_afname.tijdverloop.hiervoor
+              }
             />
             <Text>{ggdText.totaal_getest_week_uitleg}</Text>
           </KpiTile>
@@ -290,6 +293,9 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
               percentage={dataGgdAverageLastValue.infected_percentage}
               difference={
                 data.difference.tested_ggd_average__infected_percentage
+              }
+              differenceStaticTimespan={
+                siteText.toe_en_afname.tijdverloop.hiervoor
               }
             />
             <Text>{ggdText.positief_getest_week_uitleg}</Text>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -66,6 +66,10 @@ const ReproductionIndex: FCWithLayout<NationalPageProps> = (props) => {
               metricName="reproduction"
               metricProperty="index_average"
               localeTextKey="reproductiegetal"
+              differenceKey="reproduction__index_average"
+              differenceStaticTimespan={
+                siteText.toe_en_afname.tijdverloop.hiervoor
+              }
             />
             <Text>{text.barscale_toelichting}</Text>
           </KpiWithIllustrationTile>
@@ -85,14 +89,14 @@ const ReproductionIndex: FCWithLayout<NationalPageProps> = (props) => {
             timeframeOptions={['all', '5weeks']}
             hideFill={true}
             footer={
-              <Box pl='30px'>
+              <Box pl="30px">
                 <Legenda
                   items={[
                     {
                       label: text.legenda_r,
                       color: 'data.primary',
                       shape: 'line',
-                   },
+                    },
                   ]}
                 />
               </Box>


### PR DESCRIPTION
## Summary

This adds support for using static timespan labels for those differences where the data-driven timespans confuse people.