### PR TITLE
Fix the prop errors from ArrowIcon

### DIFF
--- a/packages/app/src/components-styled/arrow-icon.tsx
+++ b/packages/app/src/components-styled/arrow-icon.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+import ArrowIcon from '~/assets/arrow.svg';
+
+export const ArrowIconRight = styled(ArrowIcon)`
+  transform: rotate(-90deg);
+`;

--- a/packages/app/src/components-styled/arrow-icon.tsx
+++ b/packages/app/src/components-styled/arrow-icon.tsx
@@ -4,3 +4,7 @@ import ArrowIcon from '~/assets/arrow.svg';
 export const ArrowIconRight = styled(ArrowIcon)`
   transform: rotate(-90deg);
 `;
+
+export const ArrowIconLeft = styled(ArrowIcon)`
+  transform: rotate(90deg);
+`;

--- a/packages/app/src/components-styled/article-detail.tsx
+++ b/packages/app/src/components-styled/article-detail.tsx
@@ -1,4 +1,3 @@
-import css from '@styled-system/css';
 import { ArrowIconLeft } from '~/components-styled/arrow-icon';
 
 import { Box } from '~/components-styled/base';

--- a/packages/app/src/components-styled/article-detail.tsx
+++ b/packages/app/src/components-styled/article-detail.tsx
@@ -1,5 +1,6 @@
 import css from '@styled-system/css';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconLeft } from '~/components-styled/arrow-icon';
+
 import { Box } from '~/components-styled/base';
 import { ContentBlock } from '~/components-styled/cms/content-block';
 import { Heading } from '~/components-styled/typography';
@@ -30,10 +31,7 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
   return (
     <Box bg="white" py={{ _: 4, md: 5 }}>
       <ContentBlock spacing={3}>
-        <LinkWithIcon
-          href="/artikelen"
-          icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
-        >
+        <LinkWithIcon href="/artikelen" icon={<ArrowIconLeft />}>
           {siteText.article_detail.back_link.text}
         </LinkWithIcon>
 

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -1,6 +1,6 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import { getImageSrc } from '~/lib/sanity';
 import siteText from '~/locale';
 import { Article, Block, ImageBlock } from '~/types/cms';
@@ -81,7 +81,7 @@ const StyledArticleTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <StyledArrowIcon />
+      <ArrowIconRight />
     </span>
   );
 }

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -1,6 +1,6 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 import { getImageSrc } from '~/lib/sanity';
 import siteText from '~/locale';
 import { Article, Block, ImageBlock } from '~/types/cms';
@@ -81,7 +81,7 @@ const StyledArticleTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />
+      <StyledArrowIcon />
     </span>
   );
 }

--- a/packages/app/src/components-styled/editorial-detail.tsx
+++ b/packages/app/src/components-styled/editorial-detail.tsx
@@ -1,5 +1,5 @@
 import css from '@styled-system/css';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconLeft } from '~/components-styled/arrow-icon';
 import { Box } from '~/components-styled/base';
 import { ContentBlock } from '~/components-styled/cms/content-block';
 import { ContentImage } from '~/components-styled/cms/content-image';
@@ -18,10 +18,7 @@ export function EditorialDetail({ editorial }: EditorialDetailProps) {
   return (
     <Box bg="white" py={{ _: 4, md: 5 }}>
       <ContentBlock spacing={3}>
-        <LinkWithIcon
-          href="/"
-          icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
-        >
+        <LinkWithIcon href="/" icon={<ArrowIconLeft />}>
           {siteText.editorial_detail.back_link.text}
         </LinkWithIcon>
 

--- a/packages/app/src/components-styled/editorial-detail.tsx
+++ b/packages/app/src/components-styled/editorial-detail.tsx
@@ -1,4 +1,3 @@
-import css from '@styled-system/css';
 import { ArrowIconLeft } from '~/components-styled/arrow-icon';
 import { Box } from '~/components-styled/base';
 import { ContentBlock } from '~/components-styled/cms/content-block';

--- a/packages/app/src/components-styled/highlight-teaser.tsx
+++ b/packages/app/src/components-styled/highlight-teaser.tsx
@@ -1,6 +1,8 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+
 import { getImageSrc } from '~/lib/sanity';
 import { Block, ImageBlock } from '~/types/cms';
 import { Link } from '~/utils/link';
@@ -78,7 +80,7 @@ const StyledHightlightTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />
+      <StyledArrowIcon />
     </span>
   );
 }

