### PR TITLE
Read .env config files while running sync script

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -11,7 +11,7 @@
     "test:ci": "yarn run test",
     "compile": "tsc --pretty --noEmit",
     "lint": "echo '@TODO add eslint'",
-    "sync-assets": "ts-node scripts/sync-assets.ts",
+    "sync-assets": "ts-node -r dotenv-flow/config scripts/sync-assets.ts",
     "format": "prettier --write \"src/**/*.{js,ts,tsx}\" \"*.{js,json,md,yml}\""
   },
   "dependencies": {
@@ -40,6 +40,7 @@
     "@types/download": "^6.2.4",
     "@types/fs-extra": "^9.0.6",
     "@types/prompts": "^2.0.9",
-    "@types/react-world-flags": "^1.4.1"
+    "@types/react-world-flags": "^1.4.1",
+    "dotenv-flow": "^3.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,7 +6910,14 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^8.2.0:
+dotenv-flow@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-3.2.0.tgz#a5d79dd60ddb6843d457a4874aaf122cf659a8b7"
+  integrity sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==
+  dependencies:
+    dotenv "^8.0.0"
+
+dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
 


### PR DESCRIPTION
## Summary

scripts ran with ts-node did not pick up .env.* files.