### PR TITLE
Remove margins on text vaccine tile

### DIFF
--- a/packages/app/src/domain/topical/topical-vaccine-tile.tsx
+++ b/packages/app/src/domain/topical/topical-vaccine-tile.tsx
@@ -46,7 +46,7 @@ export function TopicalVaccineTile() {
         {formatNumber(data.administeredVaccines)}
       </Text>
 
-      <Text>
+      <Text mt={0}>
         {replaceComponentsInText(text.administered_tests, {
           administeredVaccines: (
             <strong>{formatNumber(data.administeredVaccines)}</strong>


### PR DESCRIPTION
Remove margin, but in the future, we might need to make a separate component for the title + the counter?