### PR TITLE
Rendering fewer ticks on bar chart when width is less than 400px

### DIFF
--- a/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
+++ b/packages/app/src/components-styled/bar-chart/bar-chart-coordinates.ts
@@ -61,7 +61,7 @@ function generateBarChartCoordinates(
   const barsHeight = values.length * 35;
   const height = barsHeight + spacing.top + spacing.bottom;
 
-  const numTicks = 10;
+  const numTicks = width > 400 ? 10 : 6;
 
   const getValue = (value: BarChartValue): number => value.value;
   const getLabel = (value: BarChartValue): string => value.label;


### PR DESCRIPTION
## Summary

Rendering fewer ticks on the bar chart on mobile so there is no tick label overlap

## Detailed design

Conditionally setting the number of ticks in `generateBarChartCoordinates` based on the width

