### PR TITLE
Update sitemap grid and arrow from quicklinks

### DIFF
--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -2,6 +2,7 @@ import css from '@styled-system/css';
 import { ReactNode } from 'react';
 import { UrlObject } from 'url';
 import { Link } from '~/utils/link';
+import { Box } from './base';
 
 interface LinkWithIconProps {
   href: UrlObject | string;
@@ -10,6 +11,10 @@ interface LinkWithIconProps {
   iconPlacement?: 'left' | 'right';
   fontWeight?: 'bold' | 'normal';
   headingLink?: boolean | undefined;
+}
+
+interface IconProps {
+  icon: ReactNode;
 }
 
 export function LinkWithIcon({
@@ -21,6 +26,68 @@ export function LinkWithIcon({
   headingLink,
 }: LinkWithIconProps) {
   const splittedString = children.split(' ');
+  const firstWords = `${splittedString.slice(0, -1).join(' ')} `;
+
+  return (
+    <Link href={href} passHref>
+      <a
+        css={css({
+          display: 'inline-block',
+          fontWeight,
+          position: 'relative',
+          textDecoration: 'none',
+          color: headingLink ? 'body' : '',
+          '&:hover,&:focus': {
+            color: headingLink ? 'blue' : '',
+            textDecoration: headingLink ? '' : 'underline',
+          },
+        })}
+      >
+        {iconPlacement == 'right' && !headingLink && (
+          <>
+            {!splittedString.length ? children : firstWords}
+            <Box as="span" display="inline-block">
+              {splittedString[splittedString.length - 1]}
+              <IconSmall icon={icon} />
+            </Box>
+          </>
+        )}
+        {iconPlacement == 'left' && !headingLink && (
+          <Box as="span">
+            <IconSmall icon={icon} />
+            {children}
+          </Box>
+        )}
+        {headingLink && (
+          <>
+            {!splittedString.length ? children : firstWords}
+            <span css={css({ display: 'inline-block' })}>
+              {splittedString[splittedString.length - 1]}
+              <IconLarge icon={icon} />
+            </span>
+          </>
+        )}
+      </a>
+    </Link>
+  );
+
+  function IconSmall({ icon }: IconProps) {
+    return (
+      <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
+        {icon}
+      </span>
+    );
+  }
+
+  function IconLarge({ icon }: IconProps) {
+    return (
+      <span
+        css={css({ svg: { height: '16px', width: '18px', marginLeft: 2 } })}
+      >
+        {icon}
+      </span>
+    );
+  }
 
   return (
     <Link href={href} passHref>

--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -15,6 +15,7 @@ interface LinkWithIconProps {
 
 interface IconProps {
   icon: ReactNode;
+  singleWord?: boolean;
 }
 
 export function LinkWithIcon({
@@ -63,7 +64,7 @@ export function LinkWithIcon({
             {!splittedString.length ? children : firstWords}
             <span css={css({ display: 'inline-block' })}>
               {splittedString[splittedString.length - 1]}
-              <IconLarge icon={icon} />
+              <IconLarge icon={icon} singleWord={splittedString.length === 1} />
             </span>
           </>
         )}
@@ -79,64 +80,21 @@ export function LinkWithIcon({
     );
   }
 
-  function IconLarge({ icon }: IconProps) {
+  function IconLarge({ icon, singleWord }: IconProps) {
     return (
       <span
-        css={css({ svg: { height: '16px', width: '18px', marginLeft: 2 } })}
+        css={css({
+          svg: {
+            height: '16px',
+            width: '18px',
+            marginLeft: 2,
+            position: singleWord ? 'absolute' : 'relative',
+            minHeight: '100%',
+          },
+        })}
       >
         {icon}
       </span>
     );
   }
-
-  return (
-    <Link href={href} passHref>
-      <a
-        css={css({
-          display: 'inline-block',
-          fontWeight,
-          position: 'relative',
-          textDecoration: 'none',
-          color: headingLink ? 'body' : '',
-          '&:hover,&:focus': {
-            color: headingLink ? 'blue' : '',
-            textDecoration: headingLink ? '' : 'underline',
-          },
-        })}
-      >
-        {iconPlacement == 'right' && !headingLink && children}
-        {!headingLink && (
-          <span
-            css={css({
-              svg: {
-                height: '11px',
-                width: '13px',
-                mx: '3px',
-              },
-            })}
-          >
-            {icon}
-          </span>
-        )}
-        {iconPlacement == 'left' && !headingLink && children}
-        {headingLink && (
-          <>
-            {!splittedString.length
-              ? children
-              : `${splittedString.slice(0, -1).join(' ')} `}
-            <span css={css({ display: 'inline-block' })}>
-              {splittedString[splittedString.length - 1]}
-              <span
-                css={css({
-                  svg: { height: '16px', width: '18px', marginLeft: 2 },
-                })}
-              >
-                {icon}
-              </span>
-            </span>
-          </>
-        )}
-      </a>
-    </Link>
-  );
 }

--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -28,6 +28,7 @@ export function LinkWithIcon({
 }: LinkWithIconProps) {
   const splittedString = children.split(' ');
   const firstWords = `${splittedString.slice(0, -1).join(' ')} `;
+  const singleWord = splittedString.length === 1;
 
   return (
     <Link href={href} passHref>
@@ -60,13 +61,13 @@ export function LinkWithIcon({
           </Box>
         )}
         {headingLink && (
-          <>
+          <Box paddingRight={singleWord ? `calc(0.5rem + 18px)` : ''}>
             {!splittedString.length ? children : firstWords}
             <span css={css({ display: 'inline-block' })}>
               {splittedString[splittedString.length - 1]}
-              <IconLarge icon={icon} singleWord={splittedString.length === 1} />
+              <IconLarge icon={icon} singleWord={singleWord} />
             </span>
-          </>
+          </Box>
         )}
       </a>
     </Link>
@@ -90,6 +91,8 @@ export function LinkWithIcon({
             marginLeft: 2,
             position: singleWord ? 'absolute' : 'relative',
             minHeight: '100%',
+            right: 0,
+            top: 0,
           },
         })}
       >

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -184,12 +184,9 @@ const Item = styled.li(
 
 const LinkBox = styled(Box)(
   css({
-    width: asResponsiveArray({ md: 'calc(33% - 32px)', lg: 'auto' }),
-    '&:nth-child(3n+2)': {
-      mx: asResponsiveArray({ md: '48px', lg: 0 }),
-    },
-    marginTop: asResponsiveArray({ md: 3, lg: 0 }),
-    ':nth-child(-n+3)': {
+    width: asResponsiveArray({ md: '25%', lg: 'auto' }),
+    marginTop: asResponsiveArray({ md: 4, lg: 0 }),
+    ':nth-child(-n+4)': {
       marginTop: 0,
     },
   })

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -8,6 +8,7 @@ import { LinkWithIcon } from '~/components-styled/link-with-icon';
 import { InlineText, Text } from '~/components-styled/typography';
 import siteText from '~/locale/index';
 import { useBreakpoints } from '~/utils/useBreakpoints';
+import { asResponsiveArray } from '~/style/utils';
 
 export function DataSitemap() {
   const breakpoints = useBreakpoints(true);
@@ -28,8 +29,13 @@ export function DataSitemap() {
         <Box maxWidth={{ md: 'maxWidthText' }} mb={4}>
           <Text>{siteText.nationaal_actueel.data_sitemap_toelichting}</Text>
         </Box>
-        <Box display="flex" flexDirection="row" justifyContent="space-between">
-          <Box spacing={2}>
+        <Box
+          display="flex"
+          flexDirection="row"
+          justifyContent={{ lg: 'space-between' }}
+          flexWrap={{ md: 'wrap', lg: 'nowrap' }}
+        >
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.vaccinaties}
             </StyledHeader>
@@ -39,8 +45,8 @@ export function DataSitemap() {
                 text={siteText.vaccinaties.titel_sidebar}
               />
             </List>
-          </Box>
-          <Box spacing={2}>
+          </LinkBox>
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.besmettingen}
             </StyledHeader>
@@ -62,8 +68,8 @@ export function DataSitemap() {
                 text={siteText.sterfte.titel_sidebar}
               />
             </List>
-          </Box>
-          <Box spacing={2}>
+          </LinkBox>
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.ziekenhuizen}
             </StyledHeader>
@@ -77,8 +83,8 @@ export function DataSitemap() {
                 text={siteText.ic_opnames_per_dag.titel_sidebar}
               />
             </List>
-          </Box>
-          <Box spacing={2}>
+          </LinkBox>
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.kwetsbare_groepen}
             </StyledHeader>
@@ -98,8 +104,8 @@ export function DataSitemap() {
                 text={siteText.thuiswonende_ouderen.titel_sidebar}
               />
             </List>
-          </Box>
-          <Box spacing={2}>
+          </LinkBox>
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.vroege_signalen}
             </StyledHeader>
@@ -113,8 +119,8 @@ export function DataSitemap() {
                 text={siteText.verdenkingen_huisartsen.titel_sidebar}
               />
             </List>
-          </Box>
-          <Box spacing={2}>
+          </LinkBox>
+          <LinkBox>
             <StyledHeader>
               {siteText.nationaal_layout.headings.gedrag}
             </StyledHeader>
@@ -124,7 +130,7 @@ export function DataSitemap() {
                 text={siteText.nl_gedrag.sidebar.titel}
               />
             </List>
-          </Box>
+          </LinkBox>
         </Box>
       </Box>
     </Box>
@@ -172,6 +178,19 @@ const Item = styled.li(
     marginBottom: 2,
     ':last-of-type': {
       marginBottom: 0,
+    },
+  })
+);
+
+const LinkBox = styled(Box)(
+  css({
+    width: asResponsiveArray({ md: 'calc(33% - 32px)', lg: 'auto' }),
+    '&:nth-child(3n+2)': {
+      mx: asResponsiveArray({ md: '48px', lg: 0 }),
+    },
+    marginTop: asResponsiveArray({ md: 3, lg: 0 }),
+    ':nth-child(-n+3)': {
+      marginTop: 0,
     },
   })
 );


### PR DESCRIPTION
The problem was the sitemap didn't fit properly on medium-size screens. It is now breaking to a 4-2 row layout.

Another problem was that in the mini-trend-tile component on a long word the arrow still moves to the next line from a certain point.  Took some time to figure it out but I've set it to absolute only when there is 1 word in the title. Then set it properly and add extra padding to still make the arrow clickable. 

I've also added the span wrapping for the regular link with icons so that when there are 2 words or more and there is a line break the arrow follows it.