### PR TITLE
Add clickhandler back on tooltips choropleth

### DIFF
--- a/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
@@ -14,10 +14,7 @@ export function TooltipContent(props: IProps) {
   const { title, onSelect, children } = props;
 
   return (
-    <StyledTooltipContent
-      onClick={onSelect}
-      hasClickHandler={onSelect ? true : false}
-    >
+    <StyledTooltipContent onClick={onSelect}>
       <TooltipHeader>
         <Heading
           level={3}
@@ -36,7 +33,7 @@ export function TooltipContent(props: IProps) {
   );
 }
 
-const StyledTooltipContent = styled.div<{ hasClickHandler?: boolean }>((x) =>
+const StyledTooltipContent = styled.div((x) =>
   css({
     color: 'body',
     width: '100%',

--- a/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
@@ -14,7 +14,10 @@ export function TooltipContent(props: IProps) {
   const { title, onSelect, children } = props;
 
   return (
-    <StyledTooltipContent hasClickHandler={onSelect ? true : false}>
+    <StyledTooltipContent
+      onClick={onSelect}
+      hasClickHandler={onSelect ? true : false}
+    >
       <TooltipHeader>
         <Heading
           level={3}


### PR DESCRIPTION
By accident the click handler on the choropleth tooltips was missing, this should revert it.