### PR TITLE
Bring lighthouse score back to 💯

### DIFF
--- a/packages/app/src/components-styled/chart-tile.tsx
+++ b/packages/app/src/components-styled/chart-tile.tsx
@@ -113,19 +113,20 @@ function ChartTileHeader({
     >
       <div css={css({ mb: [3, null, null, null, 0], mr: [0, 0, 2] })}>
         <Heading level={3}>{title}</Heading>
-        {!description && (
-          <div css={css({ display: 'none' })} aria-labelledby={ariaLabelledBy}>
-            {ariaDescription}
-          </div>
-        )}
-        {description &&
-          (typeof description === 'string' ? (
-            <p aria-labelledby={ariaLabelledBy} css={css({ m: 0 })}>
+
+        {description ? (
+          typeof description === 'string' ? (
+            <p id={ariaLabelledBy} css={css({ m: 0 })}>
               {description}
             </p>
           ) : (
-            <div aria-labelledby={ariaLabelledBy}>{description}</div>
-          ))}
+            <div id={ariaLabelledBy}>{description}</div>
+          )
+        ) : (
+          <Box display="none" id={ariaLabelledBy}>
+            {ariaDescription}
+          </Box>
+        )}
       </div>
       {timeframe && onTimeframeChange && (
         <div css={css({ ml: [0, 0, 2] })}>

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -24,6 +24,7 @@ import { Layout } from '~/domain/layout/layout';
 import siteText from '~/locale/index';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { Box } from '~/components-styled/base';
+
 interface NationalLayoutProps {
   lastGenerated: string;
   data: National;
@@ -86,28 +87,29 @@ function NationalLayout(props: NationalLayoutProps) {
 
       <AppContent
         sidebarComponent={
-          <nav
+          <Box
+            as="nav"
             /** re-mount when route changes in order to blur anchors */
             key={router.asPath}
             id="metric-navigation"
             aria-label={siteText.aria_labels.metriek_navigatie}
             role="navigation"
+            pt={4}
           >
             <Menu>
-              <Box spacing={3} pt={4}>
-                <MetricMenuItemLink
-                  href={{
-                    pathname: '/landelijk/maatregelen',
-                    query: breakpoints.md
-                      ? {} // only add menu flags on narrow devices
-                      : isMenuOpen
-                      ? { menu: '0' }
-                      : { menu: '1' },
-                  }}
-                  title={siteText.nationaal_maatregelen.titel_sidebar}
-                  subtitle={siteText.nationaal_maatregelen.subtitel_sidebar}
-                />
-              </Box>
+              <MetricMenuItemLink
+                href={{
+                  pathname: '/landelijk/maatregelen',
+                  query: breakpoints.md
+                    ? {} // only add menu flags on narrow devices
+                    : isMenuOpen
+                    ? { menu: '0' }
+                    : { menu: '1' },
+                }}
+                title={siteText.nationaal_maatregelen.titel_sidebar}
+                subtitle={siteText.nationaal_maatregelen.subtitel_sidebar}
+              />
+
               <CategoryMenu
                 title={siteText.nationaal_layout.headings.vaccinaties}
               >
@@ -336,7 +338,7 @@ function NationalLayout(props: NationalLayoutProps) {
                 </MetricMenuItemLink>
               </CategoryMenu>
             </Menu>
-          </nav>
+          </Box>
         }
       >
         {children}

--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -104,42 +104,41 @@ function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
              * and therefore optional
              */}
             {data && showMetricLinks && (
-              <nav
+              <Box
+                as="nav"
                 /** re-mount when route changes in order to blur anchors */
                 key={router.asPath}
                 id="metric-navigation"
                 aria-label={siteText.aria_labels.metriek_navigatie}
                 role="navigation"
+                spacing={3}
               >
                 <Text fontSize={3} fontWeight="bold" px={3} m={0}>
                   {safetyRegionName}
                 </Text>
+
                 <Menu>
-                  <Box pt={3}>
-                    <MetricMenuItemLink
-                      href={`/veiligheidsregio/${code}/maatregelen`}
-                      title={
-                        siteText.veiligheidsregio_maatregelen.titel_sidebar
-                      }
-                      subtitle={
-                        siteText.veiligheidsregio_maatregelen.subtitel_sidebar
-                      }
-                    />
-                    <MetricMenuItemLink
-                      href={`/veiligheidsregio/${code}/risiconiveau`}
-                      title={'Risiconiveau'}
-                    >
-                      <Box mt={2}>
-                        <EscalationLevelInfoLabel
-                          escalationLevel={
-                            data.escalation_level.level as EscalationLevel
-                          }
-                          hasSmallIcon
-                          useLevelColor
-                        />
-                      </Box>
-                    </MetricMenuItemLink>
-                  </Box>
+                  <MetricMenuItemLink
+                    href={`/veiligheidsregio/${code}/maatregelen`}
+                    title={siteText.veiligheidsregio_maatregelen.titel_sidebar}
+                    subtitle={
+                      siteText.veiligheidsregio_maatregelen.subtitel_sidebar
+                    }
+                  />
+                  <MetricMenuItemLink
+                    href={`/veiligheidsregio/${code}/risiconiveau`}
+                    title={'Risiconiveau'}
+                  >
+                    <Box mt={2}>
+                      <EscalationLevelInfoLabel
+                        escalationLevel={
+                          data.escalation_level.level as EscalationLevel
+                        }
+                        hasSmallIcon
+                        useLevelColor
+                      />
+                    </Box>
+                  </MetricMenuItemLink>
 
                   <CategoryMenu
                     title={
@@ -309,7 +308,7 @@ function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
                     </MetricMenuItemLink>
                   </CategoryMenu>
                 </Menu>
-              </nav>
+              </Box>
             )}
           </>
         }


### PR DESCRIPTION
## Summary
Fix some html errors like lists with `div`s instead of `li`s.
Also fixed an a11y issue where `aria-labelledby` wasn't correctly used. The attribute `aria-labelledby` can be set on stuff like an svg and should point to the element with an id which holds the description. The bug was that the element with the description also had an `aria-labelledby`-property, instead of the `id` property.