### PR TITLE
Some visual tweaks to the actueel header components

### DIFF
--- a/packages/app/src/components-styled/warning-tile.tsx
+++ b/packages/app/src/components-styled/warning-tile.tsx
@@ -1,10 +1,11 @@
 import css from '@styled-system/css';
+import { ComponentType, ReactNode } from 'react';
 import styled from 'styled-components';
 import WarningIcon from '~/assets/warning.svg';
-import { Box } from './base';
 import { Tile } from '~/components-styled/tile';
 import { asResponsiveArray } from '~/style/utils';
-import { ReactNode, ComponentType } from 'react';
+import { useBreakpoints } from '~/utils/useBreakpoints';
+import { Box } from './base';
 
 type WarningMessageVariant = 'emphasis' | 'default';
 
@@ -21,12 +22,21 @@ export function WarningTile({
   icon = WarningIcon,
 }: WarningMessageProps) {
   const Icon = icon;
+
+  const breakpoints = useBreakpoints();
+
+  const isSmallScreen = !breakpoints.md;
+
   return (
     <StyledTile>
       <WarningBox variant={variant}>
-        <IconWrapper>
-          <Icon />
-        </IconWrapper>
+        {isSmallScreen ? (
+          <Box width="10px" />
+        ) : (
+          <IconWrapper>
+            <Icon />
+          </IconWrapper>
+        )}
       </WarningBox>
       <WarningMessageBox variant={variant}>
         {typeof message === 'string' ? (
@@ -50,12 +60,13 @@ const StyledTile = styled(Tile)(
     flexDirection: 'row',
     padding: 0,
     boxShadow: 'none',
+    display: 'inline-flex',
   })
 );
 
 const WarningBox = styled(Box)<{ variant: WarningMessageVariant }>(
   ({ variant }) => {
-    const backgroundColor = variant === 'emphasis' ? '#FFE060' : 'white';
+    const backgroundColor = variant === 'emphasis' ? '#FEE670' : 'white';
     return css({
       display: 'flex',
       alignItems: 'center',
@@ -83,13 +94,13 @@ const IconWrapper = styled(Box)(
 
 const WarningMessageBox = styled(Box)<{ variant: WarningMessageVariant }>(
   ({ variant }) => {
-    const backgroundColor = variant === 'emphasis' ? '#FFEE87' : 'white';
+    const backgroundColor = variant === 'emphasis' ? '#FFF4C1' : 'white';
     return css({
       display: 'flex',
       alignItems: 'center',
       flex: '1 1 auto',
-      py: 3,
-      pl: 3,
+      py: 2,
+      pl: 2,
       backgroundColor,
       borderBottomRightRadius: 1,
       borderTopRightRadius: 1,

--- a/packages/app/src/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip.tsx
@@ -4,7 +4,7 @@ import {
   MunicipalityProperties,
 } from '@corona-dashboard/common';
 import { ReactNode } from 'react';
-import { InlineText, Text } from '~/components-styled/typography'
+import { InlineText, Text } from '~/components-styled/typography';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
 import { TooltipSubject } from '~/components/choropleth/tooltips/tooltip-subject';
 import siteText from '~/locale/index';

--- a/packages/app/src/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip.tsx
@@ -4,7 +4,7 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import { ReactNode } from 'react';
-import { InlineText } from '~/components-styled/typography'
+import { InlineText } from '~/components-styled/typography';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
 import { TooltipSubject } from '~/components/choropleth/tooltips/tooltip-subject';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';

--- a/packages/app/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip.tsx
@@ -4,7 +4,7 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import { ReactNode } from 'react';
-import { InlineText, Text } from '~/components-styled/typography'
+import { InlineText, Text } from '~/components-styled/typography';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
 import { TooltipSubject } from '~/components/choropleth/tooltips/tooltip-subject';
 import siteText from '~/locale/index';

--- a/packages/app/src/components/choropleth/tooltips/region/create-sewer-regional-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/create-sewer-regional-tooltip.tsx
@@ -4,7 +4,7 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import { ReactNode } from 'react';
-import { InlineText, Text } from '~/components-styled/typography'
+import { InlineText, Text } from '~/components-styled/typography';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
 import { TooltipSubject } from '~/components/choropleth/tooltips/tooltip-subject';
 import siteText from '~/locale/index';

--- a/packages/app/src/domain/topical/topical-page-header.tsx
+++ b/packages/app/src/domain/topical/topical-page-header.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 import { ArrowIconLeft } from '~/components-styled/arrow-icon';
-
 import { Box } from '~/components-styled/base';
 import { LinkWithIcon } from '~/components-styled/link-with-icon';
 import { RelativeDate } from '~/components-styled/relative-date';
@@ -13,12 +12,14 @@ interface TopicalPageHeaderProps {
   title: ReactNode;
   lastGenerated: number;
   showBackLink?: boolean;
+  link?: ReactNode;
 }
 
 export function TopicalPageHeader({
   title,
   lastGenerated,
   showBackLink,
+  link,
 }: TopicalPageHeaderProps) {
   return (
     <Box spacing={3}>
@@ -31,16 +32,27 @@ export function TopicalPageHeader({
       )}
 
       <Box>
-        <Heading
-          level={1}
-          fontWeight="normal"
-          m={0}
-          lineHeight={0}
-          mb={2}
-          fontSize={{ _: '2rem', lg: '2.75rem' }}
+        <Box
+          borderBottomColor="border"
+          borderBottomStyle="solid"
+          borderBottomWidth="1px"
+          pb={{ _: 2, lg: 3 }}
+          mb={{ _: 2, lg: 3 }}
+          display="flex"
+          flexDirection={{ _: 'column', lg: 'row' }}
+          alignItems="baseline"
         >
-          {title}
-        </Heading>
+          <Heading
+            level={1}
+            m={0}
+            mb={{ _: 2, lg: 0 }}
+            lineHeight={0}
+            fontSize={{ _: '2rem', lg: '2.75rem' }}
+          >
+            {title}
+          </Heading>
+          {link && <Box ml={{ _: 0, lg: 4 }}>{link}</Box>}
+        </Box>
         <InlineText color="bodyLight">
           {replaceComponentsInText(text.common_actueel.laatst_bijgewerkt, {
             date: <RelativeDate dateInSeconds={lastGenerated} />,

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -759,13 +759,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2067,11 +2061,7 @@
     "expected_page_additions": {
       "title": "Expected data on vaccinations",
       "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "",
@@ -2196,11 +2186,7 @@
       "kpi_expected_page_additions": {
         "title": "Expected data on vaccinations",
         "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2246,6 +2232,7 @@
   },
   "nationaal_actueel": {
     "title": "The current situation in {{the_netherlands}}",
+    "title_link": "View all data for the Netherlands",
     "the_netherlands": "The Netherlands",
     "metadata": {
       "title": "Coronavirus Dashboard | COVID-19 | Government.nl",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -759,13 +759,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2067,11 +2061,7 @@
     "expected_page_additions": {
       "title": "Verwachte toevoegingen aan deze pagina",
       "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "Do not remove this key. It is required as a temporary workaround",
@@ -2196,11 +2186,7 @@
       "kpi_expected_page_additions": {
         "title": "Verwachte toevoegingen aan deze pagina",
         "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2246,6 +2232,7 @@
   },
   "nationaal_actueel": {
     "title": "De actuele situatie in {{the_netherlands}}",
+    "title_link": "Bekijk alle cijfers van Nederland",
     "the_netherlands": "Nederland",
     "metadata": {
       "title": "Coronadashboard | COVID-19 | Rijksoverheid.nl",

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -5,6 +5,7 @@ import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box } from '~/components-styled/base';
 import { DataDrivenText } from '~/components-styled/data-driven-text';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
+import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
@@ -41,7 +42,6 @@ import { Link } from '~/utils/link';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/gm';
-import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -92,17 +92,17 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
       <Box bg="white" pb={4}>
         <MaxWidth>
           <TileList>
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
-
             <TopicalPageHeader
               showBackLink
               lastGenerated={Number(props.lastGenerated)}
               title={replaceComponentsInText(text.title, {
                 municipalityName: <strong>{municipalityName}</strong>,
               })}
+            />
+
+            <WarningTile
+              message={siteText.regionaal_index.belangrijk_bericht}
+              variant="emphasis"
             />
 
             <MiniTrendTileLayout>

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -5,6 +5,7 @@ import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box } from '~/components-styled/base';
 import { DataDrivenText } from '~/components-styled/data-driven-text';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
+import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
@@ -38,7 +39,6 @@ import { Link } from '~/utils/link';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/vr';
-import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -78,17 +78,17 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
       <Box bg="white" pb={4}>
         <MaxWidth>
           <TileList>
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
-
             <TopicalPageHeader
               showBackLink
               lastGenerated={Number(props.lastGenerated)}
               title={replaceComponentsInText(text.title, {
                 safetyRegionName: <strong>{props.safetyRegionName}</strong>,
               })}
+            />
+
+            <WarningTile
+              message={siteText.regionaal_index.belangrijk_bericht}
+              variant="emphasis"
             />
 
             <MiniTrendTileLayout>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -109,7 +109,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               }
             />
 
-            <Box width={{ _: '100%', lg: '75%' }}>
+            <Box width={{ lg: '75%' }}>
               <Search />
             </Box>
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -1,10 +1,13 @@
 import { useRouter } from 'next/router';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
+import { ArrowIconRight } from '~/components-styled/arrow-icon';
 import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box } from '~/components-styled/base';
 import { DataDrivenText } from '~/components-styled/data-driven-text';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
+import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
+import { LinkWithIcon } from '~/components-styled/link-with-icon';
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
 import { SEOHead } from '~/components-styled/seo-head';
@@ -37,7 +40,6 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
-import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -90,18 +92,30 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
       <Box bg="white" pb={4}>
         <MaxWidth>
           <TileList>
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
-
-            <Search />
-
             <TopicalPageHeader
               lastGenerated={Number(lastGenerated)}
               title={replaceComponentsInText(text.title, {
-                the_netherlands: <strong>{text.the_netherlands}</strong>,
+                the_netherlands: text.the_netherlands,
               })}
+              link={
+                <LinkWithIcon
+                  href="/landelijk/vaccinaties"
+                  icon={<ArrowIconRight />}
+                  iconPlacement="right"
+                  fontWeight="bold"
+                >
+                  {text.title_link}
+                </LinkWithIcon>
+              }
+            />
+
+            <Box width={{ _: '100%', lg: '75%' }}>
+              <Search />
+            </Box>
+
+            <WarningTile
+              message={siteText.regionaal_index.belangrijk_bericht}
+              variant="emphasis"
             />
 
             <MiniTrendTileLayout>


### PR DESCRIPTION
## Summary

- Change the order (first the header, then the search bar, then the warningbox)
- Header text is now bold
- Tighten the margins on mobile
- Add a link to the 'landelijk' page to the landelijk actueel header
- Change the colors of the warningbox
- Warningbox fits the size of its contents instead of full width
- Warningbox doesn't show icon on mobile
- Reduce the length of the search bar (no longer full size)

## Motivation

Design requests

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
