### PR TITLE
Make highlighted-articles field a shared field

### DIFF
--- a/packages/cms/schemas/documents/fields/highlighted-article.js
+++ b/packages/cms/schemas/documents/fields/highlighted-article.js
@@ -1,0 +1,7 @@
+export const HIGHLIGHTED_ARTICLE = {
+  title: 'Uitgelichte artikelen',
+  name: 'articles',
+  type: 'array',
+  of: [{ type: 'reference', to: { type: 'article' } }],
+  validation: (Rule) => Rule.required().unique().max(2),
+};

--- a/packages/cms/schemas/documents/fields/highlighted-articles.js
+++ b/packages/cms/schemas/documents/fields/highlighted-articles.js
@@ -1,4 +1,4 @@
-export const HIGHLIGHTED_ARTICLE = {
+export const HIGHLIGHTED_ARTICLES = {
   title: 'Uitgelichte artikelen',
   name: 'articles',
   type: 'array',

--- a/packages/cms/schemas/documents/pages/behavior-page.js
+++ b/packages/cms/schemas/documents/pages/behavior-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Naleving en gedrag',
   name: 'behaviorPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/behavior-page.js
+++ b/packages/cms/schemas/documents/pages/behavior-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Naleving en gedrag',
   name: 'behaviorPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(1),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/deceased-page.js
+++ b/packages/cms/schemas/documents/pages/deceased-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Sterfte pagina',
   name: 'deceasedPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/deceased-page.js
+++ b/packages/cms/schemas/documents/pages/deceased-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Sterfte pagina',
   name: 'deceasedPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(2),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/hospital-page.js
+++ b/packages/cms/schemas/documents/pages/hospital-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Ziekenhuis opnames',
   name: 'hospitalPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(1),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/hospital-page.js
+++ b/packages/cms/schemas/documents/pages/hospital-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Ziekenhuis opnames',
   name: 'hospitalPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/intensive-care-page.js
+++ b/packages/cms/schemas/documents/pages/intensive-care-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Intensive care pagina',
   name: 'intensiveCarePage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/intensive-care-page.js
+++ b/packages/cms/schemas/documents/pages/intensive-care-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Intensive care pagina',
   name: 'intensiveCarePage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(1),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/positive-tests-page.js
+++ b/packages/cms/schemas/documents/pages/positive-tests-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Positieve testen',
   name: 'positiveTestsPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/positive-tests-page.js
+++ b/packages/cms/schemas/documents/pages/positive-tests-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Positieve testen',
   name: 'positiveTestsPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(2),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/reproduction-page.js
+++ b/packages/cms/schemas/documents/pages/reproduction-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Reproductiegetal',
   name: 'reproductionPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/reproduction-page.js
+++ b/packages/cms/schemas/documents/pages/reproduction-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Reproductiegetal',
   name: 'reproductionPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(1),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/sewer-page.js
+++ b/packages/cms/schemas/documents/pages/sewer-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Rioolwater pagina',
   name: 'sewerPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(2),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };

--- a/packages/cms/schemas/documents/pages/sewer-page.js
+++ b/packages/cms/schemas/documents/pages/sewer-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Rioolwater pagina',
   name: 'sewerPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/vaccinations-page.js
+++ b/packages/cms/schemas/documents/pages/vaccinations-page.js
@@ -1,8 +1,8 @@
-import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
 
 export default {
   title: 'Vaccinaties pagina',
   name: 'vaccinationsPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLE],
+  fields: [HIGHLIGHTED_ARTICLES],
 };

--- a/packages/cms/schemas/documents/pages/vaccinations-page.js
+++ b/packages/cms/schemas/documents/pages/vaccinations-page.js
@@ -1,14 +1,8 @@
+import { HIGHLIGHTED_ARTICLE } from '../fields/highlighted-article';
+
 export default {
   title: 'Vaccinaties pagina',
   name: 'vaccinationsPage',
   type: 'document',
-  fields: [
-    {
-      title: 'Uitgelichte artikelen',
-      name: 'articles',
-      type: 'array',
-      of: [{ type: 'reference', to: { type: 'article' } }],
-      validation: (Rule) => Rule.required().unique().max(2),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLE],
 };


### PR DESCRIPTION
## Summary

As the title explains

## Motivation

As it turns out, the maximum number of article strip items is the same across all pages, so I've refactored the highlighted-article field into a shared field that's used by the separate page schemas.

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
