### PR TITLE
Actueel risicokaart and latest articles layout 

### DIFF
--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -32,8 +32,8 @@ export function ArticleTeaser(props: ArticleLinkProps) {
       borderRadius={4}
       minHeight={'26rem'}
       maxHeight={'26rem'}
-      minWidth={{ _: '20rem', lg: '24rem' }}
-      maxWidth={{ _: '20rem', lg: '24rem' }}
+      minWidth={{ _: '100%', lg: '24rem' }}
+      maxWidth={{ _: '100%', lg: '24rem' }}
       overflow="hidden"
     >
       {<CoverImage image={cover} />}

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -32,8 +32,7 @@ export function ArticleTeaser(props: ArticleLinkProps) {
       borderRadius={4}
       minHeight={'26rem'}
       maxHeight={'26rem'}
-      minWidth={{ _: '100%', lg: '24rem' }}
-      maxWidth={{ _: '100%', lg: '24rem' }}
+      width="100%"
       overflow="hidden"
     >
       {<CoverImage image={cover} />}

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -32,7 +32,6 @@ export function ArticleTeaser(props: ArticleLinkProps) {
       borderRadius={4}
       minHeight={'26rem'}
       maxHeight={'26rem'}
-      width="100%"
       overflow="hidden"
     >
       {<CoverImage image={cover} />}

--- a/packages/app/src/components-styled/news-message.tsx
+++ b/packages/app/src/components-styled/news-message.tsx
@@ -1,6 +1,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import ExternalLinkIcon from '~/assets/external-link.svg';
+import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
 import { ExternalLink } from './external-link';
 import { Tile } from './tile';
@@ -30,13 +31,13 @@ export function NewsMessage(props: NewsMessageProps) {
     <Tile
       css={css({
         bg: 'contextualContent',
-        flexDirection: [null, 'row'],
+        flexDirection: asResponsiveArray({ lg: 'row' }),
       })}
     >
-      <Box flex="1 1 25%">
+      <Box flex={{ lg: '1 1 25%' }}>
         <img src={imageSrc} />
       </Box>
-      <Box flex="1 1 75%" pl={[null, 4]}>
+      <Box flex={{ lg: '1 1 75%' }} pl={[null, 4]}>
         <Text mt={0} color="gray">
           {subtitle}
           {' • '}

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -25,7 +25,6 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
       css={css({
         display: 'flex',
         flexDirection: 'column',
-        padding: 4,
       })}
     >
       <Heading level={2}>

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -59,12 +59,7 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
           )}
         </Box>
       </Box>
-      <Box
-        display="flex"
-        spacingHorizontal={breakpoints.lg}
-        flexDirection={{ _: 'column', lg: 'row' }}
-        flexWrap="wrap"
-      >
+      <Box display="block" margin={0} maxWidth="100%" mt={3}>
         {articleSummaries.map((summary) => (
           <ArticleBox key={summary.slug.current}>
             <ArticleTeaser
@@ -75,6 +70,14 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
             />
           </ArticleBox>
         ))}
+        <ArticleBox key={'JA'}>
+          <ArticleTeaser
+            title={articleSummaries[0].title}
+            slug={articleSummaries[0].slug.current}
+            summary={articleSummaries[0].summary}
+            cover={articleSummaries[0].cover}
+          />
+        </ArticleBox>
       </Box>
     </Box>
   );
@@ -82,8 +85,16 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
 
 const ArticleBox = styled.div(
   css({
-    flex: '0 0 auto',
-    marginTop: 3,
-    marginRight: asResponsiveArray({ _: 0, lg: 4 }),
+    display: 'inline-block',
+    marginBottom: 4,
+    width: asResponsiveArray({
+      _: '100%',
+      sm: '50%',
+      md: 'calc(33% - 32px)',
+      lg: 'calc(33% - 32px)',
+    }),
+    '&:nth-child(3n+2)': {
+      mx: asResponsiveArray({ md: 4, lg: 4 }),
+    },
   })
 );

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -21,7 +21,13 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
   const breakpoints = useBreakpoints();
 
   return (
-    <Box>
+    <Box
+      css={css({
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 4,
+      })}
+    >
       <Heading level={2}>
         {siteText.nationaal_actueel.latest_articles.title}
       </Heading>

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -80,10 +80,13 @@ const ArticleBox = styled.div(
     marginBottom: 4,
     width: asResponsiveArray({
       _: '100%',
-      sm: '50%',
+      sm: 'calc(50% - 16px)',
       md: 'calc(33% - 32px)',
       lg: 'calc(33% - 32px)',
     }),
+    '&:nth-child(n+2)': {
+      ml: asResponsiveArray({ sm: '32px' }),
+    },
     '&:nth-child(3n+2)': {
       mx: asResponsiveArray({ md: '48px', lg: '48px' }),
     },

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -69,14 +69,6 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
             />
           </ArticleBox>
         ))}
