### PR TITLE
Tweak topical header for non-national pages

### DIFF
--- a/packages/app/src/components-styled/relative-date.tsx
+++ b/packages/app/src/components-styled/relative-date.tsx
@@ -8,6 +8,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import { formatDateFromSeconds } from '~/utils/formatDate';
+import { useIsMounted } from '~/utils/use-is-mounted';
 
 interface RelativeDateProps {
   dateInSeconds: number;
@@ -18,22 +19,18 @@ export function RelativeDate({
   dateInSeconds,
   isCapitalized,
 }: RelativeDateProps) {
+  const isMounted = useIsMounted();
   const isoDate = formatDateFromSeconds(dateInSeconds, 'iso');
   const fullDate = formatDateFromSeconds(dateInSeconds, 'medium');
-
-  // Relative dates only become relative when run in the browser with JS on.
-  // Non-JS versions are the day and month.
   let displayDate = formatDateFromSeconds(dateInSeconds, 'relative');
 
   if (isCapitalized) {
     displayDate = displayDate.charAt(0).toUpperCase() + displayDate.substr(1);
   }
 
-  // @Todo useIsMounted hook which will be available when the actueel search is merged
-
   return (
     <Time dateTime={isoDate} title={fullDate}>
-      {displayDate}
+      {isMounted ? displayDate : fullDate}
     </Time>
   );
 }

--- a/packages/app/src/domain/topical/topical-page-header.tsx
+++ b/packages/app/src/domain/topical/topical-page-header.tsx
@@ -1,0 +1,47 @@
+import css from '@styled-system/css';
+import { ReactNode } from 'react';
+import ArrowIcon from '~/assets/arrow.svg';
+
+import { Box } from '~/components-styled/base';
+import { LinkWithIcon } from '~/components-styled/link-with-icon';
+import { RelativeDate } from '~/components-styled/relative-date';
+import { Heading, InlineText } from '~/components-styled/typography';
+import text from '~/locale';
+import { formatDateFromSeconds } from '~/utils/formatDate';
+import { replaceComponentsInText } from '~/utils/replace-components-in-text';
+
+interface TopicalPageHeaderProps {
+  title: ReactNode;
+  lastGenerated: number;
+}
+
+export function TopicalPageHeader({
+  title,
+  lastGenerated,
+}: TopicalPageHeaderProps) {
+  return (
+    <Box spacing={3}>
+      <Box fontSize="1.125rem">
+        <LinkWithIcon
+          href="/"
+          fontWeight="bold"
+          icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
+        >
+          {text.common_actueel.terug_naar_landelijk}
+        </LinkWithIcon>
+      </Box>
+
+      <Box>
+        <Heading level={1} fontWeight="normal" m={0}>
+          {title}
+        </Heading>
+        <InlineText color="bodyLight">
+          {replaceComponentsInText(text.common_actueel.laatst_bijgewerkt, {
+            date: <RelativeDate dateInSeconds={lastGenerated} />,
+            time: formatDateFromSeconds(lastGenerated, 'time'),
+          })}
+        </InlineText>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -620,6 +620,10 @@
     "date_yesterday": "yesterday",
     "date_day_before_yesterday": "the day before yesterday"
   },
+  "common_actueel": {
+    "terug_naar_landelijk": "Terug naar landelijke situtatie",
+    "laatst_bijgewerkt": "Laatst bijgewerkt: {{date}} om {{time}}"
+  },
   "nationaal_actueel": {
     "title": "Actuele situatie in {{the_netherlands}}",
     "the_netherlands": "The Netherlands",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -620,6 +620,10 @@
     "date_yesterday": "gisteren",
     "date_day_before_yesterday": "eergisteren"
   },
+  "common_actueel": {
+    "terug_naar_landelijk": "Terug naar landelijke situtatie",
+    "laatst_bijgewerkt": "Laatst bijgewerkt: {{date}} om {{time}}"
+  },
   "nationaal_actueel": {
     "title": "Actuele situatie in {{the_netherlands}}",
     "the_netherlands": "Nederland",

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -9,18 +9,17 @@ import { MaxWidth } from '~/components-styled/max-width';
 import { MessageTile } from '~/components-styled/message-tile';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { TileList } from '~/components-styled/tile-list';
-import { Heading } from '~/components-styled/typography';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
 import { SEOHead } from '~/components/seoHead';
 import { FCWithLayout, getDefaultLayout } from '~/domain/layout/layout';
-import { Search } from '~/domain/topical/components/search';
 import { DataSitemap } from '~/domain/topical/data-sitemap';
 import { EscalationLevelExplanations } from '~/domain/topical/escalation-level-explanations';
 import { MiniTrendTile } from '~/domain/topical/mini-trend-tile';
 import { MiniTrendTileLayout } from '~/domain/topical/mini-trend-tile-layout';
 import { TopicalChoroplethContainer } from '~/domain/topical/topical-choropleth-container';
+import { TopicalPageHeader } from '~/domain/topical/topical-page-header';
 import { TopicalTile } from '~/domain/topical/topical-tile';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -73,13 +72,12 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
               message={siteText.regionaal_index.belangrijk_bericht}
             />
 
-            <Search initialValue={municipalityName} />
-
-            <Heading level={1} fontWeight="normal">
-              {replaceComponentsInText(text.title, {
+            <TopicalPageHeader
+              lastGenerated={Number(props.lastGenerated)}
+              title={replaceComponentsInText(text.title, {
                 municipalityName: <strong>{municipalityName}</strong>,
               })}
-            </Heading>
+            />
 
             <MiniTrendTileLayout>
               <MiniTrendTile

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -10,18 +10,17 @@ import { MessageTile } from '~/components-styled/message-tile';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
 import { TileList } from '~/components-styled/tile-list';
-import { Heading } from '~/components-styled/typography';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
 import { SEOHead } from '~/components/seoHead';
 import { FCWithLayout, getDefaultLayout } from '~/domain/layout/layout';
-import { Search } from '~/domain/topical/components/search';
 import { DataSitemap } from '~/domain/topical/data-sitemap';
 import { EscalationLevelExplanations } from '~/domain/topical/escalation-level-explanations';
 import { MiniTrendTile } from '~/domain/topical/mini-trend-tile';
 import { MiniTrendTileLayout } from '~/domain/topical/mini-trend-tile-layout';
 import { TopicalChoroplethContainer } from '~/domain/topical/topical-choropleth-container';
+import { TopicalPageHeader } from '~/domain/topical/topical-page-header';
 import { TopicalTile } from '~/domain/topical/topical-tile';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -82,13 +81,12 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
               message={siteText.regionaal_index.belangrijk_bericht}
             />
 
-            <Search initialValue={props.safetyRegionName} />
-
-            <Heading level={1} fontWeight="normal">
-              {replaceComponentsInText(text.title, {
+            <TopicalPageHeader
+              lastGenerated={Number(props.lastGenerated)}
+              title={replaceComponentsInText(text.title, {
                 safetyRegionName: <strong>{props.safetyRegionName}</strong>,
               })}
-            </Heading>
+            />
 
             <MiniTrendTileLayout>
               <MiniTrendTile

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -85,6 +85,7 @@ const mediaQueries = {
 
 export const colors = {
   body: '#000000',
+  bodyLight: '#555555',
   page: '#f3f3f3',
   blue: '#01689b',
   icon: '#01689b',

--- a/packages/app/src/utils/formatDate.ts
+++ b/packages/app/src/utils/formatDate.ts
@@ -40,6 +40,7 @@ interface DateTimeFormatOptions extends Intl.DateTimeFormatOptions {
 }
 
 type formatStyle =
+  | 'time'
   | 'long'
   | 'medium'
   | 'short'
@@ -47,6 +48,11 @@ type formatStyle =
   | 'iso'
   | 'axis'
   | 'weekday-medium';
+
+const Time = new Intl.DateTimeFormat(locale, {
+  timeStyle: 'short',
+  timeZone: 'Europe/Amsterdam',
+} as DateTimeFormatOptions);
 
 const Long = new Intl.DateTimeFormat(locale, {
   dateStyle: 'long',
@@ -105,7 +111,7 @@ export function formatDateFromMilliseconds(
   style?: formatStyle
 ): string {
   assert(!isNaN(milliseconds), 'milliseconds is NaN');
-
+  if (style === 'time') return Time.format(milliseconds); // '09:24'
   if (style === 'iso') return new Date(milliseconds).toISOString(); // '2020-07-23T10:01:16.000Z'
   if (style === 'long') return Long.format(milliseconds); // '23 juli 2020 om 12:01'
   if (style === 'medium') return Medium.format(milliseconds); // '23 juli 2020'


### PR DESCRIPTION
## Summary

With these changes we get rid of the search input on non-national topical pages.

![image](https://user-images.githubusercontent.com/73584448/105366879-1fe83880-5c00-11eb-9c06-ce22312d1c6e.png)
