### PR TITLE
Bar scale max fix

### DIFF
--- a/packages/app/src/components/barScale/index.tsx
+++ b/packages/app/src/components/barScale/index.tsx
@@ -155,14 +155,6 @@ export function BarScale({
               <text x={`${scale(xMin)}%`} y={64} className={styles.tick}>
                 {`${formatNumber(xMin)}`}
               </text>
-              <text
-                x={`${scale(xMax)}%`}
-                y={64}
-                className={styles.tick}
-                textAnchor="end"
-              >
-                {`${formatNumber(xMax)}`}
-              </text>
             </g>
           )}
         </svg>

--- a/packages/app/src/components/barScale/index.tsx
+++ b/packages/app/src/components/barScale/index.tsx
@@ -38,7 +38,7 @@ export function BarScale({
 
   const text = siteText.common.barScale;
 
-  const [xMin, xMax] = scale.domain();
+  const [xMin] = scale.domain();
 
   const textAlign = scaleThreshold<number, 'start' | 'middle' | 'end'>()
     .domain([20, 80])

--- a/packages/app/src/utils/useDynamicScale.ts
+++ b/packages/app/src/utils/useDynamicScale.ts
@@ -27,7 +27,7 @@ export function useDynamicScale(
   const scale: ScaleLinear<number, number> = scaleLinear()
     .domain([scaleMin, scaleMax])
     .range([0, 100])
-    .nice(2);
+    .nice(10);
 
   return scale;
 }


### PR DESCRIPTION
## Summary

* Remove max value from page bar scales
* Shrink scale to be only 10% above maximum

<img width="1436" alt="Screenshot 2021-01-21 at 13 45 23" src="https://user-images.githubusercontent.com/71320230/105353010-fb379500-5bee-11eb-8165-67fa0cb7d549.png">
