### PR TITLE
Move all topical routes to /actueel

### DIFF
--- a/packages/app/src/components-styled/layout/app-content.tsx
+++ b/packages/app/src/components-styled/layout/app-content.tsx
@@ -32,7 +32,7 @@ export function AppContent({
    * but it's good enough for now I guess
    */
   const isMenuOpen =
-    (router.pathname === '/' && !('menu' in router.query)) ||
+    (router.pathname === '/landelijk' && !('menu' in router.query)) ||
     router.query.menu === '1';
 
   return (
@@ -49,7 +49,7 @@ export function AppContent({
             })}
           >
             <LinkWithIcon icon={<ArrowIcon />} href={menuOpenUrl}>
-              {router.pathname === '/'
+              {router.pathname === '/landelijk'
                 ? siteText.nav.terug_naar_alle_cijfers_homepage
                 : siteText.nav.terug_naar_alle_cijfers}
             </LinkWithIcon>
@@ -73,7 +73,7 @@ export function AppContent({
             </ResponsiveVisible>
             <MenuLinkContainer isVisible={!isMenuOpen}>
               <LinkWithIcon icon={<ArrowIcon />} href={menuOpenUrl}>
-                {router.pathname === '/'
+                {router.pathname === '/landelijk'
                   ? siteText.nav.terug_naar_alle_cijfers_homepage
                   : siteText.nav.terug_naar_alle_cijfers}
               </LinkWithIcon>

--- a/packages/app/src/components-styled/layout/components/top-navigation.tsx
+++ b/packages/app/src/components-styled/layout/components/top-navigation.tsx
@@ -50,7 +50,13 @@ export function TopNavigation() {
         >
           <MaxWidth>
             <NavList>
-              <NavItem href="/" isActive={router.pathname === '/'}>
+              <NavItem
+                href="/"
+                isActive={
+                  router.pathname === '/' ||
+                  router.pathname.startsWith('/actueel')
+                }
+              >
                 {text.nav.links.actueel}
               </NavItem>
               <NavItem

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -68,7 +68,7 @@ function NationalLayout(props: NationalLayoutProps) {
   const breakpoints = useBreakpoints();
 
   const isMenuOpen =
-    (router.pathname === '/' && !('menu' in router.query)) ||
+    (router.pathname === '/landelijk' && !('menu' in router.query)) ||
     router.query.menu === '1';
 
   return (

--- a/packages/app/src/domain/topical/components/search/use-search-results.ts
+++ b/packages/app/src/domain/topical/components/search/use-search-results.ts
@@ -78,13 +78,13 @@ const ALL_HITS: Option[] = [
     code: x.gemcode,
     name: x.displayName || x.name,
     searchTerms: [x.name, x.displayName].filter(isPresent),
-    link: `/gemeente/${x.gemcode}/actueel`,
+    link: `/actueel/gemeente/${x.gemcode}`,
   })),
   ...safetyRegions.map((x) => ({
     type: 'vr' as const,
     code: x.code,
     name: x.name,
     searchTerms: [x.name, ...(x.searchTerms || [])].filter(isPresent),
-    link: `/veiligheidsregio/${x.code}/actueel`,
+    link: `/actueel/veiligheidsregio/${x.code}`,
   })),
 ].sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary

The `actueel` pages should live under the route `/actueel/(gemeente|veiligheidsregio)/{code}`.