### PR TITLE
Allow the Search component to have an initial value

### DIFF
--- a/packages/app/src/domain/topical/components/search/context.tsx
+++ b/packages/app/src/domain/topical/components/search/context.tsx
@@ -75,7 +75,7 @@ function useSearchContextValue<T extends Element>(
   /**
    * By default narrow devices will show search-results when the input field
    * has a value. We don't want to show these results when the value is
-   * preset/prepolated.
+   * pre-set/pre-populated.
    * To fix this we will listen to an initial focus event on the input element,
    * if that initial event is recognized, we'll allow the results to show.
    */

--- a/packages/app/src/domain/topical/components/search/context.tsx
+++ b/packages/app/src/domain/topical/components/search/context.tsx
@@ -19,6 +19,7 @@ type SearchContext = ReturnType<typeof useSearchContextValue>;
 interface SearchContextProviderProps<T extends Element> {
   containerRef: RefObject<T>;
   children: (context: SearchContext) => ReactNode;
+  initialValue?: string;
 }
 
 const searchContext = createContext<SearchContext | undefined>(undefined);
@@ -26,8 +27,9 @@ const searchContext = createContext<SearchContext | undefined>(undefined);
 export function SearchContextProvider<T extends Element>({
   children,
   containerRef,
+  initialValue = '',
 }: SearchContextProviderProps<T>) {
-  const value = useSearchContextValue(containerRef);
+  const value = useSearchContextValue(initialValue, containerRef);
 
   return (
     <searchContext.Provider value={value}>
@@ -44,7 +46,10 @@ export function useSearchContext() {
   return context;
 }
 
-function useSearchContextValue<T extends Element>(containerRef: RefObject<T>) {
+function useSearchContextValue<T extends Element>(
+  initialValue: string,
+  containerRef: RefObject<T>
+) {
   const router = useRouter();
   const breakpoints = useBreakpoints();
 
@@ -53,7 +58,7 @@ function useSearchContextValue<T extends Element>(containerRef: RefObject<T>) {
   /**
    * current search term
    */
-  const [term, setTerm] = useState('');
+  const [term, setTerm] = useState(initialValue);
 
   /**
    * when a hit is selected (e.g. hitting return-key) the input's value will be
@@ -66,6 +71,18 @@ function useSearchContextValue<T extends Element>(containerRef: RefObject<T>) {
    */
   const [hasInputFocus, setHasInputFocus] = useState(false);
   const [hasHitFocus, setHasHitFocus] = useState(false);
+
+  /**
+   * By default narrow devices will show search-results when the input field
+   * has a value. We don't want to show these results when the value is
+   * preset/prepolated.
+   * To fix this we will listen to an initial focus event on the input element,
+   * if that initial event is recognized, we'll allow the results to show.
+   */
+  const [hasHadInputFocus, setHasHadInputFocus] = useState(false);
+  useEffect(() => {
+    if (hasInputFocus) setHasHadInputFocus(true);
+  }, [hasInputFocus]);
 
   /**
    * the useSearchResults-hook which will perform the actual search
@@ -102,7 +119,9 @@ function useSearchContextValue<T extends Element>(containerRef: RefObject<T>) {
   const getOptionId = (index: number) => `${id}-result-${index}`;
 
   const showResults =
-    !!term && (hasInputFocus || hasHitFocus || !breakpoints.md);
+    hasHadInputFocus &&
+    !!term &&
+    (hasInputFocus || hasHitFocus || !breakpoints.md);
 
   useOnClickOutside([containerRef], () => setHasHitFocus(false));
 

--- a/packages/app/src/domain/topical/components/search/search.tsx
+++ b/packages/app/src/domain/topical/components/search/search.tsx
@@ -9,7 +9,7 @@ import { SearchContextProvider } from './context';
 import { SearchInput } from './search-input';
 import { SearchResults } from './search-results';
 
-export function Search() {
+export function Search({ initialValue }: { initialValue?: string }) {
   const { height, ref: heightRef } = useResizeObserver<HTMLDivElement>();
   const containerRef = useRef<HTMLFormElement>(null);
 
@@ -17,7 +17,10 @@ export function Search() {
   const breakpoints = useBreakpoints();
 
   return (
-    <SearchContextProvider containerRef={containerRef}>
+    <SearchContextProvider
+      containerRef={containerRef}
+      initialValue={initialValue}
+    >
       {(context) => (
         <SearchForm
           ref={containerRef}

--- a/packages/app/src/pages/gemeente/[code]/actueel.tsx
+++ b/packages/app/src/pages/gemeente/[code]/actueel.tsx
@@ -4,10 +4,12 @@ import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { Tile } from '~/components-styled/tile';
+import { TileList } from '~/components-styled/tile-list';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
+import { Search } from '~/domain/topical/components/search';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
@@ -40,58 +42,63 @@ const MunicipalityActueel: FCWithLayout<typeof getStaticProps> = (props) => {
 
   return (
     <MaxWidth>
-      <Tile>De actuele situatie in {municipalityName}</Tile>
-      <Tile>Artikelen</Tile>
-      <ChoroplethTile
-        title={text.risiconiveaus.selecteer_titel}
-        description={
-          <>
-            <span
-              dangerouslySetInnerHTML={{
-                __html: text.risiconiveaus.selecteer_toelichting,
-              }}
-            />
-            <EscalationMapLegenda
-              data={choropleth.vr}
-              metricName="escalation_levels"
-              metricProperty="escalation_level"
-            />
-          </>
-        }
-      >
-        <SafetyRegionChoropleth
-          data={choropleth.vr}
-          metricName="escalation_levels"
-          metricProperty="escalation_level"
-          onSelect={createSelectRegionHandler(router)}
-          tooltipContent={escalationTooltip(createSelectRegionHandler(router))}
-        />
-      </ChoroplethTile>
+      <TileList>
+        <Search initialValue={municipalityName} />
+        <Tile>De actuele situatie in {municipalityName}</Tile>
+        <Tile>Artikelen</Tile>
+        <ChoroplethTile
+          title={text.risiconiveaus.selecteer_titel}
+          description={
+            <>
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: text.risiconiveaus.selecteer_toelichting,
+                }}
+              />
+              <EscalationMapLegenda
+                data={choropleth.vr}
+                metricName="escalation_levels"
+                metricProperty="escalation_level"
+              />
+            </>
+          }
+        >
+          <SafetyRegionChoropleth
+            data={choropleth.vr}
+            metricName="escalation_levels"
+            metricProperty="escalation_level"
+            onSelect={createSelectRegionHandler(router)}
+            tooltipContent={escalationTooltip(
+              createSelectRegionHandler(router)
+            )}
+          />
+        </ChoroplethTile>
 
-      <QuickLinks
-        header={text.quick_links.header}
-        links={[
-          { href: '/landelijk', text: text.quick_links.links.nationaal },
-          safetyRegionForMunicipality
-            ? {
-                href: `/veiligheidsregio/${safetyRegionForMunicipality.code}/positief-geteste-mensen`,
-                text: replaceVariablesInText(
-                  text.quick_links.links.veiligheidsregio,
-                  { safetyRegionName: safetyRegionForMunicipality.name }
-                ),
-              }
-            : {
-                href: '/veiligheidsregio',
-                text: text.quick_links.links.veiligheidsregio_fallback,
-              },
-          {
-            href: '/gemeentes',
-            text: replaceVariablesInText(text.quick_links.links.gemeente, {
-              municipalityName: municipalityName,
-            }),
-          },
-        ]}
-      ></QuickLinks>
+        <QuickLinks
+          header={text.quick_links.header}
+          links={[
+            { href: '/landelijk', text: text.quick_links.links.nationaal },
+            safetyRegionForMunicipality
+              ? {
+                  href: `/veiligheidsregio/${safetyRegionForMunicipality.code}/positief-geteste-mensen`,
+                  text: replaceVariablesInText(
+                    text.quick_links.links.veiligheidsregio,
+                    { safetyRegionName: safetyRegionForMunicipality.name }
+                  ),
+                }
+              : {
+                  href: '/veiligheidsregio',
+                  text: text.quick_links.links.veiligheidsregio_fallback,
+                },
+            {
+              href: '/gemeentes',
+              text: replaceVariablesInText(text.quick_links.links.gemeente, {
+                municipalityName: municipalityName,
+              }),
+            },
+          ]}
+        />
+      </TileList>
     </MaxWidth>
   );
 };

--- a/packages/app/src/pages/veiligheidsregio/[code]/actueel.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/actueel.tsx
@@ -4,10 +4,12 @@ import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { Tile } from '~/components-styled/tile';
+import { TileList } from '~/components-styled/tile-list';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
+import { Search } from '~/domain/topical/components/search';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
@@ -35,48 +37,53 @@ const SafetyRegionActueel: FCWithLayout<typeof getStaticProps> = (props) => {
 
   return (
     <MaxWidth>
-      <Tile>De actuele situatie in {props.safetyRegionName}</Tile>
-      <Tile>Artikelen</Tile>
-      <ChoroplethTile
-        title={text.risiconiveaus.selecteer_titel}
-        description={
-          <>
-            <span
-              dangerouslySetInnerHTML={{
-                __html: text.risiconiveaus.selecteer_toelichting,
-              }}
-            />
-            <EscalationMapLegenda
-              data={choropleth.vr}
-              metricName="escalation_levels"
-              metricProperty="escalation_level"
-            />
-          </>
-        }
-      >
-        <SafetyRegionChoropleth
-          data={choropleth.vr}
-          metricName="escalation_levels"
-          metricProperty="escalation_level"
-          onSelect={createSelectRegionHandler(router)}
-          tooltipContent={escalationTooltip(createSelectRegionHandler(router))}
-        />
-      </ChoroplethTile>
+      <TileList>
+        <Search initialValue={props.safetyRegionName} />
+        <Tile>De actuele situatie in {props.safetyRegionName}</Tile>
+        <Tile>Artikelen</Tile>
+        <ChoroplethTile
+          title={text.risiconiveaus.selecteer_titel}
+          description={
+            <>
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: text.risiconiveaus.selecteer_toelichting,
+                }}
+              />
+              <EscalationMapLegenda
+                data={choropleth.vr}
+                metricName="escalation_levels"
+                metricProperty="escalation_level"
+              />
+            </>
+          }
+        >
+          <SafetyRegionChoropleth
+            data={choropleth.vr}
+            metricName="escalation_levels"
+            metricProperty="escalation_level"
+            onSelect={createSelectRegionHandler(router)}
+            tooltipContent={escalationTooltip(
+              createSelectRegionHandler(router)
+            )}
+          />
+        </ChoroplethTile>
 
-      <QuickLinks
-        header={text.quick_links.header}
-        links={[
-          { href: '/landelijk', text: text.quick_links.links.nationaal },
-          {
-            href: `/veiligheidsregio/${router.query.code}/positief-geteste-mensen`,
-            text: replaceVariablesInText(
-              text.quick_links.links.veiligheidsregio,
-              { safetyRegionName: props.safetyRegionName }
-            ),
-          },
-          { href: '/gemeentes', text: text.quick_links.links.gemeente },
-        ]}
-      ></QuickLinks>
+        <QuickLinks
+          header={text.quick_links.header}
+          links={[
+            { href: '/landelijk', text: text.quick_links.links.nationaal },
+            {
+              href: `/veiligheidsregio/${router.query.code}/positief-geteste-mensen`,
+              text: replaceVariablesInText(
+                text.quick_links.links.veiligheidsregio,
+                { safetyRegionName: props.safetyRegionName }
+              ),
+            },
+            { href: '/gemeentes', text: text.quick_links.links.gemeente },
+          ]}
+        />
+      </TileList>
     </MaxWidth>
   );
 };


### PR DESCRIPTION
## Summary

The search component should be able to have an initial value.

There was a small issue for narrow devices where the search results would always show as long as there was a value. In the case of this initial value we don't want this behavior.
The fix is to listen for an initial focus event on the input element, as long as that event doesn't fire we won't show any search results. When the event gets triggered we can fallback to the default implementation.

The diff contains as lot of whitespace changes, I suggest to see the diff with the `?w=1` url parameter.