### PR TITLE
Update link with icon hover

### DIFF
--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -49,18 +49,15 @@ export function LinkWithIcon({
       >
         {iconPlacement === 'right' && !headingLink && (
           <>
-            {!words.length ? children : firstWords}
-            <Box as="span" display="inline-block">
-              {words[words.length - 1]}
-              <IconSmall icon={icon} width={11} height={13} />
-            </Box>
+            {children}
+            <IconSmall icon={icon} width={11} height={13} />
           </>
         )}
         {iconPlacement === 'left' && !headingLink && (
-          <Box as="span">
+          <>
             <IconSmall icon={icon} width={11} height={13} />
             {children}
-          </Box>
+          </>
         )}
         {headingLink && (
           <Box paddingRight={isSingleWord ? `calc(0.5rem + 18px)` : ''}>


### PR DESCRIPTION
When working on the quick-link block there wasn't enough space so I tried to wrap certain words so that line-breaks would work better. Didn't notice that the hover was sometimes only half visible. This should revert my code back to how it was.
Since there are multiple rows on smaller screens for the quick-link this problem didn't even exist anymore, so it's better to revert it back.

**The problem**
<img width="251" alt="Screenshot 2021-02-01 at 09 56 59" src="https://user-images.githubusercontent.com/76471292/106436228-24201b80-6474-11eb-928f-00dcc6452436.png">
