### PR TITLE
Make bar chart x axis label responsive

### DIFF
--- a/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
@@ -51,7 +51,7 @@ function generateBarChartCoordinates(
   const spacing = {
     top: 0,
     right: 0,
-    bottom: 50, // used for x axis values and label
+    bottom: 54, // used for x axis values and label
     left: 108, // for y axis labels
   };
 

--- a/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
@@ -100,8 +100,8 @@ export function BarChartGraph({
         labelProps={{
           verticalAnchor: 'start',
           textAnchor: 'middle',
-          width: width - spacing.left,
-          x: (width - spacing.left) / 2,
+          width: barsWidth,
+          x: barsWidth / 2,
         }}
         labelClassName="bar-chart-x-axis-label"
       />

--- a/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-graph.tsx
@@ -97,6 +97,12 @@ export function BarChartGraph({
         tickFormat={(a) => `${a}`}
         tickComponent={TickValue}
         label={xAxisLabel}
+        labelProps={{
+          verticalAnchor: 'start',
+          textAnchor: 'middle',
+          width: width - spacing.left,
+          x: (width - spacing.left) / 2,
+        }}
         labelClassName="bar-chart-x-axis-label"
       />
 


### PR DESCRIPTION
## Summary

This PR fixes the bar chart's x-axis label was overflowing the graph on smaller screens.

## Detailed design

Passed labelProps to the `AxisBottom` component to give the text the appropriate props to line wrap

Increased the bottom spacing from 50 -> 54 so that it looked ok on an iPhone 5

![image](https://user-images.githubusercontent.com/75375917/109795941-d97ef400-7c17-11eb-843b-0f8a459fad17.png)

Note: yAxis and xAxis tick label issues in the image have separate tickets
