### PR TITLE
Add new vaccination tile

### DIFF
--- a/packages/app/src/components-styled/kpi-tile.tsx
+++ b/packages/app/src/components-styled/kpi-tile.tsx
@@ -1,13 +1,13 @@
-import { Box, Spacer } from './base';
-import { Heading } from './typography';
 import { Tile } from '~/components-styled/tile';
-import { MetadataProps, Metadata } from './metadata';
+import { Box, Spacer } from './base';
+import { Metadata, MetadataProps } from './metadata';
+import { Heading } from './typography';
 
 interface KpiTileProps {
   title: string;
   description?: string;
   children: React.ReactNode;
-  metadata: MetadataProps;
+  metadata?: MetadataProps;
 }
 
 /**
@@ -38,7 +38,7 @@ export function KpiTile({
       )}
       {/* Using a spacer to push the footer down */}
       <Spacer m="auto" />
-      <Metadata {...metadata} />
+      {metadata && <Metadata {...metadata} />}
     </Tile>
   );
 }

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -764,13 +764,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2048,28 +2042,70 @@
         "administered": [
           {
             "value": "152253",
-            "description": "administered by municipal health services (GGDs)"
+            "description": "administered by municipal health services (GGDs)",
+            "report_date": ""
           },
           {
             "value": "57216",
-            "description": "administered by hospitals*"
+            "description": "administered by hospitals*",
+            "report_date": ""
           },
           {
             "value": "16829",
-            "description": "administered by long-term care institutions*"
+            "description": "administered by long-term care institutions*",
+            "report_date": ""
           },
           {
             "value": "",
-            "description": ""
+            "description": "",
+            "report_date": ""
           },
           {
             "value": "",
-            "description": ""
+            "description": "",
+            "report_date": ""
           }
         ],
         "description_first": "This is the number of vaccine doses that have been administered. Because vaccination figures are sometimes reported later, the actual number of vaccination doses administered is higher.",
         "description_second": "* These numbers are reported by phone. Please note: the actual number of vaccination doses administered is therefore higher than reported here.",
