### PR TITLE
Change legend item order of the new sewer water chart

### DIFF
--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -343,11 +343,13 @@ export function SewerChart(props: SewerChartProps) {
 
       <Legenda
         items={[
-          stationValuesFiltered.length > 0
+          sewerStationSelectProps.value
             ? {
-                color: 'rgba(89, 89, 89, 0.3)',
-                label: text.secondary_label_text,
-                shape: 'circle' as const,
+                color: colors.data.secondary,
+                label: replaceVariablesInText(text.daily_label_text, {
+                  name: sewerStationSelectProps.value,
+                }),
+                shape: 'line' as const,
               }
             : undefined,
           {
@@ -357,13 +359,11 @@ export function SewerChart(props: SewerChartProps) {
             label: text.average_label_text,
             shape: 'line' as const,
           },
-          sewerStationSelectProps.value
+          stationValuesFiltered.length > 0
             ? {
-                color: colors.data.secondary,
-                label: replaceVariablesInText(text.daily_label_text, {
-                  name: sewerStationSelectProps.value,
-                }),
-                shape: 'line' as const,
+                color: 'rgba(89, 89, 89, 0.3)',
+                label: text.secondary_label_text,
+                shape: 'circle' as const,
               }
             : undefined,
         ].filter(isPresent)}


### PR DESCRIPTION
## Summary

Changed the order to the following:

- selected sewerwater installation
- weekly average
- individual measurements

## Motivation

Design request

## Detailed design

n/a

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
