### PR TITLE
Removing transitions when prefer-reduced-motion is enabled

### DIFF
--- a/packages/app/src/components-styled/layout/components/top-navigation.tsx
+++ b/packages/app/src/components-styled/layout/components/top-navigation.tsx
@@ -20,7 +20,6 @@ export function TopNavigation() {
   const breakpoints = useBreakpoints(true);
   const isSmallScreen = !breakpoints.md;
   const [panelHeight, setPanelHeight] = useState(0);
-  const [isAnimating, setIsAnimating] = useState(false);
   const navMenu = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -37,14 +36,7 @@ export function TopNavigation() {
   }, [isMenuOpen]);
 
   function toggleMenu() {
-    if (isAnimating) return;
-
-    setIsAnimating(!isAnimating);
     setIsMenuOpen(!isMenuOpen);
-  }
-
-  function handleTransitionEnd() {
-    setIsAnimating(false);
   }
 
   return (
@@ -67,7 +59,6 @@ export function TopNavigation() {
         role="navigation"
         aria-label={text.aria_labels.pagina_keuze}
         ref={navMenu}
-        onTransitionEnd={handleTransitionEnd}
         css={css({
           maxHeight: asResponsiveArray({ _: `${panelHeight}px`, md: '100%' }),
           opacity: asResponsiveArray({ _: isMenuOpen ? 1 : 0, md: 1 }),
@@ -76,10 +67,7 @@ export function TopNavigation() {
             md: 'auto',
           }),
           transition: asResponsiveArray({
-            _:
-              isMenuOpen || isAnimating
-                ? 'max-height 0.4s ease-in-out, opacity 0.4s ease-in-out'
-                : 'none',
+            _: 'max-height 0.4s ease-in-out, opacity 0.4s ease-in-out',
             md: 'none',
           }),
         })}

--- a/packages/app/src/style/global-style.tsx
+++ b/packages/app/src/style/global-style.tsx
@@ -119,4 +119,11 @@ figure {
 p {
   margin-top: 0;
 }
+
+@media (prefers-reduced-motion) {
+  * { 
+    transition-duration: 0 !important;
+    transition: none !important;
+  }
+}
 `;


### PR DESCRIPTION
## Summary

Removes transitions when prefer-reduced-motion is enabled

## Detailed design

Removed transitions globally via the prefer-reduced-motion media query and removed (what seemed to be) unnecessary animation code from the topbar that was causing issues when transitions were disabled

