### PR TITLE
Update naming choropleth safety regions legenda

### DIFF
--- a/packages/app/src/components-styled/escalation-map-legenda.tsx
+++ b/packages/app/src/components-styled/escalation-map-legenda.tsx
@@ -114,7 +114,13 @@ function EscalationBarLegenda(props: EscalationBarLegendaProps) {
       <Box flexGrow={barWidth} backgroundColor={info.color} paddingRight={1} />
       <Box paddingLeft={2}>
         {info.amount
-          ? replaceVariablesInText(label.regios, { amount: info.amount })
+          ? info.amount === 1
+            ? replaceVariablesInText(label.regios.singular, {
+                amount: info.amount,
+              })
+            : replaceVariablesInText(label.regios.plural, {
+                amount: info.amount,
+              })
           : label.geen_regio}
       </Box>
     </Box>

--- a/packages/app/src/components-styled/escalation-map-legenda.tsx
+++ b/packages/app/src/components-styled/escalation-map-legenda.tsx
@@ -117,13 +117,10 @@ function EscalationBarLegenda(props: EscalationBarLegendaProps) {
       <Box flexGrow={barWidth} backgroundColor={info.color} paddingRight={1} />
       <Box paddingLeft={2}>
         {info.amount
-          ? info.amount === 1
-            ? replaceVariablesInText(label.regios.singular, {
-                amount: info.amount,
-              })
-            : replaceVariablesInText(label.regios.plural, {
-                amount: info.amount,
-              })
+          ? replaceVariablesInText(
+              info.amount === 1 ? label.regios.singular : label.regios.plural,
+              { amount: info.amount }
+            )
           : label.geen_regio}
       </Box>
     </Box>

--- a/packages/app/src/components-styled/escalation-map-legenda.tsx
+++ b/packages/app/src/components-styled/escalation-map-legenda.tsx
@@ -99,7 +99,10 @@ interface EscalationBarLegendaProps {
   label: {
     titel: string;
     geen_regio: string;
-    regios: string;
+    regios: {
+      singular: string;
+      plural: string;
+    };
   };
   totalItems: number;
 }

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1011,7 +1011,10 @@
     "legenda": {
       "titel": "Legend",
       "geen_regio": "no regions",
-      "regios": "{{amount}} regions"
+      "regios": {
+        "singular": "{{amount}} region",
+        "plural": "{{amount}} regions"
+      }
     },
     "valid_from": "Valid from {{validFrom}}",
     "sidebar_label": "Risk level:",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1011,7 +1011,10 @@
     "legenda": {
       "titel": "Legenda",
       "geen_regio": "geen regio's",
-      "regios": "{{amount}} regio's"
+      "regios": {
+        "singular": "{{amount}} regio",
+        "plural": "{{amount}} regio's"
+      }
     },
     "valid_from": "Geldig vanaf {{validFrom}}",
     "sidebar_label": "Risiconiveau:",


### PR DESCRIPTION
When there is only 1 safety region with a specific level it now displays region instead of regions