### PR TITLE
Update color of the icon compliance and support table

### DIFF
--- a/packages/app/src/domain/behavior/components/behavior-trend.tsx
+++ b/packages/app/src/domain/behavior/components/behavior-trend.tsx
@@ -1,25 +1,24 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-
 import Gelijk from '~/assets/gelijk.svg';
 import PijlOmhoog from '~/assets/pijl-omhoog.svg';
 import PijlOmlaag from '~/assets/pijl-omlaag.svg';
 import { BehaviorTrendType } from '../behavior-types';
 import siteText from '~/locale/index';
-
+import { colors } from '~/style/theme';
 const commonText = siteText.gedrag_common;
 
 interface BehaviorTrendProps {
   trend: BehaviorTrendType | undefined;
 }
 
-const Trend = styled.span(
+const Trend = styled.span((a) =>
   css({
     whiteSpace: 'nowrap',
     display: 'inline-block',
 
     svg: {
-      color: '#0090DB',
+      color: a.color ?? '#0090DB',
       mr: 1,
       width: '12px',
       height: '12px',
@@ -49,7 +48,7 @@ export function BehaviorTrend({ trend }: BehaviorTrendProps) {
     );
   }
   return (
-    <Trend>
+    <Trend color={colors.data.neutral}>
       <Gelijk />
       {commonText.basisregels.trend_gelijk}
     </Trend>


### PR DESCRIPTION
Changed the color of the icon in the table at "Compliance and support" when the trend is the same.