### PR TITLE
Fixed overflow on titles at the age demographic chart to show on small screens

### DIFF
--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
@@ -74,6 +74,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
         tabIndex={0}
         onKeyUp={(event) => onKeyInput(event)}
         css={css({
+          overflow: 'visible',
           '&:focus': {
             outline: 'none',
           },


### PR DESCRIPTION
Small fix to show titles on smaller screen sizes when the title is out of bounds of the SVG on the age demographic chart.