-        <ArticleBox key={'JA'}>
-          <ArticleTeaser
-            title={articleSummaries[0].title}
-            slug={articleSummaries[0].slug.current}
-            summary={articleSummaries[0].summary}
-            cover={articleSummaries[0].cover}
-          />
-        </ArticleBox>
       </Box>
     </Box>
   );
@@ -93,7 +85,7 @@ const ArticleBox = styled.div(
       lg: 'calc(33% - 32px)',
     }),
     '&:nth-child(3n+2)': {
-      mx: asResponsiveArray({ md: 4, lg: 4 }),
+      mx: asResponsiveArray({ md: '48px', lg: '48px' }),
     },
   })
 );

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -27,13 +27,16 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
         flexDirection: 'column',
       })}
     >
-      <Heading level={2}>
-        {siteText.nationaal_actueel.latest_articles.title}
-      </Heading>
+      <Box px={{ _: 4, md: 0 }}>
+        <Heading level={2}>
+          {siteText.nationaal_actueel.latest_articles.title}
+        </Heading>
+      </Box>
       <Box
         display="flex"
         alignItems={{ lg: 'flex-end' }}
         flexDirection={{ _: 'column', lg: 'row' }}
+        px={{ _: 4, md: 0 }}
       >
         <Box flex={{ lg: '0 0 33%' }}>
           <Text m={0}>
@@ -84,7 +87,7 @@ const ArticleBox = styled.div(
       md: 'calc(33% - 32px)',
       lg: 'calc(33% - 32px)',
     }),
