### PR TITLE
Add indentifers for topical pages to enable quick jumps

### DIFF
--- a/packages/app/src/domain/topical/mini-trend-tile-layout.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile-layout.tsx
@@ -3,9 +3,13 @@ import { Box } from '~/components-styled/base';
 
 type MiniTrendTileLayoutProps = {
   children: ReactNode;
+  id?: string;
 };
 
-export function MiniTrendTileLayout({ children }: MiniTrendTileLayoutProps) {
+export function MiniTrendTileLayout({
+  children,
+  id,
+}: MiniTrendTileLayoutProps) {
   const tiles = Children.toArray(children);
 
   const columnWidth = `${Math.floor(100 / tiles.length)}%`;
@@ -16,6 +20,7 @@ export function MiniTrendTileLayout({ children }: MiniTrendTileLayoutProps) {
       display={{ _: 'block', md: 'flex' }}
       overflow="hidden"
       mx={-gutterSize}
+      id={id}
     >
       {tiles.map((tile: ReactNode, index: number) => (
         <Box flex={`1 1 ${columnWidth}`} key={index} mx={gutterSize}>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -92,7 +92,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
         })}
       />
       <Box bg="white" pb={4}>
-        <MaxWidth>
+        <MaxWidth id="content">
           <TileList>
             <TopicalSectionHeader
               showBackLink
@@ -122,7 +122,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
               variant="emphasis"
             />
 
-            <MiniTrendTileLayout>
+            <MiniTrendTileLayout id="metric-navigation">
               <MiniTrendTile
                 title={text.mini_trend_tiles.positief_getest.title}
                 text={

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -92,7 +92,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
           </Heading>
         </VisuallyHidden>
 
-        <MaxWidth>
+        <MaxWidth id="content">
           <TileList>
             <TopicalSectionHeader
               showBackLink
@@ -122,7 +122,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
               variant="emphasis"
             />
 
-            <MiniTrendTileLayout>
+            <MiniTrendTileLayout id="metric-navigation">
               <MiniTrendTile
                 title={text.mini_trend_tiles.positief_getest.title}
                 text={

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -98,7 +98,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
           <Heading level={1}>{text.title}</Heading>
         </VisuallyHidden>
 
-        <MaxWidth>
+        <MaxWidth id="content">
           <TileList>
             <TopicalSectionHeader
               lastGenerated={Number(lastGenerated)}
@@ -120,7 +120,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               variant="emphasis"
             />
 
-            <MiniTrendTileLayout>
+            <MiniTrendTileLayout id="metric-navigation">
               <MiniTrendTile
                 title={text.mini_trend_tiles.positief_getest.title}
                 text={


### PR DESCRIPTION
They're some of the quick jumps didn't work on the topical pages.
This should then enable them again.