### PR TITLE
Fix several styling issues

### DIFF
--- a/packages/app/src/components-styled/typography/heading.tsx
+++ b/packages/app/src/components-styled/typography/heading.tsx
@@ -1,9 +1,9 @@
+import css from '@styled-system/css';
 import React from 'react';
 import styled from 'styled-components';
 import {
   color,
   ColorProps,
-  compose,
   margin,
   MarginProps,
   padding,
@@ -48,55 +48,39 @@ type StyledHeadingProps = MarginProps &
   TypographyProps &
   ColorProps;
 
-const composedStyles = compose(margin, padding, typography, color);
+const composedStyles = [
+  css({
+    fontFamily: 'body',
+    lineHeight: 2,
+    mt: 0,
+  }),
+  margin,
+  padding,
+  typography,
+  color,
+];
 
-const Heading1 = styled.h1<StyledHeadingProps>(composedStyles);
+const Heading1 = styled.h1<StyledHeadingProps>(
+  css({ fontSize: 5, mb: 4 }),
+  ...composedStyles
+);
 
-Heading1.defaultProps = {
-  fontFamily: 'body',
-  fontSize: 5,
-  lineHeight: 2,
-  color: 'body',
-  mt: 0,
-  mb: 4,
-};
+const Heading2 = styled.h2<StyledHeadingProps>(
+  css({ fontSize: 4, mb: 3 }),
+  ...composedStyles
+);
 
-const Heading2 = styled.h2<StyledHeadingProps>(composedStyles);
+const Heading3 = styled.h3<StyledHeadingProps>(
+  css({ fontSize: 3, mb: 3 }),
+  ...composedStyles
+);
 
-Heading2.defaultProps = {
-  fontFamily: 'body',
-  fontSize: 4,
-  lineHeight: 2,
-  mt: 0,
-  mb: 3,
-};
+const Heading4 = styled.h4<StyledHeadingProps>(
+  css({ fontSize: 2, mb: 3 }),
+  ...composedStyles
+);
 
-const Heading3 = styled.h3<StyledHeadingProps>(composedStyles);
-
-Heading3.defaultProps = {
-  fontFamily: 'body',
-  fontSize: 3,
-  lineHeight: 2,
-  mt: 0,
-  mb: 3,
-};
-
-const Heading4 = styled.h4<StyledHeadingProps>(composedStyles);
-
-Heading4.defaultProps = {
-  fontFamily: 'body',
-  fontSize: 2,
-  lineHeight: 2,
-  mt: 0,
-  mb: 3,
-};
-
-const Heading5 = styled.h5<StyledHeadingProps>(composedStyles);
-
-Heading5.defaultProps = {
-  fontFamily: 'body',
-  fontSize: 1,
-  lineHeight: 2,
-  mt: 0,
-  mb: 3,
-};
+const Heading5 = styled.h5<StyledHeadingProps>(
+  css({ fontSize: 1, mb: 3 }),
+  ...composedStyles
+);

--- a/packages/app/src/style/global-style.tsx
+++ b/packages/app/src/style/global-style.tsx
@@ -66,7 +66,7 @@ html {
 */
  body {
   font-family: 'RO Sans', Calibri, sans-serif;
-  color: $text-color;
+  color: ${(x) => x.theme.colors.body};
   font-style: normal;
   font-weight: normal;
   font-size: ${(x) => x.theme.fontSizes[2]} ;

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -82,6 +82,7 @@ const mediaQueries = {
 } as const;
 
 export const colors = {
+  body: '#000000',
   page: '#f3f3f3',
   blue: '#01689b',
   icon: '#01689b',


### PR DESCRIPTION
## Summary

This PR fixes a bug with the headings where certain styled-system props were not correctly applied to the component.

The issue was caused by configuring `defaultProps` on the Heading components. A defaultProp with `mb: 3` could live together with its passed synonym `marginBottom={6}`. One of them would eventually "win", which in my specific case was the default prop. A fix would be to _not_ set `marginBottom` on the props, instead use the `mb` variant, but that wouldn't really fix the actual problem.

The fix is to set default styles with "plain css" (using styled system's css-utility) and overwrite those styles with incoming props. Styled components will figure out which styles override other styles.