-        "warning": "Please note: the actual number of vaccine doses administered is higher than reported here."
+        "warning": "",
+        "first_tab_title": "Geschatte aantallen",
+        "second_tab_title": "Gemelde aantallen",
+        "tab_total_estimated": {
+          "value": "226298",
+          "description": "",
+          "date_of_report_unix": "1612006032",
+          "date_of_insertion_unix": "1612006032",
+          "administered": [
+            {
+              "value": "152253",
+              "description": "gezet door GGD'en",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "57216",
+              "description": "gezet door ziekenhuizen*",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "16829",
+              "description": "gezet door langdurige zorginstellingen",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "",
+              "description": "",
+              "report_date": ""
+            },
+            {
+              "value": "",
+              "description": "",
+              "report_date": ""
+            }
+          ],
+          "description_first": "Dit getal is een schatting van hoeveel prikken er gezet zijn. We maken de schatting door te kijken naar hoeveel vaccins er zijn bezorgd bij priklocaties. Lees hier meer over hoe deze schatting wordt berekend",
+          "description_second": "De meeste vaccins worden binnen een week na bezorging toegediend aan mensen. Mensen hebben twee prikken nodig voor een volledige vaccinatie. "
+        }
       },
       "kpi_expected_delivery": {
         "title": "Approved vaccines to be delivered",
@@ -2077,6 +2113,11 @@
         "description": "This is the number of approved vaccine doses the Netherlands expects to receive over the next six weeks. The Netherlands will receive a new delivery each week. People need two separately administered doses for the vaccine to be maximally effective.",
         "date_of_report_unix": "1611600708",
         "date_of_insertion_unix": "1611600708"
+      },
+      "kpi_expected_page_additions": {
+        "title": "",
+        "description": "",
+        "additions": ["", "", ""]
       },
       "kpi_stock": {
         "title": "",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -764,13 +764,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2040,36 +2034,78 @@
         }
       },
       "kpi_total": {
-        "title": "Aantal gemelde prikken",
+        "title": "Aantal gezette prikken",
         "value": "226298",
-        "description": "Dit getal laat zien hoeveel prikken er in totaal zijn gezet. Het kan een tijd duren voordat een prik wordt gemeld. Het daadwerkelijke aantal gezette prikken ligt daarom hoger.",
+        "description": "",
         "date_of_report_unix": "1612006032",
         "date_of_insertion_unix": "1612006032",
         "administered": [
           {
             "value": "152253",
-            "description": "gezet door GGD'en"
+            "description": "gezet door GGD'en",
+            "report_date": "Gemeld aantal t/m 28 jan"
           },
           {
             "value": "57216",
-            "description": "gezet door ziekenhuizen*"
+            "description": "gezet door ziekenhuizen",
+            "report_date": "Gemeld aantal t/m 28 jan"
           },
           {
             "value": "16829",
-            "description": "gezet door langdurige zorginstellingen*"
+            "description": "gezet door [langdurige zorginstellingen](/verantwoording#vaccinatie)",
+            "report_date": "Gemeld aantal t/m 28 jan"
           },
           {
             "value": "",
-            "description": ""
+            "description": "",
+            "report_date": ""
           },
           {
             "value": "",
-            "description": ""
+            "description": "",
+            "report_date": ""
           }
         ],
         "description_first": "Dit getal laat zien hoeveel prikken er in totaal zijn gezet. Het kan een tijd duren voordat een prik wordt gemeld. Het daadwerkelijke aantal gezette prikken ligt daarom hoger.",
-        "description_second": "* Deze cijfers worden aan de telefoon doorgegeven. Let op: het daadwerkelijke aantal gezette prikken ligt daarom hoger dan hier vermeld.",
-        "warning": "Let op: het daadwerkelijk aantal gezette prikken ligt hoger."
+        "description_second": "De meeste vaccins worden binnen een week na bezorging toegediend aan mensen. Mensen hebben twee prikken nodig voor een volledige vaccinatie.",
+        "warning": "",
+        "first_tab_title": "Geschatte aantallen",
+        "second_tab_title": "Gemelde aantallen",
+        "tab_total_estimated": {
+          "value": "226298",
+          "description": "",
+          "date_of_report_unix": "1612006032",
+          "date_of_insertion_unix": "1612006032",
+          "administered": [
+            {
+              "value": "152253",
+              "description": "gezet door GGD'en",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "57216",
+              "description": "gezet door ziekenhuizen",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "16829",
+              "description": "gezet door langdurige zorginstellingen",
+              "report_date": "Gemeld aantal t/m 28 jan"
+            },
+            {
+              "value": "",
+              "description": "",
+              "report_date": ""
+            },
+            {
+              "value": "",
+              "description": "",
+              "report_date": ""
+            }
+          ],
+          "description_first": "Dit getal is een schatting van hoeveel prikken er gezet zijn. We maken de schatting door te kijken naar hoeveel vaccins er zijn bezorgd bij priklocaties. [Lees hier meer over hoe deze schatting wordt berekend.](http://google.com)",
+          "description_second": "De meeste vaccins worden binnen een week na bezorging toegediend aan mensen. Mensen hebben twee prikken nodig voor een volledige vaccinatie. "
+        }
       },
       "kpi_expected_delivery": {
         "title": "Verwachte levering goedgekeurde vaccins",
@@ -2077,6 +2113,15 @@
         "description": "Aantal goedgekeurde vaccins dat Nederland de komende zes weken verwacht te krijgen. Elke week ontvangt Nederland een deel van de vaccins. Mensen hebben twee prikken nodig voor een volledige vaccinatie.",
         "date_of_report_unix": "1611600708",
         "date_of_insertion_unix": "1611600708"
+      },
+      "kpi_expected_page_additions": {
+        "title": "Verwachte toevoegingen aan deze pagina",
+        "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer:",
+        "additions": [
+          "Vaccinatiebereidheid",
+          "Vaccinatiegraad",
+          "Vaccins op voorraad"
+        ]
       },
       "kpi_stock": {
         "title": "",

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,19 +1,18 @@
 import { css } from '@styled-system/css';
 import { ParentSize } from '@visx/responsive';
-import { Fragment } from 'react';
-import styled from 'styled-components';
+import { Fragment, useState } from 'react';
 import VaccinatieIcon from '~/assets/vaccinaties.svg';
-import WarningIcon from '~/assets/warning.svg';
 import { Box } from '~/components-styled/base';
 import { ChartTile } from '~/components-styled/chart-tile';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
+import { RadioGroup } from '~/components-styled/radio-group';
 import { SEOHead } from '~/components-styled/seo-head';
 import { StackedChart } from '~/components-styled/stacked-chart';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { Heading, Text } from '~/components-styled/typography';
+import { InlineText, Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -35,6 +34,9 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
   text: siteText,
 }) => {
   const text = siteText.vaccinaties;
+  const [selectedTab, setSelectedTab] = useState(
+    text.data.kpi_total.first_tab_title
+  );
 
   return (
     <>
@@ -64,63 +66,135 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
               source: text.bronnen.all_left,
             }}
           >
