### PR TITLE
Fix the content of the infected people  tooltip

### DIFF
--- a/packages/app/src/components-styled/line-chart/index.tsx
+++ b/packages/app/src/components-styled/line-chart/index.tsx
@@ -356,7 +356,9 @@ function formatDefaultTooltip<T extends Value>(
   if (isDaily) {
     return (
       <>
-        <Text as="span" fontWeight="bold">{formatDateFromMilliseconds(value.__date.getTime())}: </Text>
+        <Text as="span" fontWeight="bold">
+          {formatDateFromMilliseconds(value.__date.getTime())}:{' '}
+        </Text>
         {isPercentage
           ? `${formatPercentage(value.__value)}%`
           : formatNumber(value.__value)}

--- a/packages/app/src/components-styled/line-chart/index.tsx
+++ b/packages/app/src/components-styled/line-chart/index.tsx
@@ -357,7 +357,7 @@ function formatDefaultTooltip<T extends Value>(
     return (
       <>
         <Text as="span" fontWeight="bold">
-          {formatDateFromMilliseconds(value.__date.getTime())}:{' '}
+          {`${formatDateFromMilliseconds(value.__date.getTime())}: `}
         </Text>
         {isPercentage
           ? `${formatPercentage(value.__value)}%`

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -39,6 +39,7 @@ import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { formatDateFromMilliseconds } from '~/utils/formatDate';
 
 /* Retrieves certain age demographic data to be used in the example text. */
 function getAgeDemographicExampleData(data: NationalTestedPerAgeGroup) {
@@ -222,6 +223,41 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
           linesConfig={[{ metricProperty: 'infected_per_100k' }]}
           metadata={{
             source: text.bronnen.rivm,
+          }}
+          formatTooltip={(values) => {
+            const value = values[0];
+
+            return (
+              <Text textAlign="center" m={0}>
+                <span style={{ fontWeight: 'bold' }}>
+                  {formatDateFromMilliseconds(value.__date.getTime())}
+                </span>
+                <br />
+                <span
+                  style={{
+                    height: '0.5em',
+                    width: '0.5em',
+                    marginBottom: '0.5px',
+                    backgroundColor: colors.data.primary,
+                    borderRadius: '50%',
+                    display: 'inline-block',
+                  }}
+                />{' '}
+                {replaceVariablesInText(
+                  siteText.common.tooltip.positive_tested_value,
+                  {
+                    totalPositiveValue: formatNumber(value.__value),
+                  }
+                )}
+                <br />
+                {replaceVariablesInText(
+                  siteText.common.tooltip.positive_tested_people,
+                  {
+                    totalPositiveTestedPeople: formatNumber(value.infected),
+                  }
+                )}
+              </Text>
+            );
           }}
         />
 


### PR DESCRIPTION
Changed the tooltip of the infected people it should show now in order:
The date
dot Amount per 100.000
Absolute total