### PR TITLE
Fix vaccine chart legend rendering incorrectly in IE11

### DIFF
--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -255,96 +255,98 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
           <Box>
             <ParentSize>
               {({ width }) => (
-                <AreaChart<
-                  NlVaccineDeliveryValue | NlVaccineDeliveryEstimateValue,
-                  | NlVaccineAdministeredValue
-                  | NlVaccineAdministeredEstimateValue
-                >
-                  valueAnnotation={siteText.waarde_annotaties.x_miljoen}
-                  width={width}
-                  timeframe="all"
-                  formatTooltip={createDeliveryTooltipFormatter(siteText)}
-                  divider={{
-                    color: colors.annotation,
-                    leftLabel: text.data.vaccination_chart.left_divider_label,
-                    rightLabel: text.data.vaccination_chart.right_divider_label,
-                  }}
-                  trends={[
-                    {
-                      values: vaccineDeliveryValues,
-                      displays: [
+                <>
+                  <AreaChart<
+                    NlVaccineDeliveryValue | NlVaccineDeliveryEstimateValue,
+                    | NlVaccineAdministeredValue
+                    | NlVaccineAdministeredEstimateValue
+                  >
+                    valueAnnotation={siteText.waarde_annotaties.x_miljoen}
+                    width={width}
+                    timeframe="all"
+                    formatTooltip={createDeliveryTooltipFormatter(siteText)}
+                    divider={{
+                      color: colors.annotation,
+                      leftLabel: text.data.vaccination_chart.left_divider_label,
+                      rightLabel:
+                        text.data.vaccination_chart.right_divider_label,
+                    }}
+                    trends={[
+                      {
+                        values: vaccineDeliveryValues,
+                        displays: [
+                          {
+                            metricProperty: 'total',
+                            strokeWidth: 3,
+                            color: colors.data.emphasis,
+                            legendLabel: text.data.vaccination_chart.delivered,
+                          },
+                        ],
+                      },
+                      {
+                        values: vaccineDeliveryEstimateValues,
+                        displays: [
+                          {
+                            metricProperty: 'total',
+                            style: 'dashed',
+                            strokeWidth: 3,
+                            legendLabel: text.data.vaccination_chart.estimated,
+                            color: colors.data.emphasis,
+                          },
+                        ],
+                      },
+                    ]}
+                    areas={[
+                      {
+                        values: vaccineAdministeredValues,
+                        displays: vaccineNames.map((key) => ({
+                          metricProperty: key as any,
+                          color: (colors.data.vaccines as any)[key],
+                          legendLabel: key,
+                        })),
+                      },
+                      {
+                        values: vaccineAdministeredEstimateValues,
+                        displays: vaccineNames.map((key) => ({
+                          metricProperty: key as any,
+                          pattern: 'hatched',
+                          color: (colors.data.vaccines as any)[key],
+                          legendLabel: key,
+                        })),
+                      },
+                    ]}
+                  />
+                  <Legenda
+                    items={[
+                      {
+                        label: text.data.vaccination_chart.legend.available,
+                        color: 'data.emphasis',
+                        shape: 'line',
+                      },
+                      {
+                        label: text.data.vaccination_chart.legend.expected,
+                        color: 'black',
+                        shape: 'custom',
+                        ShapeComponent: HatchedSquare,
+                      },
+                    ]}
+                  />
+                  <Legenda
+                    items={vaccineNames.map((key) => ({
+                      label: replaceVariablesInText(
+                        text.data.vaccination_chart.legend_label,
                         {
-                          metricProperty: 'total',
-                          strokeWidth: 3,
-                          color: colors.data.emphasis,
-                          legendLabel: text.data.vaccination_chart.delivered,
-                        },
-                      ],
-                    },
-                    {
-                      values: vaccineDeliveryEstimateValues,
-                      displays: [
-                        {
-                          metricProperty: 'total',
-                          style: 'dashed',
-                          strokeWidth: 3,
-                          legendLabel: text.data.vaccination_chart.estimated,
-                          color: colors.data.emphasis,
-                        },
-                      ],
-                    },
-                  ]}
-                  areas={[
-                    {
-                      values: vaccineAdministeredValues,
-                      displays: vaccineNames.map((key) => ({
-                        metricProperty: key as any,
-                        color: (colors.data.vaccines as any)[key],
-                        legendLabel: key,
-                      })),
-                    },
-                    {
-                      values: vaccineAdministeredEstimateValues,
-                      displays: vaccineNames.map((key) => ({
-                        metricProperty: key as any,
-                        pattern: 'hatched',
-                        color: (colors.data.vaccines as any)[key],
-                        legendLabel: key,
-                      })),
-                    },
-                  ]}
-                />
+                          name: (text.data.vaccination_chart
+                            .product_names as any)[key],
+                        }
+                      ),
+                      color: `data.vaccines.${key}`,
+                      shape: 'square',
+                    }))}
+                  />
+                </>
               )}
             </ParentSize>
-            <Legenda
-              items={[
-                {
-                  label: text.data.vaccination_chart.legend.available,
-                  color: 'data.emphasis',
-                  shape: 'line',
-                },
-                {
-                  label: text.data.vaccination_chart.legend.expected,
-                  color: 'black',
-                  shape: 'custom',
-                  ShapeComponent: HatchedSquare,
-                },
-              ]}
-            />
-            <Legenda
-              items={vaccineNames.map((key) => ({
-                label: replaceVariablesInText(
-                  text.data.vaccination_chart.legend_label,
-                  {
-                    name: (text.data.vaccination_chart.product_names as any)[
-                      key
-                    ],
-                  }
-                ),
-                color: `data.vaccines.${key}`,
-                shape: 'square',
-              }))}
-            />
           </Box>
         </ChartTile>
 


### PR DESCRIPTION
## Summary

Currently, IE11 (and Edge17) renders the legend underneath the vaccine chart like this:

![image](https://user-images.githubusercontent.com/69849293/109948661-d6990780-7cda-11eb-99d2-b5bf2ec851bb.png)

This PR fixes that situation.

## Motivation

Bug report

## Detailed design

Moving the legend into the ParentSize component fixed the issue

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
