### PR TITLE
Add remaining differences

### DIFF
--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -56,6 +56,18 @@
     },
     "reproduction__index_average": {
       "$ref": "#/definitions/diff_decimal"
+    },
+    "disability_care__newly_infected_people": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "disability_care__infected_locations_total": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "elderly_at_home__positive_tested_daily": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "deceased_rivm__covid_daily": {
+      "$ref": "#/definitions/diff_integer"
     }
   },
   "required": [
@@ -76,7 +88,11 @@
     "sewer__average",
     "nursing_home__newly_infected_people",
     "nursing_home__infected_locations_total",
-    "nursing_home__deceased_daily"
+    "nursing_home__deceased_daily",
+    "disability_care__newly_infected_people",
+    "disability_care__infected_locations_total",
+    "elderly_at_home__positive_tested_daily",
+    "deceased_rivm__covid_daily"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/vr/__difference.json
+++ b/packages/app/schema/vr/__difference.json
@@ -35,6 +35,18 @@
     },
     "nursing_home__deceased_daily": {
       "$ref": "#/definitions/diff_integer"
+    },
+    "disability_care__newly_infected_people": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "disability_care__infected_locations_total": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "elderly_at_home__positive_tested_daily": {
+      "$ref": "#/definitions/diff_integer"
+    },
+    "deceased_rivm__covid_daily": {
+      "$ref": "#/definitions/diff_integer"
     }
   },
   "required": [
@@ -48,7 +60,11 @@
     "sewer__average",
     "nursing_home__newly_infected_people",
     "nursing_home__infected_locations_total",
-    "nursing_home__deceased_daily"
+    "nursing_home__deceased_daily",
+    "disability_care__newly_infected_people",
+    "disability_care__infected_locations_total",
+    "elderly_at_home__positive_tested_daily",
+    "deceased_rivm__covid_daily"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/src/components-styled/sidebar-metric/sidebar-metric.tsx
+++ b/packages/app/src/components-styled/sidebar-metric/sidebar-metric.tsx
@@ -4,7 +4,7 @@ import { Box } from '~/components-styled/base';
 import {
   Metric,
   MetricKeys,
-  DifferenceKeys,
+  DifferenceKey,
 } from '~/components/choropleth/shared';
 import siteText, { TALLLanguages } from '~/locale/index';
 import {
@@ -29,7 +29,7 @@ interface SidebarMetricProps<T extends { difference: unknown }> {
    */
   metricProperty?: string;
   localeTextKey: keyof TALLLanguages;
-  differenceKey?: DifferenceKeys;
+  differenceKey?: DifferenceKey;
   showBarScale?: boolean;
   annotationKey?: string;
 

--- a/packages/app/src/components-styled/sidebar-metric/sidebar-metric.tsx
+++ b/packages/app/src/components-styled/sidebar-metric/sidebar-metric.tsx
@@ -1,7 +1,11 @@
 import { get } from 'lodash';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components-styled/base';
-import { Metric, MetricKeys } from '~/components/choropleth/shared';
+import {
+  Metric,
+  MetricKeys,
+  DifferenceKeys,
+} from '~/components/choropleth/shared';
 import siteText, { TALLLanguages } from '~/locale/index';
 import {
   DataScope,
@@ -25,7 +29,7 @@ interface SidebarMetricProps<T extends { difference: unknown }> {
    */
   metricProperty?: string;
   localeTextKey: keyof TALLLanguages;
-  differenceKey?: string;
+  differenceKey?: DifferenceKeys;
   showBarScale?: boolean;
   annotationKey?: string;
 

--- a/packages/app/src/components/choropleth/shared.d.ts
+++ b/packages/app/src/components/choropleth/shared.d.ts
@@ -19,7 +19,7 @@ export type MetricKeys<T> = keyof Omit<
 export type MunicipalitiesMetricName = MetricKeys<Municipalities>;
 export type RegionsMetricName = MetricKeys<Regions>;
 
-export type DifferenceKeys =
+export type DifferenceKey =
   | keyof NationalDifference
   | keyof RegionaalDifference
   | keyof MunicipalDifference;

--- a/packages/app/src/components/choropleth/shared.d.ts
+++ b/packages/app/src/components/choropleth/shared.d.ts
@@ -1,5 +1,10 @@
 import { FeatureCollection, MultiPolygon } from 'geojson';
-import { Municipalities, Regions } from '~/types/data';
+import {
+  MunicipalDifference,
+  Municipalities,
+  NationalDifference,
+  Regions,
+} from '~/types/data';
 
 export type Metric<T> = {
   values: T[];
@@ -13,6 +18,13 @@ export type MetricKeys<T> = keyof Omit<
 
 export type MunicipalitiesMetricName = MetricKeys<Municipalities>;
 export type RegionsMetricName = MetricKeys<Regions>;
+
+// export type NationalDifferenceKeys = keyof NationalDifference;
+
+export type DifferenceKeys =
+  | keyof NationalDifference
+  | keyof RegionaalDifference
+  | keyof MunicipalDifference;
 
 export interface SafetyRegionProperties {
   vrcode: string;

--- a/packages/app/src/components/choropleth/shared.d.ts
+++ b/packages/app/src/components/choropleth/shared.d.ts
@@ -19,8 +19,6 @@ export type MetricKeys<T> = keyof Omit<
 export type MunicipalitiesMetricName = MetricKeys<Municipalities>;
 export type RegionsMetricName = MetricKeys<Regions>;
 
-// export type NationalDifferenceKeys = keyof NationalDifference;
-
 export type DifferenceKeys =
   | keyof NationalDifference
   | keyof RegionaalDifference

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -181,6 +181,7 @@ function NationalLayout(props: NationalLayoutProps) {
                     metricName="deceased_rivm"
                     metricProperty="covid_daily"
                     localeTextKey="sterfte"
+                    differenceKey="deceased_rivm__covid_daily"
                   />
                 </MetricMenuItemLink>
               </CategoryMenu>
@@ -257,6 +258,7 @@ function NationalLayout(props: NationalLayoutProps) {
                     metricName="disability_care"
                     metricProperty="newly_infected_people"
                     localeTextKey="gehandicaptenzorg_positief_geteste_personen"
+                    differenceKey="disability_care__newly_infected_people"
                   />
                 </MetricMenuItemLink>
 
@@ -271,6 +273,7 @@ function NationalLayout(props: NationalLayoutProps) {
                     metricName="elderly_at_home"
                     metricProperty="positive_tested_daily"
                     localeTextKey="thuiswonende_ouderen"
+                    differenceKey="elderly_at_home__positive_tested_daily"
                   />
                 </MetricMenuItemLink>
               </CategoryMenu>

--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -152,6 +152,7 @@ function SafetyRegionLayout(
                         metricName="deceased_rivm"
                         metricProperty="covid_daily"
                         localeTextKey="veiligheidsregio_sterfte"
+                        differenceKey="deceased_rivm__covid_daily"
                       />
                     </MetricMenuItemLink>
                   </CategoryMenu>
@@ -216,6 +217,7 @@ function SafetyRegionLayout(
                         metricName="disability_care"
                         metricProperty="newly_infected_people"
                         localeTextKey="veiligheidsregio_gehandicaptenzorg_positief_geteste_personen"
+                        differenceKey="disability_care__newly_infected_people"
                       />
                     </MetricMenuItemLink>
 
@@ -233,6 +235,7 @@ function SafetyRegionLayout(
                         metricName="elderly_at_home"
                         metricProperty="positive_tested_daily"
                         localeTextKey="veiligheidsregio_thuiswonende_ouderen"
+                        differenceKey="elderly_at_home__positive_tested_daily"
                       />
                     </MetricMenuItemLink>
                   </CategoryMenu>

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -71,6 +71,9 @@ const DisabilityCare: FCWithLayout<NationalPageProps> = (props) => {
             <KpiValue
               data-cy="newly_infected_people"
               absolute={lastValue.newly_infected_people}
+              difference={
+                data.difference.disability_care__newly_infected_people
+              }
             />
           </KpiTile>
         </TwoKpiSection>
@@ -113,6 +116,9 @@ const DisabilityCare: FCWithLayout<NationalPageProps> = (props) => {
               data-cy="infected_locations_total"
               absolute={lastValue.infected_locations_total}
               percentage={lastValue.infected_locations_percentage}
+              difference={
+                data.difference.disability_care__infected_locations_total
+              }
             />
             <Text>{infectedLocationsText.kpi_toelichting}</Text>
           </KpiTile>

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -55,6 +55,7 @@ const DeceasedNationalPage: FCWithLayout<NationalPageProps> = (props) => {
             <KpiValue
               data-cy="covid_daily"
               absolute={dataRivm.last_value.covid_daily}
+              difference={props.data.difference.deceased_rivm__covid_daily}
             />
             <Text>
               {text.section_deceased_rivm.kpi_covid_daily_description}

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -78,6 +78,9 @@ const DisabilityCare: FCWithLayout<ISafetyRegionData> = (props) => {
             <KpiValue
               data-cy="newly_infected_people"
               absolute={lastValue.newly_infected_people}
+              difference={
+                data.difference.disability_care__newly_infected_people
+              }
             />
           </KpiTile>
         </TwoKpiSection>
@@ -122,6 +125,9 @@ const DisabilityCare: FCWithLayout<ISafetyRegionData> = (props) => {
               data-cy="infected_locations_total"
               absolute={lastValue.infected_locations_total}
               percentage={lastValue.infected_locations_percentage}
+              difference={
+                data.difference.disability_care__infected_locations_total
+              }
             />
             <Text>{locationsText.kpi_toelichting}</Text>
           </KpiTile>

--- a/packages/app/src/types/data.d.ts
+++ b/packages/app/src/types/data.d.ts
@@ -145,6 +145,10 @@ export interface NationalDifference {
   nursing_home__infected_locations_total: DifferenceInteger;
   nursing_home__deceased_daily: DifferenceInteger;
   reproduction__index_average: DifferenceDecimal;
+  disability_care__newly_infected_people: DifferenceInteger;
+  disability_care__infected_locations_total: DifferenceInteger;
+  elderly_at_home__positive_tested_daily: DifferenceInteger;
+  deceased_rivm__covid_daily: DifferenceInteger;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -454,6 +458,10 @@ export interface RegionalDifference {
   nursing_home__newly_infected_people: DifferenceInteger;
   nursing_home__infected_locations_total: DifferenceInteger;
   nursing_home__deceased_daily: DifferenceInteger;
+  disability_care__newly_infected_people: DifferenceInteger;
+  disability_care__infected_locations_total: DifferenceInteger;
+  elderly_at_home__positive_tested_daily: DifferenceInteger;
+  deceased_rivm__covid_daily: DifferenceInteger;
 }
 export interface DifferenceDecimal {
   old_value: number;


### PR DESCRIPTION
## Summary

This adds the remaining relevant differences for existing metrics

NL difference
```
disability_care__newly_infected_people
disability_care__infected_locations_total
elderly_at_home__positive_tested_daily
deceased_rivm__covid_daily
```

VR difference
```
disability_care__newly_infected_people
disability_care__infected_locations_total
elderly_at_home__positive_tested_daily
deceased_rivm__covid_daily
```
