### PR TITLE
Add link with arrow in the trend tiles and the risk level indicator

### DIFF
--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -5,10 +5,11 @@ import { Link } from '~/utils/link';
 
 interface LinkWithIconProps {
   href: UrlObject | string;
-  children: ReactNode;
+  children: string;
   icon: ReactNode;
   iconPlacement?: 'left' | 'right';
   fontWeight?: 'bold' | 'normal';
+  headingLink?: boolean | undefined;
 }
 
 export function LinkWithIcon({
@@ -17,32 +18,57 @@ export function LinkWithIcon({
   children,
   iconPlacement = 'left',
   fontWeight = 'normal',
+  headingLink,
 }: LinkWithIconProps) {
+  const splittedString = children.split(' ');
+
   return (
     <Link href={href} passHref>
       <a
         css={css({
           display: 'inline-block',
           fontWeight,
+          position: 'relative',
           textDecoration: 'none',
+          color: headingLink ? 'body' : '',
           '&:hover,&:focus': {
-            textDecoration: 'underline',
+            color: headingLink ? 'blue' : '',
+            textDecoration: headingLink ? '' : 'underline',
           },
         })}
       >
-        {iconPlacement == 'right' && children}
-        <span
-          css={css({
-            svg: {
-              height: '11px',
-              width: '13px',
-              mx: '3px',
-            },
-          })}
-        >
-          {icon}
-        </span>
-        {iconPlacement == 'left' && children}
+        {iconPlacement == 'right' && !headingLink && children}
+        {!headingLink && (
+          <span
+            css={css({
+              svg: {
+                height: '11px',
+                width: '13px',
+                mx: '3px',
+              },
+            })}
+          >
+            {icon}
+          </span>
+        )}
+        {iconPlacement == 'left' && !headingLink && children}
+        {headingLink && (
+          <>
+            {!splittedString.length
+              ? children
+              : `${splittedString.slice(0, -1).join(' ')} `}
+            <span css={css({ display: 'inline-block' })}>
+              {splittedString[splittedString.length - 1]}
+              <span
+                css={css({
+                  svg: { height: '16px', width: '18px', marginLeft: 2 },
+                })}
+              >
+                {icon}
+              </span>
+            </span>
+          </>
+        )}
       </a>
     </Link>
   );

--- a/packages/app/src/components-styled/metadata.tsx
+++ b/packages/app/src/components-styled/metadata.tsx
@@ -41,7 +41,13 @@ export function Metadata({ date, source }: MetadataProps) {
               <ExternalLink href={source.href}>{source.text}</ExternalLink>
             )}
             {!source.href && (
-              <Text css={css({ display: 'inline-block', my: '0', fontSize: 'inherit' })}>
+              <Text
+                css={css({
+                  display: 'inline-block',
+                  my: '0',
+                  fontSize: 'inherit',
+                })}
+              >
                 {source.text}
               </Text>
             )}

--- a/packages/app/src/components-styled/risk-level-indicator.tsx
+++ b/packages/app/src/components-styled/risk-level-indicator.tsx
@@ -59,15 +59,15 @@ export function RiskLevelIndicator(props: RiskLevelIndicatorProps) {
         <Stopwatch />
       </Box>
       <Heading level={3} as="h2" py={2} pl={{ _: '3.5rem' }}>
-      <LinkWithIcon
+        <LinkWithIcon
           href={href}
           icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink
-          >
-              {title}
-          </LinkWithIcon>
+        >
+          {title}
+        </LinkWithIcon>
       </Heading>
       <Box>
         <Box

--- a/packages/app/src/components-styled/risk-level-indicator.tsx
+++ b/packages/app/src/components-styled/risk-level-indicator.tsx
@@ -7,6 +7,8 @@ import { Heading, Text } from '~/components-styled/typography';
 import { regionThresholds } from '~/components/choropleth/region-thresholds';
 import { EscalationLevel } from '~/domain/restrictions/type';
 import { assert } from '~/utils/assert';
+import { LinkWithIcon } from '~/components-styled/link-with-icon';
+import ArrowIcon from '~/assets/arrow.svg';
 
 const escalationThresholds =
   regionThresholds.escalation_levels.escalation_level;
@@ -25,6 +27,7 @@ interface RiskLevelIndicatorProps {
   escalationTypes: Record<escalationRecord, escalationTypesType>;
   escalationLevel: EscalationLevel | number;
   children?: ReactNode;
+  href: string;
 }
 
 export function RiskLevelIndicator(props: RiskLevelIndicatorProps) {
@@ -34,6 +37,7 @@ export function RiskLevelIndicator(props: RiskLevelIndicatorProps) {
     children,
     escalationTypes,
     escalationLevel,
+    href,
   } = props;
 
   const filteredEscalationLevel = escalationThresholds.find(
@@ -55,7 +59,15 @@ export function RiskLevelIndicator(props: RiskLevelIndicatorProps) {
         <Stopwatch />
       </Box>
       <Heading level={3} as="h2" py={2} pl={{ _: '3.5rem' }}>
-        {title}
+      <LinkWithIcon
+          href={href}
+          icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+          iconPlacement="right"
+          fontWeight="bold"
+          headingLink
+          >
+              {title}
+          </LinkWithIcon>
       </Heading>
       <Box>
         <Box

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -11,6 +11,8 @@ import text from '~/locale';
 import { formatNumber } from '~/utils/formatNumber';
 import styled from 'styled-components';
 import css from '@styled-system/css';
+import { LinkWithIcon } from '~/components-styled/link-with-icon';
+import ArrowIcon from '~/assets/arrow.svg';
 
 type MiniTrendTileProps<T extends Value> = {
   icon: JSX.Element;
@@ -18,10 +20,11 @@ type MiniTrendTileProps<T extends Value> = {
   text: ReactNode;
   trendData: T[];
   metricProperty: NumberProperty<T>;
+  href: string;
 };
 
 export function MiniTrendTile<T extends Value>(props: MiniTrendTileProps<T>) {
-  const { icon, title, text, trendData, metricProperty } = props;
+  const { icon, title, text, trendData, metricProperty, href } = props;
 
   const value = trendData[trendData.length - 1][metricProperty];
 
@@ -38,7 +41,15 @@ export function MiniTrendTile<T extends Value>(props: MiniTrendTileProps<T>) {
         mb={2}
         lineHeight={{ md: 0, lg: 2 }}
       >
-        {title}
+        <LinkWithIcon
+          href={href}
+          icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+          iconPlacement="right"
+          fontWeight="bold"
+          headingLink
+          >
+              {title}
+          </LinkWithIcon>
       </Heading>
       <Text fontSize="2.75rem" fontWeight="bold" my={0} lineHeight={0} mb={2}>
         {formatNumber((value as unknown) as number)}

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -114,6 +114,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<GetestIcon />}
                 trendData={dataInfectedTotal.values}
                 metricProperty="infected"
+                href={`/gemeente/${router.query.code}/positief-geteste-mensen`}
               />
 
               <MiniTrendTile
@@ -133,6 +134,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<ZiekenhuisIcon />}
                 trendData={dataHospitalIntake.values}
                 metricProperty="admissions_on_date_of_reporting"
+                href={`/gemeente/${router.query.code}/ziekenhuis-opnames`}
               />
 
               <RiskLevelIndicator
@@ -141,6 +143,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
                 escalationLevel={filteredRegion.escalation_level}
                 code={filteredRegion.vrcode}
                 escalationTypes={escalationText.types}
+                href={`/veiligheidsregio/${safetyRegionForMunicipality?.code}/maatregelen`}
               >
                 {safetyRegionForMunicipality && (
                   <>

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -111,6 +111,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<GetestIcon />}
                 trendData={dataInfectedTotal.values}
                 metricProperty="infected"
+                href={`/gemeente/${router.query.code}/positief-geteste-mensen`}
               />
 
               <MiniTrendTile
@@ -130,6 +131,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<ZiekenhuisIcon />}
                 trendData={dataHospitalIntake.values}
                 metricProperty="admissions_on_date_of_reporting"
+                href={`/gemeente/${router.query.code}/ziekenhuis-opnames`}
               />
 
               <RiskLevelIndicator
@@ -138,6 +140,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
                 escalationLevel={filteredRegion.escalation_level}
                 code={filteredRegion.vrcode}
                 escalationTypes={escalationText.types}
+                href={`/veiligheidsregio/${router.query.code}/maatregelen`}
               >
                 <Link href={`/veiligheidsregio/${regionCode}/maatregelen`}>
                   <a>{text.risoconiveau_maatregelen.bekijk_href}</a>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -134,6 +134,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<GetestIcon />}
                 trendData={dataInfectedTotal.values}
                 metricProperty="infected"
+                href="/landelijk/positief-geteste-mensen"
               />
 
               <MiniTrendTile
@@ -153,6 +154,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<ZiekenhuisIcon />}
                 trendData={dataHospitalIntake.values}
                 metricProperty="admissions_on_date_of_reporting"
+                href="/landelijk/ziekenhuis-opnames"
               />
 
               <MiniTrendTile
@@ -174,6 +176,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 icon={<ArtsIcon />}
                 trendData={dataIntake.values}
                 metricProperty="admissions_moving_average"
+                href="/landelijk/intensive-care-opnames"
               />
             </MiniTrendTileLayout>
 


### PR DESCRIPTION
It is now possible to click on the header to go to a certain page.
Since I wanted the arrow to follow the flow of the parent I had to wrap the last word including the arrow in a span if the string had at least 2 words. To prevent that the arrow is only jumping to the next line.