### PR TITLE
Update height of arrows and removed direct css attribute from arrow

### DIFF
--- a/packages/app/src/components-styled/article-strip.tsx
+++ b/packages/app/src/components-styled/article-strip.tsx
@@ -1,6 +1,6 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import { Box } from '~/components-styled/base';
 import { Tile } from '~/components-styled/tile';
 import { SanityImage } from '~/components-styled/cms/sanity-image';
@@ -75,7 +75,7 @@ function ArticleStripItem(props: ArticleStripItemProps) {
           </Text>
           <LinkWithIcon
             href={`/artikelen/${slug}`}
-            icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+            icon={<ArrowIconRight />}
             iconPlacement="right"
           >
             {siteText.common.read_more}

--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -50,12 +50,12 @@ export function LinkWithIcon({
         {iconPlacement === 'right' && !headingLink && (
           <>
             {children}
-            <IconSmall icon={icon} width={11} height={13} />
+            <IconSmall icon={icon} width={11} height={10} />
           </>
         )}
         {iconPlacement === 'left' && !headingLink && (
           <>
-            <IconSmall icon={icon} width={11} height={13} />
+            <IconSmall icon={icon} width={11} height={10} />
             {children}
           </>
         )}
@@ -68,7 +68,7 @@ export function LinkWithIcon({
                 icon={icon}
                 isSingleWord={isSingleWord}
                 width={16}
-                height={18}
+                height={13}
               />
             </span>
           </Box>

--- a/packages/app/src/components-styled/risk-level-indicator.tsx
+++ b/packages/app/src/components-styled/risk-level-indicator.tsx
@@ -8,7 +8,7 @@ import { regionThresholds } from '~/components/choropleth/region-thresholds';
 import { EscalationLevel } from '~/domain/restrictions/type';
 import { assert } from '~/utils/assert';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
-import ArrowIcon from '~/assets/arrow.svg';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 
 const escalationThresholds = regionThresholds.escalation_levels.level;
 
@@ -53,7 +53,7 @@ export function RiskLevelIndicator(props: RiskLevelIndicatorProps) {
       <Heading level={3} as="h2" py={2} pl={{ _: '3.5rem' }}>
         <LinkWithIcon
           href={href}
-          icon={<ArrowIcon css={css({ transform: 'rotate(-90deg)' })} />}
+          icon={<ArrowIconRight />}
           iconPlacement="right"
           fontWeight="bold"
           headingLink


### PR DESCRIPTION
Update all the arrows that caused `Warning: Invalid value for prop `_css2` on <svg> tag.`
Reduced the height of the arrows so that they align better to their text (no difference in size, just vertical alignment).
See on [live](https://coronadashboard.rijksoverheid.nl/) that the first and the third arrows of the title are slightly misaligned. 