### PR TITLE
Update appearance for iPhone Safari also

### DIFF
--- a/packages/app/src/domain/topical/components/search/search-input.tsx
+++ b/packages/app/src/domain/topical/components/search/search-input.tsx
@@ -70,7 +70,7 @@ const StyledSearchInput = styled.input(
     borderWidth: '1px',
     borderColor: 'lightGray',
     fontSize: ['1rem', null, null, '1.125rem'],
-    appearance: 'textfield',
+    appearance: 'none',
     m: 0,
     '&::-webkit-search-cancel-button': {
       display: 'none',


### PR DESCRIPTION
It seems that` appearance: textfield;` fixes the border-radius perfectly on macOS Safari even when you emulate a phone. But when you look at safari on an actual device it didn't do much. With this small change, it is working on both.