### PR TITLE
Remove data annotation from municipal sewerwater barchart

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -15,6 +15,7 @@ import { SEOHead } from '~/components-styled/seo-head';
 import { SewerChart } from '~/components-styled/sewer-chart';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
+import { Text } from '~/components-styled/typography';
 import { WarningTile } from '~/components-styled/warning-tile';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
@@ -26,10 +27,9 @@ import {
   getLastGeneratedDate,
   getText,
 } from '~/static-props/get-data';
+import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { getSewerWaterBarChartData } from '~/utils/sewer-water/municipality-sewer-water.util';
-import { replaceComponentsInText } from '~/utils/replace-components-in-text';
-import { Text } from '~/components-styled/typography';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -196,7 +196,6 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
               accessibilityDescription={
                 text.bar_chart_accessibility_description
               }
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
             />
           </ChartTile>
         )}


### PR DESCRIPTION
## Summary

Remove the 'x 100 billion' annotation from the sewerwater bar chart (to keep it the same as the safety region page)

## Motivation

Design request

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
