### PR TITLE
Enable last-values validation on production environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ RUN yarn
 ARG SANITY_AUTH_TOKEN
 ARG SANITY_DATASET
 ARG SANITY_ASSETS_CACHE_DIR
+ARG IS_PRODUCTION=false
 RUN yarn workspace @corona-dashboard/common build
 RUN yarn workspace @corona-dashboard/cli validate-json
 # We need to have an ENV var switch to only enable this in production, because
 # BE does not guarantee consistent data in develop.
-# RUN yarn workspace @corona-dashboard/cli validate-last-values
+RUN if ["$IS_PRODUCTION" = "false"]; then echo "Skipping last-values validation because of non-production environment"; else yarn workspace @corona-dashboard/cli validate-last-values; fi
 RUN yarn workspace @corona-dashboard/cli generate-typescript
 RUN yarn workspace @corona-dashboard/cms sync-assets
 


### PR DESCRIPTION
## Summary

This uses the IS_PRODUCTION build argument in the OTAP pipeline to toggle the last values validation script. It provides a default "false" for when no build argument is given, to prevent an error in Docker.