### PR TITLE
Vaccine progress header

### DIFF
--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -152,13 +152,7 @@ export function ContentHeader(props: ContentHeaderProps) {
                 headingLevel={headingLevel}
               />
             ) : (
-              <Box
-                display="flex"
-                flexDirection="row"
-                flexWrap="nowrap"
-                alignItems="center"
-                mb={-2}
-              >
+              <Box display="flex" flexWrap="nowrap" alignItems="center" mb={-2}>
                 <Box>
                   <Heading level={headingLevel} mb={0}>
                     {title}

--- a/packages/app/src/components-styled/content-header/index.tsx
+++ b/packages/app/src/components-styled/content-header/index.tsx
@@ -143,30 +143,34 @@ export function ContentHeader(props: ContentHeaderProps) {
             )}
           </CategoryHeading>
         )}
-        {icon ? (
-          <HeadingWithIcon
-            icon={icon}
-            title={title}
-            headingLevel={headingLevel}
-          />
-        ) : (
-          <Box
-            display="flex"
-            flexDirection="row"
-            flexWrap="nowrap"
-            alignItems="center"
-            mb={-2}
-          >
-            <Box>
-              <Heading level={headingLevel} mb={0}>
-                {title}
-              </Heading>
-            </Box>
-          </Box>
+        {title && (
+          <>
+            {icon ? (
+              <HeadingWithIcon
+                icon={icon}
+                title={title}
+                headingLevel={headingLevel}
+              />
+            ) : (
+              <Box
+                display="flex"
+                flexDirection="row"
+                flexWrap="nowrap"
+                alignItems="center"
+                mb={-2}
+              >
+                <Box>
+                  <Heading level={headingLevel} mb={0}>
+                    {title}
+                  </Heading>
+                </Box>
+              </Box>
+            )}
+          </>
         )}
 
         <Box
-          spacing={3}
+          spacing={{ _: 3, md: 0 }}
           display="flex"
           flexDirection={['column', null, null, null, 'row']}
           ml={[null, null, null, hasIcon ? 5 : null]}
@@ -197,7 +201,7 @@ export function ContentHeader(props: ContentHeaderProps) {
 
 interface ContentHeaderProps {
   id?: string;
-  title: string;
+  title?: string;
   subtitle?: string;
   metadata?: MetadataProps;
   reference?: {

--- a/packages/app/src/components-styled/kpi-value.tsx
+++ b/packages/app/src/components-styled/kpi-value.tsx
@@ -31,6 +31,7 @@ const StyledValue = styled.div(
     fontSize: '1.80203rem',
     fontWeight: 600,
     fontVariantNumeric: 'tabular-nums',
+    lineHeight: 1,
   },
   color
 );

--- a/packages/app/src/components-styled/line-chart/logic/background-rectangle.tsx
+++ b/packages/app/src/components-styled/line-chart/logic/background-rectangle.tsx
@@ -32,7 +32,7 @@ export function addBackgroundRectangleCallback(
   };
 }
 
-function createBackgroundRectangle(
+export function createBackgroundRectangle(
   dateRange: DateRange,
   xScale: ScaleTime<number, number>,
   yScale: ScaleLinear<number, number>,

--- a/packages/app/src/components-styled/two-kpi-section.tsx
+++ b/packages/app/src/components-styled/two-kpi-section.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { assert } from '~/utils/assert';
-import { Box, BoxProps } from './base';
+import { Box } from './base';
 
-interface TwoKpiSectionProps extends BoxProps {
+interface TwoKpiSectionProps {
   children: React.ReactNode;
   spacing?: number;
 }
 
-export function TwoKpiSection({
-  children,
-  spacing = 3,
-  ...props
-}: TwoKpiSectionProps) {
+export function TwoKpiSection({ children, spacing = 3 }: TwoKpiSectionProps) {
   const childrenCount = React.Children.count(children);
 
   assert(
@@ -23,7 +19,7 @@ export function TwoKpiSection({
   const childrenArray = React.Children.toArray(children);
 
   return (
-    <Box display={{ lg: 'flex' }} {...(props as any)}>
+    <Box display={{ lg: 'flex' }}>
       <Box flex={`1 1 ${hasTwoChildren ? 50 : 100}%`} mb={{ _: 4, lg: 0 }}>
         {childrenArray[0]}
       </Box>

--- a/packages/app/src/components-styled/two-kpi-section.tsx
+++ b/packages/app/src/components-styled/two-kpi-section.tsx
@@ -4,9 +4,14 @@ import { Box, BoxProps } from './base';
 
 interface TwoKpiSectionProps extends BoxProps {
   children: React.ReactNode;
+  spacing?: number;
 }
 
-export function TwoKpiSection({ children, ...props }: TwoKpiSectionProps) {
+export function TwoKpiSection({
+  children,
+  spacing = 3,
+  ...props
+}: TwoKpiSectionProps) {
   const childrenCount = React.Children.count(children);
 
   assert(
@@ -23,7 +28,7 @@ export function TwoKpiSection({ children, ...props }: TwoKpiSectionProps) {
         {childrenArray[0]}
       </Box>
       {hasTwoChildren && (
-        <Box flex="1 1 50%" ml={{ lg: 3 }}>
+        <Box flex="1 1 50%" ml={{ lg: spacing }}>
           {childrenArray[1]}
         </Box>
       )}

--- a/packages/app/src/domain/vaccine/vaccine-content-header.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-content-header.tsx
@@ -32,77 +32,82 @@ export function VaccineContentHeader({
   return (
     <Box spacing={4}>
       <Tile>
-        <HeadingWithIcon
-          icon={<VaccinatieIcon />}
-          title={text.title}
-          headingLevel={1}
-        />
+        <Box spacing={3}>
+          <HeadingWithIcon
+            icon={<VaccinatieIcon />}
+            title={text.title}
+            headingLevel={1}
+          />
+          <Box spacing={4} px={{ md: 5 }}>
+            <Text fontSize="1.625rem" m={0}>
+              {replaceComponentsInText(
+                text.current_amount_of_administrations_text,
+                {
+                  amount: (
+                    <InlineText color="data.primary" fontWeight="bold">
+                      {formatPercentage(
+                        data.vaccine_administered_total.last_value.estimated /
+                          1_000_000
+                      )}{' '}
+                      {siteText.common.miljoen}
+                    </InlineText>
+                  ),
+                }
+              )}
+            </Text>
 
-        <Box spacing={4} pt={4} px={{ md: 5 }}>
-          <Text fontSize="1.625rem" m={0}>
-            {replaceComponentsInText(
-              text.current_amount_of_administrations_text,
-              {
-                amount: (
-                  <InlineText color="data.primary" fontWeight="bold">
-                    {formatPercentage(
-                      data.vaccine_administered_total.last_value.estimated /
-                        1_000_000
-                    )}{' '}
-                    {siteText.common.miljoen}
-                  </InlineText>
-                ),
-              }
-            )}
-          </Text>
+            <TwoKpiSection spacing={4}>
+              <Box as="article" spacing={3}>
+                <Heading level={3}>Gezette prikken over tijd</Heading>
+                <Text m={0}>
+                  Deze grafiek toont het berekend totaal aantal gezette prikken
+                  sinds 4 januari 2021.
+                </Text>
 
-          <TwoKpiSection spacing={4}>
-            <Box as="article" spacing={3}>
-              <Heading level={3}>Gezette prikken over tijd</Heading>
-              <Text m={0}>
-                Deze grafiek toont het berekend totaal aantal gezette prikken
-                sinds 4 januari 2021.
-              </Text>
+                <ParentSize>
+                  {(parent) => (
+                    <LineChart
+                      width={parent.width}
+                      timeframe="all"
+                      values={data.vaccine_administered_total.values}
+                      height={180}
+                      linesConfig={[
+                        {
+                          metricProperty: 'estimated',
+                          areaFillOpacity: 0.25,
+                          strokeWidth: 3,
+                        },
+                      ]}
+                      componentCallback={componentCallback}
+                      showMarkerLine
+                      formatTooltip={(values) =>
+                        formatNumber(values[0].__value)
+                      }
+                      padding={{
+                        top: 13,
+                        left: 0,
+                        right: 0,
+                      }}
+                    />
+                  )}
+                </ParentSize>
+              </Box>
 
-              <ParentSize>
-                {(parent) => (
-                  <LineChart
-                    width={parent.width}
-                    timeframe="all"
-                    values={data.vaccine_administered_total.values}
-                    height={180}
-                    linesConfig={[
-                      {
-                        metricProperty: 'estimated',
-                        areaFillOpacity: 0.25,
-                        strokeWidth: 3,
-                      },
-                    ]}
-                    componentCallback={componentCallback}
-                    showMarkerLine
-                    formatTooltip={(values) => formatNumber(values[0].__value)}
-                    padding={{
-                      top: 13,
-                      left: 0,
-                      right: 0,
-                    }}
-                  />
-                )}
-              </ParentSize>
-            </Box>
-
-            <Box as="article" spacing={3}>
-              <Heading level={3}>Geplande prikken deze week</Heading>
-              <KpiValue
-                absolute={data.vaccine_administered_total.last_value.estimated}
-              />
-              <Text m={0}>
-                Berekend aantal prikken die gepland zijn van 22 tot en met 28
-                februari. Dit aantal kan afwijken door bijvoorbeeld annuleringen
-                of logistieke factoren.
-              </Text>
-            </Box>
-          </TwoKpiSection>
+              <Box as="article" spacing={3}>
+                <Heading level={3}>Geplande prikken deze week</Heading>
+                <KpiValue
+                  absolute={
+                    data.vaccine_administered_total.last_value.estimated
+                  }
+                />
+                <Text m={0}>
+                  Berekend aantal prikken die gepland zijn van 22 tot en met 28
+                  februari. Dit aantal kan afwijken door bijvoorbeeld
+                  annuleringen of logistieke factoren.
+                </Text>
+              </Box>
+            </TwoKpiSection>
+          </Box>
         </Box>
       </Tile>
 

--- a/packages/app/src/domain/vaccine/vaccine-content-header.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-content-header.tsx
@@ -1,0 +1,217 @@
+import { National } from '@corona-dashboard/common';
+import { AxisBottom, AxisLeft, TickFormatter } from '@visx/axis';
+import { GridRows } from '@visx/grid';
+import { ParentSize } from '@visx/responsive';
+import VaccinatieIcon from '~/assets/vaccinaties.svg';
+import { Box } from '~/components-styled/base';
+import { ContentHeader } from '~/components-styled/content-header';
+import { HeadingWithIcon } from '~/components-styled/heading-with-icon';
+import { KpiValue } from '~/components-styled/kpi-value';
+import { LineChart } from '~/components-styled/line-chart';
+import { ComponentCallbackInfo } from '~/components-styled/line-chart/components';
+import { createBackgroundRectangle } from '~/components-styled/line-chart/logic/background-rectangle';
+import { Tile } from '~/components-styled/tile';
+import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { Heading, InlineText, Text } from '~/components-styled/typography';
+import siteText, { Locale } from '~/locale';
+import { colors } from '~/style/theme';
+import { createDate } from '~/utils/createDate';
+import { formatNumber, formatPercentage } from '~/utils/formatNumber';
+import { replaceComponentsInText } from '~/utils/replace-components-in-text';
+
+interface VaccinesContentHeaderProps {
+  text: Locale['vaccinaties'];
+  data: National;
+}
+
+export function VaccineContentHeader({
+  text,
+  data,
+}: VaccinesContentHeaderProps) {
+  return (
+    <Box spacing={4}>
+      <Tile>
+        <HeadingWithIcon
+          icon={<VaccinatieIcon />}
+          title={text.title}
+          headingLevel={1}
+        />
+
+        <Box spacing={4} pt={4} px={{ md: 5 }}>
+          <Text fontSize="1.625rem" m={0}>
+            {replaceComponentsInText(
+              text.current_amount_of_administrations_text,
+              {
+                amount: (
+                  <InlineText color="data.primary" fontWeight="bold">
+                    {formatPercentage(
+                      data.vaccine_administered_total.last_value.estimated /
+                        1_000_000
+                    )}{' '}
+                    {siteText.common.miljoen}
+                  </InlineText>
+                ),
+              }
+            )}
+          </Text>
+
+          <TwoKpiSection spacing={4}>
+            <Box as="article" spacing={3}>
+              <Heading level={3}>Gezette prikken over tijd</Heading>
+              <Text m={0}>
+                Deze grafiek toont het berekend totaal aantal gezette prikken
+                sinds 4 januari 2021.
+              </Text>
+
+              <ParentSize>
+                {(parent) => (
+                  <LineChart
+                    width={parent.width}
+                    timeframe="all"
+                    values={data.vaccine_administered_total.values}
+                    height={180}
+                    linesConfig={[
+                      {
+                        metricProperty: 'estimated',
+                        areaFillOpacity: 0.25,
+                        strokeWidth: 3,
+                      },
+                    ]}
+                    componentCallback={componentCallback}
+                    showMarkerLine
+                    formatTooltip={(values) => formatNumber(values[0].__value)}
+                    padding={{
+                      top: 13,
+                      left: 0,
+                      right: 0,
+                    }}
+                  />
+                )}
+              </ParentSize>
+            </Box>
+
+            <Box as="article" spacing={3}>
+              <Heading level={3}>Geplande prikken deze week</Heading>
+              <KpiValue
+                absolute={data.vaccine_administered_total.last_value.estimated}
+              />
+              <Text m={0}>
+                Berekend aantal prikken die gepland zijn van 22 tot en met 28
+                februari. Dit aantal kan afwijken door bijvoorbeeld annuleringen
+                of logistieke factoren.
+              </Text>
+            </Box>
+          </TwoKpiSection>
+        </Box>
+      </Tile>
+
+      <Box px={{ _: 3, sm: 4 }}>
+        <ContentHeader
+          subtitle={text.description}
+          reference={text.reference}
+          metadata={{
+            datumsText: text.datums,
+            dateOrRange: data.vaccine_administered_total.last_value.date_unix,
+            dateOfInsertionUnix:
+              data.vaccine_administered_total.last_value.date_of_insertion_unix,
+            dataSources: [],
+          }}
+        />
+      </Box>
+    </Box>
+  );
+
+  function componentCallback(callbackInfo: ComponentCallbackInfo) {
+    switch (callbackInfo.type) {
+      case 'CustomBackground': {
+        const { xScale, yScale, bounds } = callbackInfo.props;
+        const dateRange = [
+          createDate(data.vaccine_administered_total.values[0].date_unix),
+          new Date('30 January 2021'),
+        ];
+
+        return createBackgroundRectangle(dateRange, xScale, yScale, bounds, {
+          fill: colors.data.underReported,
+        });
+      }
+      case 'GridRows': {
+        const domain = callbackInfo.props.scale.domain();
+        const lastItem = domain[domain.length - 1];
+        return (
+          <GridRows
+            {...(callbackInfo.props as any)}
+            tickValues={[0, lastItem / 2, lastItem]}
+          />
+        );
+      }
+      case 'AxisBottom': {
+        const domain = callbackInfo.props.scale.domain();
+        const defaultTickFormat = callbackInfo.props.tickFormat;
+        const tickFormat = (d: Date) => {
+          if (d === domain[0]) {
+            return defaultTickFormat ? defaultTickFormat(d, 0, domain) : '';
+          }
+          return formatLastDate(d, defaultTickFormat);
+        };
+
+        const tickLabelProps = (value: Date, index: number) => {
+          const labelProps = callbackInfo.props.tickLabelProps
+            ? callbackInfo.props.tickLabelProps(value, index)
+            : {};
+          labelProps.textAnchor = value === domain[0] ? 'start' : 'end';
+          labelProps.dx = 0;
+          labelProps.dy = -4;
+          return labelProps;
+        };
+
+        return (
+          <AxisBottom
+            {...(callbackInfo.props as any)}
+            tickLabelProps={tickLabelProps}
+            tickFormat={tickFormat}
+            tickValues={domain}
+          />
+        );
+      }
+      case 'AxisLeft': {
+        const domain = callbackInfo.props.scale.domain();
+        const lastItem = domain[domain.length - 1];
+
+        const tickLabelProps = (value: Date, index: number) => {
+          const labelProps = callbackInfo.props.tickLabelProps
+            ? callbackInfo.props.tickLabelProps(value, index)
+            : {};
+          labelProps.textAnchor = 'start';
+          labelProps.dx = 10;
+          labelProps.dy = -9;
+          return labelProps;
+        };
+
+        return (
+          <AxisLeft
+            {...(callbackInfo.props as any)}
+            tickLabelProps={tickLabelProps}
+            tickValues={[lastItem]}
+          />
+        );
+      }
+    }
+  }
+}
+
+const DAY_IN_SECONDS = 24 * 60 * 60;
+function formatLastDate(date: Date, defaultFormat?: TickFormatter<any>) {
+  const days = Math.floor(
+    (Date.now() / 1000 - date.valueOf() / 1000) / DAY_IN_SECONDS
+  );
+
+  if (days < 1) {
+    return siteText.common.vandaag;
+  }
+
+  if (days < 2) {
+    return siteText.common.gisteren;
+  }
+
+  return defaultFormat ? defaultFormat(date, 0, []) : '';
+}

--- a/packages/app/src/domain/vaccine/vaccine-content-header.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-content-header.tsx
@@ -17,6 +17,7 @@ import siteText, { Locale } from '~/locale';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/createDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
+import { DateRange } from '~/utils/get-trailing-date-range';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 
 interface VaccinesContentHeaderProps {
@@ -125,7 +126,8 @@ export function VaccineContentHeader({
     switch (callbackInfo.type) {
       case 'CustomBackground': {
         const { xScale, yScale, bounds } = callbackInfo.props;
-        const dateRange = [
+
+        const dateRange: DateRange = [
           createDate(data.vaccine_administered_total.values[0].date_unix),
           new Date('30 January 2021'),
         ];

--- a/packages/app/src/domain/vaccine/vaccine-page-introduction.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-page-introduction.tsx
@@ -20,15 +20,15 @@ import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { DateRange } from '~/utils/get-trailing-date-range';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 
-interface VaccinesContentHeaderProps {
+interface VaccinePageIntroductionProps {
   text: Locale['vaccinaties'];
   data: National;
 }
 
-export function VaccineContentHeader({
+export function VaccinePageIntroduction({
   text,
   data,
-}: VaccinesContentHeaderProps) {
+}: VaccinePageIntroductionProps) {
   return (
     <Box spacing={4}>
       <Tile>

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -654,7 +654,8 @@
     "vandaag": "Today",
     "read_more": "Read more",
     "absolute_date_template": "on {{date}}",
-    "inwoners": "residents"
+    "inwoners": "residents",
+    "miljoen": "million"
   },
   "seoHead": {
     "default_description": "Information on the development of the coronavirus in The Netherlands.",
@@ -762,13 +763,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1999,6 +1994,7 @@
     },
     "title": "COVID-19 vaccinations",
     "description": "Vaccination is the most important step towards getting life back to normal. The Netherlands began vaccinating people against COVID-19 on 6 January 2021. Eventually, the vaccine will be offered to everyone aged 18 and over. This page shows how many doses of vaccine have been administered and how many doses are on their way.",
+    "current_amount_of_administrations_text": "Op dit moment zijn er naar verwachting {{amount}} prikken gezet in Nederland",
     "datums": "Last values obtained on {{dateOfInsertion}}. Is updated on a daily basis.",
     "date_unix": "1613650547",
     "date_of_insertion_unix": "1613650547",
@@ -2078,11 +2074,7 @@
     "expected_page_additions": {
       "title": "Expected data on vaccinations",
       "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "",
@@ -2207,11 +2199,7 @@
       "kpi_expected_page_additions": {
         "title": "Expected data on vaccinations",
         "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -654,7 +654,8 @@
     "vandaag": "Vandaag",
     "read_more": "Lees meer",
     "absolute_date_template": "op {{date}}",
-    "inwoners": "inwoners"
+    "inwoners": "inwoners",
+    "miljoen": "miljoen"
   },
   "seoHead": {
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",
@@ -762,13 +763,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -1999,6 +1994,7 @@
     },
     "title": "COVID-19-vaccinaties",
     "description": "Vaccineren is de belangrijkste stap naar een samenleving zonder coronaregels. Op 6 januari 2021 is Nederland begonnen met vaccineren. Uiteindelijk komt iedereen van 18 jaar of ouder aan de beurt. De cijfers op deze pagina laten zien hoeveel prikken zijn gezet en hoeveel vaccins er beschikbaar komen.",
+    "current_amount_of_administrations_text": "Op dit moment zijn er naar verwachting {{amount}} prikken gezet in Nederland",
     "datums": "Laatste waardes verkregen op {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",
     "date_unix": "1613650547",
     "date_of_insertion_unix": "1613650547",
@@ -2078,11 +2074,7 @@
     "expected_page_additions": {
       "title": "Verwachte toevoegingen aan deze pagina",
       "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "Do not remove this key. It is required as a temporary workaround",
@@ -2207,11 +2199,7 @@
       "kpi_expected_page_additions": {
         "title": "Verwachte toevoegingen aan deze pagina",
         "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -32,7 +32,7 @@ import {
 } from '~/domain/vaccine/milestones-view';
 import { useVaccineDeliveryData } from '~/domain/vaccine/use-vaccine-delivery-data';
 import { useVaccineNames } from '~/domain/vaccine/use-vaccine-names';
-import { VaccineContentHeader } from '~/domain/vaccine/vaccine-content-header';
+import { VaccinePageIntroduction } from '~/domain/vaccine/vaccine-page-introduction';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { vaccineMilestonesQuery } from '~/queries/vaccine-milestones-query';
@@ -97,7 +97,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
         description={text.metadata.description}
       />
       <TileList>
-        <VaccineContentHeader data={data} text={text} />
+        <VaccinePageIntroduction data={data} text={text} />
 
         <ArticleStrip articles={content.highlight.articles} />
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -8,13 +8,11 @@ import { css } from '@styled-system/css';
 import { ParentSize } from '@visx/responsive';
 import { useState } from 'react';
 import styled from 'styled-components';
-import VaccinatieIcon from '~/assets/vaccinaties.svg';
 import { AreaChart } from '~/components-styled/area-chart';
 import { ArticleStrip } from '~/components-styled/article-strip';
 import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box, Spacer } from '~/components-styled/base';
 import { ChartTile } from '~/components-styled/chart-tile';
-import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { Legenda } from '~/components-styled/legenda';
@@ -34,6 +32,7 @@ import {
 } from '~/domain/vaccine/milestones-view';
 import { useVaccineDeliveryData } from '~/domain/vaccine/use-vaccine-delivery-data';
 import { useVaccineNames } from '~/domain/vaccine/use-vaccine-names';
+import { VaccineContentHeader } from '~/domain/vaccine/vaccine-content-header';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { vaccineMilestonesQuery } from '~/queries/vaccine-milestones-query';
@@ -98,20 +97,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
         description={text.metadata.description}
       />
       <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.vaccinaties}
-          title={text.title}
-          icon={<VaccinatieIcon />}
-          subtitle={text.description}
-          reference={text.reference}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: data.vaccine_administered_total.last_value.date_unix,
-            dateOfInsertionUnix:
-              data.vaccine_administered_total.last_value.date_of_insertion_unix,
-            dataSources: [],
-          }}
-        />
+        <VaccineContentHeader data={data} text={text} />
 
         <ArticleStrip articles={content.highlight.articles} />
 


### PR DESCRIPTION
## Summary

- Default `<ContentHeader/>`'s title has become optional in order to allow rendering that component without title: the vaccination page renders the title inside a separate Tile.
- `<TwoKpiSection />` can receive a spacing prop to define the space between the sections. Also all Box props have been removed, they were not used.
- There are still a couple of static texts inside the vaccine header component. I'll fix these in another PR.