### PR TITLE
Make tooltip fit on tiny screens

### DIFF
--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -296,19 +296,22 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
           <Box mb={2}>
             <InlineText fontWeight="bold">
               {`${replaceVariablesInText(
-                siteText.vaccinaties.verwachte_leveringen.van_week_tot_week,
+                isTinyScreen
+                  ? siteText.vaccinaties.verwachte_leveringen
+                      .van_week_tot_week_klein_scherm
+                  : siteText.vaccinaties.verwachte_leveringen.van_week_tot_week,
                 { weekNumberFrom, weekNumberTo }
               )}: `}
             </InlineText>
             {isTotalMillion
               ? `${formatPercentage(seriesSumByKey[key] / NUM_1M)} mln `
               : `${formatNumber(Math.round(seriesSumByKey[key] / NUM_1K))} k `}
-            {siteText.waarde_annotaties.totaal}
+            {!isTinyScreen && siteText.waarde_annotaties.totaal}
           </Box>
         </Box>
       );
     },
-    [labelByKey, seriesSumByKey, series]
+    [labelByKey, seriesSumByKey, series, isTinyScreen]
   );
 
   /**
@@ -346,9 +349,9 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
 
     // @ts-expect-error
     const coords = localPoint(event.target.ownerSVGElement, event);
-    const left = tooltipData.x + tooltipData.width / 2;
+    const left = tooltipData.x - tooltipData.width / 2;
     showTooltip({
-      tooltipLeft: Math.max(coords?.x || 0 - 20, left),
+      tooltipLeft: Math.max(coords?.x || 0 + 0, left),
       tooltipTop: coords?.y || 0,
       tooltipData,
     });
@@ -475,6 +478,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
             left={tooltipLeft}
             top={tooltipTop}
             style={tooltipStyles}
+            offsetLeft={isTinyScreen ? 0 : 10}
           >
             <TooltipContainer>
               {props.formatTooltip

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -351,7 +351,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
     const coords = localPoint(event.target.ownerSVGElement, event);
     const left = tooltipData.x - tooltipData.width / 2;
     showTooltip({
-      tooltipLeft: Math.max(coords?.x || 0 + 0, left),
+      tooltipLeft: Math.max(coords?.x || 0, left),
       tooltipTop: coords?.y || 0,
       tooltipData,
     });

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -349,9 +349,8 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
 
     // @ts-expect-error
     const coords = localPoint(event.target.ownerSVGElement, event);
-    const left = tooltipData.x - tooltipData.width / 2;
     showTooltip({
-      tooltipLeft: Math.max(coords?.x || 0, left),
+      tooltipLeft: coords?.x || 0,
       tooltipTop: coords?.y || 0,
       tooltipData,
     });

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -764,13 +764,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2117,7 +2111,8 @@
       "omschrijving": "This graph shows the number of approved vaccine doses the Netherlands expects to receive over the next six weeks."
     },
     "verwachte_leveringen": {
-      "van_week_tot_week": "Week {{weekNumberFrom}} to week {{weekNumberTo}}"
+      "van_week_tot_week": "Week {{weekNumberFrom}} to week {{weekNumberTo}}",
+      "van_week_tot_week_klein_scherm": "Week {{weekNumberFrom}} to {{weekNumberTo}}"
     }
   },
   "editorial_detail": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -764,13 +764,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2117,7 +2111,8 @@
       "omschrijving": "Deze grafiek toont het aantal goedgekeurde vaccins dat Nederland de komende zes weken verwacht te krijgen."
     },
     "verwachte_leveringen": {
-      "van_week_tot_week": "Week {{weekNumberFrom}} tot week {{weekNumberTo}}"
+      "van_week_tot_week": "Week {{weekNumberFrom}} tot week {{weekNumberTo}}",
+      "van_week_tot_week_klein_scherm": "Week {{weekNumberFrom}} tot {{weekNumberTo}}"
     }
   },
   "editorial_detail": {


### PR DESCRIPTION
## Summary

The tooltip did not fit on the smallest screens. I have solved this by removing the default tooltip x-offset and making the text shorter (also by removing the kind of redundant word "totaal").

![image](https://user-images.githubusercontent.com/71320230/106175057-f6965200-6195-11eb-8a9f-68a83516c5d8.png)

![image](https://user-images.githubusercontent.com/71320230/106175062-f8601580-6195-11eb-939f-3dd17a19679a.png)