-            <KpiValue absolute={parseFloat(text.data.kpi_total.value)} />
-            <Box display="flex" alignItems="center">
-              <WarningIcon height="3em" width="3em" fill="#000" />
-              <Text fontWeight="600" ml={3}>
-                {text.data.kpi_total.warning}
-              </Text>
-            </Box>
             <Box
-              borderBottomStyle="solid"
-              borderBottomWidth="1px"
-              borderBottomColor="grey"
-              pb={3}
-              mb={4}
+              css={css({ '& div': { justifyContent: 'flex-start' } })}
+              mb={3}
             >
-              <Text mb={3}>{text.data.kpi_total.description_first}</Text>
+              <RadioGroup
+                value={selectedTab}
+                onChange={(value) => setSelectedTab(value)}
+                items={[
+                  {
+                    label: text.data.kpi_total.first_tab_title,
+                    value: text.data.kpi_total.first_tab_title,
+                  },
+                  {
+                    label: text.data.kpi_total.second_tab_title,
+                    value: text.data.kpi_total.second_tab_title,
+                  },
+                ]}
+              />
             </Box>
-            {text.data.kpi_total.administered.map((item, index) => (
-              <Fragment key={index}>
-                {item.value && item.description && (
-                  <Text>
-                    <span css={css({ color: 'data.primary' })}>
-                      {formatNumber(parseFloat(item.value))}
-                    </span>
-                    {` ${item.description}`}
-                  </Text>
-                )}
-              </Fragment>
-            ))}
-            <Text mb={3}>
-              <em>{text.data.kpi_total.description_second}</em>
-            </Text>
-          </KpiTile>
-
-          <KpiTile
-            title={text.data.kpi_expected_delivery.title}
-            metadata={{
-              date: parseFloat(
-                text.data.kpi_expected_delivery.date_of_report_unix
-              ),
-              source: text.bronnen.all_right,
-            }}
-          >
-            <KpiValue
-              absolute={parseFloat(text.data.kpi_expected_delivery.value)}
-            />
-            <Text mb={4}>{text.data.kpi_expected_delivery.description}</Text>
-
-            <Heading level={3} mt={4}>
-              {text.section_vaccinations_more_information.title}
-            </Heading>
-            <Text
-              mb={0}
-              as={StyledParagraph}
-              dangerouslySetInnerHTML={{
-                __html: text.section_vaccinations_more_information.description,
-              }}
-            />
+            {selectedTab == text.data.kpi_total.first_tab_title && (
+              <>
+                <KpiValue
+                  absolute={parseFloat(
+                    text.data.kpi_total.tab_total_estimated.value
+                  )}
+                />
+                <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
+                  <Box flex={{ lg: '1 1 50%' }}>
+                    <Text
+                      mb={3}
+                      dangerouslySetInnerHTML={{
+                        __html:
+                          text.data.kpi_total.tab_total_estimated
+                            .description_first,
+                      }}
+                    />
+                    <Text
+                      mb={3}
+                      dangerouslySetInnerHTML={{
+                        __html:
+                          text.data.kpi_total.tab_total_estimated
+                            .description_second,
+                      }}
+                    />
+                  </Box>
+                  <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
+                    {text.data.kpi_total.tab_total_estimated.administered.map(
+                      (item, index) => (
+                        <Fragment key={index}>
+                          {item.value && item.description && (
+                            <Text fontWeight="bold">
+                              <InlineText css={css({ color: 'data.primary' })}>
+                                {formatNumber(parseFloat(item.value))}
+                              </InlineText>{' '}
+                              <InlineText
+                                css={css({
+                                  '& p': { display: 'inline-block', m: 0 },
+                                })}
+                                dangerouslySetInnerHTML={{
+                                  __html: item.description,
+                                }}
+                              />
+                              <br />
+                              <InlineText
+                                fontWeight="normal"
+                                fontSize={1}
+                                color="annotation"
+                              >
+                                {item.report_date}
+                              </InlineText>
+                            </Text>
+                          )}
+                        </Fragment>
+                      )
+                    )}
+                  </Box>
+                </Box>
+              </>
+            )}
+            {selectedTab == text.data.kpi_total.second_tab_title && (
+              <>
+                <KpiValue absolute={parseFloat(text.data.kpi_total.value)} />
+                <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
+                  <Box flex={{ lg: '1 1 50%' }}>
+                    <Text
+                      mb={3}
+                      dangerouslySetInnerHTML={{
+                        __html: text.data.kpi_total.description_first,
+                      }}
+                    />
+                    <Text
+                      mb={3}
+                      dangerouslySetInnerHTML={{
+                        __html: text.data.kpi_total.description_second,
+                      }}
+                    />
+                  </Box>
+                  <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
+                    {text.data.kpi_total.administered.map((item, index) => (
+                      <Fragment key={index}>
+                        {item.value && item.description && (
+                          <Text fontWeight="bold">
+                            <InlineText css={css({ color: 'data.primary' })}>
+                              {formatNumber(parseFloat(item.value))}
+                            </InlineText>{' '}
+                            <InlineText
+                              css={css({
+                                '& p': { display: 'inline-block', m: 0 },
+                              })}
+                              dangerouslySetInnerHTML={{
+                                __html: item.description,
+                              }}
+                            />
+                            <br />
+                            <InlineText
+                              fontWeight="normal"
+                              fontSize={1}
+                              color="annotation"
+                            >
+                              {item.report_date}
+                            </InlineText>
+                          </Text>
+                        )}
+                      </Fragment>
+                    ))}
+                  </Box>
+                </Box>
+              </>
+            )}
           </KpiTile>
         </TwoKpiSection>
 
