### PR TITLE
Create the "tile"-like content header

### DIFF
--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -1,20 +1,22 @@
+import { assert } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
+import { Box } from '~/components-styled/base';
 import {
   Metadata,
   MetadataProps,
 } from '~/components-styled/content-header/metadata';
 import { HeadingWithIcon } from '~/components-styled/heading-with-icon';
+import { Tile } from '~/components-styled/tile';
 import {
   Heading,
   HeadingLevel,
   InlineText,
   Text,
 } from '~/components-styled/typography';
-import { Link } from '~/utils/link';
 import { asResponsiveArray } from '~/style/utils';
-import { Box } from '../base';
+import { Link } from '~/utils/link';
 
 /*
   the left margin '-100w' and left padding '100w' hack ensures skip link anchors to have a (non visible) start at the left side of the screen.
@@ -50,7 +52,7 @@ const Header = (props: HeaderProps) => {
       {skipLinkAnchor ? (
         <PointerEventsBox>{children}</PointerEventsBox>
       ) : (
-        children
+        <Box spacing={4}>{children}</Box>
       )}
     </HeaderBox>
   );
@@ -128,69 +130,101 @@ export function ContentHeader(props: ContentHeaderProps) {
     reference,
     headingLevel = 2,
     id,
+    isTileLayout,
+    children,
   } = props;
+
+  assert(
+    !children || isTileLayout,
+    'ContentHeader only accepts children when `isTileLayout=true`'
+  );
 
   const hasIcon = icon !== undefined;
 
+  const ContainerComponent = isTileLayout ? Tile : Box;
+
+  const subContent = (
+    <>
+      {reference && (
+        <ReferenceBox>
+          <Text m={0}>
+            {subtitle}{' '}
+            <Link href={reference.href}>
+              <Text as="a" href={reference.href}>
+                {reference.text}
+              </Text>
+            </Link>
+          </Text>
+        </ReferenceBox>
+      )}
+
+      {metadata && (
+        <MetadataBox>
+          <Metadata {...metadata} accessibilitySubject={title} />
+        </MetadataBox>
+      )}
+    </>
+  );
+
   return (
     <Header id={id} skipLinkAnchor={skipLinkAnchor} hasIcon={hasIcon}>
-      <Box px={[3, null, 0]} spacing={1}>
-        {category && (
-          <CategoryHeading level={1} hide={hideCategory} hasIcon={hasIcon}>
-            {category}
-            {screenReaderCategory && (
-              <AriaInlineText> - {screenReaderCategory}</AriaInlineText>
-            )}
-          </CategoryHeading>
-        )}
-        {icon ? (
-          <HeadingWithIcon
-            icon={icon}
-            title={title}
-            headingLevel={headingLevel}
-          />
-        ) : (
-          <Box
-            display="flex"
-            flexDirection="row"
-            flexWrap="nowrap"
-            alignItems="center"
-            mb={-2}
-          >
-            <Box>
-              <Heading level={headingLevel} mb={0}>
-                {title}
-              </Heading>
+      <ContainerComponent>
+        <Box px={[3, null, 0]} spacing={1}>
+          {category && (
+            <CategoryHeading level={1} hide={hideCategory} hasIcon={hasIcon}>
+              {category}
+              {screenReaderCategory && (
+                <AriaInlineText> - {screenReaderCategory}</AriaInlineText>
+              )}
+            </CategoryHeading>
+          )}
+          {icon ? (
+            <HeadingWithIcon
+              icon={icon}
+              title={title}
+              headingLevel={headingLevel}
+            />
+          ) : (
+            <Box
+              display="flex"
+              flexDirection="row"
+              flexWrap="nowrap"
+              alignItems="center"
+              mb={-2}
+            >
+              <Box>
+                <Heading level={headingLevel} mb={0}>
+                  {title}
+                </Heading>
+              </Box>
             </Box>
-          </Box>
-        )}
-
-        <Box
-          spacing={3}
-          display="flex"
-          flexDirection={['column', null, null, null, 'row']}
-          ml={[null, null, null, hasIcon ? 5 : null]}
-        >
-          {reference && (
-            <ReferenceBox>
-              <Text m={0}>
-                {subtitle}{' '}
-                <Link href={reference.href}>
-                  <Text as="a" href={reference.href}>
-                    {reference.text}
-                  </Text>
-                </Link>
-              </Text>
-            </ReferenceBox>
           )}
 
-          {metadata && (
-            <MetadataBox>
-              <Metadata {...metadata} accessibilitySubject={title} />
-            </MetadataBox>
+          {!isTileLayout && (
+            <Box
+              spacing={3}
+              display="flex"
+              flexDirection={{ _: 'column', lg: 'row' }}
+              ml={{ md: hasIcon ? 5 : undefined }}
+            >
+              {subContent}
+            </Box>
           )}
+
+          {children}
         </Box>
-      </Box>
+      </ContainerComponent>
+
+      {isTileLayout && (
+        <Box
+          display="flex"
+          spacing={3}
+          flexDirection={{ _: 'column', lg: 'row' }}
+          px={{ _: 3, sm: 4 }}
+        >
+          {subContent}
+        </Box>
+      )}
     </Header>
   );
 }
@@ -210,4 +244,6 @@ interface ContentHeaderProps {
   icon?: JSX.Element;
   skipLinkAnchor?: boolean;
   headingLevel?: HeadingLevel;
+  isTileLayout?: boolean;
+  children?: ReactNode;
 }

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -664,7 +664,8 @@
     "vandaag": "Today",
     "read_more": "Read more",
     "absolute_date_template": "on {{date}}",
-    "inwoners": "residents"
+    "inwoners": "residents",
+    "miljoen": "million"
   },
   "seoHead": {
     "default_description": "Information on the development of the coronavirus in The Netherlands.",
@@ -2014,6 +2015,7 @@
       "description": "The Netherlands began vaccinating people against COVID-19 on 6 January 2021. The Coronavirus Dashboard shows how many doses of vaccine have been administered and how many doses are on their way."
     },
     "title": "COVID-19 vaccinations",
+    "current_amount_of_administrations_text": "Op dit moment zijn er naar verwachting {{amount}} prikken gezet in Nederland",
     "description": "Vaccination is the most important step towards getting life back to normal. The Netherlands began vaccinating people against COVID-19 on 6 January 2021. Eventually, the vaccine will be offered to everyone aged 18 and over. This page shows how many doses of vaccine have been administered and how many doses are on their way.",
     "datums": "Last values obtained on {{dateOfInsertion}}. Is updated on a daily basis.",
     "date_unix": "1613650547",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -664,7 +664,8 @@
     "vandaag": "Vandaag",
     "read_more": "Lees meer",
     "absolute_date_template": "op {{date}}",
-    "inwoners": "inwoners"
+    "inwoners": "inwoners",
+    "miljoen": "miljoen"
   },
   "seoHead": {
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
@@ -2014,6 +2015,7 @@
       "description": "Op 6 januari 2021 is Nederland begonnen met vaccineren. De cijfers op het Coronadashboard laten zien hoeveel prikken zijn gezet en hoeveel vaccins er beschikbaar komen."
     },
     "title": "COVID-19-vaccinaties",
+    "current_amount_of_administrations_text": "Op dit moment zijn er naar verwachting {{amount}} prikken gezet in Nederland",
     "description": "Vaccineren is de belangrijkste stap naar een samenleving zonder coronaregels. Op 6 januari 2021 is Nederland begonnen met vaccineren. Uiteindelijk komt iedereen van 18 jaar of ouder aan de beurt. De cijfers op deze pagina laten zien hoeveel prikken zijn gezet en hoeveel vaccins er beschikbaar komen.",
     "datums": "Laatste waardes verkregen op {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",
     "date_unix": "1613650547",

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -48,6 +48,7 @@ import {
   MilestonesView,
   MilestoneViewProps,
 } from '~/domain/vaccine/milestones-view';
+import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -61,7 +62,7 @@ export const getStaticProps = createGetStaticProps(
   }>(
     `{
       "milestones": ${vaccineMilestonesQuery},
-      "highlight": ${createPageArticlesQuery('vaccinationsPage')} 
+      "highlight": ${createPageArticlesQuery('vaccinationsPage')}
     }`
   )
 );
@@ -99,7 +100,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
       />
       <TileList>
         <ContentHeader
-          category={siteText.nationaal_layout.headings.vaccinaties}
+          isTileLayout
           title={text.title}
           icon={<VaccinatieIcon />}
           subtitle={text.description}
@@ -111,7 +112,24 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
               data.vaccine_administered_total.last_value.date_of_insertion_unix,
             dataSources: [],
           }}
-        />
+        >
+          <Text fontSize="1.625rem">
+            {replaceComponentsInText(
+              text.current_amount_of_administrations_text,
+              {
+                amount: (
+                  <InlineText color="data.primary" fontWeight="bold">
+                    {formatPercentage(
+                      data.vaccine_administered_total.last_value.estimated /
+                        1_000_000
+                    )}{' '}
+                    {siteText.common.miljoen}
+                  </InlineText>
+                ),
+              }
+            )}
+          </Text>
+        </ContentHeader>
 
         <ArticleStrip articles={content.highlight.articles} />
 


### PR DESCRIPTION
## Summary

The vaccine progress content header will be rendered with a Tile layout, hence these changes.

I'd suggest to review it with the ignore whitespace option (`&w=1` query param) to reduce the amount of changed LOC.

![image](https://user-images.githubusercontent.com/73584448/109662095-f8737c80-7b6a-11eb-8abe-06abf337505c.png)
