### PR TITLE
Align icons and text in lockdown table better

### DIFF
--- a/packages/app/src/components/restrictions/lockdown-table.tsx
+++ b/packages/app/src/components/restrictions/lockdown-table.tsx
@@ -60,11 +60,13 @@ function MobileLockdownTable(props: LockdownTableData) {
                           key={restriction._key}
                           display="flex"
                           flexDirection="row"
-                          alignItems="center"
+                          alignItems="flex-start"
+                          mb="1"
                         >
                           <Box
                             as="span"
                             flexShrink={0}
+                            mr="2"
                             css={css({
                               svg: {
                                 display: 'block',
@@ -77,7 +79,7 @@ function MobileLockdownTable(props: LockdownTableData) {
                               <Box size={36} />
                             )}
                           </Box>
-                          <Box>{restriction.text}</Box>
+                          <Box mt="2">{restriction.text}</Box>
                         </Box>
                       );
                     })}
@@ -126,11 +128,13 @@ function DesktopLockdownTable(props: LockdownTableData) {
                         key={restriction._key}
                         display="flex"
                         flexDirection="row"
-                        alignItems="center"
+                        alignItems="flex-start"
+                        mb="1"
                       >
                         <Box
                           as="span"
                           flexShrink={0}
+                          mr="2"
                           css={css({
                             svg: {
                               display: 'block',
@@ -143,7 +147,7 @@ function DesktopLockdownTable(props: LockdownTableData) {
                             <Box size={36} />
                           )}
                         </Box>
-                        <Box as="span" ml={1}>
+                        <Box as="span" ml={1} mt={2}>
                           {restriction.text}
                         </Box>
                       </Box>

--- a/packages/app/src/pages/landelijk/maatregelen.tsx
+++ b/packages/app/src/pages/landelijk/maatregelen.tsx
@@ -1,3 +1,4 @@
+import css from '@styled-system/css';
 import { ContentHeader } from '~/components-styled/content-header';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
@@ -6,8 +7,10 @@ import { KpiSection } from '~/components-styled/kpi-section';
 import { LockdownTable } from '~/components/restrictions/lockdown-table';
 import { PortableText } from '~/lib/sanity';
 import { SEOHead } from '~/components/seoHead';
+import { Box } from '~/components-styled/base/box';
 import { TileList } from '~/components-styled/tile-list';
 import Maatregelen from '~/assets/maatregelen.svg';
+
 import text from '~/locale';
 import {
   getNlData,
@@ -64,10 +67,16 @@ const NationalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
 
         {showLockdown && (
           <KpiSection flexDirection="column">
-            <>
+            <Box
+              css={css({
+                'p:last-child': {
+                  margin: '0',
+                },
+              })}
+            >
               <Heading level={3}>{lockdown.message.title}</Heading>
               <PortableText blocks={lockdown.message.description} />
-            </>
+            </Box>
           </KpiSection>
         )}
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
@@ -1,3 +1,4 @@
+import css from '@styled-system/css';
 import { useRouter } from 'next/router';
 import Maatregelen from '~/assets/maatregelen.svg';
 import { AnchorTile } from '~/components-styled/anchor-tile';
@@ -9,6 +10,7 @@ import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
 // import { EscalationLevel } from '~/components/restrictions/type';
 import { SEOHead } from '~/components/seoHead';
+import { Box } from '~/components-styled/base/box';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import siteText from '~/locale/index';
@@ -91,10 +93,16 @@ const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
 
         {showLockdown && (
           <KpiSection flexDirection="column">
-            <>
+            <Box
+              css={css({
+                'p:last-child': {
+                  margin: '0',
+                },
+              })}
+            >
               <Heading level={3}>{lockdown.message.title}</Heading>
               <PortableText blocks={lockdown.message.description} />
-            </>
+            </Box>
           </KpiSection>
         )}
 


### PR DESCRIPTION
## Summary

With the re-implementation of the lockdown table some layout bugs slipped through.
This PR fixes them.