### PR TITLE
Decouple Sanity in development mode from the production environment

### DIFF
--- a/packages/cms/sanity.json
+++ b/packages/cms/sanity.json
@@ -18,7 +18,10 @@
   ],
   "env": {
     "development": {
-      "plugins": ["@sanity/vision"]
+      "plugins": ["@sanity/vision"],
+      "api": {
+        "dataset": "development"
+      }
     }
   },
   "parts": [


### PR DESCRIPTION
## Summary

- When running Sanity locally, we want it to talk to the development database. Not the production database. I changed sanity.json to automatically switch based on environments.