### PR TITLE
Remove margin-top and on paragraph elements

### DIFF
--- a/packages/app/src/components-styled/aside/category.tsx
+++ b/packages/app/src/components-styled/aside/category.tsx
@@ -7,7 +7,7 @@ export const Category = styled(Text)(
     fontSize: 3,
     lineHeight: 1,
     px: 3,
-    m: 0,
+    mb: 3,
     fontWeight: 'bold',
   })
 );

--- a/packages/app/src/components-styled/aside/title.tsx
+++ b/packages/app/src/components-styled/aside/title.tsx
@@ -25,7 +25,7 @@ export function Title(props: TitleProps) {
       flexDirection="row"
       flexWrap="nowrap"
       alignItems="center"
-      mb={-2}
+      mb={2}
     >
       {icon && <Icon>{icon}</Icon>}
 

--- a/packages/app/src/components-styled/categorical-bar-scale.tsx
+++ b/packages/app/src/components-styled/categorical-bar-scale.tsx
@@ -89,7 +89,7 @@ export function CategoricalBarScale({
         />
       </Box>
 
-      <Box>
+      <Box mb={3}>
         {barPieces.map((category) => (
           <Fragment key={category.name}>
             {/* 0.25px offset is used for sharper rendering of the circle */}

--- a/packages/app/src/components-styled/cms/content-image.tsx
+++ b/packages/app/src/components-styled/cms/content-image.tsx
@@ -50,8 +50,9 @@ export function ContentImage({
   ) : (
     <ContentWrapper>
       <Box as="figure" role="group" spacing={3} my={2} textAlign="center">
-        <SanityImage {...getImageProps(node, { sizes })} />
-
+        <Box mb={3}>
+          <SanityImage {...getImageProps(node, { sizes })} />
+        </Box>
         {caption}
       </Box>
     </ContentWrapper>

--- a/packages/app/src/components-styled/collapsible.tsx
+++ b/packages/app/src/components-styled/collapsible.tsx
@@ -84,7 +84,6 @@ const Panel = styled(DisclosurePanel)(
     px: 3,
     py: 0,
     transition: 'max-height 0.4s ease-in-out, opacity 0.4s ease-in-out',
-
     '&[data-state="open"]': {
       opacity: 1,
     },

--- a/packages/app/src/components-styled/kpi-tile.tsx
+++ b/packages/app/src/components-styled/kpi-tile.tsx
@@ -26,11 +26,11 @@ export function KpiTile({
       <Box>{children}</Box>
       {description && (
         <Box
-          as="p"
+          as="div"
           maxWidth="400px"
           fontSize={2}
           lineHeight={2}
-          mb={0}
+          mb={3}
           dangerouslySetInnerHTML={{
             __html: description,
           }}

--- a/packages/app/src/components-styled/kpi-tile.tsx
+++ b/packages/app/src/components-styled/kpi-tile.tsx
@@ -26,11 +26,11 @@ export function KpiTile({
       <Box>{children}</Box>
       {description && (
         <Box
-          as="div"
+          as="p"
           maxWidth="400px"
-          mt={3}
           fontSize={2}
           lineHeight={2}
+          mb={0}
           dangerouslySetInnerHTML={{
             __html: description,
           }}

--- a/packages/app/src/components-styled/kpi-value.tsx
+++ b/packages/app/src/components-styled/kpi-value.tsx
@@ -1,11 +1,11 @@
+import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
 import styled from 'styled-components';
 import { color } from 'styled-system';
 import { isDefined } from 'ts-is-present';
-import { formatNumber, formatPercentage } from '~/utils/formatNumber';
-import { ValueAnnotation } from '~/components-styled/value-annotation';
-import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
+import { Box } from '~/components-styled/base';
 import { DifferenceIndicator } from '~/components-styled/difference-indicator';
-
+import { ValueAnnotation } from '~/components-styled/value-annotation';
+import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 interface KpiValueProps {
   absolute?: number;
   percentage?: number;
@@ -49,7 +49,7 @@ export function KpiValue({
   ...otherProps
 }: KpiValueProps) {
   return (
-    <>
+    <Box mb={3}>
       {isDefined(percentage) && isDefined(absolute) ? (
         <StyledValue color={color} {...otherProps}>
           {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}
@@ -74,6 +74,6 @@ export function KpiValue({
         />
       )}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}
-    </>
+    </Box>
   );
 }

--- a/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
+++ b/packages/app/src/components-styled/kpi-with-illustration-tile.tsx
@@ -2,7 +2,7 @@ import { Box } from './base';
 import { Tile } from '~/components-styled/tile';
 import { Metadata, MetadataProps } from './metadata';
 import { Heading, Text } from './typography';
-
+import { css } from '@styled-system/css';
 interface Illustration {
   image: string;
   alt: string;
@@ -50,6 +50,7 @@ export function KpiWithIllustrationTile({
             loading="lazy"
             src={illustration.image}
             alt={illustration.alt}
+            css={css({ mb: 3 })}
           />
           <p>{illustration.description}</p>
         </Box>

--- a/packages/app/src/components-styled/layout/app-footer.tsx
+++ b/packages/app/src/components-styled/layout/app-footer.tsx
@@ -70,7 +70,7 @@ function LastGeneratedMessage({ date }: { date: string }) {
 
   return (
     <Box maxWidth={450}>
-      <Box fontSize={3} fontWeight="bold">
+      <Box fontSize={3} fontWeight="bold" mb={3}>
         {text.laatst_bijgewerkt.title}
       </Box>
       <p

--- a/packages/app/src/components-styled/page-barscale.tsx
+++ b/packages/app/src/components-styled/page-barscale.tsx
@@ -111,7 +111,7 @@ export function PageBarScale<T>({
   }
 
   return (
-    <Box spacing={2}>
+    <Box spacing={2} mb={3}>
       <BarScale
         min={config.barScale.min}
         max={config.barScale.max}

--- a/packages/app/src/domain/behavior/behavior-choropleth-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-choropleth-tile.tsx
@@ -40,7 +40,7 @@ export function BehaviorChoroplethTile({
       title={text.verdeling_in_nederland.titel}
       description={
         <>
-          <Box display="flex" justifyContent="start">
+          <Box display="flex" justifyContent="start" mb={3}>
             <BehaviorTypeControl value={type} onChange={setType} />
           </Box>
           <p>{text.verdeling_in_nederland.intro}</p>

--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -66,7 +66,7 @@ export function BehaviorLineChartTile({
         </Box>
       </Header>
 
-      <Box display="flex" justifyContent="start">
+      <Box display="flex" justifyContent="start" mb={3}>
         <BehaviorTypeControl value={type} onChange={setType} />
       </Box>
 

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -109,7 +109,7 @@ function MunicipalityLayout(props: MunicipalityLayoutProps) {
                 aria-label={siteText.aria_labels.metriek_navigatie}
               >
                 <Box>
-                  <Category marginBottom={0}>{municipalityName}</Category>
+                  <Category>{municipalityName}</Category>
                   {safetyRegion && (
                     <Text pl={3}>
                       {siteText.common.veiligheidsregio_label}{' '}

--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -16,11 +16,13 @@ type EscalationLevelExplanationProps = {
 function EscalationLevelExplanation(props: EscalationLevelExplanationProps) {
   const { level, explanation } = props;
   return (
-    <Box display="flex" flexDirection={{ _: 'column', md: 'row' }}>
+    <Box display="flex" flexDirection={{ _: 'column', md: 'row' }} py={3}>
       <Box width="10rem" display="flex" flexGrow={0} flexShrink={0}>
         <EscalationLevelInfoLabel level={level} />
       </Box>
-      <Text css={css({ maxWidth: 'maxWidthText' })}>{explanation}</Text>
+      <Text mb={0} css={css({ maxWidth: 'maxWidthText' })}>
+        {explanation}
+      </Text>
     </Box>
   );
 }

--- a/packages/app/src/domain/topical/topical-choropleth-container.tsx
+++ b/packages/app/src/domain/topical/topical-choropleth-container.tsx
@@ -53,6 +53,7 @@ export function TopicalChoroplethContainer({
           level={2}
           fontSize={{ _: '2rem', lg: '2.75em' }}
           lineHeight="1em"
+          mb={4}
         >
           {title}
         </Heading>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -220,7 +220,9 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 </Box>
               </TopicalTile>
             </Box>
+
             <DataSitemap />
+
             <Box mt={{ md: 5 }}>
               <ArticleList articleSummaries={content.articles} />
             </Box>

--- a/packages/app/src/pages/over-risiconiveaus.tsx
+++ b/packages/app/src/pages/over-risiconiveaus.tsx
@@ -12,7 +12,7 @@ import { CollapsibleList, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
 import { RichContent } from '~/components-styled/cms/rich-content';
-
+import { Box } from '~/components-styled/base';
 interface OverRisiconiveausData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -86,7 +86,11 @@ const OverRisicoNiveaus: FCWithLayout<typeof getStaticProps> = (props) => {
                   const id = getSkipLinkId(item.title);
                   return item.content ? (
                     <Collapsible key={id} id={id} summary={item.title}>
-                      {item.content && <RichContent blocks={item.content} />}
+                      {item.content && (
+                        <Box mt={3}>
+                          <RichContent blocks={item.content} />
+                        </Box>
+                      )}
                     </Collapsible>
                   ) : null;
                 })}

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -12,7 +12,7 @@ import {
 import { CollapsibleList, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
-
+import { Box } from '~/components-styled/base';
 interface VeelgesteldeVragenData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -87,7 +87,11 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
                   const id = getSkipLinkId(item.title);
                   return (
                     <Collapsible key={id} id={id} summary={item.title}>
-                      {item.content && <RichContent blocks={item.content} />}
+                      {item.content && (
+                        <Box mt={3}>
+                          <RichContent blocks={item.content} />
+                        </Box>
+                      )}
                     </Collapsible>
                   );
                 })}

--- a/packages/app/src/pages/verantwoording.tsx
+++ b/packages/app/src/pages/verantwoording.tsx
@@ -12,7 +12,7 @@ import {
 import { CollapsibleList, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
-
+import { Box } from '~/components-styled/base';
 interface VerantwoordingData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -87,7 +87,11 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
                   const id = getSkipLinkId(item.title);
                   return item.content ? (
                     <Collapsible key={id} id={id} summary={item.title}>
-                      {item.content && <RichContent blocks={item.content} />}
+                      {item.content && (
+                        <Box mt={3}>
+                          <RichContent blocks={item.content} />
+                        </Box>
+                      )}
                     </Collapsible>
                   ) : null;
                 })}

--- a/packages/app/src/style/global-style.tsx
+++ b/packages/app/src/style/global-style.tsx
@@ -115,4 +115,8 @@ button::-moz-focus-inner {
 figure {
   margin: 0
 }
+
+p {
+  margin-top: 0;
+}
 `;


### PR DESCRIPTION
Globally remove all the margin-top from the paragraph tag, went through **all** the pages to spot some difference in the layout compared to the live version. Numerous small changes that were relying on the margin-top from the paragraph tag.