### PR TITLE
Improve tooltip layout + 100k scale

### DIFF
--- a/packages/app/src/components-styled/stacked-chart/logic.ts
+++ b/packages/app/src/components-styled/stacked-chart/logic.ts
@@ -136,7 +136,7 @@ export function getSeriesData<T extends Value>(
   return metricValues.map(
     (x) =>
       ({
-        ...mapValues(pick(x, metricProperties), (v) => v / 1000000),
+        ...mapValues(pick(x, metricProperties), (v) => v),
         __date: getDateFromValue(x),
       } as SeriesValue)
   );

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -44,8 +44,12 @@ const tooltipStyles = {
 
 const NUM_TICKS = 3;
 const NO_HOVER_INDEX = -1;
+const NUM_1K = 1000;
+const NUM_100K = 100000;
+const NUM_1M = 1000000;
 
-const tickFormatNumber = (v: NumberValue) => formatNumber(v.valueOf());
+const tickFormatNumber = (v: NumberValue) =>
+  formatNumber(v.valueOf() / NUM_100K);
 const tickFormatPercentage = (v: NumberValue) =>
   `${formatPercentage(v.valueOf())}%`;
 
@@ -253,29 +257,35 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
     (data: SeriesValue, key: string) => {
       const date = getDate(data);
 
+      const isMillion = (v: number) => v / NUM_1M > 1;
+
       const [year, weekNumber, weekStartDate, weekEndDate] = getWeekNumber(
         date
       );
 
+      const isTotalMillion = isMillion(seriesSumByKey[key]);
+      const isWeekMillion = isMillion(data[key]);
+
       return (
         <Box p={2}>
           <Box mb={2}>
-            <InlineText fontWeight="bold">{labelByKey[key]}:</InlineText>
-            {` ${formatPercentage(seriesSumByKey[key])} mln ${
-              siteText.waarde_annotaties.totaal
-            } `}
+            <InlineText fontWeight="bold">
+              {`${formatDayMonth(weekStartDate)} - ${formatDayMonth(
+                weekEndDate
+              )}`}
+              :
+            </InlineText>
+            {isWeekMillion
+              ? ` ${formatPercentage(data[key] / NUM_1M)} mln`
+              : ` ${formatNumber(Math.round(data[key] / NUM_1K))} k`}
           </Box>
 
           <Box mb={2}>
-            <InlineText fontWeight="bold">
-              {`Week ${weekNumber} ${year}`}:
-            </InlineText>
-            {` ${formatPercentage(data[key])} mln`}
-          </Box>
-          <Box>
-            {`${formatDayMonth(weekStartDate)} - ${formatDayMonth(
-              weekEndDate
-            )}`}
+            <InlineText fontWeight="bold">{labelByKey[key]}:</InlineText>
+            {isTotalMillion
+              ? ` ${formatPercentage(seriesSumByKey[key] / NUM_1M)} mln `
+              : ` ${formatNumber(Math.round(seriesSumByKey[key] / NUM_1K))} k `}
+            {siteText.waarde_annotaties.totaal}
           </Box>
         </Box>
       );

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -259,9 +259,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
 
       const isMillion = (v: number) => v / NUM_1M > 1;
 
-      const [year, weekNumber, weekStartDate, weekEndDate] = getWeekNumber(
-        date
-      );
+      const [, , weekStartDate, weekEndDate] = getWeekNumber(date);
 
       const isTotalMillion = isMillion(seriesSumByKey[key]);
       const isWeekMillion = isMillion(data[key]);

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -762,13 +762,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1222,9 +1216,9 @@
     "url": "https://coronadashboard.government.nl/veelgestelde-vragen"
   },
   "waarde_annotaties": {
-    "riool_normalized": "x100 billion",
-    "x_miljoen": "",
-    "totaal": ""
+    "riool_normalized": "x 100 billion",
+    "x_100k": "x 100.000",
+    "totaal": "total"
   },
   "gedrag_onderwerpen": {
     "wash_hands": "Wash your hands often",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -762,13 +762,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1223,7 +1217,7 @@
   },
   "waarde_annotaties": {
     "riool_normalized": "x100 miljard",
-    "x_miljoen": "x miljoen",
+    "x_100k": "x 100.000",
     "totaal": "totaal"
   },
   "gedrag_onderwerpen": {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -126,17 +126,19 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
             {({ width }) => (
               <StackedChart
                 width={width}
-                valueAnnotation={siteText.waarde_annotaties.x_miljoen}
+                valueAnnotation={siteText.waarde_annotaties.x_100k}
                 values={data.vaccine_delivery.values}
                 config={[
                   {
                     metricProperty: 'pfizer',
-                    color: '#007AEA',
+                    // color: '#007AEA',
+                    color: '#00BBB5',
                     legendLabel: 'BioNTech/Pfizer',
                   },
                   {
                     metricProperty: 'moderna',
-                    color: '#6AB4F9',
+                    // color: '#6AB4F9',
+                    color: '#C263EF',
                     legendLabel: 'Moderna',
                   },
                   /*  {


### PR DESCRIPTION
## Summary

- Improve the tooltip layout + number formatting
- Use 100k scale for y axis

This is not the fully proposed tooltip layout improvement yet, but a step in the right direction.

<img width="955" alt="Screenshot 2021-01-27 at 17 59 30" src="https://user-images.githubusercontent.com/71320230/106026238-de590100-60c9-11eb-8806-e19f96e4fbe3.png">
