### PR TITLE
Remove unnecessary margins on topical page

### DIFF
--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -90,7 +90,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
         })}
       />
       <Box bg="white" pb={4}>
-        <MaxWidth px={{ _: 3, sm: 0 }}>
+        <MaxWidth>
           <TileList>
             <WarningTile
               message={siteText.regionaal_index.belangrijk_bericht}

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -76,7 +76,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
         })}
       />
       <Box bg="white" pb={4}>
-        <MaxWidth px={{ _: 3, sm: 0 }}>
+        <MaxWidth>
           <TileList>
             <WarningTile
               message={siteText.regionaal_index.belangrijk_bericht}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -88,7 +88,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
         description={text.metadata.description}
       />
       <Box bg="white" pb={4}>
-        <MaxWidth px={{ _: 3, sm: 0 }}>
+        <MaxWidth>
           <TileList>
             <WarningTile
               message={siteText.regionaal_index.belangrijk_bericht}


### PR DESCRIPTION
Seems like there were double margins on the topical pages, I've removed them

**Before:**
<img width="410" alt="Screenshot 2021-02-18 at 13 35 57" src="https://user-images.githubusercontent.com/76471292/108357886-5361b700-71ee-11eb-85c0-a53afbf4fb2f.png">

**After:**
<img width="420" alt="Screenshot 2021-02-18 at 13 35 20" src="https://user-images.githubusercontent.com/76471292/108357878-4fce3000-71ee-11eb-867e-286944268f3f.png">