### PR TITLE
Fix font-size for text metadata

### DIFF
--- a/packages/app/src/components-styled/content-header/metadata.tsx
+++ b/packages/app/src/components-styled/content-header/metadata.tsx
@@ -105,7 +105,7 @@ function MetadataItem(props: MetadataItemProps) {
               <ExternalLink href={item.href}>{item.text}</ExternalLink>
             )}
             {!item.href && (
-              <Text css={css({ display: 'inline-block', my: '0' })}>
+              <Text css={css({ display: 'inline-block', my: '0', fontSize: 'inherit' })}>
                 {item.text}
               </Text>
             )}

--- a/packages/app/src/components-styled/metadata.tsx
+++ b/packages/app/src/components-styled/metadata.tsx
@@ -41,7 +41,7 @@ export function Metadata({ date, source }: MetadataProps) {
               <ExternalLink href={source.href}>{source.text}</ExternalLink>
             )}
             {!source.href && (
-              <Text css={css({ display: 'inline-block', my: '0' })}>
+              <Text css={css({ display: 'inline-block', my: '0', fontSize: 'inherit' })}>
                 {source.text}
               </Text>
             )}


### PR DESCRIPTION
Since the vaccine page is "temporary" possible to add metadata without a link, the font-size was 0.125rem to big. Now it inherits from the parent 