### PR TITLE
Add full date after relative date (if its today or yesterday)

### DIFF
--- a/packages/app/src/components-styled/relative-date.tsx
+++ b/packages/app/src/components-styled/relative-date.tsx
@@ -43,9 +43,13 @@ export function RelativeDate({
     displayDate = displayDate.charAt(0).toUpperCase() + displayDate.substr(1);
   }
 
+  // if the displaydate is something like 'today' or 'yesterday', we put the full date behind it
+  const suffix = fullDate.startsWith(displayDate) ? '' : ` (${fullDate})`;
+
   return (
     <Time dateTime={isoDate} title={fullDate}>
       {displayDate}
+      {suffix}
     </Time>
   );
 }


### PR DESCRIPTION
## Summary

This suffixes the 'last generated' date with the full date in the case the relative date is today or yesterday, etc.
I.e. before it was rendered as: Last generated: yesterday
Now it will be rendered as: Last generated: yesterday (4 March 2021)

## Motivation

Feature request

## Detailed design

In RelativeDate we check whether the displaydate is part of the full date, if that's not the case we can assume the displaydate is something in the vain of 'today' or 'yesterday', in which case we suffix the the fulldate.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