-    '&:nth-child(n+2)': {
+    '&:nth-child(even)': {
       ml: asResponsiveArray({ sm: '32px' }),
     },
     '&:nth-child(3n+2)': {

--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -1,3 +1,4 @@
+import css from '@styled-system/css';
 import ArrowIcon from '~/assets/arrow.svg';
 import { Box } from '~/components-styled/base';
 import { Collapsible } from '~/components-styled/collapsible';
@@ -47,7 +48,7 @@ export function EscalationLevelExplanations() {
         <Box mt={4}>
           <LinkWithIcon
             href="/over-risiconiveaus"
-            icon={<ArrowIcon />}
+            icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
             iconPlacement="right"
           >
             {siteText.escalatie_niveau.lees_meer}

--- a/packages/app/src/domain/topical/topical-choropleth-container.tsx
+++ b/packages/app/src/domain/topical/topical-choropleth-container.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Box } from '~/components-styled/base';
 import { ChoroplethLegenda } from '~/components-styled/choropleth-legenda';
 import { Heading, Text } from '~/components-styled/typography';
@@ -14,7 +15,7 @@ interface DataProps {
   'data-cy'?: string;
 }
 
-interface ChoroplethTileProps extends DataProps {
+interface TopicalChoroplethContainerProps extends DataProps {
   title: string;
   description?: string | React.ReactNode;
   children: React.ReactNode;
@@ -22,18 +23,22 @@ interface ChoroplethTileProps extends DataProps {
     title: string;
     thresholds: ChoroplethThresholdsValue[];
   };
+  legendComponent?: ReactNode;
 }
 
-export function TopicalChoroplethTile({
+export function TopicalChoroplethContainer({
   title,
   description,
   legend,
+  legendComponent,
   children,
-}: ChoroplethTileProps) {
+}: TopicalChoroplethContainerProps) {
   const breakpoints = useBreakpoints();
-  const legendaComponent = legend && (
-    <ChoroplethLegenda thresholds={legend.thresholds} title={legend.title} />
-  );
+  const legendaComponent =
+    (legend && (
+      <ChoroplethLegenda thresholds={legend.thresholds} title={legend.title} />
+    )) ??
+    legendComponent;
 
   return (
     <Box
@@ -44,7 +49,11 @@ export function TopicalChoroplethTile({
     >
       <Box mb={3} flex={{ lg: 1 }} as="figcaption">
         <Box mb={[0, 2]}>
-          <Heading level={2} fontSize="3.5em" lineHeight="1em">
+          <Heading
+            level={2}
+            fontSize={{ _: '2.5em', lg: '3.5em' }}
+            lineHeight="1em"
+          >
             {title}
           </Heading>
           {typeof description === 'string' ? (
@@ -54,11 +63,7 @@ export function TopicalChoroplethTile({
           )}
         </Box>
 
-        {legendaComponent && breakpoints.lg && (
-          <Box display="flex" flexDirection="row" alignItems="flex-center">
-            {legendaComponent}
-          </Box>
-        )}
+        {legendaComponent && breakpoints.lg && <div>{legendaComponent}</div>}
       </Box>
 
       <Box flex={{ lg: 1 }} ml={[0, 0, 3]}>

--- a/packages/app/src/domain/topical/topical-choropleth-container.tsx
+++ b/packages/app/src/domain/topical/topical-choropleth-container.tsx
@@ -41,13 +41,8 @@ export function TopicalChoroplethContainer({
     legendComponent;
 
   return (
-    <Box
-      display="flex"
-      flexDirection={{ _: 'column', lg: 'row' }}
-      m={0}
-      as="figure"
-    >
-      <Box mb={3} flex={{ lg: 1 }} as="figcaption">
+    <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }} m={0}>
+      <Box mb={3} flex={{ lg: 1 }}>
         <Box mb={[0, 2]}>
           <Heading
             level={2}

--- a/packages/app/src/domain/topical/topical-choropleth-tile.tsx
+++ b/packages/app/src/domain/topical/topical-choropleth-tile.tsx
@@ -1,0 +1,75 @@
+import { Box } from '~/components-styled/base';
+import { ChoroplethLegenda } from '~/components-styled/choropleth-legenda';
+import { Heading, Text } from '~/components-styled/typography';
+import { ChoroplethThresholdsValue } from '~/components/choropleth/shared';
+import { useBreakpoints } from '~/utils/useBreakpoints';
+
+/**
+ * We could use strong typing here for the values and also enforce the data
+ * prop to be set. Might be a good idea.
+ *
+ * @TODO move to a shared location
+ */
+interface DataProps {
+  'data-cy'?: string;
+}
+
+interface ChoroplethTileProps extends DataProps {
+  title: string;
+  description?: string | React.ReactNode;
+  children: React.ReactNode;
+  legend?: {
+    title: string;
+    thresholds: ChoroplethThresholdsValue[];
+  };
+}
+
+export function TopicalChoroplethTile({
+  title,
+  description,
+  legend,
+  children,
+}: ChoroplethTileProps) {
+  const breakpoints = useBreakpoints();
+  const legendaComponent = legend && (
+    <ChoroplethLegenda thresholds={legend.thresholds} title={legend.title} />
+  );
+
+  return (
+    <Box
+      display="flex"
+      flexDirection={{ _: 'column', lg: 'row' }}
+      m={0}
+      as="figure"
+    >
+      <Box mb={3} flex={{ lg: 1 }} as="figcaption">
+        <Box mb={[0, 2]}>
+          <Heading level={2} fontSize="3.5em" lineHeight="1em">
+            {title}
+          </Heading>
+          {typeof description === 'string' ? (
+            <Text>{description}</Text>
+          ) : (
+            description
+          )}
+        </Box>
+
+        {legendaComponent && breakpoints.lg && (
+          <Box display="flex" flexDirection="row" alignItems="flex-center">
+            {legendaComponent}
+          </Box>
+        )}
+      </Box>
+
+      <Box flex={{ lg: 1 }} ml={[0, 0, 3]}>
+        <div>{children}</div>
+
+        {legendaComponent && !breakpoints.lg && (
+          <Box display="flex" justifyContent="center">
+            {legendaComponent}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/app/src/domain/topical/topical-tile.tsx
+++ b/packages/app/src/domain/topical/topical-tile.tsx
@@ -1,0 +1,13 @@
+import { css } from '@styled-system/css';
+import styled from 'styled-components';
+import { Box } from '~/components-styled/base';
+
+export const TopicalTile = styled(Box).attrs({ as: 'article' })(
+  css({
+    display: 'flex',
+    flexDirection: 'column',
+    bg: 'tileGray',
+    padding: 4,
+    borderRadius: 1,
+  })
+);

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -620,8 +620,8 @@
   },
   "nationaal_actueel": {
     "risiconiveaus": {
-      "selecteer_titel": "Risiconiveaus",
-      "selecteer_toelichting": "De kaart geeft het risiconiveau per veiligheidsregio weer.\n\n[Meer over de risiconiveaus](/over-risiconiveaus)"
+      "selecteer_titel": "",
+      "selecteer_toelichting": ""
     },
     "data_sitemap_titel": "",
     "data_sitemap_toelichting": "",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -621,7 +621,7 @@
   "nationaal_actueel": {
     "risiconiveaus": {
       "selecteer_titel": "De risicokaart van Nederland",
-      "selecteer_toelichting": "Iedere week wordt bekeken of de situatie rond het coronavirus zich positief of negatief ontwikkelt. In welk risiconiveau een regio zit, wordt bepaald door te kijken naar de situatie van een regio, die van de omliggende regio's en de situatie in de rest van het land.\n\n**Er geldt een [landelijke lockdown](/landelijk/maatregelen) tot en met in ieder geval 9 februari..**"
+      "selecteer_toelichting": "Iedere week wordt bekeken of de situatie rond het coronavirus zich positief of negatief ontwikkelt. In welk risiconiveau een regio zit, wordt bepaald door te kijken naar de situatie van een regio, die van de omliggende regio's en de situatie in de rest van het land.\n\n**Er geldt een [landelijke lockdown](/landelijk/maatregelen) tot en met in ieder geval 9 februari.**"
     },
     "data_sitemap_titel": "Alle landelijke cijfers op dit dashboard",
     "data_sitemap_toelichting": "Op het corona dashboard worden de cijfers van meerdere onderwerpen gepresenteerd. In verloop van tijd zullen er nieuwe onderwerpen worden toegevoegd of bestaande ondeerwerpen worden uitgebreid. Alle onderwerpen zijn onderverdeelt in categorieen. Dit is een overzicht van de categorieen en hun onderwerpen.",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -620,8 +620,8 @@
   },
   "nationaal_actueel": {
     "risiconiveaus": {
-      "selecteer_titel": "Risiconiveaus",
-      "selecteer_toelichting": "De kaart geeft het risiconiveau per veiligheidsregio weer.\n\n[Meer over de risiconiveaus](/over-risiconiveaus)"
+      "selecteer_titel": "De risicokaart van Nederland",
+      "selecteer_toelichting": "Iedere week wordt bekeken of de situatie rond het coronavirus zich positief of negatief ontwikkelt. In welk risiconiveau een regio zit, wordt bepaald door te kijken naar de situatie van een regio, die van de omliggende regio's en de situatie in de rest van het land."
     },
     "data_sitemap_titel": "Alle landelijke cijfers op dit dashboard",
     "data_sitemap_toelichting": "Op het corona dashboard worden de cijfers van meerdere onderwerpen gepresenteerd. In verloop van tijd zullen er nieuwe onderwerpen worden toegevoegd of bestaande ondeerwerpen worden uitgebreid. Alle onderwerpen zijn onderverdeelt in categorieen. Dit is een overzicht van de categorieen en hun onderwerpen.",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -621,7 +621,7 @@
   "nationaal_actueel": {
     "risiconiveaus": {
       "selecteer_titel": "De risicokaart van Nederland",
-      "selecteer_toelichting": "Iedere week wordt bekeken of de situatie rond het coronavirus zich positief of negatief ontwikkelt. In welk risiconiveau een regio zit, wordt bepaald door te kijken naar de situatie van een regio, die van de omliggende regio's en de situatie in de rest van het land."
+      "selecteer_toelichting": "Iedere week wordt bekeken of de situatie rond het coronavirus zich positief of negatief ontwikkelt. In welk risiconiveau een regio zit, wordt bepaald door te kijken naar de situatie van een regio, die van de omliggende regio's en de situatie in de rest van het land.\n\n**Er geldt een [landelijke lockdown](/landelijk/maatregelen) tot en met in ieder geval 9 februari..**"
     },
     "data_sitemap_titel": "Alle landelijke cijfers op dit dashboard",
     "data_sitemap_toelichting": "Op het corona dashboard worden de cijfers van meerdere onderwerpen gepresenteerd. In verloop van tijd zullen er nieuwe onderwerpen worden toegevoegd of bestaande ondeerwerpen worden uitgebreid. Alle onderwerpen zijn onderverdeelt in categorieen. Dit is een overzicht van de categorieen en hun onderwerpen.",

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -179,7 +179,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               <TopicalChoroplethContainer
                 title={text.risiconiveaus.selecteer_titel}
                 description={
-                  <span
+                  <div
                     dangerouslySetInnerHTML={{
                       __html: text.risiconiveaus.selecteer_toelichting,
                     }}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -1,11 +1,11 @@
+import css from '@styled-system/css';
 import { groq } from 'next-sanity';
 import { useRouter } from 'next/router';
 import ArtsIcon from '~/assets/arts.svg';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
-import { Box } from '~/components-styled/base';
 import { ArticleSummary } from '~/components-styled/article-teaser';
-import { ChoroplethTile } from '~/components-styled/choropleth-tile';
+import { Box } from '~/components-styled/base';
 import { DataDrivenText } from '~/components-styled/data-driven-text';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
 import { MaxWidth } from '~/components-styled/max-width';
@@ -24,6 +24,8 @@ import { DataSitemap } from '~/domain/topical/data-site-map';
 import { EscalationLevelExplanations } from '~/domain/topical/escalation-level-explanations';
 import { MiniTrendTile } from '~/domain/topical/mini-trend-tile';
 import { MiniTrendTileLayout } from '~/domain/topical/mini-trend-tile-layout';
+import { TopicalChoroplethTile } from '~/domain/topical/topical-choropleth-tile';
+import { TopicalTile } from '~/domain/topical/topical-tile';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
@@ -172,35 +174,48 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
             title={notificatie.titel}
           />
 
-          <ChoroplethTile
-            title={text.risiconiveaus.selecteer_titel}
-            description={
-              <>
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: text.risiconiveaus.selecteer_toelichting,
-                  }}
-                />
-                <EscalationMapLegenda
+          <TopicalTile>
+            <>
+              <TopicalChoroplethTile
+                title={text.risiconiveaus.selecteer_titel}
+                description={
+                  <>
+                    <span
+                      dangerouslySetInnerHTML={{
+                        __html: text.risiconiveaus.selecteer_toelichting,
+                      }}
+                    />
+                    <EscalationMapLegenda
+                      data={choropleth.vr}
+                      metricName="escalation_levels"
+                      metricProperty="escalation_level"
+                    />
+                  </>
+                }
+              >
+                <SafetyRegionChoropleth
                   data={choropleth.vr}
                   metricName="escalation_levels"
                   metricProperty="escalation_level"
+                  onSelect={createSelectRegionHandler(router, 'maatregelen')}
+                  tooltipContent={escalationTooltip(
+                    createSelectRegionHandler(router, 'maatregelen')
+                  )}
                 />
-              </>
-            }
-          >
-            <SafetyRegionChoropleth
-              data={choropleth.vr}
-              metricName="escalation_levels"
-              metricProperty="escalation_level"
-              onSelect={createSelectRegionHandler(router, 'maatregelen')}
-              tooltipContent={escalationTooltip(
-                createSelectRegionHandler(router, 'maatregelen')
-              )}
-            />
-          </ChoroplethTile>
-
-          <EscalationLevelExplanations />
+              </TopicalChoroplethTile>
+              <Box
+                borderTopWidth="1px"
+                borderTopStyle="solid"
+                borderTopColor="gray"
+                mt={3}
+                mx={-4}
+              >
+                <TopicalTile css={css({ mb: 0, pb: 0 })}>
+                  <EscalationLevelExplanations />
+                </TopicalTile>
+              </Box>
+            </>
+          </TopicalTile>
 
           <DataSitemap />
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -24,7 +24,7 @@ import { DataSitemap } from '~/domain/topical/data-site-map';
 import { EscalationLevelExplanations } from '~/domain/topical/escalation-level-explanations';
 import { MiniTrendTile } from '~/domain/topical/mini-trend-tile';
 import { MiniTrendTileLayout } from '~/domain/topical/mini-trend-tile-layout';
-import { TopicalChoroplethTile } from '~/domain/topical/topical-choropleth-tile';
+import { TopicalChoroplethContainer } from '~/domain/topical/topical-choropleth-container';
 import { TopicalTile } from '~/domain/topical/topical-tile';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -176,21 +176,21 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
 
           <TopicalTile>
             <>
-              <TopicalChoroplethTile
+              <TopicalChoroplethContainer
                 title={text.risiconiveaus.selecteer_titel}
                 description={
-                  <>
-                    <span
-                      dangerouslySetInnerHTML={{
-                        __html: text.risiconiveaus.selecteer_toelichting,
-                      }}
-                    />
-                    <EscalationMapLegenda
-                      data={choropleth.vr}
-                      metricName="escalation_levels"
-                      metricProperty="escalation_level"
-                    />
-                  </>
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: text.risiconiveaus.selecteer_toelichting,
+                    }}
+                  />
+                }
+                legendComponent={
+                  <EscalationMapLegenda
+                    data={choropleth.vr}
+                    metricName="escalation_levels"
+                    metricProperty="escalation_level"
+                  />
                 }
               >
                 <SafetyRegionChoropleth
@@ -202,7 +202,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                     createSelectRegionHandler(router, 'maatregelen')
                   )}
                 />
-              </TopicalChoroplethTile>
+              </TopicalChoroplethContainer>
               <Box
                 borderTopWidth="1px"
                 borderTopStyle="solid"

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -93,6 +93,7 @@ export const colors = {
   shadow: '#e5e5e5',
   gray: '#808080',
   lightGray: '#dfdfdf',
+  tileGray: '#f8f8f8',
   annotation: '#595959',
   header: '#cd005a',
   notification: '#cd005a',

--- a/packages/app/src/utils/parse-markdown-in-locale.ts
+++ b/packages/app/src/utils/parse-markdown-in-locale.ts
@@ -17,6 +17,7 @@ const MARKDOWN_KEYS = [
   'positief_geteste_personen.kpi_toelichting',
   'veiligheidsregio_positief_geteste_personen.kpi_toelichting',
   'gemeente_positief_geteste_personen.kpi_toelichting',
+  'nationaal_actueel.risiconiveaus.selecteer_toelichting',
 ];
 
 export function parseMarkdownInLocale(text: TALLLanguages) {


### PR DESCRIPTION
## Summary

A load of layout tweaks to make the actueel page look more like the designs

## Motivation

Design request

## Detailed design

Add some domain specific components to domain/topical. The rest is css tweaks.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
