### PR TITLE
Fix sitemap link "gedrag" to go to correct page

### DIFF
--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -124,7 +124,7 @@ export function DataSitemap() {
             </StyledHeader>
             <List>
               <SitemapItem
-                href="/landelijk/rioolwater"
+                href="/landelijk/gedrag"
                 text={siteText.nl_gedrag.sidebar.titel}
               />
             </List>


### PR DESCRIPTION
Currently, it goes to the "rioolwatermeting" page. This appears to be a copy/paste mistake.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [X] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [X] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [X] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
