### PR TITLE
Add design improvements to vaccine delivery chart

### DIFF
--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -23,7 +23,6 @@ import styled from 'styled-components';
 import { Box } from '~/components-styled/base';
 import { Legenda, LegendItem } from '~/components-styled/legenda';
 import { InlineText } from '~/components-styled/typography';
-import { ValueAnnotation } from '~/components-styled/value-annotation';
 import siteText from '~/locale';
 import { colors } from '~/style/theme';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
@@ -52,8 +51,16 @@ const NUM_1K = 1000;
 const NUM_100K = 100000;
 const NUM_1M = 1000000;
 
-const tickFormatNumber = (v: NumberValue) =>
-  formatNumber(v.valueOf() / NUM_100K);
+const tickFormatNumber = (v: NumberValue) => {
+  const value1M = v.valueOf() / NUM_1M;
+  const value100K = v.valueOf() / NUM_100K;
+
+  return value1M > 0
+    ? `${value1M}mln`
+    : value100K > 0
+    ? `${value100K}00k`
+    : '0';
+};
 const tickFormatPercentage = (v: NumberValue) =>
   `${formatPercentage(v.valueOf())}%`;
 
@@ -119,7 +126,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
    * passed-in formatter functions or their default counterparts that have the
    * same name.
    */
-  const { values, config, width, valueAnnotation, isPercentage } = props;
+  const { values, config, width, isPercentage } = props;
 
   const {
     tooltipData,
@@ -140,7 +147,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
         top: 10,
         right: isExtraSmallScreen ? 0 : 30,
         bottom: 20,
-        left: 24,
+        left: 32,
       } as const),
     [isExtraSmallScreen]
   );
@@ -380,10 +387,6 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
 
   return (
     <Box>
-      {valueAnnotation && (
-        <ValueAnnotation mb={2}>{valueAnnotation}</ValueAnnotation>
-      )}
-
       <Box position="relative">
         <svg width={width} height={height} role="img">
           <Group left={padding.left} top={padding.top}>
@@ -460,7 +463,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
                         /**
                          * Create a little gap between the stacked bars
                          */
-                        height={bar.height - (isTinyScreen ? 2 : 3)}
+                        height={bar.height - (isTinyScreen ? 1 : 2)}
                         width={bar.width}
                         fill={fillColor}
                         onMouseLeave={handleHoverWithBar}

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -175,7 +175,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
   }, [config, metricProperties]);
 
   const hoverColors = useMemo(
-    () => config.map((x) => transparentize(0.8, x.color)),
+    () => config.map((x) => transparentize(0.6, x.color)),
     [config]
   );
 
@@ -457,7 +457,10 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
                         key={barId}
                         x={bar.x}
                         y={bar.y}
-                        height={bar.height}
+                        /**
+                         * Create a little gap between the stacked bars
+                         */
+                        height={bar.height - (isTinyScreen ? 2 : 3)}
                         width={bar.width}
                         fill={fillColor}
                         onMouseLeave={handleHoverWithBar}

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -55,7 +55,7 @@ const tickFormatNumber = (v: NumberValue) => {
   const value1M = v.valueOf() / NUM_1M;
   const value100K = v.valueOf() / NUM_100K;
 
-  return value1M > 0
+  return value1M > 1
     ? `${value1M}mln`
     : value100K > 0
     ? `${value100K}00k`

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -144,7 +144,7 @@ export function StackedChart<T extends Value>(props: StackedChartProps<T>) {
   const padding = useMemo(
     () =>
       ({
-        top: 10,
+        top: 0,
         right: isExtraSmallScreen ? 0 : 30,
         bottom: 20,
         left: 32,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -126,37 +126,14 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 config={[
                   {
                     metricProperty: 'pfizer',
-                    // color: '#007AEA',
-                    color: '#00BBB5',
+                    color: '#007BC7',
                     legendLabel: 'BioNTech/Pfizer',
                   },
                   {
                     metricProperty: 'moderna',
-                    // color: '#6AB4F9',
-                    color: '#C263EF',
+                    color: '#00BBB5',
                     legendLabel: 'Moderna',
                   },
-                  /*  {
-                    metricProperty: 'astra_zeneca',
-                    color: '#00BBB5',
-                    legendLabel: 'AstraZeneca',
-                  },
-                  {
-                    metricProperty: 'cure_vac',
-                    color: '#C263EF',
-                    legendLabel: 'Curevac',
-                  },
-                  {
-                    metricProperty: 'janssen',
-                    color: '#C8AEFF',
-                    legendLabel: 'Janssen',
-                  },
-
-                  {
-                    metricProperty: 'sanofi',
-                    color: '#96E4E4',
-                    legendLabel: 'Sanofi',
-                  }, */
                 ]}
               />
             )}


### PR DESCRIPTION
## Summary

- Add white line between stack (2px voor tiny and 3px for other screens)
- Improve colors
- Decrease hover transparency from 80% to 60%

![image](https://user-images.githubusercontent.com/71320230/106260707-f8592780-6220-11eb-98ec-2c9746545f6a.png)

![image](https://user-images.githubusercontent.com/71320230/106260731-00b16280-6221-11eb-9206-beff3cfd8475.png)
