### PR TITLE
Update search input bug disabled

### DIFF
--- a/packages/app/src/domain/topical/components/search/context.tsx
+++ b/packages/app/src/domain/topical/components/search/context.tsx
@@ -156,7 +156,6 @@ function useSearchContextValue<T extends Element>(
       'aria-autocomplete': 'list',
       'aria-controls': id,
       'aria-activedescendant': getOptionId(focusIndex),
-      disabled: !!termSubmitted,
     },
 
     comboboxProps: {

--- a/packages/app/src/domain/topical/components/search/search-input.tsx
+++ b/packages/app/src/domain/topical/components/search/search-input.tsx
@@ -21,7 +21,7 @@ export function SearchInput() {
         <SearchIcon />
       </IconContainer>
 
-      {!inputProps.disabled && inputProps.value && (
+      {inputProps.value && (
         <IconContainer
           as="button"
           align="right"


### PR DESCRIPTION
Update for the bug mentioned [here](https://github.com/minvws/nl-covid19-data-dashboard/issues/1868), by removing the disabled tag for the input.