### PR TITLE
Add pointer events none when collapsible menu is closed

### DIFF
--- a/packages/app/src/components-styled/layout/components/top-navigation.tsx
+++ b/packages/app/src/components-styled/layout/components/top-navigation.tsx
@@ -71,6 +71,10 @@ export function TopNavigation() {
         css={css({
           maxHeight: asResponsiveArray({ _: `${panelHeight}px`, md: '100%' }),
           opacity: asResponsiveArray({ _: isMenuOpen ? 1 : 0, md: 1 }),
+          pointerEvents: asResponsiveArray({
+            _: isMenuOpen ? 'auto' : 'none',
+            md: 'auto',
+          }),
           transition: asResponsiveArray({
             _:
               isMenuOpen || isAnimating


### PR DESCRIPTION
Add pointer-events none to the content, so that you can't click on it when it is closed.