### PR TITLE
Update accessible link

### DIFF
--- a/packages/app/src/components-styled/content-header/metadata.tsx
+++ b/packages/app/src/components-styled/content-header/metadata.tsx
@@ -62,7 +62,7 @@ export function Metadata(props: MetadataProps) {
         icon={<DatabaseIcon aria-hidden />}
         items={dataSources}
         label={text.source}
-        accessibilityString={siteText.accessibility.link_source}
+        accessibilityText={siteText.accessibility.text_source}
         accessibilitySubject={accessibilitySubject}
       />
 
@@ -77,7 +77,7 @@ export function Metadata(props: MetadataProps) {
         }
         items={dataDownloads}
         label={text.download}
-        accessibilityString={siteText.accessibility.link_download}
+        accessibilityText={siteText.accessibility.text_download}
         accessibilitySubject={accessibilitySubject}
       />
     </Box>
@@ -91,18 +91,12 @@ interface MetadataItemProps {
     href: string;
     text: string;
   }[];
-  accessibilityString?: string;
+  accessibilityText?: string;
   accessibilitySubject?: string;
 }
 
 function MetadataItem(props: MetadataItemProps) {
-  const {
-    icon,
-    label,
-    items,
-    accessibilityString,
-    accessibilitySubject,
-  } = props;
+  const { icon, label, items, accessibilityText, accessibilitySubject } = props;
 
   if (!items.length) {
     return null;
@@ -122,8 +116,8 @@ function MetadataItem(props: MetadataItemProps) {
               <ExternalLink
                 href={item.href}
                 ariaLabel={
-                  accessibilityString && accessibilitySubject
-                    ? replaceVariablesInText(accessibilityString, {
+                  accessibilityText && accessibilitySubject
+                    ? replaceVariablesInText(accessibilityText, {
                         subject: accessibilitySubject,
                         source: item.text,
                       })

--- a/packages/app/src/components-styled/content-header/metadata.tsx
+++ b/packages/app/src/components-styled/content-header/metadata.tsx
@@ -9,7 +9,6 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Box } from '../base';
 import { ExternalLink } from '../external-link';
 import { Text } from '../typography';
-import { VisuallyHidden } from '~/components-styled/visually-hidden';
 interface Datasource {
   href: string;
   text: string;
@@ -26,7 +25,7 @@ export interface MetadataProps {
   datumsText: string;
   dateOrRange: number | DateRange;
   dateOfInsertionUnix: number;
-  accessibilitySubject?: string;
+  accessibilitySubject: string;
 }
 
 const text = siteText.common.metadata;
@@ -63,10 +62,8 @@ export function Metadata(props: MetadataProps) {
         icon={<DatabaseIcon aria-hidden />}
         items={dataSources}
         label={text.source}
-        accessibilityText={replaceVariablesInText(
-          siteText.accessibility.link_source,
-          { subject: accessibilitySubject }
-        )}
+        accessibilityString={siteText.accessibility.link_source}
+        accessibilitySubject={accessibilitySubject}
       />
 
       <MetadataItem
@@ -80,10 +77,8 @@ export function Metadata(props: MetadataProps) {
         }
         items={dataDownloads}
         label={text.download}
-        accessibilityText={replaceVariablesInText(
-          siteText.accessibility.link_download,
-          { subject: accessibilitySubject }
-        )}
+        accessibilityString={siteText.accessibility.link_download}
+        accessibilitySubject={accessibilitySubject}
       />
     </Box>
   );
@@ -96,11 +91,18 @@ interface MetadataItemProps {
     href: string;
     text: string;
   }[];
-  accessibilityText: string;
+  accessibilityString: string;
+  accessibilitySubject: string;
 }
 
 function MetadataItem(props: MetadataItemProps) {
-  const { icon, label, items, accessibilityText } = props;
+  const {
+    icon,
+    label,
+    items,
+    accessibilityString,
+    accessibilitySubject,
+  } = props;
 
   if (!items.length) {
     return null;
@@ -117,9 +119,14 @@ function MetadataItem(props: MetadataItemProps) {
           <Fragment key={index + item.href}>
             {index > 0 && ' & '}
             {item.href && (
-              <ExternalLink href={item.href}>
+              <ExternalLink
+                href={item.href}
+                ariaLabel={replaceVariablesInText(accessibilityString, {
+                  subject: accessibilitySubject,
+                  source: item.text,
+                })}
+              >
                 {item.text}
-                <VisuallyHidden>{accessibilityText}</VisuallyHidden>
               </ExternalLink>
             )}
             {!item.href && item.text}

--- a/packages/app/src/components-styled/content-header/metadata.tsx
+++ b/packages/app/src/components-styled/content-header/metadata.tsx
@@ -25,7 +25,7 @@ export interface MetadataProps {
   datumsText: string;
   dateOrRange: number | DateRange;
   dateOfInsertionUnix: number;
-  accessibilitySubject: string;
+  accessibilitySubject?: string;
 }
 
 const text = siteText.common.metadata;
@@ -91,8 +91,8 @@ interface MetadataItemProps {
     href: string;
     text: string;
   }[];
-  accessibilityString: string;
-  accessibilitySubject: string;
+  accessibilityString?: string;
+  accessibilitySubject?: string;
 }
 
 function MetadataItem(props: MetadataItemProps) {
@@ -121,10 +121,14 @@ function MetadataItem(props: MetadataItemProps) {
             {item.href && (
               <ExternalLink
                 href={item.href}
-                ariaLabel={replaceVariablesInText(accessibilityString, {
-                  subject: accessibilitySubject,
-                  source: item.text,
-                })}
+                ariaLabel={
+                  accessibilityString && accessibilitySubject
+                    ? replaceVariablesInText(accessibilityString, {
+                        subject: accessibilitySubject,
+                        source: item.text,
+                      })
+                    : undefined
+                }
               >
                 {item.text}
               </ExternalLink>

--- a/packages/app/src/components-styled/external-link.tsx
+++ b/packages/app/src/components-styled/external-link.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { assert } from '~/utils/assert';
 interface ExternalLinkProps {
   href: string;
   children: React.ReactNode;
@@ -13,6 +13,12 @@ export function ExternalLink({
   className,
   ariaLabel,
 }: ExternalLinkProps) {
+  if (ariaLabel || 0 === ariaLabel?.length)
+    assert(
+      ariaLabel.length > 0,
+      'When adding an ariaLabel props, please include some valid text for it'
+    );
+
   return (
     <a
       href={href}

--- a/packages/app/src/components-styled/external-link.tsx
+++ b/packages/app/src/components-styled/external-link.tsx
@@ -4,15 +4,22 @@ interface ExternalLinkProps {
   href: string;
   children: React.ReactNode;
   className?: string;
+  ariaLabel?: string;
 }
 
-export function ExternalLink({ href, children, className }: ExternalLinkProps) {
+export function ExternalLink({
+  href,
+  children,
+  className,
+  ariaLabel,
+}: ExternalLinkProps) {
   return (
     <a
       href={href}
       rel="noopener noreferrer"
       target="_blank"
       className={className}
+      aria-label={ariaLabel}
     >
       {children}
     </a>

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1954,8 +1954,8 @@
       "vaccin_levering_en_prikken": "The left-hand side of the graph shows how many vaccine doses have been delivered to the Netherlands and how many doses have been administered. The right-hand side of the graph shows how many vaccine doses we expect will be delivered and how many doses are to be administered in the coming weeks.",
       "vaccinatie_draagvlak": "This graph shows the percentage of the population that wishes to be vaccinated against COVID-19."
     },
-    "link_source": "View date source for \"{{subject}}\" at {{source}}",
-    "link_download": "Download date source for \"{{subject}}\" at {{source}}"
+    "text_source": "View date source for \"{{subject}}\" at {{source}}",
+    "text_download": "Download date source for \"{{subject}}\" at {{source}}"
   },
   "deceased_age_groups": {
     "title": "COVID-19 deaths by age",

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1954,8 +1954,8 @@
       "vaccin_levering_en_prikken": "The left-hand side of the graph shows how many vaccine doses have been delivered to the Netherlands and how many doses have been administered. The right-hand side of the graph shows how many vaccine doses we expect will be delivered and how many doses are to be administered in the coming weeks.",
       "vaccinatie_draagvlak": "This graph shows the percentage of the population that wishes to be vaccinated against COVID-19."
     },
-    "link_source": "View date source for \"{{subject}}\" at",
-    "link_download": "Download date source for \"{{subject}}\" at"
+    "link_source": "View date source for \"{{subject}}\" at {{source}}",
+    "link_download": "Download date source for \"{{subject}}\" at {{source}}"
   },
   "deceased_age_groups": {
     "title": "COVID-19 deaths by age",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1954,8 +1954,8 @@
       "vaccin_levering_en_prikken": "Het linkerdeel van de grafiek laat zien hoeveel vaccins Nederland in totaal heeft gekregen en hoeveel prikken daarmee zijn gezet. Het gestreepte deel rechts van de verticale lijn laat zien hoeveel vaccins we de komende weken in totaal verwachten te krijgen en hoeveel prikken we verwachten te zetten.",
       "vaccinatie_draagvlak": "Deze grafiek toont hoeveel procent van de bevolking zelf een prik tegen corona wil hebben."
     },
-    "link_source": "Bekijk de databron van \"{{subject}}\" op",
-    "link_download": "Download de databron van \"{{subject}}\" op"
+    "link_source": "Bekijk de databron van \"{{subject}}\" op {{source}}",
+    "link_download": "Download de databron van \"{{subject}}\" op {{source}}"
   },
   "deceased_age_groups": {
     "title": "COVID-19 sterfte: verdeling naar leeftijd",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1954,8 +1954,8 @@
       "vaccin_levering_en_prikken": "Het linkerdeel van de grafiek laat zien hoeveel vaccins Nederland in totaal heeft gekregen en hoeveel prikken daarmee zijn gezet. Het gestreepte deel rechts van de verticale lijn laat zien hoeveel vaccins we de komende weken in totaal verwachten te krijgen en hoeveel prikken we verwachten te zetten.",
       "vaccinatie_draagvlak": "Deze grafiek toont hoeveel procent van de bevolking zelf een prik tegen corona wil hebben."
     },
-    "link_source": "Bekijk de databron van \"{{subject}}\" op {{source}}",
-    "link_download": "Download de databron van \"{{subject}}\" op {{source}}"
+    "text_source": "Bekijk de databron van \"{{subject}}\" op {{source}}",
+    "text_download": "Download de databron van \"{{subject}}\" op {{source}}"
   },
   "deceased_age_groups": {
     "title": "COVID-19 sterfte: verdeling naar leeftijd",


### PR DESCRIPTION
There was some confusion on how to use the accessible from the Lokale. By adding a `{{source}}` in the Lokale they have more control and overview of what is happening. Also removed the visibility text and used an `aria-label` what gave me a little more control but with Voiceover the workings are the same.