### PR TITLE
Update warning-tile link in locale

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -613,7 +613,7 @@
     "select_region_municipality_legend": "Select a municipality:",
     "select_region_type_legend": "Show numbers from:",
     "your_municipality": "Municipality",
-    "belangrijk_bericht": "There is a [national lockdown](https://coronadashboard.government.nl/landelijk/maatregelen) until at least 9 February."
+    "belangrijk_bericht": "There is a [national lockdown](/landelijk/maatregelen) until at least 9 February."
   },
   "common": {
     "metadata": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -613,7 +613,7 @@
     "select_region_municipality_legend": "Selecteer een gemeente:",
     "select_region_type_legend": "Toon cijfers van:",
     "your_municipality": "Gemeente",
-    "belangrijk_bericht": "Er geldt een [landelijke lockdown](https://coronadashboard.rijksoverheid.nl/landelijk/maatregelen) tot en met in ieder geval 9 februari."
+    "belangrijk_bericht": "Er geldt een [landelijke lockdown](/landelijk/maatregelen) tot en met in ieder geval 9 februari."
   },
   "common": {
     "metadata": {


### PR DESCRIPTION
Changed link for the warning tile so that it goes to `/landelijk/maatregelen`.