### PR TITLE
Remove default export from useUniqueId hook

### DIFF
--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -6,7 +6,7 @@ import { ChartTileContainer } from './chart-tile-container';
 import { ChartTimeControls } from './chart-time-controls';
 import { MetadataProps } from './metadata';
 import { Heading } from './typography';
-import useUniqueId from '~/utils/useUniqueId';
+import { useUniqueId } from '~/utils/useUniqueId';
 import { assert } from '~/utils/assert';
 interface ChartTileProps {
   children: React.ReactNode;

--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -4,7 +4,7 @@ import { Value } from '~/components-styled/line-chart/helpers';
 import { TimeframeOption } from '~/utils/timeframe';
 import { ChartTileWithTimeframe } from './chart-tile';
 import { MetadataProps } from './metadata';
-import useUniqueId from '~/utils/useUniqueId';
+import { useUniqueId } from '~/utils/useUniqueId';
 import { assert } from '~/utils/assert';
 interface LineChartTileProps<T extends Value> extends LineChartProps<T> {
   title: string;

--- a/packages/app/src/components-styled/radio-group.tsx
+++ b/packages/app/src/components-styled/radio-group.tsx
@@ -2,7 +2,7 @@ import { css } from '@styled-system/css';
 import { Fragment, useState } from 'react';
 import styled from 'styled-components';
 import { asResponsiveArray } from '~/style/utils';
-import useUniqueId from '~/utils/useUniqueId';
+import { useUniqueId } from '~/utils/useUniqueId';
 import { Box } from './base';
 interface RadioGroupItem<T extends string> {
   label: string;

--- a/packages/app/src/components/choropleth/choropleth.tsx
+++ b/packages/app/src/components/choropleth/choropleth.tsx
@@ -9,7 +9,7 @@ import { TCombinedChartDimensions } from './hooks/use-chart-dimensions';
 import { Path } from './path';
 import { Tooltip } from './tooltips/tooltipContainer';
 import { countryGeo } from './topology';
-import uniqueId from '~/utils/useUniqueId';
+import { useUniqueId } from '~/utils/useUniqueId';
 
 export type TooltipSettings = {
   left: number;
@@ -120,8 +120,8 @@ const ChoroplethMap: <T1, T3>(
     description,
   } = props;
 
-  const clipPathId = uniqueId();
-  const dataDescriptionId = uniqueId();
+  const clipPathId = useUniqueId();
+  const dataDescriptionId = useUniqueId();
 
   const timeout = useRef(-1);
   const isTouch = useIsTouchDevice();

--- a/packages/app/src/utils/useUniqueId.ts
+++ b/packages/app/src/utils/useUniqueId.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-export default function useUniqueId() {
+export function useUniqueId() {
   const uniqueId = useMemo(() => {
     return `_${Math.random().toString(36).substring(2, 15)}`;
   }, []);


### PR DESCRIPTION
## Summary

Because we chose to avoid default exports where we can.