### PR TITLE
Fix for padding input on safari

### DIFF
--- a/packages/app/src/domain/topical/components/search/search-input.tsx
+++ b/packages/app/src/domain/topical/components/search/search-input.tsx
@@ -70,6 +70,7 @@ const StyledSearchInput = styled.input(
     borderWidth: '1px',
     borderColor: 'lightGray',
     fontSize: ['1rem', null, null, '1.125rem'],
+    appearance: 'textfield',
     m: 0,
     '&::-webkit-search-cancel-button': {
       display: 'none',


### PR DESCRIPTION
There was no padding on desktop safari in the input search field, by adding the `appearance`  attribute it is shown now.