### PR TITLE
Yet another chart in visx continued

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/benchmark.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/benchmark.tsx
@@ -1,0 +1,29 @@
+import { colors } from '~/style/theme';
+import { Group } from '@visx/group';
+import { Line } from '@visx/shape';
+import { Text } from '@visx/text';
+
+interface BenchmarkProps {
+  value: number;
+  label: string;
+  top: number;
+  width: number;
+}
+
+const color = colors.data.benchmark;
+
+export function Benchmark({ top, value, label, width }: BenchmarkProps) {
+  return (
+    <Group top={top}>
+      <Text fontSize="14px" dy={-8} fill={color}>
+        {`${label}: ${value}`}
+      </Text>
+      <Line
+        stroke={color}
+        strokeDasharray="4,3"
+        from={{ x: 0, y: 0 }}
+        to={{ x: width, y: 0 }}
+      />
+    </Group>
+  );
+}

--- a/packages/app/src/components-styled/time-series-chart/components/chart-container.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/chart-container.tsx
@@ -9,7 +9,6 @@
  * components as part of its children.
  */
 import { Group } from '@visx/group';
-import { Bar } from '@visx/shape';
 import React from 'react';
 import { Padding } from '../logic';
 
@@ -18,9 +17,6 @@ interface ChartContainerProps {
   width: number;
   height: number;
   padding: Padding;
-  onHover: (
-    event: React.TouchEvent<SVGElement> | React.MouseEvent<SVGElement>
-  ) => void;
   valueAnnotation?: string;
   ariaLabelledBy: string;
 }
