### PR TITLE
Add unit tests for data sorting

### DIFF
--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.+(ts|tsx|js)',
+    '**/?(*.)+(spec|test).+(ts|tsx|js)',
+  ],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+};

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,8 +9,8 @@
     "dist/**/*"
   ],
   "scripts": {
-    "test": "echo 'There are no tests for packages/common yet'",
-    "test:ci": "echo 'There are no tests for packages/common yet.'",
+    "test": "jest --watch",
+    "test:ci": "jest --ci",
     "build": "tsc && tscpaths -p tsconfig.json -s ./src -o ./dist",
     "clean": "del-cli dist tsconfig.tsbuildinfo",
     "compile": "tsc -b .",

--- a/packages/common/src/__tests__/data-sorting.ts
+++ b/packages/common/src/__tests__/data-sorting.ts
@@ -1,0 +1,237 @@
+import { sortTimeSeriesInDataInPlace } from '../data-sorting';
+
+// Items that should be ignored
+const filler = {
+  filler1: {},
+  filler2: {
+    last_value: true,
+  },
+};
+
+const dateSeriesValues = [
+  {
+    date_unix: 1582848000,
+    admissions_on_date_of_admission: 0,
+    admissions_on_date_of_reporting: 0,
+    date_of_insertion_unix: 1612966742,
+  },
+  {
+    date_unix: 1582934400,
+    admissions_on_date_of_admission: 0,
+    admissions_on_date_of_reporting: 0,
+    date_of_insertion_unix: 1612966742,
+  },
+  {
+    date_unix: 1582761600,
+    admissions_on_date_of_admission: 0,
+    admissions_on_date_of_reporting: 0,
+    date_of_insertion_unix: 1612966742,
+  },
+  {
+    date_unix: 1582914400,
+    admissions_on_date_of_admission: 0,
+    admissions_on_date_of_reporting: 0,
+    date_of_insertion_unix: 1612966742,
+  },
+];
+
+// This holds the rest of the values in a date series. Currently only holds
+// the last_value becuase it is required for a timeSeries to be valid
+const dateSeriesRest = {
+  last_value: {
+    date_unix: 1612828800,
+    admissions_on_date_of_admission: 0,
+    admissions_on_date_of_reporting: 0,
+    date_of_insertion_unix: 1612966742,
+  },
+};
+
+const dateSpanSeriesValues = [
+  {
+    date_start_unix: 1600646400,
+    date_end_unix: 1601164800,
+    average: 0.0,
+    total_installation_count: 1,
+    date_of_insertion_unix: 1612965967,
+  },
+  {
+    date_start_unix: 1600041600,
+    date_end_unix: 1600560000,
+    average: 0.0,
+    total_installation_count: 1,
+    date_of_insertion_unix: 1612965967,
+  },
+  {
+    date_start_unix: 1601251200,
+    date_end_unix: 1601769600,
+    average: 58.07,
+    total_installation_count: 1,
+    date_of_insertion_unix: 1612965967,
+  },
+  {
+    date_start_unix: 1599436800,
+    date_end_unix: 1599955200,
+    average: 8.39,
+    total_installation_count: 1,
+    date_of_insertion_unix: 1612965967,
+  },
+];
+
+// This holds the rest of the values in a date span series. Currently only holds
+// the last_value becuase it is required for a timeSeries to be valid
+const dateSpanSeriesRest = {
+  last_value: {
+    date_start_unix: 1612137600,
+    date_end_unix: 1612656000,
+    average: 178.06,
+    total_installation_count: 1,
+    date_of_insertion_unix: 1612965967,
+  },
+};
+
+const sortedData = {
+  ...filler,
+  dateSeries: {
+    ...dateSeriesRest,
+    values: [...dateSeriesValues].sort((a, b) => a.date_unix - b.date_unix),
+  },
+  dateSpanSeries: {
+    ...dateSpanSeriesRest,
+    values: [...dateSpanSeriesValues].sort(
+      (a, b) => a.date_end_unix - b.date_end_unix
+    ),
+  },
+};
+
+describe('Util: sort time series in data in place', () => {
+  // Testing to make sure they are not referencing the same array of values
+  // causing the starting time series data to get sorted as well
+  it('Sorted values in test data should not match starting values ', () => {
+    expect(dateSeriesValues).not.toStrictEqual(sortedData.dateSeries.values);
+    expect(dateSpanSeriesValues).not.toStrictEqual(
+      sortedData.dateSpanSeries.values
+    );
+  });
+
+  it('Should sort valid date and date span series data when all required fields are available ', () => {
+    const testData = {
+      ...filler,
+      dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },
+      dateSpanSeries: {
+        ...dateSpanSeriesRest,
+        values: [...dateSpanSeriesValues],
+      },
+    };
+
+    // Date series values should begin the same
+    expect(dateSeriesValues).toStrictEqual(testData.dateSeries.values);
+    expect(dateSpanSeriesValues).toStrictEqual(testData.dateSpanSeries.values);
+
+    // Sorting in place
+    sortTimeSeriesInDataInPlace(testData);
+    expect(sortedData).toStrictEqual(testData);
+
+    // Sorted series values should not equal the original date series values
+    // Testing to make sure they are not referencing the same array of values
+    expect(dateSeriesValues).not.toStrictEqual(testData.dateSeries.values);
+    expect(dateSpanSeriesValues).not.toStrictEqual(
+      testData.dateSpanSeries.values
+    );
+  });
+
+  it('Should throw an error when there are no date_unix in a date series', () => {
+    const invalidDateSeries = {
+      ...dateSeriesRest,
+      values: [...dateSeriesValues].map(({ date_unix, ...rest }) => ({
+        ...rest,
+      })),
+    };
+    const invalidTestData = {
+      ...filler,
+      dateSeries: invalidDateSeries,
+      dateSpanSeries: {
+        ...dateSpanSeriesRest,
+        values: [...dateSpanSeriesValues],
+      },
+    };
+
+    // Date series values should be different
+    expect(dateSeriesValues).not.toStrictEqual(
+      invalidTestData.dateSeries.values
+    );
+
+    // Sorting in place
+    expect(() => sortTimeSeriesInDataInPlace(invalidTestData)).toThrow(Error);
+  });
+
+  it('Should throw an error when there are no date_end_unix in a date span series', () => {
+    const invalidDateSpanSeries = {
+      ...dateSpanSeriesRest,
+      values: [...dateSpanSeriesValues].map(({ date_end_unix, ...rest }) => ({
+        ...rest,
+      })),
+    };
+    const invalidTestData = {
+      ...filler,
+      dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },
+      dateSpanSeries: invalidDateSpanSeries,
+    };
+
+    // Date span series values should be different
+    expect(dateSpanSeriesValues).not.toStrictEqual(
+      invalidTestData.dateSpanSeries.values
+    );
+
+    // Sorting in place
+    expect(() => sortTimeSeriesInDataInPlace(invalidTestData)).toThrow(Error);
+  });
+
+  it('Should throw an error when there are no date_start_unix in a date span series', () => {
+    const invalidDateSpanSeries = {
+      ...dateSpanSeriesRest,
+      values: [...dateSpanSeriesValues].map(({ date_start_unix, ...rest }) => ({
+        ...rest,
+      })),
+    };
+    const invalidTestData = {
+      ...filler,
+      dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },
+      dateSpanSeries: invalidDateSpanSeries,
+    };
+
+    // Date span series values should be different
+    expect(dateSpanSeriesValues).not.toStrictEqual(
+      invalidTestData.dateSpanSeries.values
+    );
+
+    // Sorting in place
+    expect(() => sortTimeSeriesInDataInPlace(invalidTestData)).toThrow(Error);
+  });
+
+  it('Should throw an error when one date_end_unix is missin in a date span series', () => {
+    const invalidItemIndex = 2;
+
+    const invalidDateSpanSeries = {
+      ...dateSpanSeriesRest,
+      values: [
+        ...dateSpanSeriesValues,
+      ].map(({ date_end_unix, ...rest }, index) =>
+        index === invalidItemIndex ? { ...rest } : { ...rest, date_end_unix }
+      ),
+    };
+
+    const invalidTestData = {
+      ...filler,
+      dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },
+      dateSpanSeries: invalidDateSpanSeries,
+    };
+
+    // Date span series values should be different
+    expect(dateSpanSeriesValues).not.toStrictEqual(
+      invalidTestData.dateSpanSeries.values
+    );
+
+    // Sorting in place
+    expect(() => sortTimeSeriesInDataInPlace(invalidTestData)).toThrow(Error);
+  });
+});

