### PR TITLE
Update tooltip to a fix bug with the border on safari

### DIFF
--- a/packages/app/src/components-styled/line-chart/components/tooltip.tsx
+++ b/packages/app/src/components-styled/line-chart/components/tooltip.tsx
@@ -29,6 +29,7 @@ const TooltipContainer = styled.div<TooltipContainerProps>`
   min-width: 72;
   white-space: nowrap;
   background: white;
+  outline: 1px solid transparent;
   border: ${(props) => `1px solid ${props.borderColor || 'black'}`};
   ${css({
     px: 2,


### PR DESCRIPTION
The tooltip left a trail of pixels when being moved (this only happened on lower resolution screens).
By adding an outline it fixes the issue.

More about this problem [here](https://stackoverflow.com/questions/9983520/webkit-animation-is-leaving-junk-pixels-behind-on-the-screen/17822836#17822836).