### PR TITLE
Fix images from articles missing on regional pages

### DIFF
--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -55,10 +55,35 @@ export const getStaticProps = createGetStaticProps(
     highlight: { article: ArticleSummary };
   }>(
     `{
-    // Retrieve the latest 3 articles with the highlighted article filtered out:
-    'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0..2],
-    'editorial': *[_type == 'editorial'] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0],
-    'highlight': *[_type == 'topicalPage']{"article":highlightedArticle->{"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}}[0],
+      // Retrieve the latest 3 articles with the highlighted article filtered out:
+      'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {
+        "title":title.${targetLanguage},
+        slug, "summary":summary.${targetLanguage},
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        }
+      }[0..2],
+      'editorial': *[_type == 'editorial'] | order(publicationDate) {
+        "title":title.${targetLanguage},
+        slug,
+        "summary":summary.${targetLanguage},
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        }
+      }[0],
+      'highlight': *[_type == 'topicalPage'] {
+        "article":highlightedArticle->{
+          "title":title.${targetLanguage},
+          slug,
+          "summary":summary.${targetLanguage},
+          "cover": {
+            ...cover,
+            "asset": cover.asset->
+          }
+        }
+      }[0],
     }`
   )
 );

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -54,10 +54,34 @@ export const getStaticProps = createGetStaticProps(
     highlight: { article: ArticleSummary };
   }>(
     `{
-    // Retrieve the latest 3 articles with the highlighted article filtered out:
-    'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0..2],
-    'editorial': *[_type == 'editorial'] | order(publicationDate) {"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}[0],
-    'highlight': *[_type == 'topicalPage']{"article":highlightedArticle->{"title":title.${targetLanguage}, slug, "summary":summary.${targetLanguage}, cover}}[0],
+      // Retrieve the latest 3 articles with the highlighted article filtered out:
+      'articles': *[_type == 'article' && !(_id == *[_type == 'topicalPage']{"i":highlightedArticle->{_id}}[0].i._id)] | order(publicationDate) {
+        "title":title.${targetLanguage},
+        slug, "summary":summary.${targetLanguage},
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        }  
+      }[0..2],
+      'editorial': *[_type == 'editorial'] | order(publicationDate) {
+        "title":title.${targetLanguage},
+        slug, "summary":summary.${targetLanguage},
+        "cover": {
+          ...cover,
+          "asset": cover.asset->
+        }
+      }[0],
+      'highlight': *[_type == 'topicalPage']{
+        "article":highlightedArticle->{
+          "title":title.${targetLanguage},
+          slug,
+          "summary":summary.${targetLanguage},
+          "cover": {
+            ...cover,
+            "asset": cover.asset->
+          }
+        }
+      }[0],
     }`
   )
 );

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -61,7 +61,7 @@ export const getStaticProps = createGetStaticProps(
         "cover": {
           ...cover,
           "asset": cover.asset->
-        }  
+        }
       }[0..2],
       'editorial': *[_type == 'editorial'] | order(publicationDate) {
         "title":title.${targetLanguage},

--- a/packages/app/src/pages/artikelen/index.tsx
+++ b/packages/app/src/pages/artikelen/index.tsx
@@ -20,7 +20,7 @@ export const getStaticProps = createGetStaticProps(
       "cover": {
         ...cover,
         "asset": cover.asset->
-      }    
+      }
     }`
   )
 );


### PR DESCRIPTION
## Summary

We need to follow a reference with `->` when quering an image because we're not using the url builder from Sanity anymore.