### PR TITLE
Run common build as postinstall script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN yarn
 ARG SANITY_AUTH_TOKEN
 ARG SANITY_DATASET
 ARG SANITY_ASSETS_CACHE_DIR
-RUN yarn workspace @corona-dashboard/common build
 RUN yarn workspace @corona-dashboard/cli validate-json
 # We need to have an ENV var switch to only enable this in production, because
 # BE does not guarantee consistent data in develop.
@@ -27,7 +26,6 @@ COPY --from=react-build-base /app/node_modules /app/node_modules
 COPY --from=react-build-base /app/packages/app/ /app/packages/app/node_modules
 COPY --from=react-build-base /app/packages/app/public/ /app/packages/app/public/
 COPY . .
-RUN yarn workspace @corona-dashboard/common build
 RUN yarn workspace @corona-dashboard/app build
 RUN yarn workspace @corona-dashboard/app export
 
@@ -41,7 +39,6 @@ COPY --from=react-build-base /app/node_modules /app/node_modules
 COPY --from=react-build-base /app/packages/app/ /app/packages/app/node_modules
 COPY --from=react-build-base /app/packages/app/public/ /app/packages/app/public/
 COPY . .
-RUN yarn workspace @corona-dashboard/common build
 RUN yarn workspace @corona-dashboard/app build
 RUN yarn workspace @corona-dashboard/app export
 

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -26,7 +26,6 @@ RUN yarn workspace @corona-dashboard/cli validate-json
 RUN yarn workspace @corona-dashboard/cli generate-typescript
 
 # Stage 2 - Build EN application
-RUN yarn workspace @corona-dashboard/common build
 RUN yarn workspace @corona-dashboard/app build
 
 #FROM node:14-alpine

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "generate-typescript": "yarn workspace @corona-dashboard/cli generate-typescript",
     "e2e": "yarn workspace @corona-dashboard/e2e e2e",
     "e2e:ci": "yarn workspace @corona-dashboard/e2e e2e:ci",
-    "cms": "yarn workspace @corona-dashboard/cms start"
+    "cms": "yarn workspace @corona-dashboard/cms start",
+    "postinstall": "yarn workspace @corona-dashboard/common build"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Summary

Now that more packages like CLI are depending on common, I think it makes sense to build common in the NPM postinstall phase, so that we are sure it is always ready to be used.