### PR TITLE
Adds preview settings to Sanity documents

### DIFF
--- a/packages/cms/schemas/documents/cijfer-verantwoording.js
+++ b/packages/cms/schemas/documents/cijfer-verantwoording.js
@@ -23,4 +23,10 @@ export default {
       of: [{ type: "collapsible" }],
     },
   ],
+  preview: {
+    select: {
+      title: "title.nl",
+      subtitle: "description.nl",
+    },
+  },
 };

--- a/packages/cms/schemas/documents/over-dit-dashboard.js
+++ b/packages/cms/schemas/documents/over-dit-dashboard.js
@@ -15,4 +15,10 @@ export default {
       title: "Beschrijving",
     },
   ],
+  preview: {
+    select: {
+      title: "title.nl",
+      subtitle: "description.nl",
+    },
+  },
 };

--- a/packages/cms/schemas/documents/over-risico-niveaus.js
+++ b/packages/cms/schemas/documents/over-risico-niveaus.js
@@ -23,4 +23,10 @@ export default {
       of: [{ type: "collapsible" }],
     },
   ],
+  preview: {
+    select: {
+      title: "title.nl",
+      subtitle: "description.nl",
+    },
+  },
 };

--- a/packages/cms/schemas/documents/veelgestelde-vragen.js
+++ b/packages/cms/schemas/documents/veelgestelde-vragen.js
@@ -23,4 +23,10 @@ export default {
       of: [{ type: "collapsible" }],
     },
   ],
+  preview: {
+    select: {
+      title: "title.nl",
+      subtitle: "description.nl",
+    },
+  },
 };


### PR DESCRIPTION
## Summary

Sanity uses some default keys (title/subtitle/description?) to generate previews of your documents in the UI. These previews are used in the sidebar or when using a reference to another document.

Since our documents use localized keys, these default assumptions about key names don't work.

This PR adds instructions for Sanity how to generate the previews for some of these documents.