@@ -30,7 +26,6 @@ export function ChartContainer({
   height,
   padding,
   ariaLabelledBy,
-  onHover,
   children,
 }: ChartContainerProps) {
   return (
@@ -41,24 +36,6 @@ export function ChartContainer({
       aria-labelledby={ariaLabelledBy}
     >
       <Group left={padding.left} top={padding.top}>
-        {/**
-         * The Bar captures all mouse movements outside of trend elements. The Trend components * are rendered op top (in DOM) so that they can have their own hover state and
-         * handlers. Trend hover handlers also have the advantage that we don't need to
-         * do nearest point calculation on that event, because we already know the trend
-         * index in the handler.
-         */}
-        <Bar
-          x={0}
-          y={0}
-          width={width}
-          height={height}
-          fill="transparent"
-          onTouchStart={onHover}
-          onTouchMove={onHover}
-          onMouseMove={onHover}
-          onMouseLeave={onHover}
-        />
-
         {children}
       </Group>
     </svg>

--- a/packages/app/src/components-styled/time-series-chart/components/index.ts
+++ b/packages/app/src/components-styled/time-series-chart/components/index.ts
@@ -8,3 +8,4 @@ export * from './overlay';
 export * from './point-markers';
 export * from './range-trend';
 export * from './tooltip';
+export * from './timespan-annotation';

--- a/packages/app/src/components-styled/time-series-chart/components/range-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/range-trend.tsx
@@ -21,7 +21,7 @@ export function RangeTrend({
   getY1,
   bounds,
   color,
-  fillOpacity = 0.5,
+  fillOpacity = 0.6,
 }: RangeTrendProps) {
   const id = useUniqueId();
 

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -1,0 +1,97 @@
+import { assert, TimestampedValue } from '@corona-dashboard/common';
+import { ScaleLinear } from 'd3-scale';
+import { memo } from 'react';
+import { AreaTrend, LineTrend, RangeTrend } from '.';
+import {
+  SeriesDoubleValue,
+  SeriesSingleValue,
+  SeriesConfig,
+  SeriesList,
+  Bounds,
+  HoverHandler,
+  GetX,
+  GetY,
+  GetY0,
+  GetY1,
+} from '../logic';
+
+interface SeriesProps<T extends TimestampedValue> {
+  onHover: HoverHandler;
+  seriesConfig: SeriesConfig<T>;
+  seriesList: SeriesList;
+  getX: GetX;
+  getY: GetY;
+  getY0: GetY0;
+  getY1: GetY1;
+  yScale: ScaleLinear<number, number>;
+  bounds: Bounds;
+}
+
+export const Series = memo(SeriesUnmemoized) as typeof SeriesUnmemoized;
+
+function SeriesUnmemoized<T extends TimestampedValue>({
+  onHover,
+  seriesConfig,
+  seriesList,
+  getX,
+  getY,
+  getY0,
+  getY1,
+  yScale,
+  bounds,
+}: SeriesProps<T>) {
+  assert(yScale, 'wut');
+  return (
+    <>
+      {seriesList.map((series, index) => {
+        const config = seriesConfig[index];
+
+        switch (config.type) {
+          case 'line':
+            return (
+              <LineTrend
+                key={config.metricProperty as string}
+                series={series as SeriesSingleValue[]}
+                color={config.color}
+                style={config.style}
+                strokeWidth={config.strokeWidth}
+                getX={getX}
+                getY={getY}
+                onHover={(evt) => onHover(evt, index)}
+              />
+            );
+          case 'area':
+            return (
+              <AreaTrend
+                key={index}
+                series={series as SeriesSingleValue[]}
+                color={config.color}
+                style={config.style}
+                fillOpacity={config.fillOpacity}
+                strokeWidth={config.strokeWidth}
+                getX={getX}
+                getY={getY}
+                yScale={yScale}
+                onHover={(evt) => onHover(evt, index)}
+              />
+            );
+
+          case 'range':
+            return (
+              <RangeTrend
+                key={config.metricPropertyLow as string}
+                series={series as SeriesDoubleValue[]}
+                color={config.color}
+                fillOpacity={config.fillOpacity}
+                strokeWidth={config.strokeWidth}
+                getX={getX}
+                getY0={getY0}
+                getY1={getY1}
+                bounds={bounds}
+              />
+            );
+        }
+      })}
+    </>
+  );
+}

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -40,7 +40,6 @@ function SeriesUnmemoized<T extends TimestampedValue>({
   yScale,
   bounds,
 }: SeriesProps<T>) {
-  assert(yScale, 'wut');
   return (
     <>
       {seriesList.map((series, index) => {

--- a/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
@@ -1,0 +1,45 @@
+import { Bar } from '@visx/shape';
+import { colors } from '~/style/theme';
+import { GetX } from '../logic';
+
+export function TimespanAnnotation({
+  start,
+  end,
+  domain,
+  getX,
+  height,
+  color = colors.data.underReported,
+}: {
+  start: number;
+  end: number;
+  domain: [number, number];
+  height: number;
+  getX: GetX;
+  color?: string;
+}) {
+  const [min, max] = domain;
+
+  /**
+   * Clip the start / end dates to the domain of the x-axis, so that we can
+   * conveniently pass in things like Infinity for end date.
+   */
+  const clippedStart = Math.max(start, min);
+  const clippedEnd = Math.min(end, max);
+
+  const x0 = getX({ __date_unix: clippedStart });
+  const x1 = getX({ __date_unix: clippedEnd });
+
+  // console.log('clipped domain', clippedStart, clippedEnd);
+  // console.log('x0 x1', x0, x1);
+  /**
+   * Here we do not have to calculate where the dates fall on the x-axis because
+   * the unix timestamps are used directly for the xScale.
+   */
+  const width = x1 - x0;
+
+  if (width <= 0) return null;
+
+  return (
+    <Bar height={height} x={x0} width={width} fill={color} opacity={0.2} />
+  );
+}

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
@@ -192,6 +192,7 @@ export function DefaultTooltip<T extends TimestampedValue>({
       <Heading level={5} my={2}>
         Debug Info:
       </Heading>
+      <div>{dateString}</div>
       <div>Active: {__valueKey}</div>
       <div>AnnotationIndex: {timespanAnnotationIndex}</div>
     </section>

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
@@ -18,7 +18,7 @@ import { VisuallyHidden } from '~/components-styled/visually-hidden';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { useBreakpoints } from '~/utils/useBreakpoints';
-import { SeriesConfig } from '../logic';
+import { SeriesConfig, DataOptions } from '../logic';
 
 const tooltipStyles = {
   ...defaultStyles,
@@ -38,6 +38,20 @@ export type TooltipData<T extends TimestampedValue> = {
    * is needed.
    */
   config: SeriesConfig<T>;
+
+  /**
+   * The options are also essential to know whether to format percentages or
+   * show date span annotation labels.
+   */
+  options: DataOptions;
+
+  /**
+   * When hovering a date span annotation, the tooltip needs to know about it so
+   * that it can render the label accordingly. I am assuming here that we won't
+   * ever define overlapping annotations for now, because in that case we would
+   * need an array of numbers...
+   */
+  timespanAnnotationIndex?: number;
 };
 
 export type TooltipFormatter<T extends TimestampedValue> = (args: {
@@ -54,7 +68,7 @@ interface TooltipProps<T extends TimestampedValue> {
   left: number;
   top: number;
   formatTooltip?: TooltipFormatter<T>;
-  isPercentage?: boolean;
+  // options?: DataOptions;
 }
 
 export function Tooltip<T extends TimestampedValue>({
@@ -64,8 +78,8 @@ export function Tooltip<T extends TimestampedValue>({
   left,
   top,
   formatTooltip,
-  isPercentage,
-}: TooltipProps<T>) {
+}: // options = {},
+TooltipProps<T>) {
   const breakpoints = useBreakpoints();
   const isTinyScreen = !breakpoints.xs;
 
@@ -84,11 +98,7 @@ export function Tooltip<T extends TimestampedValue>({
         {typeof formatTooltip === 'function' ? (
           formatTooltip(tooltipData)
         ) : (
-          <DefaultTooltip
-            title={title}
-            {...tooltipData}
-            isPercentage={isPercentage}
-          />
+          <DefaultTooltip title={title} {...tooltipData} />
         )}
       </TooltipContainer>
     </TooltipWithBounds>
@@ -117,7 +127,8 @@ interface DefaultTooltipProps<T extends TimestampedValue> {
   value: T;
   valueKey: keyof T;
   config: SeriesConfig<T>;
-  isPercentage?: boolean;
+  options: DataOptions;
+  timespanAnnotationIndex?: number;
 }
 
 export function DefaultTooltip<T extends TimestampedValue>({
@@ -125,9 +136,12 @@ export function DefaultTooltip<T extends TimestampedValue>({
   value,
   valueKey: __valueKey,
   config,
-  isPercentage,
+  options,
+  timespanAnnotationIndex,
 }: DefaultTooltipProps<T>) {
   const dateString = getDateStringFromValue(value);
+
+  // console.log('timespanAnnotationIndex', timespanAnnotationIndex);
 
   return (
     <section>
@@ -135,7 +149,7 @@ export function DefaultTooltip<T extends TimestampedValue>({
         {title}
       </Heading>
       <VisuallyHidden>{dateString}</VisuallyHidden>
-      {/* <span>Active: {valueKey}</span> */}
+
       <TooltipList>
         {[...config].reverse().map((x, index) => {
           if (x.type === 'range') {
@@ -147,11 +161,11 @@ export function DefaultTooltip<T extends TimestampedValue>({
                     {`${getValueStringForKey(
                       value,
                       x.metricPropertyLow,
-                      isPercentage
+                      options.isPercentage
                     )} - ${getValueStringForKey(
                       value,
                       x.metricPropertyHigh,
-                      isPercentage
+                      options.isPercentage
                     )}`}
                   </b>
                 </TooltipValueContainer>
@@ -166,7 +180,7 @@ export function DefaultTooltip<T extends TimestampedValue>({
                     {getValueStringForKey(
                       value,
                       x.metricProperty,
-                      isPercentage
+                      options.isPercentage
                     )}
                   </b>
                 </TooltipValueContainer>
@@ -175,6 +189,11 @@ export function DefaultTooltip<T extends TimestampedValue>({
           }
         })}
       </TooltipList>
+      <Heading level={5} my={2}>
+        Debug Info:
+      </Heading>
+      <div>Active: {__valueKey}</div>
+      <div>AnnotationIndex: {timespanAnnotationIndex}</div>
     </section>
   );
 }
@@ -208,9 +227,6 @@ const TooltipListItem = styled.li<TooltipListItemProps>`
 const TooltipValueContainer = styled.span`
   display: flex;
   width: 100%;
-  /* min-width: 130px; */
-  /* padding-left: 2em; */
-  /* margin-right: 1em; */
   justify-content: space-between;
 `;
 

--- a/packages/app/src/components-styled/time-series-chart/logic/common.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/common.ts
@@ -1,7 +1,24 @@
+export interface DataOptions {
+  annotation?: string;
+  forcedMaximumValue?: number;
+  isPercentage?: boolean;
+  benchmark?: {
+    value: number;
+    label: string;
+  };
+  timespanAnnotations?: TimespanAnnotationConfig[];
+}
+
+export interface TimespanAnnotationConfig {
+  start: number;
+  end: number;
+  color?: string;
+  label: string;
+}
+
 /**
  * @TODO find a more common place for this.
  */
-
 export type Padding = {
   top: number;
   right: number;

--- a/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
@@ -41,7 +41,7 @@ interface HoverState<T> {
 
 type Event = React.TouchEvent<SVGElement> | React.MouseEvent<SVGElement>;
 
-type HoverHandler = (event: Event, seriesIndex?: number) => void;
+export type HoverHandler = (event: Event, seriesIndex?: number) => void;
 
 type UseHoveStateResponse<T> = [HoverHandler, HoverState<T> | undefined];
 

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -1,5 +1,6 @@
 import { scaleBand, scaleLinear } from '@visx/scale';
 import { extent } from 'd3-array';
+import { ScaleLinear } from 'd3-scale';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Bounds } from './common';
@@ -9,6 +10,21 @@ import {
   SeriesList,
   SeriesSingleValue,
 } from './series';
+
+export type GetX = (x: SeriesItem) => number;
+export type GetY = (x: SeriesSingleValue) => number;
+export type GetY0 = (x: SeriesDoubleValue) => number;
+export type GetY1 = (x: SeriesDoubleValue) => number;
+
+interface UseScalesResult {
+  xScale: ScaleLinear<number, number>;
+  yScale: ScaleLinear<number, number>;
+  getX: GetX;
+  getY: GetY;
+  getY0: GetY0;
+  getY1: GetY1;
+  dateSpanWidth: number;
+}
 
 export function useScales(args: {
   seriesList: SeriesList;
@@ -63,20 +79,16 @@ export function useScales(args: {
       nice: numTicks,
     });
 
-    const getX = (x: SeriesItem) => xScale(x.__date_unix);
-
-    const getY = (x: SeriesSingleValue) => yScale(x.__value);
-    const getY0 = (x: SeriesDoubleValue) => yScale(x.__value_a);
-    const getY1 = (x: SeriesDoubleValue) => yScale(x.__value_b);
-
-    return {
+    const result: UseScalesResult = {
       xScale,
       yScale,
-      getX,
-      getY,
-      getY0,
-      getY1,
+      getX: (x: SeriesItem) => xScale(x.__date_unix),
+      getY: (x: SeriesSingleValue) => yScale(x.__value),
+      getY0: (x: SeriesDoubleValue) => yScale(x.__value_a),
+      getY1: (x: SeriesDoubleValue) => yScale(x.__value_b),
       dateSpanWidth: dateSpanScale.bandwidth(),
     };
+
+    return result;
   }, [seriesList, maximumValue, bounds, numTicks]);
 }

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -1,21 +1,18 @@
 import { TimestampedValue } from '@corona-dashboard/common';
 import { useTooltip } from '@visx/tooltip';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components-styled/base';
 import { TimeframeOption } from '~/utils/timeframe';
 import { Legend } from '../legend';
 import { ValueAnnotation } from '../value-annotation';
 import {
-  AreaTrend,
   Axes,
   ChartContainer,
   DateLineMarker,
   DateSpanMarker,
-  LineTrend,
   Overlay,
   PointMarkers,
-  RangeTrend,
   Tooltip,
   TooltipData,
   TooltipFormatter,
@@ -25,8 +22,6 @@ import { Series } from './components/series';
 import {
   calculateSeriesMaximum,
   SeriesConfig,
-  SeriesDoubleValue,
-  SeriesSingleValue,
   useHoverState,
   useLegendItems,
   useScales,
@@ -193,70 +188,6 @@ export function TimeSeriesChart<T extends TimestampedValue>({
     }
   }, [hoverState, seriesConfig, values, hideTooltip, showTooltip]);
 
-  const renderSeries = useCallback(
-    () =>
-      seriesList.map((series, index) => {
-        const config = seriesConfig[index];
-
-        switch (config.type) {
-          case 'line':
-            return (
-              <LineTrend
-                key={index}
-                series={series as SeriesSingleValue[]}
-                color={config.color}
-                style={config.style}
-                strokeWidth={config.strokeWidth}
-                getX={getX}
-                getY={getY}
-                onHover={(evt) => handleHover(evt, index)}
-              />
-            );
-          case 'area':
-            return (
-              <AreaTrend
-                key={index}
-                series={series as SeriesSingleValue[]}
-                color={config.color}
-                style={config.style}
-                fillOpacity={config.fillOpacity}
-                strokeWidth={config.strokeWidth}
-                getX={getX}
-                getY={getY}
-                yScale={yScale}
-                onHover={(evt) => handleHover(evt, index)}
-              />
-            );
-
-          case 'range':
-            return (
-              <RangeTrend
-                key={index}
-                series={series as SeriesDoubleValue[]}
-                color={config.color}
-                fillOpacity={config.fillOpacity}
-                strokeWidth={config.strokeWidth}
-                getX={getX}
-                getY0={getY0}
-                getY1={getY1}
-                bounds={bounds}
-              />
-            );
-        }
-      }),
-    [
-      handleHover,
-      seriesConfig,
-      seriesList,
-      getX,
-      getY,
-      getY0,
-      getY1,
-      yScale,
-      bounds,
-    ]
-  );
-
   return (
     <Box>
       {annotation && <ValueAnnotation mb={2}>{annotation}</ValueAnnotation>}
@@ -277,7 +208,28 @@ export function TimeSeriesChart<T extends TimestampedValue>({
             isPercentage={isPercentage}
           />
 
-          {renderSeries()}
+          {/**
+           * The renderSeries() callback has been replaced by this component. As
+           * long as we use only very standardized series this might be a good
+           * idea because it removes quite some lines of code from the main
+           * component.
+           *
+           * With this amount of props if does feel like the wrong type of
+           * abstraction, but I still think it's an improvement over
+           * having it mixed in with the main component.
+           */}
+          <Series
+            seriesConfig={seriesConfig}
+            seriesList={seriesList}
+            onHover={handleHover}
+            getX={getX}
+            getY={getY}
+            getY0={getY0}
+            getY1={getY1}
+            bounds={bounds}
+            yScale={yScale}
+          />
+
           {benchmark && (
             <Benchmark
               value={benchmark.value}

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -20,6 +20,8 @@ import {
   TooltipData,
   TooltipFormatter,
 } from './components';
+import { Benchmark } from './components/benchmark';
+import { Series } from './components/series';
 import {
   calculateSeriesMaximum,
   SeriesConfig,
@@ -93,9 +95,12 @@ export type TimeSeriesChartProps<T extends TimestampedValue> = {
   formatTooltip?: TooltipFormatter<T>;
   dataOptions?: {
     annotation?: string;
-    benchmarkValue?: number;
     forcedMaximumValue?: number;
     isPercentage?: boolean;
+  };
+  benchmark?: {
+    value: number;
+    label: string;
   };
   numTicks?: number;
   tickValues?: number[];
@@ -118,6 +123,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   paddingLeft,
   ariaLabelledBy,
   title,
+  benchmark,
 }: TimeSeriesChartProps<T>) {
   const {
     tooltipData,
@@ -128,12 +134,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
     tooltipOpen,
   } = useTooltip<TooltipData<T>>();
 
-  const {
-    benchmarkValue,
-    annotation,
-    isPercentage,
-    forcedMaximumValue,
-  } = dataOptions;
+  const { annotation, isPercentage, forcedMaximumValue } = dataOptions;
 
   const { padding, bounds } = useDimensions(width, height, paddingLeft);
 
@@ -141,17 +142,9 @@ export function TimeSeriesChart<T extends TimestampedValue>({
 
   const seriesList = useSeriesList(values, seriesConfig, timeframe);
 
-  // const benchmark = useMemo(
-  //   () =>
-  //     benchmarkValue
-  //       ? { value: signaalwaarde, label: text.common.barScale.signaalwaarde }
-  //       : undefined,
-  //   [signaalwaarde]
-  // );
-
   const calculatedSeriesMax = useMemo(
-    () => calculateSeriesMaximum(values, seriesConfig, benchmarkValue),
-    [values, seriesConfig, benchmarkValue]
+    () => calculateSeriesMaximum(values, seriesConfig, benchmark?.value),
+    [values, seriesConfig, benchmark]
   );
 
   const seriesMax = isDefined(forcedMaximumValue)
@@ -285,6 +278,14 @@ export function TimeSeriesChart<T extends TimestampedValue>({
           />
 
           {renderSeries()}
+          {benchmark && (
+            <Benchmark
+              value={benchmark.value}
+              label={benchmark.label}
+              top={yScale(benchmark.value)}
+              width={bounds.width}
+            />
+          )}
         </ChartContainer>
 
         <Tooltip

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -30,6 +30,7 @@ import {
   DataOptions,
 } from './logic';
 import { useDimensions } from './logic/dimensions';
+import { Bar } from '@visx/shape';
 export type { SeriesConfig } from './logic';
 
 /**
@@ -96,8 +97,8 @@ export type TimeSeriesChartProps<T extends TimestampedValue> = {
   paddingLeft?: number;
   /**
    * The data specific options are grouped together. This way we can pass them
-   * together with the seriesConfig to the tooltip formatter. The options contain
-   * things that are essential to rendering a full tooltip layout
+   * together with the seriesConfig to the tooltip formatter. The options
+   * contain things that are essential to rendering a full tooltip layout
    */
   dataOptions?: DataOptions;
 };
@@ -204,7 +205,6 @@ export function TimeSeriesChart<T extends TimestampedValue>({
         <ChartContainer
           width={width}
           height={height}
-          onHover={handleHover}
           padding={padding}
           ariaLabelledBy={ariaLabelledBy}
         >
@@ -214,6 +214,26 @@ export function TimeSeriesChart<T extends TimestampedValue>({
             xScale={xScale}
             yScale={yScale}
             isPercentage={isPercentage}
+          />
+
+          <Bar
+            /**
+             * The Bar captures all mouse movements outside of trend elements.
+             * The Trend components * are rendered op top (in DOM) so that they
+             * can have their own hover state and handlers. Trend hover handlers
+             * also have the advantage that we don't need to do nearest point
+             * calculation on that event, because we already know the trend
+             * index in the handler.
+             */
+            x={0}
+            y={0}
+            width={bounds.width}
+            height={bounds.height}
+            fill="transparent"
+            onTouchStart={handleHover}
+            onTouchMove={handleHover}
+            onMouseMove={handleHover}
+            onMouseLeave={handleHover}
           />
 
           {dateSpanAnnotations &&

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -484,6 +484,10 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                   isPercentage: true,
                   forcedMaximumValue: 100,
                 }}
+                benchmark={{
+                  label: 'This is an important value',
+                  value: 77,
+                }}
                 seriesConfig={[
                   {
                     /**

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -483,10 +483,27 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 dataOptions={{
                   isPercentage: true,
                   forcedMaximumValue: 100,
-                }}
-                benchmark={{
-                  label: 'This is an important value',
-                  value: 77,
+                  benchmark: {
+                    label: 'This is an important value',
+                    value: 77,
+                  },
+                  timespanAnnotations: [
+                    {
+                      start: data.vaccine_support.values[1].date_start_unix,
+                      end: data.vaccine_support.values[1].date_end_unix,
+                      label: 'Only second item',
+                      color: 'hotpink',
+                    },
+                    {
+                      start:
+                        data.vaccine_support.values[
+                          data.vaccine_support.values.length - 2
+                        ].date_start_unix,
+                      end: Infinity,
+                      label: 'Last two items',
+                      color: 'rebeccapurple',
+                    },
+                  ],
                 }}
                 seriesConfig={[
                   {


### PR DESCRIPTION
## Summary

This is continuation of #2123. It adds some things to the API to make it closer to being a suitable for creating the normal LineChart.

- Add ability to configure benchmark / signaalwaarde
- Add ability to configure (multiple) timespan annotations

Some refactoring:

- The signature for the tooltip formatting function has been changed so that DataOptions are passed fully. Allowing the tooltip to render labels from timespan annotations.
- The global hoverstate capture Bar component has been taken out of the ChartContainer component, since there was really no benefit to place it there.
- The renderSeries function has been converted to a regular component, to clean up the main component file.

The lookup of the active timespan annotation is not yet working (it debug value -42 now always), because I discovered a fundamental flaw in the scales / span calculations. But that has to be fixed in the other implementation as well, and therefor I have not marked this as draft.