### PR TITLE
Add escalation level explanations tile

### DIFF
--- a/packages/app/src/components-styled/collapsible.tsx
+++ b/packages/app/src/components-styled/collapsible.tsx
@@ -3,11 +3,10 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from '@reach/disclosure';
-import { ReactNode, useState, useEffect, useCallback, useRef } from 'react';
-
-import { BoxProps, Box } from './base';
-import styled from 'styled-components';
 import { css } from '@styled-system/css';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { Box, BoxProps } from './base';
 
 const Summary = styled(DisclosureButton)(
   css({
@@ -95,9 +94,15 @@ interface CollapsableProps extends BoxProps {
   summary: string;
   children: ReactNode;
   id?: string;
+  hideBorder?: boolean;
 }
 
-export const Collapsible = ({ summary, children, id }: CollapsableProps) => {
+export const Collapsible = ({
+  summary,
+  children,
+  id,
+  hideBorder,
+}: CollapsableProps) => {
   const [open, setOpen] = useState(false);
   const [panelHeight, setPanelHeight] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -169,13 +174,20 @@ export const Collapsible = ({ summary, children, id }: CollapsableProps) => {
   }, [checkLocationHash]);
 
   return (
-    <Box as="section" borderTop="1px solid" borderTopColor="lightGray" id={id}>
+    <Box
+      as="section"
+      borderTop={hideBorder ? undefined : '1px solid'}
+      borderTopColor={hideBorder ? undefined : 'lightGray'}
+      id={id}
+    >
       <Disclosure open={open} onChange={toggle}>
         <Summary>
           {summary}
-          <AnchorLink onClick={(e) => e.stopPropagation()} href={`#${id}`}>
-            #
-          </AnchorLink>
+          {id && (
+            <AnchorLink onClick={(e) => e.stopPropagation()} href={`#${id}`}>
+              #
+            </AnchorLink>
+          )}
         </Summary>
         <Panel
           ref={panelReference}

--- a/packages/app/src/components-styled/escalation-level.tsx
+++ b/packages/app/src/components-styled/escalation-level.tsx
@@ -6,21 +6,13 @@ import siteText from '~/locale/index';
 
 export type EscalationLevelProps = {
   escalationLevel: EscalationLevel;
-  width?: string;
 };
 
 export function EscalationLevelInfoLabel(props: EscalationLevelProps) {
-  const { escalationLevel, width } = props;
+  const { escalationLevel } = props;
 
   return (
-    <Box
-      display="flex"
-      width={width}
-      alignItems="center"
-      justifyContent="flex-start"
-      flexGrow={0}
-      flexShrink={0}
-    >
+    <Box display="flex" alignItems="center" justifyContent="flex-start">
       <EscalationLevelIcon level={escalationLevel} />
       <Text as="span" ml={2} fontWeight="bold">
         {siteText.escalatie_niveau.types[escalationLevel].titel}

--- a/packages/app/src/components-styled/escalation-level.tsx
+++ b/packages/app/src/components-styled/escalation-level.tsx
@@ -3,24 +3,29 @@ import { EscalationLevelIcon } from '~/components-styled/escalation-level-icon';
 import { Text } from '~/components-styled/typography';
 import { EscalationLevel } from '~/components/restrictions/type';
 import siteText from '~/locale/index';
-import { useEscalationColor } from '~/utils/use-escalation-color';
 
 export type EscalationLevelProps = {
   escalationLevel: EscalationLevel;
+  width?: string;
 };
 
 export function EscalationLevelInfoLabel(props: EscalationLevelProps) {
-  const { escalationLevel } = props;
-
-  const color = useEscalationColor(escalationLevel);
+  const { escalationLevel, width } = props;
 
   return (
-    <>
+    <Box
+      display="flex"
+      width={width}
+      alignItems="center"
+      justifyContent="flex-start"
+      flexGrow={0}
+      flexShrink={0}
+    >
       <EscalationLevelIcon level={escalationLevel} />
-      <Text as="span" marginLeft=".5em" color={color} fontWeight="bold">
+      <Text as="span" ml={2} fontWeight="bold">
         {siteText.escalatie_niveau.types[escalationLevel].titel}
       </Text>
-    </>
+    </Box>
   );
 }
 

--- a/packages/app/src/domain/topical/escalation-level-explanations-tile.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations-tile.tsx
@@ -1,0 +1,59 @@
+import Chevron from '~/assets/chevron.svg';
+import { Box } from '~/components-styled/base';
+import { Collapsible } from '~/components-styled/collapsible';
+import { EscalationLevelInfoLabel } from '~/components-styled/escalation-level';
+import { Tile } from '~/components-styled/tile';
+import { Text } from '~/components-styled/typography';
+import { EscalationLevel } from '~/components/restrictions/type';
+import siteText from '~/locale';
+import { Link } from '~/utils/link';
+
+type EscalationLevelExplanationProps = {
+  level: EscalationLevel;
+  explanation: string;
+};
+
+function EscalationLevelExplanation(props: EscalationLevelExplanationProps) {
+  const { level, explanation } = props;
+  return (
+    <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
+      <EscalationLevelInfoLabel escalationLevel={level} width="10rem" />
+      <Text>{explanation}</Text>
+    </Box>
+  );
+}
+
+export function EscalationLevelExplanationsTile() {
+  return (
+    <Tile>
+      <Collapsible summary={siteText.escalatie_niveau.tile_title} hideBorder>
+        <Box my={3}>
+          <EscalationLevelExplanation
+            level={1}
+            explanation={siteText.escalatie_niveau.types['1'].toelichting}
+          />
+          <EscalationLevelExplanation
+            level={2}
+            explanation={siteText.escalatie_niveau.types['2'].toelichting}
+          />
+          <EscalationLevelExplanation
+            level={3}
+            explanation={siteText.escalatie_niveau.types['3'].toelichting}
+          />
+          <EscalationLevelExplanation
+            level={4}
+            explanation={siteText.escalatie_niveau.types['4'].toelichting}
+          />
+          <Box mt={4}>
+            <Link href="/over-risiconiveaus">
+              <a>
+                {siteText.escalatie_niveau.lees_meer}{' '}
+                <Chevron width="14px" height="14px" />
+              </a>
+            </Link>
+          </Box>
+        </Box>
+      </Collapsible>
+    </Tile>
+  );
+}

--- a/packages/app/src/domain/topical/escalation-level-explanations-tile.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations-tile.tsx
@@ -17,7 +17,9 @@ function EscalationLevelExplanation(props: EscalationLevelExplanationProps) {
   const { level, explanation } = props;
   return (
     <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
-      <EscalationLevelInfoLabel escalationLevel={level} width="10rem" />
+      <Box width="10rem" display="flex" flexGrow={0} flexShrink={0}>
+        <EscalationLevelInfoLabel escalationLevel={level} />
+      </Box>
       <Text>{explanation}</Text>
     </Box>
   );

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1051,6 +1051,8 @@
   },
   "escalatie_niveau": {
     "titel": "Level of risk",
+    "tile_title": "",
+    "lees_meer": "",
     "toelichting": "The map indicates the level of risk per safety region.\n\n[More about risk levels](/over-risiconiveaus)",
     "types": {
       "1": {
@@ -1077,7 +1079,7 @@
     "legenda": {
       "titel": "Legend",
       "geen_regio": "geen regio's",
-      "regios": "{{amount}} regio's"  
+      "regios": "{{amount}} regio's"
     },
     "valid_from": "Valid from {{validFrom}}",
     "sidebar_label": "Level of risk:"
@@ -2010,7 +2012,7 @@
   "common.tooltip.positive_tested_value": "",
   "search": {
     "placeholder": "Find a municipality or safery region",
-    "clear":"Clear search",
+    "clear": "Clear search",
     "no_hits": "No {{subject}} found with “{{search}}”"
   },
 

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1051,23 +1051,25 @@
   },
   "escalatie_niveau": {
     "titel": "Risiconiveaus",
+    "tile_title": "Wat betekenen de vier risiconiveau's?",
+    "lees_meer": "Meer informatie over risiconiveau's",
     "toelichting": "De kaart geeft het risiconiveau per veiligheidsregio weer.\n\n[Meer over de risiconiveaus](/over-risiconiveaus)",
     "types": {
       "1": {
         "titel": "Waakzaam",
-        "toelichting": ""
+        "toelichting": "De situatie is beheersbaar en het aantal nieuwe besmettingen is laag. Kwetsbare groepen dienen alert te zijn en er is voldoende zorgcapaciteit."
       },
       "2": {
         "titel": "Zorgelijk",
-        "toelichting": ""
+        "toelichting": "Het aantal nieuwe besmettingen en de druk op de zorgcapaciteit neemt toe. Aanvullende maatregelen zijn nodig om de verspreiding van het virus weer onder controle te krijgen."
       },
       "3": {
         "titel": "Ernstig",
-        "toelichting": ""
+        "toelichting": "Het aantal nieuwe besmettingen neemt snel toe en de zorgcapaciteit is onvoldoende. Hard ingrijpen is noodzakelijk om de kwetsbaren te beschermen."
       },
       "4": {
         "titel": "Zeer Ernstig",
-        "toelichting": ""
+        "toelichting": "Er zijn zeer veel mensen besmettelijk, het dagelijks aantal nieuwe besmettingen is hoog en de regionale zorgcapaciteit is onvoldoende. Strenge, landelijke maatregelen zijn noodzakelijk om verdere escalatie te voorkomen."
       },
       "5": {
         "titel": "Lockdown",
@@ -1077,7 +1079,7 @@
     "legenda": {
       "titel": "Legenda",
       "geen_regio": "geen regio's",
-      "regios": "{{amount}} regio's"  
+      "regios": "{{amount}} regio's"
     },
     "valid_from": "Geldig vanaf {{validFrom}}",
     "sidebar_label": "Risiconiveau:"

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -16,6 +16,7 @@ import { escalationTooltip } from '~/components/choropleth/tooltips/region/escal
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
 import { Search } from '~/domain/topical/components/search';
 import { DataSitemap } from '~/domain/topical/data-site-map';
+import { EscalationLevelExplanationsTile } from '~/domain/topical/escalation-level-explanations-tile';
 import { MiniTrendTile } from '~/domain/topical/mini-trend-tile';
 import { MiniTrendTileLayout } from '~/domain/topical/mini-trend-tile-layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -167,6 +168,8 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
             )}
           />
         </ChoroplethTile>
+
+        <EscalationLevelExplanationsTile />
 
         <NewsMessage
           imageSrc="images/toelichting-afbeelding.png"


### PR DESCRIPTION
## Summary

This PR adds a tile to the actueel page that displays a collapsable box with explanations for the various risk/escalation levels.
![image](https://user-images.githubusercontent.com/69849293/104312219-9b4a3b80-54d6-11eb-9868-1f79b477908f.png)

## Motivation

Feature request

## Detailed design

Mostly just a layout implementation, nothing too thrilling.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
