### PR TITLE
Remove margin on button to fix safari alignment milestones

### DIFF
--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -197,6 +197,7 @@ const StyledButton = styled.button(
   css({
     position: 'relative',
     padding: 0,
+    margin: 0,
     border: 'none',
     background: 'none',
     font: 'inherit',


### PR DESCRIPTION
Small fix for a safari where the user agent styles were adding a 1-pixel margin on the button.  
But there is a small refractor here https://github.com/minvws/nl-covid19-data-dashboard/pull/2114
This is just temporarily for the time being on master.