### PR TITLE
Yet another chart in Visx continued some more

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/axes.tsx
@@ -68,7 +68,7 @@ export const Axes = memo(function Axes({
            */
           textAnchor: 'middle',
         })}
-        hideTicks
+        // hideTicks
       />
       <AxisLeft
         scale={yScale}

--- a/packages/app/src/components-styled/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/axes.tsx
@@ -68,7 +68,7 @@ export const Axes = memo(function Axes({
            */
           textAnchor: 'middle',
         })}
-        // hideTicks
+        hideTicks
       />
       <AxisLeft
         scale={yScale}

--- a/packages/app/src/components-styled/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/axes.tsx
@@ -14,13 +14,19 @@ import { colors } from '~/style/theme';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { Bounds } from '../logic';
 
-const NUM_TICKS = 20;
-
 type AxesProps = {
   bounds: Bounds;
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
   isPercentage?: boolean;
+  /**
+   * The number of grid lines are by default linked to the number of y-axis
+   * ticks. By setting tick values, you overrule that number for the ticks, so
+   * you can have less labelled ticks than the number of total grid lines. For
+   * example the vaccine_support chart uses 20 grid lines but 5 of those get a
+   * label.
+   */
+  numGridLines: number;
   yTickValues?: number[];
 };
 
@@ -32,6 +38,7 @@ const formatYAxisPercentage = (y: number) => `${formatPercentage(y)}%`;
 type AnyTickFormatter = (value: any) => string;
 
 export const Axes = memo(function Axes({
+  numGridLines,
   bounds,
   isPercentage,
   yTickValues,
@@ -41,15 +48,23 @@ export const Axes = memo(function Axes({
   return (
     <>
       <GridRows
+        /**
+         * Lighter gray grid lines are used for the lines that have no label on
+         * the y-axis
+         */
         scale={yScale}
         width={bounds.width}
-        numTicks={NUM_TICKS}
+        numTicks={numGridLines}
         stroke="#E4E4E4"
       />
       <GridRows
+        /**
+         * Darker gray grid lines are used for the lines that also have a label
+         * on the y-axis.
+         */
         scale={yScale}
         width={bounds.width}
-        numTicks={5}
+        numTicks={yTickValues?.length || numGridLines}
         tickValues={yTickValues}
         stroke={colors.silver}
       />
@@ -73,6 +88,7 @@ export const Axes = memo(function Axes({
       <AxisLeft
         scale={yScale}
         tickValues={yTickValues}
+        numTicks={yTickValues?.length || numGridLines}
         hideTicks
         hideAxisLine
         stroke={colors.silver}

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -1,18 +1,18 @@
-import { assert, TimestampedValue } from '@corona-dashboard/common';
+import { TimestampedValue } from '@corona-dashboard/common';
 import { ScaleLinear } from 'd3-scale';
 import { memo } from 'react';
 import { AreaTrend, LineTrend, RangeTrend } from '.';
 import {
-  SeriesDoubleValue,
-  SeriesSingleValue,
-  SeriesConfig,
-  SeriesList,
   Bounds,
-  HoverHandler,
   GetX,
   GetY,
   GetY0,
   GetY1,
+  HoverHandler,
+  SeriesConfig,
+  SeriesDoubleValue,
+  SeriesList,
+  SeriesSingleValue,
 } from '../logic';
 
 interface SeriesProps<T extends TimestampedValue> {

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -20,6 +20,13 @@ interface SeriesProps<T extends TimestampedValue> {
   seriesConfig: SeriesConfig<T>;
   seriesList: SeriesList;
   getX: GetX;
+  /**
+   * @TODO it's maybe not worth it creating the getY functions in the hook and
+   * passing them along. Since we also need the yScale here anyway, we might as
+   * well let each component make its own y getters based on yScale. GetX is
+   * used in more places and is more universal so that might still be worth
+   * passing along instead of xScale.
+   */
   getY: GetY;
   getY0: GetY0;
   getY1: GetY1;

--- a/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
@@ -38,6 +38,13 @@ export function TimespanAnnotation({
   if (width <= 0) return null;
 
   return (
-    <Bar height={height} x={x0} width={width} fill={color} opacity={0.2} />
+    <Bar
+      pointerEvents="none"
+      height={height}
+      x={x0}
+      width={width}
+      fill={color}
+      opacity={0.2}
+    />
   );
 }

--- a/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/timespan-annotation.tsx
@@ -29,8 +29,6 @@ export function TimespanAnnotation({
   const x0 = getX({ __date_unix: clippedStart });
   const x1 = getX({ __date_unix: clippedEnd });
 
-  // console.log('clipped domain', clippedStart, clippedEnd);
-  // console.log('x0 x1', x0, x1);
   /**
    * Here we do not have to calculate where the dates fall on the x-axis because
    * the unix timestamps are used directly for the xScale.

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip.tsx
@@ -13,12 +13,13 @@ import {
 import css from '@styled-system/css';
 import { defaultStyles, TooltipWithBounds } from '@visx/tooltip';
 import styled from 'styled-components';
+import { Box } from '~/components-styled/base';
 import { Heading, InlineText } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { useBreakpoints } from '~/utils/useBreakpoints';
-import { SeriesConfig, DataOptions } from '../logic';
+import { SeriesConfig, DataOptions, TimespanAnnotationConfig } from '../logic';
 
 const tooltipStyles = {
   ...defaultStyles,
@@ -48,10 +49,9 @@ export type TooltipData<T extends TimestampedValue> = {
   /**
    * When hovering a date span annotation, the tooltip needs to know about it so
    * that it can render the label accordingly. I am assuming here that we won't
-   * ever define overlapping annotations for now, because in that case we would
-   * need an array of numbers...
+   * ever define overlapping annotations for now.
    */
-  timespanAnnotationIndex?: number;
+  timespanAnnotation?: TimespanAnnotationConfig;
 };
 
 export type TooltipFormatter<T extends TimestampedValue> = (args: {
@@ -68,7 +68,6 @@ interface TooltipProps<T extends TimestampedValue> {
   left: number;
   top: number;
   formatTooltip?: TooltipFormatter<T>;
-  // options?: DataOptions;
 }
 
 export function Tooltip<T extends TimestampedValue>({
@@ -78,8 +77,7 @@ export function Tooltip<T extends TimestampedValue>({
   left,
   top,
   formatTooltip,
-}: // options = {},
-TooltipProps<T>) {
+}: TooltipProps<T>) {
   const breakpoints = useBreakpoints();
   const isTinyScreen = !breakpoints.xs;
 
@@ -128,7 +126,7 @@ interface DefaultTooltipProps<T extends TimestampedValue> {
   valueKey: keyof T;
   config: SeriesConfig<T>;
   options: DataOptions;
-  timespanAnnotationIndex?: number;
+  timespanAnnotation?: TimespanAnnotationConfig;
 }
 
 export function DefaultTooltip<T extends TimestampedValue>({
@@ -137,11 +135,9 @@ export function DefaultTooltip<T extends TimestampedValue>({
   valueKey: __valueKey,
   config,
   options,
-  timespanAnnotationIndex,
+  timespanAnnotation,
 }: DefaultTooltipProps<T>) {
   const dateString = getDateStringFromValue(value);
-
-  // console.log('timespanAnnotationIndex', timespanAnnotationIndex);
 
   return (
     <section>
@@ -193,8 +189,10 @@ export function DefaultTooltip<T extends TimestampedValue>({
         Debug Info:
       </Heading>
       <div>{dateString}</div>
-      <div>Active: {__valueKey}</div>
-      <div>AnnotationIndex: {timespanAnnotationIndex}</div>
+      <div>Key: {__valueKey}</div>
+      {timespanAnnotation && (
+        <Box color={timespanAnnotation.color}>{timespanAnnotation.label}</Box>
+      )}
     </section>
   );
 }

--- a/packages/app/src/components-styled/time-series-chart/logic/common.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/common.ts
@@ -1,5 +1,5 @@
 export interface DataOptions {
-  annotation?: string;
+  valueAnnotation?: string;
   forcedMaximumValue?: number;
   isPercentage?: boolean;
   benchmark?: {

--- a/packages/app/src/components-styled/time-series-chart/logic/legend.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/legend.ts
@@ -1,18 +1,18 @@
 import { TimestampedValue } from '@corona-dashboard/common';
+import { transparentize } from 'polished';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { LegendItem } from '~/components-styled/legend';
+import { colors } from '~/style/theme';
+import { DataOptions } from './common';
 import { SeriesConfig } from './series';
 
 export function useLegendItems<T extends TimestampedValue>(
-  config: SeriesConfig<T>
-  /**
-   * @TODO pass date span annotations so we can include them in the legenda
-   */
-  //dateSpanAnnotations: DateSpanAnnotation[]
+  config: SeriesConfig<T>,
+  dataOptions: DataOptions
 ) {
   const legendItems = useMemo(() => {
-    return config
+    const items = config
       .map((x) => {
         switch (x.type) {
           case 'line':
@@ -36,19 +36,32 @@ export function useLegendItems<T extends TimestampedValue>(
         }
       })
       .filter(isDefined);
-  }, [config]);
 
-  /**
-   * @TODO add the other legend items that come from annotations
-   */
+    /**
+     * Add annotations to the legend
+     */
+    if (dataOptions.timespanAnnotations) {
+      for (const annotation of dataOptions.timespanAnnotations) {
+        items.push({
+          color: annotation.color
+            ? transparentize(0.7, annotation.color)
+            : colors.data.emphasis,
+          label: annotation.label,
+          shape: 'square',
+        } as LegendItem);
+      }
+    }
 
-  /**
-   * In current charts we only show a legend if there are more then 1 items. So
-   * for example a line plus an date span annotation. If it's just one line
-   * then no legend is displayed, so in that case we return an empty array.
-   *
-   * This prevents is from having to manually set (and possibly forget to set)
-   * a boolean on the chart props.
-   */
-  return legendItems.length > 1 ? legendItems : [];
+    /**
+     * In current charts we only show a legend if there are more then 1 items. So
+     * for example a line plus an date span annotation. If it's just one line
+     * then no legend is displayed, so in that case we return an empty array.
+     *
+     * This prevents is from having to manually set (and possibly forget to set)
+     * a boolean on the chart props.
+     */
+    return items.length > 1 ? items : [];
+  }, [config, dataOptions]);
+
+  return legendItems;
 }

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -4,11 +4,10 @@ import {
   isDateSeries,
   TimestampedValue,
 } from '@corona-dashboard/common';
-import { scaleBand, scaleLinear } from '@visx/scale';
+import { scaleLinear } from '@visx/scale';
 import { extent } from 'd3-array';
 import { ScaleLinear } from 'd3-scale';
 import { useMemo } from 'react';
-import { isDefined } from 'ts-is-present';
 import { Bounds } from './common';
 import {
   SeriesDoubleValue,
@@ -71,38 +70,8 @@ export function useScales<T extends TimestampedValue>(args: {
 
     // const yDomain = [0, maximumValue];
 
-    /**
-     * To calculate the timespan width we need a full series worth of
-     * timestamps. This chart assumes that all series have the same length
-     * because they all originate from the same T[] values. If a trend is not
-     * full-length it should contain null values, but still have all the
-     * timestamps.
-     */
-    // const timespanMarkerData = seriesList[0] as SeriesItem[];
-
-    // const timespanDates = isDateSeries(values)
-    //   ? (values as DateValue[]).map((x) => x.date_unix)
-    //   : (values as DateSpanValue[]).map(
-    //       (x) => x.date_start_unix
-    //       // x.date_end_unix,
-    //     );
-
-    /**
-     * ☝️ weird. Typescript 4.3 doesn't complain below when mapping over the
-     * data, but TS 4.2 thinks x is any. So I'm just leaving this cast to
-     * SeriesItem until 4.3 comes along as the official version.
-     */
-    // const dateSpanScale = scaleBand<number>({
-    //   range: [0, bounds.width],
-    //   // domain: timespanMarkerData.map((x) => x.__date_unix),
-    //   domain: timespanDates,
-    // });
-
-    // const markerPadding = dateSpanScale.bandwidth() / 2;
-
     const xScale = scaleLinear({
       domain: [start, end],
-      // range: [markerPadding, bounds.width - markerPadding],
       range: [0, bounds.width],
     });
 
@@ -115,7 +84,8 @@ export function useScales<T extends TimestampedValue>(args: {
     const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
     const dateSpanWidth = isDateSeries(values)
       ? xScale(start + ONE_DAY_IN_SECONDS) - xScale(start)
-      : xScale(end) - xScale(start);
+      : xScale((values[0] as DateSpanValue).date_end_unix) -
+        xScale((values[0] as DateSpanValue).date_start_unix);
 
     const result: UseScalesResult = {
       xScale,

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -86,7 +86,13 @@ function getTimeDomain<T extends TimestampedValue>(values: T[]) {
       isDefined(start) && isDefined(end),
       `Missing start or end timestamp in [${start}, ${end}]`
     );
-    return [start, end];
+
+    /**
+     * In cases where we render daily data, it is probably good to add a bit of
+     * time scale "padding" so that the markers and their date span fall nicely
+     * within the "stretched" domain on both ends of the graph.
+     */
+    return [start - ONE_DAY_IN_SECONDS, end + ONE_DAY_IN_SECONDS];
   }
 
   if (isDateSpanSeries(values)) {

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -87,7 +87,11 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
    * Value cannot be 0, hence the 1. If the value is below signaalwaarde, make
    * sure the signaalwaarde floats in the middle
    */
-  return Math.max(overallMaximum, benchmarkValue * 2, 1);
+
+  const artificialMax =
+    overallMaximum < benchmarkValue ? benchmarkValue * 2 : 0;
+
+  return Math.max(overallMaximum, artificialMax);
 }
 
 export type SeriesItem = {

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -91,7 +91,15 @@ export type TimeSeriesChartProps<T extends TimestampedValue> = {
   height?: number;
   timeframe?: TimeframeOption;
   formatTooltip?: TooltipFormatter<T>;
-  numTicks?: number;
+  /**
+   * The number of grid lines also by default determines the number of y-axis
+   * ticks, but the number of ticks can be overruled with specific tick values
+   * via the tickValues prop.
+   *
+   * This way you can also have many more grid lines than tick values, like in
+   * the vaccine support chart.
+   */
+  numGridLines?: number;
   tickValues?: number[];
   showDateMarker?: boolean;
   paddingLeft?: number;
@@ -111,7 +119,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   timeframe = 'all',
   formatTooltip,
   dataOptions = {},
-  numTicks = 3,
+  numGridLines = 3,
   tickValues,
   showDateMarker,
   paddingLeft,
@@ -155,7 +163,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
       values,
       maximumValue: seriesMax,
       bounds,
-      numTicks: tickValues?.length || numTicks,
+      numTicks: tickValues?.length || numGridLines,
     }
   );
 
@@ -223,6 +231,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
         >
           <Axes
             bounds={bounds}
+            numGridLines={numGridLines}
             yTickValues={tickValues}
             xScale={xScale}
             yScale={yScale}

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -128,7 +128,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   } = useTooltip<TooltipData<T>>();
 
   const {
-    annotation,
+    valueAnnotation,
     isPercentage,
     forcedMaximumValue,
     benchmark,
@@ -210,7 +210,9 @@ export function TimeSeriesChart<T extends TimestampedValue>({
 
   return (
     <Box>
-      {annotation && <ValueAnnotation mb={2}>{annotation}</ValueAnnotation>}
+      {valueAnnotation && (
+        <ValueAnnotation mb={2}>{valueAnnotation}</ValueAnnotation>
+      )}
 
       <Box position="relative">
         <ChartContainer

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -137,7 +137,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
 
   const { padding, bounds } = useDimensions(width, height, paddingLeft);
 
-  const legendItems = useLegendItems(seriesConfig);
+  const legendItems = useLegendItems(seriesConfig, dataOptions);
 
   const seriesList = useSeriesList(values, seriesConfig, timeframe);
 

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -152,6 +152,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
 
   const { xScale, yScale, getX, getY, getY0, getY1, dateSpanWidth } = useScales(
     {
+      values,
       seriesList,
       maximumValue: seriesMax,
       bounds,

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -74,8 +74,9 @@ export type { SeriesConfig } from './logic';
  *
  * @TODO
  *
- * - Include props for background rectangle aka date span annotation
- * - Finish RangeTrend component
+ * - Render date start /end on x-axis for date spans series
+ * - Configure y-axis for standard charts
+ * - Calculate timespan annotation hover state
  *
  * Known Issues:
  * - Nearest point / tooltip valueKey calculation seems to be off by some
@@ -153,7 +154,6 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   const { xScale, yScale, getX, getY, getY0, getY1, dateSpanWidth } = useScales(
     {
       values,
-      seriesList,
       maximumValue: seriesMax,
       bounds,
       numTicks: tickValues?.length || numTicks,

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -76,7 +76,6 @@ export type { SeriesConfig } from './logic';
  *
  * - Render date start /end on x-axis for date spans series
  * - Configure y-axis for standard charts
- * - Calculate timespan annotation hover state
  *
  * Known Issues:
  * - Nearest point / tooltip valueKey calculation seems to be off by some
@@ -133,7 +132,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
     isPercentage,
     forcedMaximumValue,
     benchmark,
-    timespanAnnotations: dateSpanAnnotations,
+    timespanAnnotations,
   } = dataOptions;
 
   const { padding, bounds } = useDimensions(width, height, paddingLeft);
@@ -167,11 +166,16 @@ export function TimeSeriesChart<T extends TimestampedValue>({
     seriesList,
     xScale,
     yScale,
+    timespanAnnotations,
   });
 
   useEffect(() => {
     if (hoverState) {
-      const { nearestLinePoint: nearestPoint, valuesIndex } = hoverState;
+      const {
+        nearestLinePoint: nearestPoint,
+        valuesIndex,
+        timespanAnnotationIndex,
+      } = hoverState;
 
       showTooltip({
         tooltipData: {
@@ -186,9 +190,15 @@ export function TimeSeriesChart<T extends TimestampedValue>({
           config: seriesConfig,
           options: dataOptions,
           /**
-           * @TODO add hovered annotation index
+           * Pass the full annotation data. We could just pass the index because
+           * dataOptions is already being passed, but it's cumbersome to have to
+           * dig up the annotation from the array in the tooltip logic.
            */
-          timespanAnnotationIndex: -42,
+          timespanAnnotation:
+            isDefined(dataOptions.timespanAnnotations) &&
+            isDefined(timespanAnnotationIndex)
+              ? dataOptions.timespanAnnotations[timespanAnnotationIndex]
+              : undefined,
         },
         tooltipLeft: nearestPoint.x,
         tooltipTop: nearestPoint.y,
@@ -237,8 +247,8 @@ export function TimeSeriesChart<T extends TimestampedValue>({
             onMouseLeave={handleHover}
           />
 
-          {dateSpanAnnotations &&
-            dateSpanAnnotations.map((x, index) => (
+          {timespanAnnotations &&
+            timespanAnnotations.map((x, index) => (
               <TimespanAnnotation
                 key={index}
                 start={x.start}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -489,9 +489,9 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                   },
                   timespanAnnotations: [
                     {
-                      start: data.vaccine_support.values[1].date_start_unix,
-                      end: data.vaccine_support.values[1].date_end_unix,
-                      label: 'Only second item',
+                      start: data.vaccine_support.values[0].date_start_unix,
+                      end: data.vaccine_support.values[0].date_end_unix,
+                      label: 'Only first item',
                       color: 'hotpink',
                     },
                     {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -379,6 +379,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 ariaLabelledBy="chart_vaccine_support"
                 values={data.vaccine_support.values}
                 showDateMarker
+                numGridLines={20}
                 tickValues={[0, 25, 50, 75, 100]}
                 paddingLeft={36}
                 dataOptions={{
@@ -478,11 +479,10 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 ariaLabelledBy="chart_vaccine_support"
                 values={data.vaccine_support.values}
                 showDateMarker
-                tickValues={[0, 25, 50, 75, 100]}
                 paddingLeft={36}
                 dataOptions={{
                   isPercentage: true,
-                  forcedMaximumValue: 100,
+                  // forcedMaximumValue: 100,
                   benchmark: {
                     label: 'This is an important value',
                     value: 77,
@@ -494,14 +494,12 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                       label: 'Only first item',
                       color: 'hotpink',
                     },
-
                     {
                       start: data.vaccine_support.values[3].date_start_unix,
                       end: data.vaccine_support.values[4].date_end_unix,
                       label: 'Somewhere in the middle',
                       color: 'lightgreen',
                     },
-
                     {
                       start:
                         data.vaccine_support.values[

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -482,7 +482,6 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 paddingLeft={36}
                 dataOptions={{
                   isPercentage: true,
-                  // forcedMaximumValue: 100,
                   benchmark: {
                     label: 'This is an important value',
                     value: 77,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -494,6 +494,14 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                       label: 'Only first item',
                       color: 'hotpink',
                     },
+
+                    {
+                      start: data.vaccine_support.values[3].date_start_unix,
+                      end: data.vaccine_support.values[4].date_end_unix,
+                      label: 'Somewhere in the middle',
+                      color: 'lightgreen',
+                    },
+
                     {
                       start:
                         data.vaccine_support.values[

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "es5",
     "allowJs": false,
     "noEmit": true,
+    "downlevelIteration": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]


### PR DESCRIPTION
## Summary

This is a continuation of #2179 which was a continuation of #2123 . In this PR:

- Fix scales to render full scale of dates from the dataset.
- Use actual data timestamps to calculate the date span marker width
- Add a day of padding on both sides for daily data. Allowing us to render the data span going up to the next/previous day. And it adds some easy padding to avoid clipping the markers on both ends.
- Calculate the hovered timespan annotation and pass the data to the tooltip. In the screenshot you can see the active annotation with its label color being rendered in the tooltip.
- Includes annotations at the end of the legend.
- Number of gridlines and labelled tick values are now configurable to match both regular charts and vaccine support chart.

In the current state, the same dataset but with different configuration will take you from this:

![image](https://user-images.githubusercontent.com/71320230/110154946-26fc8c00-7de5-11eb-8323-981441837108.png)

To this

![image](https://user-images.githubusercontent.com/71320230/110157395-67a9d480-7de8-11eb-872f-ada42820813d.png)

What you see in the second screenshot is a botched version of the vaccine support chart showing off the different configuration options for the components:

- 3 types of trend lines: line, area and range. Configurable on any of the metric value's properties.
- A data-driven legend, using line and blocks depending on trend type. Also appending any timespan annotations.
- Freely configurable timespan annotations with own colors. In the screenshot you see three.
- Standardized tooltip. In the screenshot you see a (data-driven) default tooltip being rendered based on the chart configuration.
- A benchmark / signaalwaarde line.
- Configurable number of ticks and grid lines. If grid lines exceed the number of labelled ticks, they will show in a lighter gray, like the original vaccine support chart is showing.
- The tooltip gets passed all information that we would ever need to render a tooltip. This includes the chart configuration, data options and the active hovered annotation, as you can see in the colored label text.
- As mentioned, date span markers (how wide the sample of data is) are now determined from actual data timestamps. Because the timestamps in this particular case are incorrect, you are seeing a more narrow span (1 week) than the 3 week span it should render. This will be solved once the data is updated.

Still to do:
- Render the full date span start/end dates on the x-axis.