### PR TITLE
Update date color on detail article page

### DIFF
--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -16,6 +16,8 @@ interface LinkWithIconProps {
 interface IconProps {
   icon: ReactNode;
   isSingleWord?: boolean;
+  width: number;
+  height: number;
 }
 
 export function LinkWithIcon({
@@ -50,13 +52,13 @@ export function LinkWithIcon({
             {!words.length ? children : firstWords}
             <Box as="span" display="inline-block">
               {words[words.length - 1]}
-              <IconSmall icon={icon} />
+              <IconSmall icon={icon} width={11} height={13} />
             </Box>
           </>
         )}
         {iconPlacement === 'left' && !headingLink && (
           <Box as="span">
-            <IconSmall icon={icon} />
+            <IconSmall icon={icon} width={11} height={13} />
             {children}
           </Box>
         )}
@@ -65,7 +67,12 @@ export function LinkWithIcon({
             {!words.length ? children : firstWords}
             <span css={css({ display: 'inline-block' })}>
               {words[words.length - 1]}
-              <IconLarge icon={icon} isSingleWord={isSingleWord} />
+              <IconLarge
+                icon={icon}
+                isSingleWord={isSingleWord}
+                width={16}
+                height={18}
+              />
             </span>
           </Box>
         )}
@@ -73,21 +80,17 @@ export function LinkWithIcon({
     </Link>
   );
 
-  function IconSmall({ icon }: IconProps) {
-    return (
-      <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-        {icon}
-      </span>
-    );
+  function IconSmall({ icon, width, height }: IconProps) {
+    return <span css={css({ svg: { height, width, mx: '3px' } })}>{icon}</span>;
   }
 
-  function IconLarge({ icon, isSingleWord }: IconProps) {
+  function IconLarge({ icon, isSingleWord, width, height }: IconProps) {
     return (
       <span
         css={css({
           svg: {
-            height: '16px',
-            width: '18px',
+            width,
+            height,
             marginLeft: 2,
             position: isSingleWord ? 'absolute' : 'relative',
             minHeight: '100%',

--- a/packages/app/src/components-styled/publication-date.tsx
+++ b/packages/app/src/components-styled/publication-date.tsx
@@ -7,7 +7,7 @@ type PublicationDateProps = {
 
 export function PublicationDate({ date }: PublicationDateProps) {
   return (
-    <time css={css({ color: 'gray' })} dateTime={date}>
+    <time css={css({ color: 'annotation' })} dateTime={date}>
       {formatDateFromString(date, 'medium')}
     </time>
   );

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -8,7 +8,6 @@ import { LinkWithIcon } from '~/components-styled/link-with-icon';
 import { InlineText, Text } from '~/components-styled/typography';
 import siteText from '~/locale/index';
 import { useBreakpoints } from '~/utils/useBreakpoints';
-import { asResponsiveArray } from '~/style/utils';
 
 export function DataSitemap() {
   const breakpoints = useBreakpoints(true);
@@ -31,11 +30,10 @@ export function DataSitemap() {
         </Box>
         <Box
           display="flex"
-          flexDirection="row"
           justifyContent={{ lg: 'space-between' }}
           flexWrap={{ md: 'wrap', lg: 'nowrap' }}
         >
-          <LinkBox>
+          <Box width={{ md: '25%', lg: 'auto' }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.vaccinaties}
             </StyledHeader>
@@ -45,8 +43,8 @@ export function DataSitemap() {
                 text={siteText.vaccinaties.titel_sidebar}
               />
             </List>
-          </LinkBox>
-          <LinkBox>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.besmettingen}
             </StyledHeader>
@@ -68,8 +66,8 @@ export function DataSitemap() {
                 text={siteText.sterfte.titel_sidebar}
               />
             </List>
-          </LinkBox>
-          <LinkBox>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.ziekenhuizen}
             </StyledHeader>
@@ -83,8 +81,8 @@ export function DataSitemap() {
                 text={siteText.ic_opnames_per_dag.titel_sidebar}
               />
             </List>
-          </LinkBox>
-          <LinkBox>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.kwetsbare_groepen}
             </StyledHeader>
@@ -104,8 +102,8 @@ export function DataSitemap() {
                 text={siteText.thuiswonende_ouderen.titel_sidebar}
               />
             </List>
-          </LinkBox>
-          <LinkBox>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.vroege_signalen}
             </StyledHeader>
@@ -119,8 +117,8 @@ export function DataSitemap() {
                 text={siteText.verdenkingen_huisartsen.titel_sidebar}
               />
             </List>
-          </LinkBox>
-          <LinkBox>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
             <StyledHeader>
               {siteText.nationaal_layout.headings.gedrag}
             </StyledHeader>
@@ -130,7 +128,7 @@ export function DataSitemap() {
                 text={siteText.nl_gedrag.sidebar.titel}
               />
             </List>
-          </LinkBox>
+          </Box>
         </Box>
       </Box>
     </Box>
@@ -178,16 +176,6 @@ const Item = styled.li(
     marginBottom: 2,
     ':last-of-type': {
       marginBottom: 0,
-    },
-  })
-);
-
-const LinkBox = styled(Box)(
-  css({
-    width: asResponsiveArray({ md: '25%', lg: 'auto' }),
-    marginTop: asResponsiveArray({ md: 4, lg: 0 }),
-    ':nth-child(-n+4)': {
-      marginTop: 0,
     },
   })
 );


### PR DESCRIPTION
* Update the color of the timestamp of an article detail page
* Couple tweaks for the data sitemap and link with icon, according to the feedback I had to add from VWSCoronadashboard8 yesterday.