### PR TITLE
Fix webp support for background images

### DIFF
--- a/packages/app/public/init.js
+++ b/packages/app/public/init.js
@@ -1,3 +1,24 @@
-try {
-  window.document.documentElement.classList.remove('has-no-js');
-} catch(err) {/** */};
+(function () {
+  /**
+   * Detect javascript
+   */
+  try {
+    window.document.documentElement.classList.remove('has-no-js');
+  } catch (err) {
+    /** */
+  }
+
+  /**
+   * Detect webp support
+   */
+  try {
+    var webp = new Image();
+    webp.onload = function () {
+      window.document.documentElement.classList.add('has-webp-support');
+    };
+    webp.src =
+      'data:image/webp;base64,UklGRjIAAABXRUJQVlA4ICYAAACyAgCdASoBAAEALmk0mk0iIiIiIgBoSygABc6zbAAA/v56QAAAAA==';
+  } catch (err) {
+    /** */
+  }
+})();

--- a/packages/app/src/components-styled/article-teaser.tsx
+++ b/packages/app/src/components-styled/article-teaser.tsx
@@ -102,7 +102,7 @@ function CoverImage({ height, image }: CoverImageProps) {
     <Box height={height} overflow="hidden">
       <BackgroundImage
         height={height}
-        backgroundImage={`url(${url})`}
+        backgroundImageUrl={url}
         backgroundPosition={bgPosition}
         backgroundRepeat="no-repeat"
         backgroundSize="cover"

--- a/packages/app/src/components-styled/background-image.tsx
+++ b/packages/app/src/components-styled/background-image.tsx
@@ -1,4 +1,3 @@
-import { maybeTransformImageUrlToWebp } from '~/lib/sanity';
 import styled, { css } from 'styled-components';
 import {
   backgroundPosition,
@@ -12,6 +11,7 @@ import {
   position,
   PositionProps,
 } from 'styled-system';
+import { maybeCreateWebpUrl } from '~/lib/sanity';
 import { styledShouldForwardProp } from '~/utils/styled-should-forward-prop';
 
 export type BackgroundImageLocalProps = {
@@ -34,20 +34,12 @@ export const BackgroundImage = styled.div.withConfig({
   layout,
   position,
   (x) => {
-    const webpUrl = maybeTransformImageUrlToWebp(x.backgroundImageUrl);
+    const webpUrl = maybeCreateWebpUrl(x.backgroundImageUrl);
     const prefix = x.backgroundImagePrefix ? `${x.backgroundImagePrefix},` : '';
     const suffix = x.backgroundImageSuffix ? `,${x.backgroundImageSuffix}` : '';
 
     return css`
-      /* Default background image */
-      background-image: url('${x.backgroundImageUrl}');
-
-      /* apply prefix and/or suffix, but only if browser has support for it */
-      @supports (
-        background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix}
-      ) {
-        background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix};
-      }
+      background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix};
 
       ${webpUrl &&
       css`

--- a/packages/app/src/components-styled/background-image.tsx
+++ b/packages/app/src/components-styled/background-image.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import {
   backgroundPosition,
   BackgroundPositionProps,

--- a/packages/app/src/components-styled/background-image.tsx
+++ b/packages/app/src/components-styled/background-image.tsx
@@ -38,15 +38,14 @@ export const BackgroundImage = styled.div.withConfig({
     const prefix = x.backgroundImagePrefix ? `${x.backgroundImagePrefix},` : '';
     const suffix = x.backgroundImageSuffix ? `,${x.backgroundImageSuffix}` : '';
 
-    return css`
-      background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix};
+    return {
+      backgroundImage: `${prefix} url('${x.backgroundImageUrl}') ${suffix}`,
 
-      ${webpUrl &&
-      css`
-        .has-webp-support && {
-          background-image: ${prefix} url('${webpUrl}') ${suffix};
-        }
-      `}
-    `;
+      ...(webpUrl && {
+        '.has-webp-support &&': {
+          backgroundImage: `${prefix} url('${webpUrl}') ${suffix}`,
+        },
+      }),
+    };
   }
 );

--- a/packages/app/src/components-styled/background-image.tsx
+++ b/packages/app/src/components-styled/background-image.tsx
@@ -1,7 +1,6 @@
-import styled from 'styled-components';
+import { maybeTransformImageUrlToWebp } from '~/lib/sanity';
+import styled, { css } from 'styled-components';
 import {
-  backgroundImage,
-  BackgroundImageProps,
   backgroundPosition,
   BackgroundPositionProps,
   backgroundRepeat,
@@ -15,8 +14,11 @@ import {
 } from 'styled-system';
 import { styledShouldForwardProp } from '~/utils/styled-should-forward-prop';
 
-export type BackgroundImageLocalProps = BackgroundImageProps &
-  BackgroundPositionProps &
+export type BackgroundImageLocalProps = {
+  backgroundImageUrl: string;
+  backgroundImagePrefix?: string;
+  backgroundImageSuffix?: string;
+} & BackgroundPositionProps &
   BackgroundSizeProps &
   BackgroundRepeatProps &
   LayoutProps &
@@ -26,10 +28,41 @@ export const BackgroundImage = styled.div.withConfig({
   shouldForwardProp: styledShouldForwardProp,
 })<BackgroundImageLocalProps>(
   { boxSizing: 'border-box', minWidth: 0 },
-  backgroundImage,
   backgroundPosition,
   backgroundSize,
   backgroundRepeat,
   layout,
-  position
+  position,
+  (x) => {
+    const webpUrl = maybeTransformImageUrlToWebp(x.backgroundImageUrl);
+    const prefix = x.backgroundImagePrefix ? `${x.backgroundImagePrefix},` : '';
+    const suffix = x.backgroundImageSuffix ? `,${x.backgroundImageSuffix}` : '';
+
+    return css`
+      background-image: url('${x.backgroundImageUrl}');
+
+      @supports (
+        background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix}
+      ) {
+        background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix};
+      }
+
+      ${webpUrl &&
+      css`
+        /* Chrome 66+, Edge 79+, Opera 53+, Android Brower 80+ */
+        @media screen and (min-resolution: 0.001dpcm) and (-webkit-min-device-pixel-ratio: 0) {
+          @supports (
+            background-image: ${prefix} -webkit-image-set(url('${webpUrl}') 1x) ${suffix}
+          ) {
+            background-image: ${prefix} -webkit-image-set(url('${webpUrl}') 1x) ${suffix};
+          }
+        }
+
+        /* FF 66+ -- note the double parentheses are necessary (styled components bug?) */
+        @supports ((flex-basis: max-content)) and ((-moz-appearance: meterbar)) {
+          background-image: ${prefix} url('${webpUrl}') ${suffix};
+        }
+      `}
+    `;
+  }
 );

--- a/packages/app/src/components-styled/background-image.tsx
+++ b/packages/app/src/components-styled/background-image.tsx
@@ -39,8 +39,10 @@ export const BackgroundImage = styled.div.withConfig({
     const suffix = x.backgroundImageSuffix ? `,${x.backgroundImageSuffix}` : '';
 
     return css`
+      /* Default background image */
       background-image: url('${x.backgroundImageUrl}');
 
+      /* apply prefix and/or suffix, but only if browser has support for it */
       @supports (
         background-image: ${prefix} url('${x.backgroundImageUrl}') ${suffix}
       ) {
@@ -49,17 +51,7 @@ export const BackgroundImage = styled.div.withConfig({
 
       ${webpUrl &&
       css`
-        /* Chrome 66+, Edge 79+, Opera 53+, Android Brower 80+ */
-        @media screen and (min-resolution: 0.001dpcm) and (-webkit-min-device-pixel-ratio: 0) {
-          @supports (
-            background-image: ${prefix} -webkit-image-set(url('${webpUrl}') 1x) ${suffix}
-          ) {
-            background-image: ${prefix} -webkit-image-set(url('${webpUrl}') 1x) ${suffix};
-          }
-        }
-
-        /* FF 66+ -- note the double parentheses are necessary (styled components bug?) */
-        @supports ((flex-basis: max-content)) and ((-moz-appearance: meterbar)) {
+        .has-webp-support && {
           background-image: ${prefix} url('${webpUrl}') ${suffix};
         }
       `}

--- a/packages/app/src/components-styled/highlight-teaser.tsx
+++ b/packages/app/src/components-styled/highlight-teaser.tsx
@@ -101,7 +101,7 @@ function CoverImage({ height, image }: CoverImageProps) {
     <Box height={height} overflow="hidden">
       <BackgroundImage
         height={height}
-        backgroundImage={`url(${url})`}
+        backgroundImageUrl={url}
         backgroundPosition={bgPosition}
         backgroundRepeat="no-repeat"
         backgroundSize="cover"

--- a/packages/app/src/domain/topical/editorial-teaser.tsx
+++ b/packages/app/src/domain/topical/editorial-teaser.tsx
@@ -111,7 +111,8 @@ function CoverImage({ image }: CoverImageProps) {
       left={0}
       height="100%"
       width="100%"
-      backgroundImage={`linear-gradient(to left, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.75)), url(${url})`}
+      backgroundImagePrefix={`linear-gradient(to left, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.75))`}
+      backgroundImageUrl={url}
       backgroundPosition={bgPosition}
       backgroundRepeat="no-repeat"
       backgroundSize="cover"

--- a/packages/app/src/lib/sanity.tsx
+++ b/packages/app/src/lib/sanity.tsx
@@ -154,7 +154,7 @@ export function getImageSrc(
   return `/cms/images/${asset.assetId}-${size}.${asset.extension}`;
 }
 
-export function maybeTransformImageUrlToWebp(url: string) {
+export function maybeCreateWebpUrl(url: string) {
   const extensionRegex = /(.(png|gif|jpe?g))$/;
 
   return url.startsWith('/cms/images') && extensionRegex.test(url)

--- a/packages/app/src/lib/sanity.tsx
+++ b/packages/app/src/lib/sanity.tsx
@@ -153,3 +153,11 @@ export function getImageSrc(
   const size = findClosestSize(defaultWidth, imageResizeTargets);
   return `/cms/images/${asset.assetId}-${size}.${asset.extension}`;
 }
+
+export function maybeTransformImageUrlToWebp(url: string) {
+  const extensionRegex = /(.(png|gif|jpe?g))$/;
+
+  return url.startsWith('/cms/images') && extensionRegex.test(url)
+    ? url.replace(extensionRegex, '.webp')
+    : undefined;
+}


### PR DESCRIPTION
## Summary

Use an early feature detection in order to have the browser fetch webp resources instead of their old-fashioned counterpart.