### PR TITLE
Enforce description and aria description on all chart tiles

### DIFF
--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -8,12 +8,13 @@ import { MetadataProps } from './metadata';
 import { Heading } from './typography';
 import { useUniqueId } from '~/utils/useUniqueId';
 import { assert } from '~/utils/assert';
+import { isEmpty } from 'lodash';
 interface ChartTileProps {
   children: React.ReactNode;
   metadata: MetadataProps;
   title: string;
-  description?: React.ReactNode;
-  ariaDescription?: string;
+  description: React.ReactNode;
+  ariaDescription: string;
   uniqueId?: string;
 }
 
@@ -21,7 +22,7 @@ interface ChartTileWithTimeframeProps extends Omit<ChartTileProps, 'children'> {
   children: (timeframe: TimeframeOption) => React.ReactNode;
   timeframeOptions?: TimeframeOption[];
   timeframeInitialValue?: TimeframeOption;
-  ariaDescription?: string;
+  ariaDescription: string;
   uniqueId?: string;
 }
 
@@ -32,9 +33,15 @@ export function ChartTile({
   children,
   ariaDescription,
 }: ChartTileProps) {
-  assert(description, `Chart ${title} requires a description.`);
-
-  assert(ariaDescription, `Chart ${title} requires an ariaDescription.`);
+  /**
+   * Description is now used as a fallback to ariaDescription. Maybe we do not
+   * want that, in which case we'll need another assert just for ariaDescription.
+   */
+  assert(!isEmpty(description), `Chart ${title} requires a description.`);
+  assert(
+    !isEmpty(ariaDescription),
+    `Chart ${title} requires an aria description.`
+  );
 
   const uniqueId = useUniqueId();
 
@@ -91,12 +98,12 @@ function ChartTileHeader({
   ariaDescription,
 }: {
   title: string;
-  description?: React.ReactNode;
+  description: React.ReactNode;
   timeframe?: TimeframeOption;
   timeframeOptions?: TimeframeOption[];
   onTimeframeChange?: (timeframe: TimeframeOption) => void;
   uniqueId?: string;
-  ariaDescription?: string;
+  ariaDescription: string;
 }) {
   return (
     <Box

--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -32,10 +32,9 @@ export function ChartTile({
   children,
   ariaDescription,
 }: ChartTileProps) {
-  assert(
-    !(!description && !ariaDescription),
-    `This graph doesn't include a valid description nor an ariaDescription, please add one of them.`
-  );
+  assert(description, `Chart ${title} requires a description.`);
+
+  assert(ariaDescription, `Chart ${title} requires an ariaDescription.`);
 
   const uniqueId = useUniqueId();
 

--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -9,11 +9,11 @@ import { assert } from '~/utils/assert';
 interface LineChartTileProps<T extends Value> extends LineChartProps<T> {
   title: string;
   metadata: MetadataProps;
-  description?: string;
+  description: string;
   timeframeOptions?: TimeframeOption[];
   timeframeInitialValue?: TimeframeOption;
   footer?: React.ReactNode;
-  ariaDescription?: string;
+  ariaDescription: string;
 }
 
 export function LineChartTile<T extends Value>({

--- a/packages/app/src/domain/deceased/deceased-monitor-section.tsx
+++ b/packages/app/src/domain/deceased/deceased-monitor-section.tsx
@@ -52,6 +52,10 @@ export function DeceasedMonitorSection({
         metadata={{ source: text.bronnen.cbs }}
         title={text.deceased_monitor_chart_title}
         description={text.deceased_monitor_chart_description}
+        /**
+         * @TODO add real aria description in lokalize
+         */
+        ariaDescription={text.deceased_monitor_chart_description}
       >
         <DeceasedMonitor
           values={data.values}

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -219,6 +219,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
         <LineChartTile
           title={text.linechart_titel}
           description={text.linechart_toelichting}
+          ariaDescription={text.linechart_toelichting}
           signaalwaarde={7}
           values={dataInfectedDelta.values}
           linesConfig={[{ metricProperty: 'infected_per_100k' }]}
@@ -265,6 +266,10 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
         <ChartTile
           title={siteText.infected_age_groups.title}
           description={replaceVariablesInText(
+            siteText.infected_age_groups.description,
+            ageDemographicExampleData
+          )}
+          ariaDescription={replaceVariablesInText(
             siteText.infected_age_groups.description,
             ageDemographicExampleData
           )}
@@ -363,6 +368,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
           timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_percentage_titel}
           description={ggdText.linechart_percentage_toelichting}
+          ariaDescription={ggdText.linechart_percentage_toelichting}
           values={dataGgdDailyValues}
           linesConfig={[{ metricProperty: 'infected_percentage' }]}
           isPercentage
@@ -375,6 +381,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
           timeframeOptions={['all', '5weeks']}
           title={ggdText.linechart_totaltests_titel}
           description={ggdText.linechart_totaltests_toelichting}
+          ariaDescription={ggdText.linechart_totaltests_toelichting}
           hideFill={true}
           showLegend
           padding={{


### PR DESCRIPTION
## Summary

Because they should not be optional it would be better to break the build when they are missing in lokalize.

This is WIP because if you run a build with this code, a lot of assertion errors occur still.