### PR TITLE
Fix click handling on choropleths

### DIFF
--- a/packages/app/src/components/choropleth/select-handlers/create-select-municipal-handler.ts
+++ b/packages/app/src/components/choropleth/select-handlers/create-select-municipal-handler.ts
@@ -8,7 +8,7 @@ export type MunicipalitySelectionHandler = (
 
 export function createSelectMunicipalHandler(
   router: NextRouter,
-  pageName: PageName = 'actueel',
+  pageName: PageName,
   openMenu?: boolean
 ): MunicipalitySelectionHandler {
   return (context: MunicipalityProperties) => {
@@ -16,6 +16,12 @@ export function createSelectMunicipalHandler(
       return;
     }
 
+    if (pageName === 'actueel') {
+      router.push(
+        `/actueel/gemeente/${context.gemcode}` + (openMenu ? '?menu=1' : '')
+      );
+      return;
+    }
     router.push(
       `/gemeente/${context.gemcode}/${pageName}` + (openMenu ? '?menu=1' : '')
     );

--- a/packages/app/src/components/choropleth/select-handlers/create-select-region-handler.ts
+++ b/packages/app/src/components/choropleth/select-handlers/create-select-region-handler.ts
@@ -6,7 +6,7 @@ export type RegionSelectionHandler = (context: SafetyRegionProperties) => void;
 
 export function createSelectRegionHandler(
   router: NextRouter,
-  pageName: RegioPageName = 'actueel'
+  pageName: RegioPageName
 ): RegionSelectionHandler {
   return (context: SafetyRegionProperties) => {
     if (pageName === 'actueel') {

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -176,9 +176,12 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
             metricName="tested_overall"
             metricProperty="infected_per_100k"
             tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-              createSelectMunicipalHandler(router)
+              createSelectMunicipalHandler(router, 'positief-geteste-mensen')
             )}
-            onSelect={createSelectMunicipalHandler(router)}
+            onSelect={createSelectMunicipalHandler(
+              router,
+              'positief-geteste-mensen'
+            )}
           />
         </ChoroplethTile>
       </TileList>

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -222,9 +222,12 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
             metricName="tested_overall"
             metricProperty="infected_per_100k"
             tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-              createSelectMunicipalHandler(router)
+              createSelectMunicipalHandler(router, 'positief-geteste-mensen')
             )}
-            onSelect={createSelectMunicipalHandler(router)}
+            onSelect={createSelectMunicipalHandler(
+              router,
+              'positief-geteste-mensen'
+            )}
           />
         </ChoroplethTile>
 


### PR DESCRIPTION
## Summary

Fix click handling on choropleths, notably the handling of `positief-geteste-mensen` page.

## Detailed design

* Removed default "actueel" value, so TS can complain when there is no value passed.
* `create-select-municipal-handler` did not have Actueel specific route handling.