### PR TITLE
Render outlier values in toggle button for sewerwater graph

### DIFF
--- a/packages/app/src/components-styled/sewer-chart/components/scatter-plot.tsx
+++ b/packages/app/src/components-styled/sewer-chart/components/scatter-plot.tsx
@@ -6,8 +6,8 @@ interface ScatterPlotProps<T> {
   getX: (datum: T) => number;
   getY: (datum: T) => number;
   color: string;
-  r: number;
-  dotted?: boolean;
+  radius: number;
+  dottedOutline?: boolean;
 }
 
 export const ScatterPlot = memo(
@@ -19,8 +19,8 @@ function ScatterPlotUnmemoized<T extends { id: string }>({
   getX,
   getY,
   color,
-  r,
-  dotted,
+  radius: r,
+  dottedOutline: dotted,
 }: ScatterPlotProps<T>) {
   return (
     <Group>

--- a/packages/app/src/components-styled/sewer-chart/components/scatter-plot.tsx
+++ b/packages/app/src/components-styled/sewer-chart/components/scatter-plot.tsx
@@ -7,6 +7,7 @@ interface ScatterPlotProps<T> {
   getY: (datum: T) => number;
   color: string;
   r: number;
+  dotted?: boolean;
 }
 
 export const ScatterPlot = memo(
@@ -19,6 +20,7 @@ function ScatterPlotUnmemoized<T extends { id: string }>({
   getY,
   color,
   r,
+  dotted,
 }: ScatterPlotProps<T>) {
   return (
     <Group>
@@ -27,8 +29,10 @@ function ScatterPlotUnmemoized<T extends { id: string }>({
           key={datum.id}
           cx={getX(datum)}
           cy={getY(datum)}
-          fill={color}
+          fill={dotted ? 'none' : color}
           r={r}
+          strokeDasharray={dotted ? '1,1' : undefined}
+          stroke={dotted ? color : undefined}
         />
       ))}
     </Group>

--- a/packages/app/src/components-styled/sewer-chart/components/toggle-outlier-button.tsx
+++ b/packages/app/src/components-styled/sewer-chart/components/toggle-outlier-button.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 export const ToggleOutlierButton = styled.button(
   css({
-    bg: 'rgba(218, 218, 218, 0.2)',
+    bg: 'transparent',
     border: 0,
     p: 1,
     color: 'blue',

--- a/packages/app/src/components-styled/sewer-chart/components/toggle-outlier-button.tsx
+++ b/packages/app/src/components-styled/sewer-chart/components/toggle-outlier-button.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 export const ToggleOutlierButton = styled.button(
   css({
-    bg: 'transparent',
+    bg: 'rgba(218, 218, 218, 0.2)',
     border: 0,
     p: 1,
     color: 'blue',

--- a/packages/app/src/components-styled/sewer-chart/logic.ts
+++ b/packages/app/src/components-styled/sewer-chart/logic.ts
@@ -167,13 +167,24 @@ export function useSelectedStationValues(
    * Here' we'll filter the final list of station values based on that boolean
    * and the
    */
-  const stationValuesFiltered = useMemo(() => {
-    return hasOutliers && !displayOutliers
-      ? stationValues.filter((x) => x.value <= outlierLimit)
-      : stationValues;
+  const [stationValuesFiltered, outlierValues] = useMemo(() => {
+    const values =
+      hasOutliers && !displayOutliers
+        ? stationValues.filter((x) => x.value <= outlierLimit)
+        : stationValues;
+    const outliers =
+      hasOutliers && !displayOutliers
+        ? stationValues.filter((x) => x.value > outlierLimit)
+        : undefined;
+    return [values, outliers];
   }, [displayOutliers, hasOutliers, outlierLimit, stationValues]);
 
-  return { stationValuesFiltered, hasOutliers, selectedStationValues };
+  return {
+    stationValuesFiltered,
+    hasOutliers,
+    selectedStationValues,
+    outlierValues,
+  };
 }
 
 export function useScatterTooltip({

--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -86,8 +86,6 @@ export function SewerChart(props: SewerChartProps) {
     displayOutliers
   );
 
-  console.dir(outlierValues);
-
   /**
    * cache paddings and bounds between renders
    */

--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -24,7 +24,6 @@ import { ToggleOutlierButton } from './components/toggle-outlier-button';
 import { DateTooltip, Tooltip } from './components/tooltip';
 import {
   Dimensions,
-  SewerChartValue,
   useLineTooltip,
   useSelectedStationValues,
   useSewerChartScales,
@@ -205,10 +204,10 @@ export function SewerChart(props: SewerChartProps) {
               <ScatterPlot
                 data={outlierValues}
                 getX={scales.getX}
-                getY={(_x: SewerChartValue) => 26}
+                getY={() => 26}
                 color="rgba(89, 89, 89, 0.8)"
-                r={4}
-                dotted
+                radius={4}
+                dottedOutline
               />
             </Group>
           )}
@@ -281,7 +280,7 @@ export function SewerChart(props: SewerChartProps) {
               getX={scales.getX}
               getY={scales.getY}
               color="rgba(89, 89, 89, 0.3)"
-              r={2}
+              radius={2}
             />
 
             <LinePath

--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -24,6 +24,7 @@ import { ToggleOutlierButton } from './components/toggle-outlier-button';
 import { DateTooltip, Tooltip } from './components/tooltip';
 import {
   Dimensions,
+  SewerChartValue,
   useLineTooltip,
   useSelectedStationValues,
   useSewerChartScales,
@@ -77,12 +78,15 @@ export function SewerChart(props: SewerChartProps) {
     stationValuesFiltered,
     hasOutliers,
     selectedStationValues,
+    outlierValues,
   } = useSelectedStationValues(
     sewerStationSelectProps.value,
     stationValues,
     averageValues,
     displayOutliers
   );
+
+  console.dir(outlierValues);
 
   /**
    * cache paddings and bounds between renders
@@ -180,7 +184,7 @@ export function SewerChart(props: SewerChartProps) {
          * The margin-bottom has been eyeballed to visually attach the
          * button to the graph, not sure how future-proof this is.
          */
-        mb={-19}
+        mb={-38}
         zIndex={1}
       >
         <ToggleOutlierButton
@@ -192,6 +196,25 @@ export function SewerChart(props: SewerChartProps) {
       </Box>
 
       <Box position="relative" ref={sizeRef} css={css({ userSelect: 'none' })}>
+        <svg
+          width={width}
+          height={52}
+          role="img"
+          style={{ pointerEvents: 'none' }}
+        >
+          {outlierValues && (
+            <Group left={dimensions.padding.left}>
+              <ScatterPlot
+                data={outlierValues}
+                getX={scales.getX}
+                getY={(_x: SewerChartValue) => 26}
+                color="rgba(89, 89, 89, 0.8)"
+                r={4}
+                dotted
+              />
+            </Group>
+          )}
+        </svg>
         <svg
           role="img"
           width={width}


### PR DESCRIPTION
## Summary

This adds the feature where the outliers are rendered in the toggle button when they are NOT rendered in the graph.
Each outlier is shown as a dotted circle on the same X coordinate as it will appear in the graph.

![image](https://user-images.githubusercontent.com/69849293/108502533-3c38cd00-72b3-11eb-8d66-b50f7f6b16b2.png)

## Motivation

Feature request

## Detailed design

The `useSelectedStationValues` hook now also returns the outlier values separately. When the button is toggled off these values are rendered in a separate SVG that lies above the actual graph. The button is then placed over this SVG giving the appearance to have those dotted circles inside the button.
I've given the outlier dots a slightly larger radius; otherwise, they would be really tough to make out.

## Drawbacks

n/a

## Alternatives

n/a

## Unresolved questions

n/a

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
