### PR TITLE
Fix errors in actueel branch

### DIFF
--- a/packages/app/src/components-styled/quick-links.tsx
+++ b/packages/app/src/components-styled/quick-links.tsx
@@ -2,7 +2,6 @@ import css from '@styled-system/css';
 import styled from 'styled-components';
 import ArrowIcon from '~/assets/arrow.svg';
 import { asResponsiveArray } from '~/style/utils';
-import { Link } from '~/utils/link';
 import { Box } from './base';
 import { LinkWithIcon } from './link-with-icon';
 import { Heading } from './typography';
@@ -26,16 +25,14 @@ export function QuickLinks({ header, links }: QuickLinksProps) {
       <List>
         {links.map((link, index) => (
           <Item key={`${link.text}-${index}`}>
-            <Link href={link.href}>
-              <LinkWithIcon
-                href={link.href}
-                icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
-                iconPlacement="right"
-                fontWeight="bold"
-              >
-                {link.text}
-              </LinkWithIcon>
-            </Link>
+            <LinkWithIcon
+              href={link.href}
+              icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+              iconPlacement="right"
+              fontWeight="bold"
+            >
+              {link.text}
+            </LinkWithIcon>
           </Item>
         ))}
       </List>

--- a/packages/app/src/components/restrictions/lockdown-table.tsx
+++ b/packages/app/src/components/restrictions/lockdown-table.tsx
@@ -141,7 +141,8 @@ function DesktopLockdownTable(props: LockdownTableData) {
                             },
                           })}
                         >
-                          {restriction.icon ? (
+                          {restriction.icon &&
+                          restrictionIcons[restriction.icon] ? (
                             getIcon(restrictionIcons[restriction.icon], color)
                           ) : (
                             <Box size={36} />
@@ -163,6 +164,6 @@ function DesktopLockdownTable(props: LockdownTableData) {
   );
 }
 
-function getIcon(IconComponent: any | undefined, color: string) {
+function getIcon(IconComponent: any, color: string) {
   return <IconComponent color={color} />;
 }

--- a/packages/app/src/utils/formatDate.ts
+++ b/packages/app/src/utils/formatDate.ts
@@ -1,7 +1,13 @@
+/**
+ * The order of including these polyfills is important:
+ * getcanonicallocales needs to be first
+ * datetimeformat needs to be second
+ * datetimeformat locale's last
+ */
+import '@formatjs/intl-getcanonicallocales/polyfill';
+import '@formatjs/intl-datetimeformat/polyfill';
 import '@formatjs/intl-datetimeformat/locale-data/en';
 import '@formatjs/intl-datetimeformat/locale-data/nl';
-import '@formatjs/intl-datetimeformat/polyfill';
-import '@formatjs/intl-getcanonicallocales/polyfill';
 import { isSameDay, isToday, isYesterday, subDays } from 'date-fns';
 import siteText from '~/locale/index';
 import { getLocale } from '~/utils/getLocale';


### PR DESCRIPTION
## Summary

Fix errors in actueel branch

## Detailed design

1) Organised imports mess up the polyfill used in the `formatDate` for IE.
2) Restrictions give an error about missing icons
3) Quicklinks implemented the `<Link>` wrong.