--- a/packages/common/src/__tests__/data-sorting.ts
+++ b/packages/common/src/__tests__/data-sorting.ts
@@ -104,8 +104,8 @@ const sortedData = {
 };
 
 describe('Util: sort time series in data in place', () => {
-  // Testing to make sure they are not referencing the same array of values
-  // causing the starting time series data to get sorted as well
+  // Testing to make sure the test data and sorted test data are not referencing the
+  // same array of values causing the starting time series data to get sorted as well
   it('Sorted values in test data should not match starting values ', () => {
     expect(dateSeriesValues).not.toStrictEqual(sortedData.dateSeries.values);
     expect(dateSpanSeriesValues).not.toStrictEqual(
@@ -193,33 +193,6 @@ describe('Util: sort time series in data in place', () => {
         ...rest,
       })),
     };
-    const invalidTestData = {
-      ...filler,
-      dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },
-      dateSpanSeries: invalidDateSpanSeries,
-    };
-
-    // Date span series values should be different
-    expect(dateSpanSeriesValues).not.toStrictEqual(
-      invalidTestData.dateSpanSeries.values
-    );
-
-    // Sorting in place
-    expect(() => sortTimeSeriesInDataInPlace(invalidTestData)).toThrow(Error);
-  });
-
-  it('Should throw an error when one date_end_unix is missin in a date span series', () => {
-    const invalidItemIndex = 2;
-
-    const invalidDateSpanSeries = {
-      ...dateSpanSeriesRest,
-      values: [
-        ...dateSpanSeriesValues,
-      ].map(({ date_end_unix, ...rest }, index) =>
-        index === invalidItemIndex ? { ...rest } : { ...rest, date_end_unix }
-      ),
-    };
-
     const invalidTestData = {
       ...filler,
       dateSeries: { ...dateSeriesRest, values: [...dateSeriesValues] },

--- a/packages/common/src/__tests__/data-sorting.ts
+++ b/packages/common/src/__tests__/data-sorting.ts
@@ -13,25 +13,21 @@ const dateSeriesValues = [
     date_unix: 1582848000,
     admissions_on_date_of_admission: 0,
     admissions_on_date_of_reporting: 0,
-    date_of_insertion_unix: 1612966742,
   },
   {
     date_unix: 1582934400,
     admissions_on_date_of_admission: 0,
     admissions_on_date_of_reporting: 0,
-    date_of_insertion_unix: 1612966742,
   },
   {
     date_unix: 1582761600,
     admissions_on_date_of_admission: 0,
     admissions_on_date_of_reporting: 0,
-    date_of_insertion_unix: 1612966742,
   },
   {
     date_unix: 1582914400,
     admissions_on_date_of_admission: 0,
     admissions_on_date_of_reporting: 0,
-    date_of_insertion_unix: 1612966742,
   },
 ];
 
@@ -42,7 +38,6 @@ const dateSeriesRest = {
     date_unix: 1612828800,
     admissions_on_date_of_admission: 0,
     admissions_on_date_of_reporting: 0,
-    date_of_insertion_unix: 1612966742,
   },
 };
 
@@ -52,28 +47,24 @@ const dateSpanSeriesValues = [
     date_end_unix: 1601164800,
     average: 0.0,
     total_installation_count: 1,
-    date_of_insertion_unix: 1612965967,
   },
   {
     date_start_unix: 1600041600,
     date_end_unix: 1600560000,
     average: 0.0,
     total_installation_count: 1,
-    date_of_insertion_unix: 1612965967,
   },
   {
     date_start_unix: 1601251200,
     date_end_unix: 1601769600,
     average: 58.07,
     total_installation_count: 1,
-    date_of_insertion_unix: 1612965967,
   },
   {
     date_start_unix: 1599436800,
     date_end_unix: 1599955200,
     average: 8.39,
     total_installation_count: 1,
-    date_of_insertion_unix: 1612965967,
   },
 ];
 

