### PR TITLE
Fix choropleth municipality tooltip click

### DIFF
--- a/packages/app/src/components/choropleth/hooks/use-municipality-data.ts
+++ b/packages/app/src/components/choropleth/hooks/use-municipality-data.ts
@@ -58,6 +58,7 @@ export function useMunicipalityNavigationData(
   return {
     getChoroplethValue: (id: string) => ({
       ...propertyData[id],
+      gmcode: propertyData[id].gmcode || propertyData[id].gemcode,
       __color_value: 0,
     }),
     hasData: true,


### PR DESCRIPTION
It was not possible to click on the tooltip to go to the specific manuplicity page.