### PR TITLE
Replace sanity url builder with images from the filesystem

### DIFF
--- a/packages/app/src/components-styled/article-detail.tsx
+++ b/packages/app/src/components-styled/article-detail.tsx
@@ -17,7 +17,8 @@ interface ArticleDetailProps {
 }
 
 export function ArticleDetail({ article }: ArticleDetailProps) {
-  const { coverAsset } = article;
+  const { asset } = article.cover;
+  console.log(article);
 
   return (
     <Box bg="white" py={{ _: 4, md: 5 }}>
@@ -41,9 +42,9 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
         </Box>
 
         <Image
-          src={`/${coverAsset.assetId}.${coverAsset.extension}`}
+          src={`/${asset.assetId}.${asset.extension}`}
           width={630}
-          height={630 / coverAsset.metadata.dimensions.aspectRatio}
+          height={630 / asset.metadata.dimensions.aspectRatio}
         />
       </ContentBlock>
 

--- a/packages/app/src/components-styled/article-detail.tsx
+++ b/packages/app/src/components-styled/article-detail.tsx
@@ -18,7 +18,6 @@ interface ArticleDetailProps {
 
 export function ArticleDetail({ article }: ArticleDetailProps) {
   const { asset } = article.cover;
-  console.log(article);
 
   return (
     <Box bg="white" py={{ _: 4, md: 5 }}>

--- a/packages/app/src/components-styled/article-detail.tsx
+++ b/packages/app/src/components-styled/article-detail.tsx
@@ -40,8 +40,6 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
           <PortableText blocks={article.intro} />
         </Box>
 
-        {/* <Image node={article.cover} /> */}
-
         <Image
           src={`/${coverAsset.assetId}.${coverAsset.extension}`}
           width={630}

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -1,14 +1,14 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import ArrowIcon from '~/assets/arrow.svg';
-import { urlFor } from '~/lib/sanity';
 import siteText from '~/locale';
 import { Article, Block, ImageBlock } from '~/types/cms';
-import { assert } from '~/utils/assert';
 import { Link } from '~/utils/link';
 import { BackgroundImage } from './background-image';
 import { Box } from './base';
 import { Heading, InlineText, Text } from './typography';
+import { imageResizeTargets } from '@corona-dashboard/common';
+import { findClosestSize } from '~/utils/findClosestSize';
 
 export type ArticleSummary = Pick<
   Article,
@@ -88,17 +88,16 @@ type CoverImageProps = {
 };
 
 function CoverImage({ height, image }: CoverImageProps) {
-  const url = urlFor(image).url();
-  assert(
-    url !== null,
-    `Could not get url for node: ${JSON.stringify(image, null, 2)}`
-  );
-
-  const { hotspot } = image;
+  const { hotspot, asset } = image;
 
   const bgPosition = hotspot
     ? `${hotspot.x * 100}% ${hotspot.y * 100}%`
     : undefined;
+
+  const url = `/cms/${asset.assetId}-${findClosestSize(
+    700,
+    imageResizeTargets
+  )}.${asset.extension}`;
 
   return (
     <Box height={height} overflow="hidden">

--- a/packages/app/src/components-styled/cms/image.tsx
+++ b/packages/app/src/components-styled/cms/image.tsx
@@ -6,8 +6,6 @@ import { ImageBlock, RichContentImageBlock } from '~/types/cms';
 import { Image as SrcSetImage } from '~/components-styled/image';
 
 export function Image({ node }: { node: ImageBlock | RichContentImageBlock }) {
-  console.log({ node });
-
   const caption = 'caption' in node && node.caption && (
     <figcaption>{node.caption}</figcaption>
   );
@@ -16,14 +14,15 @@ export function Image({ node }: { node: ImageBlock | RichContentImageBlock }) {
     <Box bg="page">
       <MaxWidth py={4} px={4}>
         <Box as="figure" role="group" spacing={3}>
-          <Box
-            as="img"
-            display="block"
+          <SrcSetImage
+            src={`/${node.asset.assetId}.${node.asset.extension}`}
+            width={node.asset.metadata.dimensions.width}
+            height={node.asset.metadata.dimensions.height}
+            alt={node.alt}
             borderRadius={1}
             boxShadow="tile"
-            src={node.asset.assetId}
-            alt={node.alt}
           />
+
           {caption}
         </Box>
       </MaxWidth>

--- a/packages/app/src/components-styled/cms/image.tsx
+++ b/packages/app/src/components-styled/cms/image.tsx
@@ -1,16 +1,12 @@
 import { Box } from '~/components-styled/base';
 import { ContentBlock } from '~/components-styled/cms/content-block';
 import { MaxWidth } from '~/components-styled/max-width';
-import { urlFor } from '~/lib/sanity';
 import { ImageBlock, RichContentImageBlock } from '~/types/cms';
-import { assert } from '~/utils/assert';
+
+import { Image as SrcSetImage } from '~/components-styled/image';
 
 export function Image({ node }: { node: ImageBlock | RichContentImageBlock }) {
-  const url = urlFor(node).toString();
-  assert(
-    url !== null,
-    `could not get url for node: ${JSON.stringify(node, null, 2)}`
-  );
+  console.log({ node });
 
   const caption = 'caption' in node && node.caption && (
     <figcaption>{node.caption}</figcaption>
@@ -25,7 +21,7 @@ export function Image({ node }: { node: ImageBlock | RichContentImageBlock }) {
             display="block"
             borderRadius={1}
             boxShadow="tile"
-            src={url}
+            src={node.asset.assetId}
             alt={node.alt}
           />
           {caption}
@@ -35,7 +31,12 @@ export function Image({ node }: { node: ImageBlock | RichContentImageBlock }) {
   ) : (
     <ContentBlock>
       <Box as="figure" role="group" spacing={3} textAlign="center">
-        <Box as="img" display="block" src={url} alt={node.alt} />
+        <SrcSetImage
+          src={`/${node.asset.assetId}.${node.asset.extension}`}
+          width={node.asset.metadata.dimensions.width}
+          height={node.asset.metadata.dimensions.height}
+          alt={node.alt}
+        />
         {caption}
       </Box>
     </ContentBlock>

--- a/packages/app/src/components-styled/image.tsx
+++ b/packages/app/src/components-styled/image.tsx
@@ -1,5 +1,7 @@
 import { imageResizeTargets } from '@corona-dashboard/common';
 import { findClosestSize } from '~/utils/findClosestSize';
+import { Box } from '~/components-styled/base';
+
 import styled from 'styled-components/';
 
 type ImageProps = {
@@ -7,9 +9,16 @@ type ImageProps = {
   width: number;
   height: number;
   alt?: string;
+  borderRadius?: number;
+  boxShadow?: string;
 };
 
-const Img = styled.img`
+const Img = styled(Box).attrs({ as: 'img' })<
+  ImageProps & {
+    srcSet: string;
+    loading: string;
+  }
+>`
   max-width: 100%;
   height: auto;
 `;
@@ -21,7 +30,7 @@ const Img = styled.img`
  * compatible with next export.
  */
 export function Image(props: ImageProps) {
-  const { src, width, height, alt } = props;
+  const { src, width, height, alt, ...imageProps } = props;
   const [filename, extension] = src.split('.');
 
   const srcSet = imageResizeTargets
@@ -44,6 +53,7 @@ export function Image(props: ImageProps) {
       width={width}
       height={Math.floor(height)}
       loading="lazy"
+      {...imageProps}
     />
   );
 }

--- a/packages/app/src/domain/topical/editorial-teaser.tsx
+++ b/packages/app/src/domain/topical/editorial-teaser.tsx
@@ -123,8 +123,6 @@ function CoverImage({ image, children }: CoverImageProps) {
     imageResizeTargets
   )}.${asset.extension}`;
 
-  console.log(url);
-
   return (
     <BackgroundImage
       height="100%"

--- a/packages/app/src/domain/topical/editorial-teaser.tsx
+++ b/packages/app/src/domain/topical/editorial-teaser.tsx
@@ -5,11 +5,11 @@ import ArrowIcon from '~/assets/arrow.svg';
 import { BackgroundImage } from '~/components-styled/background-image';
 import { Box } from '~/components-styled/base';
 import { Heading, InlineText, Text } from '~/components-styled/typography';
-import { urlFor } from '~/lib/sanity';
 import siteText from '~/locale';
 import { Block, Editorial, ImageBlock } from '~/types/cms';
-import { assert } from '~/utils/assert';
 import { Link } from '~/utils/link';
+import { imageResizeTargets } from '@corona-dashboard/common';
+import { findClosestSize } from '~/utils/findClosestSize';
 
 export type EditorialSummary = Pick<
   Editorial,
@@ -112,19 +112,18 @@ type CoverImageProps = {
 };
 
 function CoverImage({ image, children }: CoverImageProps) {
-  const url = urlFor(image).url();
-  assert(
-    url !== null,
-    `Could not get url for node: ${JSON.stringify(image, null, 2)}`
-  );
-
-  const { hotspot } = image;
+  const { hotspot, asset } = image;
 
   const bgPosition = hotspot
     ? `${hotspot.x * 100}% ${hotspot.y * 100}%`
     : undefined;
 
-  //linear-gradient(to bottom, rgba(245, 246, 252, 0.52), rgba(117, 19, 93, 0.73)),
+  const url = `/cms/${asset.assetId}-${findClosestSize(
+    700,
+    imageResizeTargets
+  )}.${asset.extension}`;
+
+  console.log(url);
 
   return (
     <BackgroundImage

--- a/packages/app/src/lib/sanity.tsx
+++ b/packages/app/src/lib/sanity.tsx
@@ -29,13 +29,15 @@ export const PortableText = BlockContent;
 // Set up the client for fetching data in the getProps page functions
 export const client = sanityClient(config);
 
-const builder = imageUrlBuilder(client);
+// const builder = imageUrlBuilder(client);
 
 /**
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.
  * Read more: https://www.sanity.io/docs/image-url
+ * CAUTION: This is commented out because we should be talking to our images on our own filesystem!
+ * Chances are high this helper will be removed completely!
  **/
-export const urlFor = (source: SanityImageSource) => builder.image(source);
+// export const urlFor = (source: SanityImageSource) => builder.image(source);
 
 export function localize<T>(value: T | T[], languages: TLanguageKey[]): T {
   const anyValue = value as any;

--- a/packages/app/src/lib/sanity.tsx
+++ b/packages/app/src/lib/sanity.tsx
@@ -1,8 +1,6 @@
 // lib/sanity.ts
 import BlockContent from '@sanity/block-content-to-react';
 import sanityClient from '@sanity/client';
-import imageUrlBuilder from '@sanity/image-url';
-import { SanityImageSource } from '@sanity/image-url/lib/types/types';
 import { TLanguageKey } from '~/locale';
 
 const config = {
@@ -30,7 +28,6 @@ export const PortableText = BlockContent;
 export const client = sanityClient(config);
 
 // const builder = imageUrlBuilder(client);
-
 /**
  * Set up a helper function for generating Image URLs with only the asset reference data in your documents.
  * Read more: https://www.sanity.io/docs/image-url

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -35,7 +35,24 @@ export const getStaticProps = createGetStaticProps(
     return `*[_type == 'article' && slug.current == '${context.params.slug}']{
       ...,
       "slug": slug.current,
-      "coverAsset": cover.asset ->
+      "coverAsset": cover.asset ->,
+      "content": {
+        "_type": content._type,
+  	    "nl": [
+  		    ...content.nl[]
+			    {
+      	    ...,
+      	    "asset": asset->
+     	    },
+		    ],
+  	    "en": [
+  		    ...content.en[]
+			    {
+      	    ...,
+      	    "asset": asset->
+     	    },
+		    ],
+	    }
     }[0]`;
   })
 );

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -10,6 +10,8 @@ import {
 } from '~/static-props/get-data';
 import { Article, Block } from '~/types/cms';
 import { assert } from '~/utils/assert';
+import { imageResizeTargets } from '@corona-dashboard/common';
+import { findClosestSize } from '~/utils/findClosestSize';
 
 const articlesQuery = `*[_type == 'article'] {"slug":slug.current}`;
 
@@ -77,13 +79,16 @@ const ArticleDetailPage: FCWithLayout<typeof getStaticProps> = (props) => {
 ArticleDetailPage.getLayout = (page, props) => {
   const { cover } = props.content;
   const { asset } = cover;
-  const url = `https://coronadashboard.rijksoverheid.nl/cms/${asset.assetId}.${asset.extension}`;
+
+  const url = `https://coronadashboard.rijksoverheid.nl/cms/${
+    asset.assetId
+  }-${findClosestSize(1200, imageResizeTargets)}.${asset.extension}`;
 
   return getLayoutWithMetadata({
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
-    openGraphImage: url || undefined,
-    twitterImage: url || undefined,
+    openGraphImage: url,
+    twitterImage: url,
   })(page, props);
 };
 

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -1,7 +1,7 @@
 import { ArticleDetail } from '~/components-styled/article-detail';
 import { Box } from '~/components-styled/base';
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
-import { client, localize, urlFor } from '~/lib/sanity';
+import { client, localize } from '~/lib/sanity';
 import { targetLanguage } from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -75,11 +75,15 @@ const ArticleDetailPage: FCWithLayout<typeof getStaticProps> = (props) => {
  * to simply have _something_
  */
 ArticleDetailPage.getLayout = (page, props) => {
+  const { cover } = props.content;
+  const { asset } = cover;
+  const url = `https://coronadashboard.rijksoverheid.nl/cms/${asset.assetId}.${asset.extension}`;
+
   return getLayoutWithMetadata({
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
-    openGraphImage: urlFor(props.content.cover).toString() || undefined,
-    twitterImage: urlFor(props.content.cover).toString() || undefined,
+    openGraphImage: url || undefined,
+    twitterImage: url || undefined,
   })(page, props);
 };
 

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -35,7 +35,10 @@ export const getStaticProps = createGetStaticProps(
     return `*[_type == 'article' && slug.current == '${context.params.slug}']{
       ...,
       "slug": slug.current,
-      "coverAsset": cover.asset ->,
+      "cover": {
+        ...cover,
+        "asset": cover.asset->
+      },
       "content": {
         "_type": content._type,
   	    "nl": [

--- a/packages/app/src/pages/artikelen/index.tsx
+++ b/packages/app/src/pages/artikelen/index.tsx
@@ -13,7 +13,15 @@ import {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<ArticleSummary[]>(
-    `*[_type == 'article'] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}`
+    `*[_type == 'article'] | order(publicationDate) {
+      "title":title.${targetLanguage},
+      slug,
+      "summary":summary.${targetLanguage},
+      "cover": {
+        ...cover,
+        "asset": cover.asset->
+      }    
+    }`
   )
 );
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -55,9 +55,35 @@ export const getStaticProps = createGetStaticProps(
   }>(
     `{
     // Retrieve the latest 3 articles with the highlighted article filtered out:
-    'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0..2],
-    'editorial': *[_type == 'editorial'] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0],
-    'highlight': *[_type == 'topicalPage']{"article":highlightedArticle->{"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}}[0],
+    'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {
+      "title":title.${targetLanguage},
+      slug,
+      "summary":summary.${targetLanguage},
+  		"cover": {
+        ...cover,
+        "asset": cover.asset->
+      }
+    }[0..2],
+    'editorial': *[_type == 'editorial'] | order(publicationDate) {
+      "title":title.${targetLanguage},
+      slug,
+      "summary":summary.${targetLanguage},
+  		"cover": {
+        ...cover,
+        "asset": cover.asset->
+      }
+    }[0],
+    'highlight': *[_type == 'topicalPage']{
+      "article":highlightedArticle->{
+        "title":title.${targetLanguage},
+        slug,
+        "summary":summary.${targetLanguage},
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        }
+      }
+    }[0],
     }`
   ),
   () => {

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -10,6 +10,8 @@ import {
 } from '~/static-props/get-data';
 import { Block, Editorial } from '~/types/cms';
 import { assert } from '~/utils/assert';
+import { imageResizeTargets } from '@corona-dashboard/common';
+import { findClosestSize } from '~/utils/findClosestSize';
 
 const editorialsQuery = `*[_type == 'editorial'] {"slug":slug.current}`;
 
@@ -76,11 +78,18 @@ const EditorialDetailPage: FCWithLayout<typeof getStaticProps> = (props) => {
  * to simply have _something_
  */
 EditorialDetailPage.getLayout = (page, props) => {
+  const { cover } = props.content;
+  const { asset } = cover;
+
+  const url = `https://coronadashboard.rijksoverheid.nl/cms/${
+    asset.assetId
+  }-${findClosestSize(1200, imageResizeTargets)}.${asset.extension}`;
+
   return getLayoutWithMetadata({
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
-    openGraphImage: urlFor(props.content.cover).toString() || undefined,
-    twitterImage: urlFor(props.content.cover).toString() || undefined,
+    openGraphImage: url || undefined,
+    twitterImage: url || undefined,
   })(page, props);
 };
 

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -1,7 +1,7 @@
 import { Box } from '~/components-styled/base';
 import { EditorialDetail } from '~/components-styled/editorial-detail';
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
-import { client, localize, urlFor } from '~/lib/sanity';
+import { client, localize } from '~/lib/sanity';
 import { targetLanguage } from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -32,7 +32,32 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<Editorial>((context) => {
     assert(context?.params?.slug, 'Slug required to retrieve article');
-    return `*[_type == 'editorial' && slug.current == '${context.params.slug}'][0]`;
+    return `
+      *[_type == 'editorial' && slug.current == '${context.params.slug}'][0]{
+        ...,
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        },
+        "content": {
+          "_type": content._type,
+          "nl": [
+            ...content.nl[]
+            {
+              ...,
+              "asset": asset->
+            },
+          ],
+          "en": [
+            ...content.en[]
+            {
+              ...,
+              "asset": asset->
+            },
+          ],
+        }
+      }
+    `;
   })
 );
 

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -88,8 +88,8 @@ EditorialDetailPage.getLayout = (page, props) => {
   return getLayoutWithMetadata({
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
-    openGraphImage: url || undefined,
-    twitterImage: url || undefined,
+    openGraphImage: url,
+    twitterImage: url,
   })(page, props);
 };
 

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -11,6 +11,8 @@ export interface SanityImageProps {
   metadata: {
     dimensions: {
       aspectRatio: number;
+      width: number;
+      height: number;
     };
   };
 }
@@ -36,10 +38,7 @@ export interface Article {
 
 interface ImageBlock {
   _type: 'image';
-  asset: {
-    _ref: string;
-    _type: 'reference';
-  };
+  asset: SanityImageProps;
   alt: string;
   crop?: {
     _type: 'sanity.imageCrop';

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -27,7 +27,6 @@ export interface Article {
     current: string;
   };
   cover: ImageBlock;
-  coverAsset: SanityImageProps;
   summary: Block;
   intro: Block;
   content: RichContentBlock[];

--- a/packages/cms/scripts/images-download.sh
+++ b/packages/cms/scripts/images-download.sh
@@ -3,11 +3,11 @@ set -e
 
 # Start with a clean slate
 [ -e *.tar.gz ] && rm *.tar.gz
-rm -rf export development-export-*
+rm -rf export production-export-*
 rm -rf ../app/public/cms
 
 # Download the data and unzip it in a predictable folder
-sanity dataset export development development.tar.gz --overwrite
+sanity dataset export production production.tar.gz --overwrite
 tar -xzf *.gz 
 mv *-export* export
 


### PR DESCRIPTION
## Summary

Parts of the codebase are talking to Sanity through the URL builder.
This PR replaces some of them with our own image component that builds a srcSet and serves images from the local file system.

## Motivation

Avoiding the Sanity CDN limits.

## Unresolved questions
- I'm quite sure the types could be better. Because I'm using a wrapper around <img> it seems TS does not understand properties such as srcSet, loading and alt natively anymore. I don't mind postponing these enhancements until after an initial release.