### PR TITLE
Add underscores for empty strings for graph descriptions

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2024,21 +2024,21 @@
   },
   "accessibility": {
     "grafieken": {
-      "reproductiegetal_verloop": "",
-      "ziekenhuisopnames": "",
-      "intensive_care_opnames": "",
-      "verpleeghuiszorg_positief_getest": "",
-      "verpleeghuiszorg_besmette_locaties": "",
-      "verpleeghuiszorg_overleden_getest": "",
-      "gehandicaptenzorg_positief_getest": "",
+      "reproductiegetal_verloop": "_",
+      "ziekenhuisopnames": "_",
+      "intensive_care_opnames": "_",
+      "verpleeghuiszorg_positief_getest": "_",
+      "verpleeghuiszorg_besmette_locaties": "_",
+      "verpleeghuiszorg_overleden_getest": "_",
+      "gehandicaptenzorg_positief_getest": "_",
       "gehandicaptenzorg_besmette_locaties": "This figure shows the progression of the number of infected disability care home locations over time.",
       "gehandicaptenzorg_overleden": "This figure shows the progression in the number of deceased disability care home residents over time.",
-      "thuiswonende_ouderen_besmettingen": "",
-      "thuiswonende_ouderen_overleden": "",
-      "rioolwater_virusdeeltjes": "",
-      "verdenkingen_huisartsen": "",
-      "ziekenhuis_opnames": "",
-      "rioolwater_meetwaarde": ""
+      "thuiswonende_ouderen_besmettingen": "_",
+      "thuiswonende_ouderen_overleden": "_",
+      "rioolwater_virusdeeltjes": "_",
+      "verdenkingen_huisartsen": "_",
+      "ziekenhuis_opnames": "_",
+      "rioolwater_meetwaarde": "_"
     }
   }
 }

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -152,6 +152,7 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
             title={text.linechart_titel}
             metadata={{ source: text.bronnen.rivm }}
             timeframeOptions={['all', '5weeks']}
+            ariaDescription={graphDescriptions.rioolwater_virusdeeltjes}
           >
             {(timeframe) => (
               <>


### PR DESCRIPTION
Add an underscore to the English aria description for graphs.
This should fix that a `Error: This graph doesn't include a valid description nor an ariaDescription, please add one of them.` is thrown when you try to build it.