### PR TITLE
Strip unnecessary NPM properties from package jsons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "corona-dashboard",
   "private": true,
+  "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "resolutions": {
     "//": "Visx internally uses d3-array@v2 but this isn't compatible with IE11",
     "d3-array": "^1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@corona-dashboard/app",
-  "version": "2.14.3",
   "private": true,
   "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@corona-dashboard/app",
   "private": true,
+  "version": "0.0.0",
   "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "dependencies": {
     "@formatjs/intl-datetimeformat": "^2.6.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@corona-dashboard/cli",
   "private": true,
+  "version": "0.0.0",
+  "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "dependencies": {
     "meow": "^8.0.0",
     "ts-node": "^9.1.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@corona-dashboard/cli",
   "private": true,
-  "version": "1.0.0",
   "dependencies": {
     "meow": "^8.0.0",
     "ts-node": "^9.1.1"

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@corona-dashboard/cms",
   "private": true,
-  "version": "2.9.0",
-  "description": "",
-  "license": "UNLICENSED",
   "scripts": {
     "start": "sanity start",
     "build": "sanity build",
@@ -16,9 +13,6 @@
     "assets:download": "bash scripts/assets-download.sh",
     "assets:image-resize": "ts-node scripts/images-resize.ts"
   },
-  "keywords": [
-    "sanity"
-  ],
   "dependencies": {
     "@sanity/base": "^2.3.2",
     "@sanity/components": "^2.2.6",

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@corona-dashboard/cms",
   "private": true,
+  "version": "0.0.0",
+  "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "scripts": {
     "start": "sanity start",
     "build": "sanity build",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@corona-dashboard/common",
   "private": true,
+  "version": "0.0.0",
+  "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corona-dashboard/common",
-  "version": "1.0.0",
+  "private": true,
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@corona-dashboard/e2e",
-  "version": "1.0.0",
-  "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "^14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.13.0",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@corona-dashboard/e2e",
   "private": true,
+  "version": "0.0.0",
+  "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "devDependencies": {
     "@types/node": "^14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.13.0",


### PR DESCRIPTION
## Summary

* Set all packages to private, because we don't intend to publish them to NPM
* Remove version info since it doesn't have a real meaning without publishing
* Remove different licenses and only keep one declaration in the root package

The versions were often overlooked when making a new release, and updating them is cumbersome and error prone. I believe we better omit them completely.