--- a/packages/common/src/__tests__/data-sorting.ts
+++ b/packages/common/src/__tests__/data-sorting.ts
@@ -133,6 +133,7 @@ describe('Util: sort time series in data in place', () => {
   it('Should throw an error when there are no date_unix in a date series', () => {
     const invalidDateSeries = {
       ...dateSeriesRest,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       values: [...dateSeriesValues].map(({ date_unix, ...rest }) => ({
         ...rest,
       })),
@@ -158,6 +159,7 @@ describe('Util: sort time series in data in place', () => {
   it('Should throw an error when there are no date_end_unix in a date span series', () => {
     const invalidDateSpanSeries = {
       ...dateSpanSeriesRest,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       values: [...dateSpanSeriesValues].map(({ date_end_unix, ...rest }) => ({
         ...rest,
       })),
@@ -180,6 +182,7 @@ describe('Util: sort time series in data in place', () => {
   it('Should throw an error when there are no date_start_unix in a date span series', () => {
     const invalidDateSpanSeries = {
       ...dateSpanSeriesRest,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       values: [...dateSpanSeriesValues].map(({ date_start_unix, ...rest }) => ({
         ...rest,
       })),


### PR DESCRIPTION
## Summary

Added unit tests for data-sorting in commons

NOTE: last test is currently failing and these tests were created based on reading the data sorting methods with no background knowledge of how this should work 

## Detailed design

Created some arrays for the time series data and am reusing them by creating new arrays with the same values. 

#### Tests
- The first test is just validating that the original time series data is not getting mutated by sorting of the same referenced array (I can remove this if preferred)
- Sorting works correctly
- Throws an error if `date_unix` is missing on all data points in a date series
- Throws an error if `date_end_unix` is missing on all data points in a date span series
- Throws an error if `date_start_unix` is missing on all data points in a date span series
- [Failing] Throws an error if `date_end_unix` is missing on the second data point in a date span series. I noticed only the first item in a series was getting checked to determine if a series was valid. I wasn't sure if this was intentional so I wasn't sure how to move forward with this. 

## Unresolved questions

Should I remove the last test and are there any other tests that we would like to add?

