### PR TITLE
Update box shadow search results

### DIFF
--- a/packages/app/src/domain/topical/components/search/search-input.tsx
+++ b/packages/app/src/domain/topical/components/search/search-input.tsx
@@ -66,7 +66,6 @@ const StyledSearchInput = styled.input(
     display: 'block',
     width: '100%',
     borderRadius: 1,
-    boxShadow: 'tile',
     border: `solid`,
     borderWidth: '1px',
     borderColor: 'lightGray',
@@ -80,6 +79,7 @@ const StyledSearchInput = styled.input(
     },
     '&:placeholder-shown': {
       pr: 2,
+      boxShadow: 'tile',
     },
   })
 );

--- a/packages/app/src/domain/topical/components/search/search.tsx
+++ b/packages/app/src/domain/topical/components/search/search.tsx
@@ -31,7 +31,11 @@ export function Search({ initialValue }: { initialValue?: string }) {
             <Box position="relative" ref={heightRef}>
               <SearchInput />
             </Box>
-            {context.showResults && <SearchResults />}
+            {context.showResults && (
+              <Box boxShadow="tile">
+                <SearchResults />
+              </Box>
+            )}
           </Box>
         </SearchForm>
       )}


### PR DESCRIPTION
Now the box-shadow is back on the search input results, had to wrap the whole content in a Box to avoid the negative margins that were added later on.