### PR TITLE
Fix logic of opening mobile menu; text and icon fixes

### DIFF
--- a/packages/app/src/components-styled/layout/app-content.tsx
+++ b/packages/app/src/components-styled/layout/app-content.tsx
@@ -14,6 +14,19 @@ interface AppContentProps {
   hideMenuButton?: boolean;
 }
 
+function getMenuOpenText(pathname: string) {
+  if (pathname.startsWith('/landelijk')) {
+    return siteText.nav.terug_naar_alle_cijfers_homepage;
+  }
+  if (pathname.startsWith('/veiligheidsregio')) {
+    return siteText.nav.terug_naar_alle_cijfers_veiligheidsregio;
+  }
+  if (pathname.startsWith('/gemeente')) {
+    return siteText.nav.terug_naar_alle_cijfers_gemeente;
+  }
+  return siteText.nav.terug_naar_alle_cijfers;
+}
+
 export function AppContent({
   children,
   sidebarComponent,
@@ -32,8 +45,9 @@ export function AppContent({
    * but it's good enough for now I guess
    */
   const isMenuOpen =
-    (router.pathname === '/landelijk' && !('menu' in router.query)) ||
-    router.query.menu === '1';
+    router.pathname == '/landelijk' || router.query.menu === '1';
+
+  const menuOpenText = getMenuOpenText(router.pathname);
 
   return (
     <MaxWidth px={[0, 0, 0, 0, 3]}>
@@ -48,10 +62,11 @@ export function AppContent({
               position: 'relative',
             })}
           >
-            <LinkWithIcon icon={<ArrowIcon />} href={menuOpenUrl}>
-              {router.pathname === '/landelijk'
-                ? siteText.nav.terug_naar_alle_cijfers_homepage
-                : siteText.nav.terug_naar_alle_cijfers}
+            <LinkWithIcon
+              icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
+              href={menuOpenUrl}
+            >
+              {menuOpenText}
             </LinkWithIcon>
           </MenuLinkContainer>
         )}
@@ -71,11 +86,12 @@ export function AppContent({
             <ResponsiveVisible isVisible={!isMenuOpen}>
               {children}
             </ResponsiveVisible>
-            <MenuLinkContainer isVisible={!isMenuOpen}>
-              <LinkWithIcon icon={<ArrowIcon />} href={menuOpenUrl}>
-                {router.pathname === '/landelijk'
-                  ? siteText.nav.terug_naar_alle_cijfers_homepage
-                  : siteText.nav.terug_naar_alle_cijfers}
+            <MenuLinkContainer isVisible={!isMenuOpen && !hideMenuButton}>
+              <LinkWithIcon
+                icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
+                href={menuOpenUrl}
+              >
+                {menuOpenText}
               </LinkWithIcon>
             </MenuLinkContainer>
           </Box>

--- a/packages/app/src/components-styled/layout/components/top-navigation.tsx
+++ b/packages/app/src/components-styled/layout/components/top-navigation.tsx
@@ -16,13 +16,17 @@ export function TopNavigation() {
   const router = useRouter();
 
   const [isMenuOpen, setIsMenuOpen] = useState(true);
+  const [needsMobileMenuLink, setNeedsMobileMenuLink] = useState(false);
   const breakpoints = useBreakpoints(true);
   const isSmallScreen = !breakpoints.md;
 
   useEffect(() => {
     // Menu is opened by default as fallback: JS opens it
     setIsMenuOpen(false);
-  }, []);
+
+    // Workaround to get the mobile menu opened when linking to a sub-page.
+    setNeedsMobileMenuLink(isSmallScreen);
+  }, [isSmallScreen]);
 
   function toggleMenu() {
     setIsMenuOpen(!isMenuOpen);
@@ -60,7 +64,9 @@ export function TopNavigation() {
                 {text.nav.links.actueel}
               </NavItem>
               <NavItem
-                href="/landelijk/vaccinaties"
+                href={`/landelijk/vaccinaties${
+                  needsMobileMenuLink ? '?menu=1' : ''
+                }`}
                 isActive={router.pathname.startsWith('/landelijk')}
               >
                 {text.nav.links.index}

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -55,6 +55,8 @@
     "title": "Corona Dashboard",
     "terug_naar_alle_cijfers": "Overview",
     "terug_naar_alle_cijfers_homepage": "Overview",
+    "terug_naar_alle_cijfers_veiligheidsregio": "Overview",
+    "terug_naar_alle_cijfers_gemeente": "Overview",
     "menu": {
       "open_menu": "Open menu",
       "close_menu": "Close menu"

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -55,6 +55,8 @@
     "title": "Corona Dashboard",
     "terug_naar_alle_cijfers": "Alle cijfers voor dit gebied",
     "terug_naar_alle_cijfers_homepage": "Alle cijfers voor dit gebied",
+    "terug_naar_alle_cijfers_veiligheidsregio": "Alle cijfers van deze veiligheidsregio",
+    "terug_naar_alle_cijfers_gemeente": "Alle cijfers van deze gemeente",
     "menu": {
       "open_menu": "Open menu",
       "close_menu": "Sluit menu"


### PR DESCRIPTION
## Summary

Fix logic of opening mobile menu; text and icon fixes

## Detailed design

* Add texts to open mobile menu specific for VR and GM.
* Fix icons
* Fix logic of opening the Mobile menu for the Landelijk link. The previous solution is not possible any more due to the Actueel page. I've added a hook to add the `?menu=1` only on small screens.