### PR TITLE
Set hospital line charts to use date of admission

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -127,7 +127,7 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
             values={data.hospital_nice.values}
             linesConfig={[
               {
-                metricProperty: 'admissions_on_date_of_reporting',
+                metricProperty: 'admissions_on_date_of_admission',
               },
             ]}
           />

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -162,7 +162,7 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           signaalwaarde={40}
           linesConfig={[
             {
-              metricProperty: 'admissions_on_date_of_reporting',
+              metricProperty: 'admissions_on_date_of_admission',
             },
           ]}
           metadata={{

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -131,7 +131,7 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
             values={data.hospital_nice.values}
             linesConfig={[
               {
-                metricProperty: 'admissions_on_date_of_reporting',
+                metricProperty: 'admissions_on_date_of_admission',
               },
             ]}
           />


### PR DESCRIPTION
## Summary

Hospital line charts should show data for admissions on date of admission and not reporting