### PR TITLE
Reduce amount of ticks on age demographic graph on smaller screens

### DIFF
--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
@@ -11,7 +11,6 @@ import { colors } from '~/style/theme';
 import { NationalTestedPerAgeGroupValue } from '~/types/data.d';
 import { formatPercentage } from '~/utils/formatNumber';
 import { AgeDemographicCoordinates } from './age-demographic-coordinates';
-import { useBreakpoints } from '~/utils/useBreakpoints';
 export const AGE_GROUP_TOOLTIP_WIDTH = 340;
 
 const text = siteText.infected_age_groups;
@@ -63,9 +62,6 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
       values,
       ageGroupRange,
     } = coordinates;
-
-    const { xs } = useBreakpoints();
-    const numTicksOnBreakpoint = xs ? numTicks : 2;
 
     return (
       <svg
@@ -178,7 +174,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           scale={ageGroupPercentageScale}
           left={margin.left}
           top={height - margin.bottom}
-          numTicks={numTicksOnBreakpoint}
+          numTicks={numTicks}
           hideTicks={true}
           hideAxisLine={true}
           tickFormat={(a) => `${formatPercentage(a as number)}%`}
@@ -189,7 +185,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           scale={infectedPercentageScale}
           left={width / 2 + ageRangeAxisWidth / 2}
           top={height - margin.bottom}
-          numTicks={numTicksOnBreakpoint}
+          numTicks={numTicks}
           hideTicks={true}
           hideAxisLine={true}
           tickFormat={(a) => `${formatPercentage(a as number)}%`}

--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
@@ -11,7 +11,7 @@ import { colors } from '~/style/theme';
 import { NationalTestedPerAgeGroupValue } from '~/types/data.d';
 import { formatPercentage } from '~/utils/formatNumber';
 import { AgeDemographicCoordinates } from './age-demographic-coordinates';
-
+import { useBreakpoints } from '~/utils/useBreakpoints';
 export const AGE_GROUP_TOOLTIP_WIDTH = 340;
 
 const text = siteText.infected_age_groups;
@@ -63,6 +63,9 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
       values,
       ageGroupRange,
     } = coordinates;
+
+    const breakpoints = useBreakpoints();
+    const numTicksOnBreakpoint = breakpoints.xs ? numTicks : 2;
 
     return (
       <svg
@@ -175,7 +178,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           scale={ageGroupPercentageScale}
           left={margin.left}
           top={height - margin.bottom}
-          numTicks={numTicks}
+          numTicks={numTicksOnBreakpoint}
           hideTicks={true}
           hideAxisLine={true}
           tickFormat={(a) => `${formatPercentage(a as number)}%`}
@@ -186,7 +189,7 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
           scale={infectedPercentageScale}
           left={width / 2 + ageRangeAxisWidth / 2}
           top={height - margin.bottom}
-          numTicks={numTicks}
+          numTicks={numTicksOnBreakpoint}
           hideTicks={true}
           hideAxisLine={true}
           tickFormat={(a) => `${formatPercentage(a as number)}%`}

--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic-chart.tsx
@@ -64,8 +64,8 @@ export const AgeDemographicChart = memo<AgeDemographicChartProps>(
       ageGroupRange,
     } = coordinates;
 
-    const breakpoints = useBreakpoints();
-    const numTicksOnBreakpoint = breakpoints.xs ? numTicks : 2;
+    const { xs } = useBreakpoints();
+    const numTicksOnBreakpoint = xs ? numTicks : 2;
 
     return (
       <svg

--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic-coordinates.ts
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic-coordinates.ts
@@ -40,17 +40,24 @@ export interface AgeDemographicCoordinates {
 export function useAgeDemographicCoordinates(
   data: NationalTestedPerAgeGroup,
   isSmallScreen: boolean,
-  parentWidth: number
+  parentWidth: number,
+  isExtraSmallScreen: boolean
 ) {
   return useMemo(() => {
-    return calculateAgeDemographicCoordinates(data, isSmallScreen, parentWidth);
-  }, [data, isSmallScreen, parentWidth]);
+    return calculateAgeDemographicCoordinates(
+      data,
+      isSmallScreen,
+      parentWidth,
+      isExtraSmallScreen
+    );
+  }, [data, isSmallScreen, parentWidth, isExtraSmallScreen]);
 }
 
 function calculateAgeDemographicCoordinates(
   data: NationalTestedPerAgeGroup,
   isSmallScreen: boolean,
-  parentWidth: number
+  parentWidth: number,
+  isExtraSmallScreen: boolean
 ): AgeDemographicCoordinates {
   const values = data.values.sort((a, b) => {
     return b.age_group_range.localeCompare(a.age_group_range);
@@ -71,7 +78,7 @@ function calculateAgeDemographicCoordinates(
     right: marginX,
   };
 
-  const numTicks = isSmallScreen ? 3 : 4;
+  const numTicks = isSmallScreen ? (isExtraSmallScreen ? 3 : 2) : 4;
 
   // Bounds of the graph
   const xMax = (width - margin.left - margin.right - ageRangeAxisWidth) / 2;

--- a/packages/app/src/domain/infected-people/age-demographic/age-demographic.tsx
+++ b/packages/app/src/domain/infected-people/age-demographic/age-demographic.tsx
@@ -19,14 +19,16 @@ interface AgeDemographicProps {
 
 export function AgeDemographic({ data }: AgeDemographicProps) {
   const [sizeRef, size] = useElementSize<HTMLDivElement>(400);
-  const breakpoints = useBreakpoints();
-  const isSmallScreen = !breakpoints.xl;
+  const { xs, xl } = useBreakpoints();
+  const isSmallScreen = !xl;
+  const isExtraSmallScreen = xs;
 
   // Calculate graph's coordinates based on the data, the component width and wheher we are on a small screen or not.
   const coordinates = useAgeDemographicCoordinates(
     data,
     isSmallScreen,
-    size.width
+    size.width,
+    isExtraSmallScreen
   );
 
   // Generate tooltip event handlers and state based on values and tooltip coordinates callback


### PR DESCRIPTION
Reduce the amount of ticks on age demographic graph on smaller screens, when it is below breakpoint XS it is capped to 2 each axes.