### PR TITLE
Set graph time periods by default to all

### DIFF
--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -39,7 +39,7 @@ export function ChartTileWithTimeframe({
   description,
   metadata,
   timeframeOptions = ['all', '5weeks', 'week'],
-  timeframeInitialValue = '5weeks',
+  timeframeInitialValue = 'all',
   children,
 }: ChartTileWithTimeframeProps) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>(

--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -19,7 +19,7 @@ export function LineChartTile<T extends Value>({
   title,
   description,
   timeframeOptions = ['all', '5weeks', 'week'],
-  timeframeInitialValue = '5weeks',
+  timeframeInitialValue = 'all',
   footer,
   ...chartProps
 }: LineChartTileProps<T>) {

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -145,7 +145,6 @@ const SewerWater: FCWithLayout<IMunicipalityData> = (props) => {
             title={text.linechart_titel}
             metadata={{ source: text.bronnen.rivm }}
             timeframeOptions={['all', '5weeks']}
-            timeframeInitialValue="all"
           >
             {(timeframe) => (
               <>

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -111,7 +111,6 @@ const IntakeHospital: FCWithLayout<IMunicipalityData> = (props) => {
             description={text.linechart_description}
             metadata={{ source: text.bronnen.rivm }}
             timeframeOptions={['all', '5weeks', 'week']}
-            timeframeInitialValue="5weeks"
             values={data.hospital_nice.values}
             linesConfig={[
               {

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -72,7 +72,6 @@ const InfectiousPeople: FCWithLayout<NationalPageProps> = (props) => {
           metadata={{ source: text.bronnen.rivm }}
           title={text.linechart_titel}
           timeframeOptions={['all', '5weeks']}
-          timeframeInitialValue="5weeks"
         >
           {(timeframe) => (
             <>

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -79,7 +79,6 @@ const DeceasedNationalPage: FCWithLayout<NationalPageProps> = (props) => {
 
         <LineChartTile
           timeframeOptions={['all', '5weeks']}
-          timeframeInitialValue="all"
           title={text.section_deceased_rivm.line_chart_covid_daily_title}
           description={
             text.section_deceased_rivm.line_chart_covid_daily_description

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -131,7 +131,6 @@ const SewerWater: FCWithLayout<ISafetyRegionData> = (props) => {
             title={text.linechart_titel}
             metadata={{ source: text.bronnen.rivm }}
             timeframeOptions={['all', '5weeks']}
-            timeframeInitialValue="all"
           >
             {(timeframe) => (
               <>

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -87,7 +87,6 @@ const DeceasedRegionalPage: FCWithLayout<ISafetyRegionData> = (props) => {
 
         <LineChartTile
           timeframeOptions={['all', '5weeks']}
-          timeframeInitialValue="all"
           title={text.section_deceased_rivm.line_chart_covid_daily_title}
           description={
             text.section_deceased_rivm.line_chart_covid_daily_description


### PR DESCRIPTION
Last merge two `timeframeInitialValue` was still set to '5 weeks' that is now changed.
Also removed `timeframeInitialValue` on graphs that were already set to 'all' since it is now the default.