--- a/packages/app/src/components-styled/highlight-teaser.tsx
+++ b/packages/app/src/components-styled/highlight-teaser.tsx
@@ -1,7 +1,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 import { getImageSrc } from '~/lib/sanity';
 import { Block, ImageBlock } from '~/types/cms';
@@ -80,7 +80,7 @@ const StyledHightlightTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <StyledArrowIcon />
+      <ArrowIconRight />
     </span>
   );
 }

--- a/packages/app/src/components-styled/layout/app-content.tsx
+++ b/packages/app/src/components-styled/layout/app-content.tsx
@@ -1,7 +1,7 @@
 import css from '@styled-system/css';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconLeft } from '~/components-styled/arrow-icon';
 import { Box } from '~/components-styled/base';
 import { MaxWidth } from '~/components-styled/max-width';
 import siteText from '~/locale/index';
@@ -62,10 +62,7 @@ export function AppContent({
               position: 'relative',
             })}
           >
-            <LinkWithIcon
-              icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
-              href={menuOpenUrl}
-            >
+            <LinkWithIcon icon={<ArrowIconLeft />} href={menuOpenUrl}>
               {menuOpenText}
             </LinkWithIcon>
           </MenuLinkContainer>
@@ -87,10 +84,7 @@ export function AppContent({
               {children}
             </ResponsiveVisible>
             <MenuLinkContainer isVisible={!isMenuOpen && !hideMenuButton}>
-              <LinkWithIcon
-                icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
-                href={menuOpenUrl}
-              >
+              <LinkWithIcon icon={<ArrowIconLeft />} href={menuOpenUrl}>
                 {menuOpenText}
               </LinkWithIcon>
             </MenuLinkContainer>

--- a/packages/app/src/components-styled/quick-links.tsx
+++ b/packages/app/src/components-styled/quick-links.tsx
@@ -1,10 +1,12 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+
 import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
 import { LinkWithIcon } from './link-with-icon';
 import { Heading } from './typography';
+
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 
 interface QuickLinksProps {
   header: string;
@@ -27,7 +29,7 @@ export function QuickLinks({ header, links }: QuickLinksProps) {
           <Item key={`${link.text}-${index}`}>
             <LinkWithIcon
               href={link.href}
-              icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+              icon={<StyledArrowIcon />}
               iconPlacement="right"
               fontWeight="bold"
             >

--- a/packages/app/src/components-styled/quick-links.tsx
+++ b/packages/app/src/components-styled/quick-links.tsx
@@ -6,7 +6,7 @@ import { Box } from './base';
 import { LinkWithIcon } from './link-with-icon';
 import { Heading } from './typography';
 
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 interface QuickLinksProps {
   header: string;
@@ -29,7 +29,7 @@ export function QuickLinks({ header, links }: QuickLinksProps) {
           <Item key={`${link.text}-${index}`}>
             <LinkWithIcon
               href={link.href}
-              icon={<StyledArrowIcon />}
+              icon={<ArrowIconRight />}
               iconPlacement="right"
               fontWeight="bold"
             >

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -1,6 +1,6 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 import {
   ArticleSummary,
   ArticleTeaser,
@@ -57,7 +57,7 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
           {!hideLink && (
             <LinkWithIcon
               href="/artikelen"
-              icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+              icon={<StyledArrowIcon />}
               iconPlacement="right"
               fontWeight="bold"
             >

--- a/packages/app/src/domain/topical/article-list.tsx
+++ b/packages/app/src/domain/topical/article-list.tsx
@@ -1,6 +1,6 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import {
   ArticleSummary,
   ArticleTeaser,
@@ -57,7 +57,7 @@ export function ArticleList({ articleSummaries, hideLink }: ArticleListProps) {
           {!hideLink && (
             <LinkWithIcon
               href="/artikelen"
-              icon={<StyledArrowIcon />}
+              icon={<ArrowIconRight />}
               iconPlacement="right"
               fontWeight="bold"
             >

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -1,7 +1,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import NederlandIcon from '~/assets/nederland.svg';
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import { Title } from '~/components-styled/aside/title';
 import { Box } from '~/components-styled/base';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
@@ -146,7 +146,7 @@ function SitemapItem(props: SitemapItemProps) {
     <Item>
       <LinkWithIcon
         href={href}
-        icon={<StyledArrowIcon />}
+        icon={<ArrowIconRight />}
         iconPlacement="right"
         fontWeight="bold"
       >

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -1,7 +1,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import NederlandIcon from '~/assets/nederland.svg';
-import ArrowIcon from '~/assets/arrow.svg';
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 import { Title } from '~/components-styled/aside/title';
 import { Box } from '~/components-styled/base';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
@@ -146,7 +146,7 @@ function SitemapItem(props: SitemapItemProps) {
     <Item>
       <LinkWithIcon
         href={href}
-        icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+        icon={<StyledArrowIcon />}
         iconPlacement="right"
         fontWeight="bold"
       >

--- a/packages/app/src/domain/topical/editorial-teaser.tsx
+++ b/packages/app/src/domain/topical/editorial-teaser.tsx
@@ -1,6 +1,8 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+
 import { BackgroundImage } from '~/components-styled/background-image';
 import { Box } from '~/components-styled/base';
 import { Heading, InlineText, Text } from '~/components-styled/typography';
@@ -86,7 +88,7 @@ const StyledEditorialTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />
+      <StyledArrowIcon />
     </span>
   );
 }

--- a/packages/app/src/domain/topical/editorial-teaser.tsx
+++ b/packages/app/src/domain/topical/editorial-teaser.tsx
@@ -1,7 +1,7 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 import { BackgroundImage } from '~/components-styled/background-image';
 import { Box } from '~/components-styled/base';
@@ -88,7 +88,7 @@ const StyledEditorialTeaser = styled.a(
 function Arrow() {
   return (
     <span css={css({ svg: { height: '11px', width: '13px', mx: '3px' } })}>
-      <StyledArrowIcon />
+      <ArrowIconRight />
     </span>
   );
 }

--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -1,5 +1,5 @@
 import css from '@styled-system/css';
-import ArrowIcon from '~/assets/arrow.svg';
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 import { Box } from '~/components-styled/base';
 import { Collapsible } from '~/components-styled/collapsible';
 import { EscalationLevelInfoLabel } from '~/components-styled/escalation-level';
@@ -48,7 +48,7 @@ export function EscalationLevelExplanations() {
         <Box mt={4}>
           <LinkWithIcon
             href="/over-risiconiveaus"
-            icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+            icon={<StyledArrowIcon />}
             iconPlacement="right"
           >
             {siteText.escalatie_niveau.lees_meer}

--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -1,5 +1,5 @@
 import css from '@styled-system/css';
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import { Box } from '~/components-styled/base';
 import { Collapsible } from '~/components-styled/collapsible';
 import { EscalationLevelInfoLabel } from '~/components-styled/escalation-level';
@@ -48,7 +48,7 @@ export function EscalationLevelExplanations() {
         <Box mt={4}>
           <LinkWithIcon
             href="/over-risiconiveaus"
-            icon={<StyledArrowIcon />}
+            icon={<ArrowIconRight />}
             iconPlacement="right"
           >
             {siteText.escalatie_niveau.lees_meer}

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -4,7 +4,6 @@ import { GridRows } from '@visx/grid';
 import { ParentSize } from '@visx/responsive';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
 import { Box } from '~/components-styled/base';
 import { LineChart } from '~/components-styled/line-chart';
 import { ComponentCallbackInfo } from '~/components-styled/line-chart/components';
@@ -15,6 +14,7 @@ import { Heading, Text } from '~/components-styled/typography';
 import text from '~/locale';
 import { formatNumber } from '~/utils/formatNumber';
 import { useBreakpoints } from '~/utils/useBreakpoints';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 type MiniTrendTileProps<T extends TimestampedValue> = {
   icon: JSX.Element;
@@ -24,10 +24,6 @@ type MiniTrendTileProps<T extends TimestampedValue> = {
   metricProperty: NumberProperty<T>;
   href: string;
 };
-
-export const StyledArrowIcon = styled(ArrowIcon)`
-  transform: rotate(-90deg);
-`;
 
 export function MiniTrendTile<T extends TimestampedValue>(
   props: MiniTrendTileProps<T>
@@ -54,7 +50,7 @@ export function MiniTrendTile<T extends TimestampedValue>(
       >
         <LinkWithIcon
           href={href}
-          icon={<StyledArrowIcon />}
+          icon={<ArrowIconRight />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -25,6 +25,10 @@ type MiniTrendTileProps<T extends TimestampedValue> = {
   href: string;
 };
 
+export const StyledArrowIcon = styled(ArrowIcon)`
+  transform: rotate(-90deg);
+`;
+
 export function MiniTrendTile<T extends TimestampedValue>(
   props: MiniTrendTileProps<T>
 ) {
@@ -50,7 +54,7 @@ export function MiniTrendTile<T extends TimestampedValue>(
       >
         <LinkWithIcon
           href={href}
-          icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+          icon={<StyledArrowIcon />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink

--- a/packages/app/src/domain/topical/topical-page-header.tsx
+++ b/packages/app/src/domain/topical/topical-page-header.tsx
@@ -1,6 +1,5 @@
-import css from '@styled-system/css';
 import { ReactNode } from 'react';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconLeft } from '~/components-styled/arrow-icon';
 
 import { Box } from '~/components-styled/base';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
@@ -25,11 +24,7 @@ export function TopicalPageHeader({
     <Box spacing={3}>
       {showBackLink && (
         <Box fontSize="1.125rem">
-          <LinkWithIcon
-            href="/"
-            fontWeight="bold"
-            icon={<ArrowIcon css={css({ transform: 'rotate(90deg)' })} />}
-          >
+          <LinkWithIcon href="/" fontWeight="bold" icon={<ArrowIconLeft />}>
             {text.common_actueel.terug_naar_landelijk}
           </LinkWithIcon>
         </Box>

--- a/packages/app/src/domain/topical/topical-vaccine-tile.tsx
+++ b/packages/app/src/domain/topical/topical-vaccine-tile.tsx
@@ -7,7 +7,7 @@ import { Heading, Text } from '~/components-styled/typography';
 import siteText from '~/locale';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 
-import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 export function TopicalVaccineTile() {
   const text = siteText.nationaal_actueel.mini_trend_tiles.toegediende_vaccins;
@@ -37,7 +37,7 @@ export function TopicalVaccineTile() {
       >
         <LinkWithIcon
           href={'/landelijk/vaccinaties'}
-          icon={<StyledArrowIcon />}
+          icon={<ArrowIconRight />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink

--- a/packages/app/src/domain/topical/topical-vaccine-tile.tsx
+++ b/packages/app/src/domain/topical/topical-vaccine-tile.tsx
@@ -1,12 +1,13 @@
 import { formatNumber } from '@corona-dashboard/common';
-import css from '@styled-system/css';
-import ArrowIcon from '~/assets/arrow.svg';
+
 import Vaccinaties from '~/assets/vaccinaties.svg';
 import { Box } from '~/components-styled/base';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
 import { Heading, Text } from '~/components-styled/typography';
 import siteText from '~/locale';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
+
+import { StyledArrowIcon } from '~/domain/topical/mini-trend-tile';
 
 export function TopicalVaccineTile() {
   const text = siteText.nationaal_actueel.mini_trend_tiles.toegediende_vaccins;
@@ -36,7 +37,7 @@ export function TopicalVaccineTile() {
       >
         <LinkWithIcon
           href={'/landelijk/vaccinaties'}
-          icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+          icon={<StyledArrowIcon />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink


### PR DESCRIPTION
## Summary

Applying the CSS prop on an SVG icon would result in console warnings. By wrapping it in styled first, the errors dissapear.

## Motivation

- ✨ _A clean console is a safe console._ ✨ 
- Having a single place to export rotated arrow icons is easier to maintain than remembering to update the css={css({})} props everywhere