### PR TITLE
Update sidebar risk level heading from lokale

### DIFF
--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -127,7 +127,7 @@ function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
                   />
                   <MetricMenuItemLink
                     href={`/veiligheidsregio/${code}/risiconiveau`}
-                    title={'Risiconiveau'}
+                    title={siteText.veiligheidsregio_layout.headings.inschaling}
                   >
                     <Box mt={2}>
                       <EscalationLevelInfoLabel


### PR DESCRIPTION
Risk level sidebar text was not coming from the Lokale, so it wasn't translated. 