### PR TITLE
Add legends to LCPS charts for bedbezetting

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -93,7 +93,9 @@
     },
     "chart_bedbezetting": {
       "title": "ICU bed occupancy over time",
-      "description": "This graph shows the progression of the number of ICU beds occupied by COVID-19 patients."
+      "description": "This graph shows the progression of the number of ICU beds occupied by COVID-19 patients.",
+      "legend_trend_label": "Bezetting IC-bedden",
+      "legend_inaccurate_label": "Iets over onnauwkeurig"
     },
     "metadata": {
       "title": "Intensive care admissions | Dashboard coronavirus | Government.nl",
@@ -187,7 +189,9 @@
     },
     "chart_bedbezetting": {
       "title": "Hospital bed occupancy over time (non ICU)",
-      "description": "This graph shows the progression of the number of non-ICU hospital beds occupied by COVID-19 patients."
+      "description": "This graph shows the progression of the number of non-ICU hospital beds occupied by COVID-19 patients.",
+      "legend_trend_label": "Bezetting hospital bedden",
+      "legend_inaccurate_label": "Iets over onnauwkeurig"
     },
     "linechart_description": "This graph shows hospital admissions, including admissions directly to ICU. The figure for each day indicates the number of people actually admitted on that day, not the number of admissions reported on that day. This gives a clear picture of the development of coronavirus in the Netherlands. There are often reporting delays of a few days for hospital admissions; data for the most recent days is therefore incomplete.",
     "metadata": {
@@ -754,13 +758,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2040,11 +2038,7 @@
     "expected_page_additions": {
       "title": "Expected data on vaccinations",
       "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "section_vaccinations_more_information": {
       "title": "Expected data on vaccinations",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -93,7 +93,9 @@
     },
     "chart_bedbezetting": {
       "title": "Bezetting IC-bedden over tijd",
-      "description": "Deze grafiek toont het verloop van het aantal IC-bedden dat is bezet door patiënten met COVID-19."
+      "description": "Deze grafiek toont het verloop van het aantal IC-bedden dat is bezet door patiënten met COVID-19.",
+      "legend_trend_label": "Bezetting IC-bedden",
+      "legend_inaccurate_label": "Iets over onnauwkeurig"
     },
     "metadata": {
       "title": "Intensive care-opnames | Dashboard coronavirus | Rijksoverheid.nl",
@@ -187,7 +189,9 @@
     },
     "chart_bedbezetting": {
       "title": "Bezetting gewone ziekenhuisbedden (exclusief IC-bedden) over tijd",
-      "description": "Deze grafiek toont het verloop in het aantal ziekenhuisbedden (exclusief IC-bedden) dat is bezet door patiënten met COVID-19."
+      "description": "Deze grafiek toont het verloop in het aantal ziekenhuisbedden (exclusief IC-bedden) dat is bezet door patiënten met COVID-19.",
+      "legend_trend_label": "Bezetting gewone ziekenhuisbedden",
+      "legend_inaccurate_label": "Iets over onnauwkeurig"
     },
     "linechart_description": "In deze grafiek staan de ziekenhuisopnames (inclusief directe IC opnames) vermeld op de dag dat mensen ook echt zijn opgenomen, in plaats van op de dag dat ze gemeld zijn. Zo kunnen we namelijk de ontwikkeling van het coronavirus in Nederland goed zien. Let op: omdat het aanmelden van ziekenhuisopnames vaak een paar dagen later gebeurt, zijn de meest recente dagen nooit compleet en kan het lijken alsof het aantal ziekenhuisopnames afneemt terwijl dit niet zo is.",
     "metadata": {
@@ -754,13 +758,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2040,11 +2038,7 @@
     "expected_page_additions": {
       "title": "Verwachte toevoegingen aan deze pagina",
       "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "section_vaccinations_more_information": {
       "title": "Verwachte data over vaccinaties",

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -162,6 +162,19 @@ const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
               </>
             );
           }}
+          legendItems={[
+            {
+              color: colors.data.primary,
+              label: text.chart_bedbezetting.legend_trend_label,
+              shape: 'line',
+            },
+            {
+              color: colors.data.underReported,
+              label: text.chart_bedbezetting.legend_inaccurate_label,
+              shape: 'square',
+            },
+          ]}
+          showLegend
         />
       </TileList>
     </>

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -283,6 +283,19 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
               </>
             );
           }}
+          legendItems={[
+            {
+              color: colors.data.primary,
+              label: text.chart_bedbezetting.legend_trend_label,
+              shape: 'line',
+            },
+            {
+              color: colors.data.underReported,
+              label: text.chart_bedbezetting.legend_inaccurate_label,
+              shape: 'square',
+            },
+          ]}
+          showLegend
         />
       </TileList>
     </>


### PR DESCRIPTION
## Summary

Add a legend explaining the gray background in LCPS charts about bedbezetting.