### PR TITLE
Generate chart aria id from title

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,6 +36,7 @@
     "remark-external-links": "^7.0.0",
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",
+    "slugify": "^1.4.6",
     "styled-components": "^5.2.0",
     "styled-system": "^5.1.5",
     "swr": "^0.3.4",

--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -6,15 +6,15 @@ import { ChartTileContainer } from './chart-tile-container';
 import { ChartTimeControls } from './chart-time-controls';
 import { MetadataProps } from './metadata';
 import { Heading } from './typography';
-import { useUniqueId } from '~/utils/useUniqueId';
 import { assert } from '~/utils/assert';
+import slugify from 'slugify';
 interface ChartTileProps {
   children: React.ReactNode;
   metadata: MetadataProps;
   title: string;
   description?: React.ReactNode;
   ariaDescription?: string;
-  uniqueId?: string;
+  ariaId?: string;
 }
 
 interface ChartTileWithTimeframeProps extends Omit<ChartTileProps, 'children'> {
@@ -22,7 +22,7 @@ interface ChartTileWithTimeframeProps extends Omit<ChartTileProps, 'children'> {
   timeframeOptions?: TimeframeOption[];
   timeframeInitialValue?: TimeframeOption;
   ariaDescription?: string;
-  uniqueId?: string;
+  ariaId?: string;
 }
 
 export function ChartTile({
@@ -37,7 +37,12 @@ export function ChartTile({
     `This graph doesn't include a valid description nor an ariaDescription, please add one of them.`
   );
 
-  const uniqueId = useUniqueId();
+  /**
+   * Chart title should be unique on a page. If we instead use useUniqueId here
+   * the SSR markup doesn't match the client-side rendered id, which generates a
+   * warning and is probably problematic for screen readers.
+   */
+  const ariaId = slugify(title);
 
   return (
     <ChartTileContainer metadata={metadata}>
@@ -45,7 +50,7 @@ export function ChartTile({
         title={title}
         description={description}
         ariaDescription={ariaDescription}
-        uniqueId={uniqueId}
+        ariaId={ariaId}
       />
       {children}
     </ChartTileContainer>
@@ -59,7 +64,7 @@ export function ChartTileWithTimeframe({
   timeframeOptions = ['all', '5weeks', 'week'],
   timeframeInitialValue = 'all',
   children,
-  uniqueId,
+  ariaId,
   ariaDescription,
 }: ChartTileWithTimeframeProps) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>(
@@ -74,7 +79,7 @@ export function ChartTileWithTimeframe({
         timeframe={timeframe}
         timeframeOptions={timeframeOptions}
         onTimeframeChange={setTimeframe}
-        uniqueId={uniqueId}
+        ariaId={ariaId}
         ariaDescription={ariaDescription}
       />
       {children(timeframe)}
@@ -88,7 +93,7 @@ function ChartTileHeader({
   timeframe,
   timeframeOptions,
   onTimeframeChange,
-  uniqueId,
+  ariaId,
   ariaDescription,
 }: {
   title: string;
@@ -96,7 +101,7 @@ function ChartTileHeader({
   timeframe?: TimeframeOption;
   timeframeOptions?: TimeframeOption[];
   onTimeframeChange?: (timeframe: TimeframeOption) => void;
-  uniqueId?: string;
+  ariaId?: string;
   ariaDescription?: string;
 }) {
   return (
@@ -109,17 +114,17 @@ function ChartTileHeader({
       <div css={css({ mb: [3, null, null, null, 0], mr: [0, 0, 2] })}>
         <Heading level={3}>{title}</Heading>
         {!description && (
-          <div css={css({ display: 'none' })} aria-labelledby={uniqueId}>
+          <div css={css({ display: 'none' })} aria-labelledby={ariaId}>
             {ariaDescription}
           </div>
         )}
         {description &&
           (typeof description === 'string' ? (
-            <p aria-labelledby={uniqueId} css={css({ m: 0 })}>
+            <p aria-labelledby={ariaId} css={css({ m: 0 })}>
               {description}
             </p>
           ) : (
-            <div aria-labelledby={uniqueId}>{description}</div>
+            <div aria-labelledby={ariaId}>{description}</div>
           ))}
       </div>
       {timeframe && onTimeframeChange && (

--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -14,7 +14,7 @@ interface ChartTileProps {
   title: string;
   description?: React.ReactNode;
   ariaDescription?: string;
-  ariaId?: string;
+  ariaLabelledBy?: string;
 }
 
 interface ChartTileWithTimeframeProps extends Omit<ChartTileProps, 'children'> {
@@ -22,7 +22,7 @@ interface ChartTileWithTimeframeProps extends Omit<ChartTileProps, 'children'> {
   timeframeOptions?: TimeframeOption[];
   timeframeInitialValue?: TimeframeOption;
   ariaDescription?: string;
-  ariaId?: string;
+  ariaLabelledBy?: string;
 }
 
 export function ChartTile({
@@ -42,7 +42,7 @@ export function ChartTile({
    * the SSR markup doesn't match the client-side rendered id, which generates a
    * warning and is probably problematic for screen readers.
    */
-  const ariaId = slugify(title);
+  const ariaLabelledBy = slugify(title);
 
   return (
     <ChartTileContainer metadata={metadata}>
@@ -50,7 +50,7 @@ export function ChartTile({
         title={title}
         description={description}
         ariaDescription={ariaDescription}
-        ariaId={ariaId}
+        ariaLabelledBy={ariaLabelledBy}
       />
       {children}
     </ChartTileContainer>
@@ -64,7 +64,7 @@ export function ChartTileWithTimeframe({
   timeframeOptions = ['all', '5weeks', 'week'],
   timeframeInitialValue = 'all',
   children,
-  ariaId,
+  ariaLabelledBy,
   ariaDescription,
 }: ChartTileWithTimeframeProps) {
   const [timeframe, setTimeframe] = useState<TimeframeOption>(
@@ -79,7 +79,7 @@ export function ChartTileWithTimeframe({
         timeframe={timeframe}
         timeframeOptions={timeframeOptions}
         onTimeframeChange={setTimeframe}
-        ariaId={ariaId}
+        ariaLabelledBy={ariaLabelledBy}
         ariaDescription={ariaDescription}
       />
       {children(timeframe)}
@@ -93,7 +93,7 @@ function ChartTileHeader({
   timeframe,
   timeframeOptions,
   onTimeframeChange,
-  ariaId,
+  ariaLabelledBy,
   ariaDescription,
 }: {
   title: string;
@@ -101,7 +101,7 @@ function ChartTileHeader({
   timeframe?: TimeframeOption;
   timeframeOptions?: TimeframeOption[];
   onTimeframeChange?: (timeframe: TimeframeOption) => void;
-  ariaId?: string;
+  ariaLabelledBy?: string;
   ariaDescription?: string;
 }) {
   return (
@@ -114,17 +114,17 @@ function ChartTileHeader({
       <div css={css({ mb: [3, null, null, null, 0], mr: [0, 0, 2] })}>
         <Heading level={3}>{title}</Heading>
         {!description && (
-          <div css={css({ display: 'none' })} aria-labelledby={ariaId}>
+          <div css={css({ display: 'none' })} aria-labelledby={ariaLabelledBy}>
             {ariaDescription}
           </div>
         )}
         {description &&
           (typeof description === 'string' ? (
-            <p aria-labelledby={ariaId} css={css({ m: 0 })}>
+            <p aria-labelledby={ariaLabelledBy} css={css({ m: 0 })}>
               {description}
             </p>
           ) : (
-            <div aria-labelledby={ariaId}>{description}</div>
+            <div aria-labelledby={ariaLabelledBy}>{description}</div>
           ))}
       </div>
       {timeframe && onTimeframeChange && (

--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -4,8 +4,8 @@ import { Value } from '~/components-styled/line-chart/helpers';
 import { TimeframeOption } from '~/utils/timeframe';
 import { ChartTileWithTimeframe } from './chart-tile';
 import { MetadataProps } from './metadata';
-import { useUniqueId } from '~/utils/useUniqueId';
 import { assert } from '~/utils/assert';
+import slugify from 'slugify';
 interface LineChartTileProps<T extends Value> extends LineChartProps<T> {
   title: string;
   metadata: MetadataProps;
@@ -30,7 +30,7 @@ export function LineChartTile<T extends Value>({
     description || ariaDescription,
     `This graph doesn't include a valid description nor an ariaDescription, please add one of them.`
   );
-  const uniqueId = useUniqueId();
+  const ariaId = slugify(title);
 
   return (
     <ChartTileWithTimeframe
@@ -39,7 +39,7 @@ export function LineChartTile<T extends Value>({
       metadata={metadata}
       timeframeOptions={timeframeOptions}
       timeframeInitialValue={timeframeInitialValue}
-      uniqueId={uniqueId}
+      ariaId={ariaId}
       ariaDescription={ariaDescription}
     >
       {(timeframe) => (
@@ -50,7 +50,7 @@ export function LineChartTile<T extends Value>({
                 {...chartProps}
                 width={parent.width}
                 timeframe={timeframe}
-                uniqueId={uniqueId}
+                uniqueId={ariaId}
               />
             )}
           </ParentSize>

--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -30,7 +30,7 @@ export function LineChartTile<T extends Value>({
     description || ariaDescription,
     `This graph doesn't include a valid description nor an ariaDescription, please add one of them.`
   );
-  const ariaId = slugify(title);
+  const ariaLabelledBy = slugify(title);
 
   return (
     <ChartTileWithTimeframe
@@ -39,7 +39,7 @@ export function LineChartTile<T extends Value>({
       metadata={metadata}
       timeframeOptions={timeframeOptions}
       timeframeInitialValue={timeframeInitialValue}
-      ariaId={ariaId}
+      ariaLabelledBy={ariaLabelledBy}
       ariaDescription={ariaDescription}
     >
       {(timeframe) => (
@@ -50,7 +50,7 @@ export function LineChartTile<T extends Value>({
                 {...chartProps}
                 width={parent.width}
                 timeframe={timeframe}
-                uniqueId={ariaId}
+                ariaLabelledBy={ariaLabelledBy}
               />
             )}
           </ParentSize>

--- a/packages/app/src/components-styled/line-chart/components/chart-axes/index.tsx
+++ b/packages/app/src/components-styled/line-chart/components/chart-axes/index.tsx
@@ -60,7 +60,7 @@ type ChartAxesProps = {
   formatYAxis: TickFormatter<number>;
   children: (props: ChartScales) => ReactNode;
   componentCallback?: ComponentCallbackFunction;
-  uniqueId?: string;
+  ariaLabelledBy?: string;
 };
 
 type AnyTickFormatter = (value: any) => string;
@@ -79,7 +79,7 @@ export const ChartAxes = memo(function ChartAxes({
   formatYAxis,
   children,
   componentCallback = () => undefined,
-  uniqueId,
+  ariaLabelledBy,
 }: ChartAxesProps) {
   const bounds: ChartBounds = {
     width: width - padding.left - padding.right,
@@ -105,7 +105,12 @@ export const ChartAxes = memo(function ChartAxes({
   ) => onHover(event, scales);
 
   return (
-    <svg width={width} height={height} role="img" aria-labelledby={uniqueId}>
+    <svg
+      width={width}
+      height={height}
+      role="img"
+      aria-labelledby={ariaLabelledBy}
+    >
       <Group left={padding.left} top={padding.top}>
         {createComponent(
           {

--- a/packages/app/src/components-styled/line-chart/index.tsx
+++ b/packages/app/src/components-styled/line-chart/index.tsx
@@ -69,7 +69,7 @@ export type LineChartProps<T extends Value> = {
   showLegend?: boolean;
   legendItems?: LegendItem[];
   componentCallback?: ComponentCallbackFunction;
-  uniqueId?: string;
+  ariaLabelledBy?: string;
 };
 
 export function LineChart<T extends Value>({
@@ -96,7 +96,7 @@ export function LineChart<T extends Value>({
       }))
     : undefined,
   componentCallback,
-  uniqueId,
+  ariaLabelledBy,
 }: LineChartProps<T>) {
   const {
     tooltipData,
@@ -308,7 +308,7 @@ export function LineChart<T extends Value>({
           onHover={handleHover}
           benchmark={benchmark}
           componentCallback={componentCallback}
-          uniqueId={uniqueId}
+          ariaLabelledBy={ariaLabelledBy}
         >
           {renderAxes}
         </ChartAxes>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15235,6 +15235,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.6.tgz#ef288d920a47fb01c2be56b3487b6722f5e34ace"
+  integrity sha512-ZdJIgv9gdrYwhXqxsH9pv7nXxjUEyQ6nqhngRxoAAOlmMGA28FDq5O4/5US4G2/Nod7d1ovNcgURQJ7kHq50KQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
## Summary

This prevent a warning about aria labelled-by id that changes between SSR and client side rendering. I'm assuming each chart has a unique title.