### PR TITLE
Tweak the dynamic scale to all have same margin on the right

### DIFF
--- a/packages/app/src/utils/useDynamicScale.ts
+++ b/packages/app/src/utils/useDynamicScale.ts
@@ -27,7 +27,12 @@ export function useDynamicScale(
   const scale: ScaleLinear<number, number> = scaleLinear()
     .domain([scaleMin, scaleMax])
     .range([0, 100])
-    .nice(10);
+    /**
+     * A very high tick count makes the rounding so that all bars have about the
+     * same margin on the right side. For example Ziekenhuis opnames (200 range)
+     * and IC opnames (30 range)
+     */
+    .nice(10000);
 
   return scale;
 }


### PR DESCRIPTION
## Summary

By increasing the "tick count" argument of `nice()` we can get approximately the same margin on the right side of each bar scale. I'm not quite sure how to explain it.

```
/**
     * Extends the domain so that it starts and ends on nice round values.
     * This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value.
     * An optional tick count argument allows greater control over the step size used to extend the bounds,
     * guaranteeing that the returned ticks will exactly cover the domain.
     * Nicing is useful if the domain is computed from data, say using extent, and may be irregular.
     * For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0].
     * If the domain has more than two values, nicing the domain only affects the first and last value.
     *
     * Nicing a scale only modifies the current domain; it does not automatically nice domains that are subsequently set using continuous.domain.
     * You must re-nice the scale after setting the new domain, if desired.
     *
     * @param count An optional number of ticks expected to be used.
     */
    nice(count?: number): this;
```

Before

<img width="581" alt="Screenshot 2021-01-26 at 08 09 15" src="https://user-images.githubusercontent.com/71320230/105812125-e6238300-5fad-11eb-8520-16e096d62c56.png">

After

<img width="459" alt="Screenshot 2021-01-26 at 07 53 12" src="https://user-images.githubusercontent.com/71320230/105812137-ec196400-5fad-11eb-860a-485d4cf748da.png">
