### PR TITLE
Renamed difference indicator text to make it more clear

### DIFF
--- a/packages/app/src/components-styled/difference-indicator.tsx
+++ b/packages/app/src/components-styled/difference-indicator.tsx
@@ -185,14 +185,14 @@ function getTimespanText(oldDate: number) {
   }
 
   if (days < 7) {
-    return `${days} ${text.tijdverloop.dagen} ${text.tijdverloop.geleden}`;
+    return `${days} ${text.tijdverloop.dagen} ${text.tijdverloop.ervoor}`;
   }
 
   const weeks = Math.floor(days / 7);
 
   if (weeks < 2) {
-    return `${weeks} ${text.tijdverloop.week.enkelvoud} ${text.tijdverloop.geleden}`;
+    return `${weeks} ${text.tijdverloop.week.enkelvoud} ${text.tijdverloop.ervoor}`;
   }
 
-  return `${weeks} ${text.tijdverloop.week.meervoud} ${text.tijdverloop.geleden}`;
+  return `${weeks} ${text.tijdverloop.week.meervoud} ${text.tijdverloop.ervoor}`;
 }

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1376,7 +1376,8 @@
         "enkelvoud": "week",
         "meervoud": "weeks"
       },
-      "hiervoor": "before"
+      "vorige_week": "last week",
+      "ervoor": "before"
     }
   },
   "aria_labels": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1368,6 +1368,7 @@
     "toename": "meer dan",
     "afname": "minder dan",
     "gelijk": "gelijk aan",
+    "ervoor": "ervoor",
     "tijdverloop": {
       "gisteren": "gisteren",
       "geleden": "geleden",
@@ -1376,7 +1377,8 @@
         "enkelvoud": "week",
         "meervoud": "weken"
       },
-      "hiervoor": "hiervoor"
+      "vorige_week": "vorige week",
+      "ervoor": "ervoor"
     }
   },
   "aria_labels": {

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -309,7 +309,7 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
               absolute={dataGgdAverageLastValue.tested_total}
               difference={data.difference.tested_ggd_average__tested_total}
               differenceStaticTimespan={
-                siteText.toe_en_afname.tijdverloop.hiervoor
+                siteText.toe_en_afname.tijdverloop.vorige_week
               }
             />
             <Text>{ggdText.totaal_getest_week_uitleg}</Text>
@@ -331,7 +331,7 @@ const PositivelyTestedPeople: FCWithLayout<NationalPageProps> = ({
                 data.difference.tested_ggd_average__infected_percentage
               }
               differenceStaticTimespan={
-                siteText.toe_en_afname.tijdverloop.hiervoor
+                siteText.toe_en_afname.tijdverloop.vorige_week
               }
             />
             <Text>{ggdText.positief_getest_week_uitleg}</Text>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -68,7 +68,7 @@ const ReproductionIndex: FCWithLayout<NationalPageProps> = (props) => {
               localeTextKey="reproductiegetal"
               differenceKey="reproduction__index_average"
               differenceStaticTimespan={
-                siteText.toe_en_afname.tijdverloop.hiervoor
+                siteText.toe_en_afname.tijdverloop.vorige_week
               }
             />
             <Text>{text.barscale_toelichting}</Text>


### PR DESCRIPTION
Renamed the difference indicator text to make it more clear for the user.
So "3 dagen geleden" becomes "3 dagen ervoor" as example.