### PR TITLE
fix: Lodash tree shaking

### DIFF
--- a/packages/common/src/utils/get-last-filled-value.ts
+++ b/packages/common/src/utils/get-last-filled-value.ts
@@ -1,4 +1,4 @@
-import { every } from 'lodash';
+import every from 'lodash/every';
 import { isFilled } from 'ts-is-present';
 import { Metric } from '~/types';
 


### PR DESCRIPTION
## Summary

Fixes the lodash tree shaking issue

## Motivation

Importing all of lodash was bloating the bundle size

## Detailed design

updated the lodash import in `common` since the babel-lodash-plugin was unable to treeshake that package