@@ -157,22 +231,41 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
             )}
           </ParentSize>
         </ChartTile>
+
+        <TwoKpiSection>
+          <KpiTile
+            title={text.data.kpi_expected_delivery.title}
+            metadata={{
+              date: parseFloat(
+                text.data.kpi_expected_delivery.date_of_report_unix
+              ),
+              source: text.bronnen.all_right,
+            }}
+          >
+            <KpiValue
+              absolute={parseFloat(text.data.kpi_expected_delivery.value)}
+            />
+            <Text mb={4}>{text.data.kpi_expected_delivery.description}</Text>
+          </KpiTile>
+          <KpiTile title={text.data.kpi_expected_page_additions.title}>
+            <Text mb={4}>
+              {text.data.kpi_expected_page_additions.description}
+            </Text>
+            <ul>
+              {text.data.kpi_expected_page_additions.additions
+                .filter((x) => x.length)
+                .map((addition) => (
+                  <li key={addition}>
+                    <InlineText>{addition}</InlineText>
+                  </li>
+                ))}
+            </ul>
+          </KpiTile>
+        </TwoKpiSection>
       </TileList>
     </>
   );
 };
-
-const StyledParagraph = styled.div(
-  css({
-    p: {
-      marginBottom: 0,
-    },
-    ul: {
-      marginTop: 0,
-      paddingLeft: '1.2rem',
-    },
-  })
-);
 
 VaccinationPage.getLayout = getNationalLayout;
 

--- a/packages/app/src/utils/parse-markdown-in-locale.ts
+++ b/packages/app/src/utils/parse-markdown-in-locale.ts
@@ -21,6 +21,12 @@ const MARKDOWN_KEYS = [
   'nationaal_actueel.risiconiveaus.selecteer_toelichting',
   'veiligheidsregio_actueel.risiconiveaus.selecteer_toelichting',
   'gemeente_actueel.risiconiveaus.selecteer_toelichting',
+  'vaccinaties.data.kpi_total.tab_total_estimated.description_first',
+  'vaccinaties.data.kpi_total.tab_total_estimated.description_second',
+  'vaccinaties.data.kpi_total.description_first',
+  'vaccinaties.data.kpi_total.description_second',
+  'vaccinaties.data.kpi_total.administered[].description',
+  'vaccinaties.data.kpi_total.tab_total_estimated.administered[].description',
 ];
 
 export function parseMarkdownInLocale(text: TALLLanguages) {


### PR DESCRIPTION
## Summary

This adds a tile with a tabbed piece of content showing estimated shot and actual shots.

## Motivation

Feature request

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
