### PR TITLE
Make sidebar clickable again with skipLinkAnchor issue

### DIFF
--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -19,6 +19,10 @@ import { Box } from '../base';
 /*
   the left margin '-100w' and left padding '100w' hack ensures skip link anchors to have a (non visible) start at the left side of the screen.
   This fixes odd skip-link behavior in IE11
+
+  Since this hack makes the part of the sidebar unclickable because the padding is overlapping it.
+  This is fixed by first setting a pointer even none to the HeaderBox element if there is a skip-link and create 
+  a new child element with the PointerEventBox that resets the pointer-events again so it works as expected.
 */
 const HeaderBox = styled.header<{
   hasIcon: boolean;
@@ -84,7 +88,7 @@ const AriaInlineText = styled(InlineText)(
   })
 );
 
-const ReferenceBox = styled(Box)(
+const ReferenceBox = styled.div(
   css({
     maxWidth: '30em',
     marginRight: 3,

--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -28,7 +28,7 @@ const HeaderBox = styled.header<{
     mt: 0,
     ml: x.skipLinkAnchor ? '-100vw' : x.hasIcon ? undefined : 5,
     pl: x.skipLinkAnchor ? '100vw' : undefined,
-    pointerEvents: 'none',
+    pointerEvents: x.skipLinkAnchor ? 'none' : 'auto',
   })
 );
 

--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -28,6 +28,7 @@ const HeaderBox = styled.header<{
     mt: 0,
     ml: x.skipLinkAnchor ? '-100vw' : x.hasIcon ? undefined : 5,
     pl: x.skipLinkAnchor ? '100vw' : undefined,
+    pointerEvents: 'none',
   })
 );
 
@@ -42,7 +43,11 @@ const Header = (props: HeaderProps) => {
   const { hasIcon, children, skipLinkAnchor, id } = props;
   return (
     <HeaderBox id={id} hasIcon={hasIcon} skipLinkAnchor={skipLinkAnchor}>
-      {children}
+      {skipLinkAnchor ? (
+        <PointerEventsBox>{children}</PointerEventsBox>
+      ) : (
+        children
+      )}
     </HeaderBox>
   );
 };
@@ -83,13 +88,19 @@ const ReferenceBox = styled(Box)(
   css({
     maxWidth: '30em',
     marginRight: 3,
-    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 60%' })
+    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 60%' }),
   })
 );
 
 const MetadataBox = styled(Box)(
   css({
-    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 40%' })
+    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 40%' }),
+  })
+);
+
+const PointerEventsBox = styled(Box)(
+  css({
+    pointerEvents: 'auto',
   })
 );
 


### PR DESCRIPTION
So since there are `skipLinkAnchor` properties and recent changes that increased the z-index from the main content.
There was an issue created with the IE11 fix `margin-left: -100vw; padding-left: 100vw;` on `skipLinkAnchor` elements, you couldn't click the sidebar anymore on that specific place.

## Current fix

First set on the `skipLinkAnchor` element the `pointer-events` attribute to none where the positioning is done, and then add an additional element that resets the pointer-events back to default.

Tested it on IE11 and everything works as expected.
The only drawback is that you can't select the element directly in your inspector anymore