### PR TITLE
Define schema for deceased per age group

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -99,6 +99,9 @@
     "deceased_rivm": {
       "$ref": "deceased_rivm.json"
     },
+    "deceased_rivm_per_age_group": {
+      "$ref": "deceased_rivm_per_age_group.json"
+    },
     "deceased_cbs": {
       "$ref": "deceased_cbs.json"
     },

--- a/packages/app/schema/nl/deceased_rivm_per_age_group.json
+++ b/packages/app/schema/nl/deceased_rivm_per_age_group.json
@@ -21,8 +21,6 @@
         "age_group_range",
         "age_group_percentage",
         "covid_percentage",
-        "date_start_unix",
-        "date_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
@@ -34,12 +32,6 @@
         },
         "covid_percentage": {
           "type": "number"
-        },
-        "date_start_unix": {
-          "type": "integer"
-        },
-        "date_end_unix": {
-          "type": "integer"
         },
         "date_of_insertion_unix": {
           "type": "integer"

--- a/packages/app/schema/nl/deceased_rivm_per_age_group.json
+++ b/packages/app/schema/nl/deceased_rivm_per_age_group.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_deceased_rivm_per_age_group",
+  "type": "object",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "nl_deceased_rivm_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "age_group_range",
+        "age_group_percentage",
+        "covid_percentage",
+        "date_start_unix",
+        "date_end_unix",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "age_group_range": {
+          "type": "string"
+        },
+        "age_group_percentage": {
+          "type": "number"
+        },
+        "covid_percentage": {
+          "type": "number"
+        },
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/src/types/data.d.ts
+++ b/packages/app/src/types/data.d.ts
@@ -405,8 +405,6 @@ export interface NlDeceasedRivmPerAgeGroupValue {
   age_group_range: string;
   age_group_percentage: number;
   covid_percentage: number;
-  date_start_unix: number;
-  date_end_unix: number;
   date_of_insertion_unix: number;
 }
 export interface NationalDeceasedCbs {

--- a/packages/app/src/types/data.d.ts
+++ b/packages/app/src/types/data.d.ts
@@ -123,6 +123,7 @@ export interface National {
   restrictions: NationalRestrictions;
   behavior: NationalBehavior;
   deceased_rivm: NationalDeceasedRivm;
+  deceased_rivm_per_age_group?: NlDeceasedRivmPerAgeGroup;
   deceased_cbs: NationalDeceasedCbs;
   elderly_at_home: NationalElderlyAtHome;
 }
@@ -395,6 +396,17 @@ export interface NationalDeceasedRivmValue {
   covid_daily: number;
   covid_total: number;
   date_unix: number;
+  date_of_insertion_unix: number;
+}
+export interface NlDeceasedRivmPerAgeGroup {
+  values: NlDeceasedRivmPerAgeGroupValue[];
+}
+export interface NlDeceasedRivmPerAgeGroupValue {
+  age_group_range: string;
+  age_group_percentage: number;
+  covid_percentage: number;
+  date_start_unix: number;
+  date_end_unix: number;
   date_of_insertion_unix: number;
 }
 export interface NationalDeceasedCbs {


### PR DESCRIPTION
## Summary

Define schema to display RIVM deceased data over the last period per age group. It differs a little from tested per age group, since here I've used date_start/end timestamps to indicate the exact period over which the data is displayed.