### PR TITLE
Show just the one line if only one installation exists in the sewerwater chart

### DIFF
--- a/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
+++ b/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
@@ -300,8 +300,6 @@ export function useSewerWaterChartOptions<
         formatter: function (): false | string {
           const tooltipType = tooltipTypes[this.series.name];
 
-          console.log('nee');
-
           if (!tooltipType) {
             return false;
           }

--- a/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
+++ b/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
@@ -1,3 +1,4 @@
+import { uniq } from 'lodash';
 import { useMemo } from 'react';
 import { colors } from '~/style/theme';
 import { formatDateFromSeconds } from '~/utils/formatDate';
@@ -113,14 +114,8 @@ export function useSewerWaterChartOptions<
       [text.secondary_label_text]: 'scatter',
     };
 
-    const installationNames = filteredScatterPlotValues.reduce<string[]>(
-      (acc, item) => {
-        if (acc.indexOf(item.rwzi_awzi_name) < 0) {
-          acc.push(item.rwzi_awzi_name);
-        }
-        return acc;
-      },
-      []
+    const installationNames = uniq(
+      filteredScatterPlotValues.map((x) => x.rwzi_awzi_name)
     );
 
     const series: (

--- a/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
+++ b/packages/app/src/components/lineChart/hooks/useSewerWaterChartOptions.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
+import { colors } from '~/style/theme';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber } from '~/utils/formatNumber';
 import { getItemFromArray } from '~/utils/getItemFromArray';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
-import { colors } from '~/style/theme';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
 
 export interface SewerPerInstallationBaseValue {
@@ -113,47 +113,62 @@ export function useSewerWaterChartOptions<
       [text.secondary_label_text]: 'scatter',
     };
 
-    const scatterSerie: Highcharts.SeriesScatterOptions = {
-      type: 'scatter',
-      name: text.secondary_label_text,
-      description: text.secondary_label_text,
-      color: '#CDCDCD',
-      enableMouseTracking: selectedRWZI === undefined,
-      data: filteredScatterPlotValues?.map((value) => ({
-        x: value.date_unix,
-        y: value.rna_normalized,
-        installationName: value.rwzi_awzi_name,
-      })),
-      marker: {
-        symbol: 'circle',
-        radius: 3,
+    const installationNames = filteredScatterPlotValues.reduce<string[]>(
+      (acc, item) => {
+        if (acc.indexOf(item.rwzi_awzi_name) < 0) {
+          acc.push(item.rwzi_awzi_name);
+        }
+        return acc;
       },
-    };
+      []
+    );
 
     const series: (
       | Highcharts.SeriesLineOptions
       | Highcharts.SeriesScatterOptions
-    )[] = [scatterSerie];
+    )[] = [];
 
-    series.push({
-      type: 'line',
-      data: filteredAverageValues.map((x) => [x.date, x.value]),
-      name: text.average_label_text,
-      description: text.average_label_text,
-      showInLegend: true,
-      color: selectedRWZI ? '#A9A9A9' : colors.data.primary,
-      enableMouseTracking: selectedRWZI === undefined,
-      allowPointSelect: false,
-      marker: {
-        symbol: 'circle',
-        enabled: !hasMultipleValues,
-      },
-      states: {
-        inactive: {
-          opacity: 1,
+    if (installationNames.length > 1) {
+      const scatterSerie: Highcharts.SeriesScatterOptions = {
+        type: 'scatter',
+        name: text.secondary_label_text,
+        description: text.secondary_label_text,
+        color: '#CDCDCD',
+        enableMouseTracking: selectedRWZI === undefined,
+        data: filteredScatterPlotValues?.map((value) => ({
+          x: value.date_unix,
+          y: value.rna_normalized,
+          installationName: value.rwzi_awzi_name,
+        })),
+        marker: {
+          symbol: 'circle',
+          radius: 3,
         },
-      },
-    });
+      };
+      series.push(scatterSerie);
+    }
+
+    if (installationNames.length > 1) {
+      series.push({
+        type: 'line',
+        data: filteredAverageValues.map((x) => [x.date, x.value]),
+        name: text.average_label_text,
+        description: text.average_label_text,
+        showInLegend: true,
+        color: selectedRWZI ? '#A9A9A9' : colors.data.primary,
+        enableMouseTracking: selectedRWZI === undefined,
+        allowPointSelect: false,
+        marker: {
+          symbol: 'circle',
+          enabled: !hasMultipleValues,
+        },
+        states: {
+          inactive: {
+            opacity: 1,
+          },
+        },
+      });
+    }
 
     // If the max scatter plot date is higher than the averages, we want to draw
     // a dotted line for the missing days between the max scatter date
@@ -284,6 +299,8 @@ export function useSewerWaterChartOptions<
         borderRadius: 0,
         formatter: function (): false | string {
           const tooltipType = tooltipTypes[this.series.name];
+
+          console.log('nee');
 
           if (!tooltipType) {
             return false;

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -12,10 +12,10 @@ import { KpiValue } from '~/components-styled/kpi-value';
 import { Select } from '~/components-styled/select';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { SewerWaterChart } from '~/components/lineChart/sewer-water-chart';
 import { SEOHead } from '~/components/seoHead';
+import { FCWithLayout } from '~/domain/layout/layout';
+import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import siteText from '~/locale/index';
 import {
   getMunicipalityData,
@@ -66,7 +66,13 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
    * Only render a scatter plot when there's data coming from more than one
    * sewer station
    */
-  const enableScatterPlot = sewerStationNames.length > 1;
+  const enableScatterPlot = useMemo(() => {
+    if (sewerStationNames.length === 1) {
+      setSelectedInstallation(sewerStationNames[0]);
+    }
+
+    return sewerStationNames.length > 1;
+  }, [sewerStationNames]);
 
   return (
     <>

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -51,19 +51,15 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
 
   const sewerAverages = data.sewer;
 
-  const [selectedInstallation, setSelectedInstallation] = useState<string>();
+  const [selectedInstallation, setSelectedInstallation] = useState<
+    string | undefined
+  >(sewerStationNames.length === 1 ? sewerStationNames[0] : undefined);
 
   /**
    * Only render a scatter plot when there's data coming from more than one
    * sewer station
    */
-  const enableScatterPlot = useMemo(() => {
-    if (sewerStationNames.length === 1) {
-      setSelectedInstallation(sewerStationNames[0]);
-    }
-
-    return sewerStationNames.length > 1;
-  }, [sewerStationNames]);
+  const enableScatterPlot = sewerStationNames.length > 1;
 
   if (!sewerAverages) {
     /**

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -53,15 +53,6 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
 
   const [selectedInstallation, setSelectedInstallation] = useState<string>();
 
-  if (!sewerAverages) {
-    /**
-     * It is possible that there is no sewer data available for this GM. Then
-     * this page should never be linked because the sidebar item is then
-     * disabled.
-     */
-    return null;
-  }
-
   /**
    * Only render a scatter plot when there's data coming from more than one
    * sewer station
@@ -73,6 +64,15 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
 
     return sewerStationNames.length > 1;
   }, [sewerStationNames]);
+
+  if (!sewerAverages) {
+    /**
+     * It is possible that there is no sewer data available for this GM. Then
+     * this page should never be linked because the sidebar item is then
+     * disabled.
+     */
+    return null;
+  }
 
   return (
     <>

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -12,10 +12,10 @@ import { KpiValue } from '~/components-styled/kpi-value';
 import { Select } from '~/components-styled/select';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { SewerWaterChart } from '~/components/lineChart/sewer-water-chart';
 import { SEOHead } from '~/components/seoHead';
+import { FCWithLayout } from '~/domain/layout/layout';
+import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import siteText from '~/locale/index';
 import {
   getSafetyRegionPaths,
@@ -53,7 +53,7 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
 
   const [selectedInstallation, setSelectedInstallation] = useState<
     string | undefined
-  >();
+  >(sewerStationNames.length === 1 ? sewerStationNames[0] : undefined);
 
   return (
     <>


### PR DESCRIPTION
## Summary

As the title states, just show the line, skip the scatter plot if only one installation exists.

## Motivation

Change request

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
