### PR TITLE
Remove general title from Measures page

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -675,7 +675,6 @@
       "overig": "Early indicators",
       "verpleeghuis": "Nursing homes",
       "laatste": "Latest developments",
-      "algemeen": "General",
       "besmettingen": "Infections",
       "ziekenhuizen": "Hospitals",
       "verpleeghuizen": "Nursing homes",
@@ -697,8 +696,7 @@
       "vroege_signalen": "Early indicators",
       "gedrag": "Behaviour",
       "kwetsbare_groepen": "Vulnerable groups",
-      "maatregelen": "Measures",
-      "algemeen": "General"
+      "maatregelen": "Measures"
     }
   },
   "veiligheidsregio_metadata": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -675,7 +675,6 @@
       "overig": "Vroegsignalering",
       "verpleeghuis": "Verpleeghuiszorg",
       "laatste": "Laatste ontwikkelingen",
-      "algemeen": "Algemeen",
       "besmettingen": "Besmettingen",
       "ziekenhuizen": "Ziekenhuizen",
       "verpleeghuizen": "Verpleeghuiszorg",
@@ -697,8 +696,7 @@
       "vroege_signalen": "Vroege signalen",
       "gedrag": "Gedrag",
       "kwetsbare_groepen": "Kwetsbare groepen",
-      "maatregelen": "Maatregelen",
-      "algemeen": "Algemeen"
+      "maatregelen": "Maatregelen"
     }
   },
   "veiligheidsregio_metadata": {

--- a/packages/app/src/pages/landelijk/maatregelen.tsx
+++ b/packages/app/src/pages/landelijk/maatregelen.tsx
@@ -77,7 +77,6 @@ const NationalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
       />
       <TileList>
         <ContentHeader
-          category={text.nationaal_layout.headings.algemeen}
           icon={<Maatregelen fill={theme.colors.restrictions} />}
           title={text.nationaal_maatregelen.titel}
         />

--- a/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
@@ -98,7 +98,6 @@ const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
       />
       <TileList>
         <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.algemeen}
           icon={<Maatregelen fill={theme.colors.restrictions} />}
           title={replaceVariablesInText(
             siteText.veiligheidsregio_maatregelen.titel,


### PR DESCRIPTION
In the sidebar, the general title was removed but was still existing on the page above "Measures", which has now been removed.