### PR TITLE
Add schema for vaccine availability graph

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -26,7 +26,8 @@
     "tested_ggd_daily",
     "tested_ggd_average",
     "tested_overall",
-    "tested_per_age_group"
+    "tested_per_age_group",
+    "vaccine_availability"
   ],
   "additionalProperties": false,
   "properties": {
@@ -104,6 +105,9 @@
     },
     "elderly_at_home": {
       "$ref": "elderly_at_home.json"
+    },
+    "vaccine_availability": {
+      "$ref": "vaccine_availability.json"
     }
   }
 }

--- a/packages/app/schema/nl/vaccine_availability.json
+++ b/packages/app/schema/nl/vaccine_availability.json
@@ -1,0 +1,65 @@
+{
+  "definitions": {
+    "value": {
+      "title": "nl_vaccine_availability_value",
+      "type": "object",
+      "required": [
+        "pfizer",
+        "moderna",
+        "astra_zeneca",
+        "cure_vac",
+        "janssen",
+        "sanofi",
+        "date_of_insertion_unix",
+        "total_installation_count",
+        "date_unix"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "pfizer": {
+          "type": "number"
+        },
+        "moderna": {
+          "type": "number"
+        },
+        "astra_zeneca": {
+          "type": "number"
+        },
+        "cure_vac": {
+          "type": "number"
+        },
+        "janssen": {
+          "type": "number"
+        },
+        "sanofi": {
+          "type": "number"
+        },
+        "total": {
+          "type": "number"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        },
+        "date_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_vaccine_availability",
+  "type": "object",
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  }
+}

--- a/packages/app/schema/nl/vaccine_availability.json
+++ b/packages/app/schema/nl/vaccine_availability.json
@@ -11,7 +11,6 @@
         "janssen",
         "sanofi",
         "date_of_insertion_unix",
-        "total_installation_count",
         "date_unix"
       ],
       "additionalProperties": false,
@@ -32,9 +31,6 @@
           "type": "number"
         },
         "sanofi": {
-          "type": "number"
-        },
-        "total": {
           "type": "number"
         },
         "date_of_insertion_unix": {

--- a/packages/app/src/types/data.d.ts
+++ b/packages/app/src/types/data.d.ts
@@ -125,6 +125,7 @@ export interface National {
   deceased_rivm: NationalDeceasedRivm;
   deceased_cbs: NationalDeceasedCbs;
   elderly_at_home: NationalElderlyAtHome;
+  vaccine_availability: NlVaccineAvailability;
 }
 export interface NationalDifference {
   tested_overall__infected_per_100k: DifferenceDecimal;
@@ -420,6 +421,20 @@ export interface NationalElderlyAtHomeValue {
   deceased_daily: number;
   date_unix: number;
   date_of_insertion_unix: number;
+}
+export interface NlVaccineAvailability {
+  values: NlVaccineAvailabilityValue[];
+  last_value: NlVaccineAvailabilityValue;
+}
+export interface NlVaccineAvailabilityValue {
+  pfizer: number;
+  moderna: number;
+  astra_zeneca: number;
+  cure_vac: number;
+  janssen: number;
+  sanofi: number;
+  date_of_insertion_unix: number;
+  date_unix: number;
 }
 
 export interface Regionaal {


### PR DESCRIPTION
## Summary

This adds a schema for the vaccine availability chart. It assumes a few things:

- The data_unix timestamp will be set to the first day of the quarter
- Total availability per vaccine type will be calculated by FE based on values from all samples combined
- If there is no availability of a certain vaccine the value will be set to 0 (to avoid having to use null)