### PR TITLE
Fix E2E test by fixing choropleth route

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -195,9 +195,12 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
               metricName="tested_overall"
               metricProperty="infected_per_100k"
               tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-                createSelectMunicipalHandler(router)
+                createSelectMunicipalHandler(router, 'positief-geteste-mensen')
               )}
-              onSelect={createSelectMunicipalHandler(router)}
+              onSelect={createSelectMunicipalHandler(
+                router,
+                'positief-geteste-mensen'
+              )}
             />
           )}
           {selectedMap === 'region' && (


### PR DESCRIPTION
## Summary

Fix E2E test by fixing choropleth route

(The default is Actueel if passing no options to `createSelectMunicipalHandler`)