### PR TITLE
POC messages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "license": "EUROPEAN UNION PUBLIC LICENCE v. 1.2",
   "dependencies": {
+    "@formatjs/cli": "^3.1.6",
     "@formatjs/intl-datetimeformat": "^3.2.7",
     "@formatjs/intl-getcanonicallocales": "^1.4.5",
     "@formatjs/intl-locale": "^2.4.14",
@@ -39,6 +40,7 @@
     "polished": "^4.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-intl": "^5.13.2",
     "rehype-stringify": "^8.0.0",
     "remark-external-links": "^8.0.0",
     "remark-parse": "^9.0.0",

--- a/packages/app/src/messages/hospitalPage.type.ts
+++ b/packages/app/src/messages/hospitalPage.type.ts
@@ -1,0 +1,46 @@
+/* Auto generated! */
+type MessageString = string;
+type MessageBlock = any[];
+
+export interface HospitalPage {
+  'intro:category': MessageString;
+  'intro:title': MessageString;
+  'intro:description': MessageBlock;
+  'barscale:title': MessageString;
+  'barscale:description': MessageString;
+  'map:title': MessageString;
+  'map:description': MessageString;
+  'linechart:title': MessageString;
+  'linechart:description': MessageString;
+  'linechart:label_title': MessageString;
+  'linechart:label_underreported': MessageString;
+  'badbezetting_kpi:title': MessageString;
+  'badbezetting_kpi:description': MessageString;
+  'map:legenda_title': MessageString;
+  'bedbezetting_chart:title': MessageString;
+  'bedbezetting_chart:description': MessageString;
+  'bedbezetting_chart:label_trend': MessageString;
+  'bedbezetting_chart:label_underreported': MessageString;
+}
+
+export const HospitalPageStringKeys = [
+  'intro:category',
+  'intro:title',
+  'barscale:title',
+  'barscale:description',
+  'map:title',
+  'map:description',
+  'linechart:title',
+  'linechart:description',
+  'linechart:label_title',
+  'linechart:label_underreported',
+  'badbezetting_kpi:title',
+  'badbezetting_kpi:description',
+  'map:legenda_title',
+  'bedbezetting_chart:title',
+  'bedbezetting_chart:description',
+  'bedbezetting_chart:label_trend',
+  'bedbezetting_chart:label_underreported',
+];
+
+export const HospitalPageBlockKeys = ['intro:description'];

--- a/packages/app/src/messages/index.ts
+++ b/packages/app/src/messages/index.ts
@@ -1,0 +1,3 @@
+export * from './hospitalPage.type';
+export * from './positiveTestsPage.type';
+export * from './sewerPage.type';

--- a/packages/app/src/messages/positiveTestsPage.type.ts
+++ b/packages/app/src/messages/positiveTestsPage.type.ts
@@ -1,0 +1,29 @@
+/* Auto generated! */
+type MessageString = string;
+type MessageBlock = any[];
+
+
+export interface PositiveTestsPage {
+'intro:category': MessageString;
+'intro:title': MessageString;
+'intro:description': MessageString;
+'infected_delta_kpi:title': MessageString;
+'infected_delta_kpi:description': MessageBlock;
+'barscale:title': MessageString;
+'barscale:description': MessageBlock;
+}
+
+
+export const PositiveTestsPageStringKeys = [
+'intro:category',
+'intro:title',
+'intro:description',
+'infected_delta_kpi:title',
+'barscale:title'
+]
+
+
+export const PositiveTestsPageBlockKeys = [
+'infected_delta_kpi:description',
+'barscale:description'
+]

--- a/packages/app/src/messages/sewerPage.type.ts
+++ b/packages/app/src/messages/sewerPage.type.ts
@@ -1,0 +1,20 @@
+/* Auto generated! */
+type MessageString = string;
+type MessageBlock = any[];
+
+
+export interface SewerPage {
+'intro:title': MessageString;
+'intro:description': MessageString;
+}
+
+
+export const SewerPageStringKeys = [
+'intro:title',
+'intro:description'
+]
+
+
+export const SewerPageBlockKeys = [
+
+]

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -28,10 +28,12 @@ import {
   createGetContent,
   getGmData,
   getLastGeneratedDate,
+  createGetMessages,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { formatDateFromMilliseconds } from '~/utils/formatDate';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { formatMessages } from '~/utils/messages/format-messages';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
 export { getStaticPaths } from '~/static-paths/gm';
@@ -44,17 +46,20 @@ export const getStaticProps = createGetStaticProps(
   }),
   createGetContent<{
     articles?: ArticleSummary[];
-  }>(createPageArticlesQuery('hospitalPage'))
+  }>(createPageArticlesQuery('hospitalPage')),
+  createGetMessages(['hospitalPage'])
 );
 
 const text = siteText.gemeente_ziekenhuisopnames_per_dag;
 const graphDescriptions = siteText.accessibility.grafieken;
 
 const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, municipalityName, content } = props;
+  const { data, choropleth, municipalityName, content, messages } = props;
   const router = useRouter();
 
   const lastValue = data.hospital_nice.last_value;
+
+  const { messageString, messageBlock } = formatMessages(messages);
 
   const underReportedRange = getTrailingDateRange(data.hospital_nice.values, 4);
 
@@ -70,12 +75,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
       />
       <TileList>
         <ContentHeader
-          category={siteText.gemeente_layout.headings.ziekenhuizen}
-          title={replaceVariablesInText(text.titel, {
+          category={messageString('intro:category')}
+          title={replaceVariablesInText(messageString('intro:title'), {
             municipality: municipalityName,
           })}
           icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
+          subtitle={messageBlock('intro:description')}
           metadata={{
             datumsText: text.datums,
             dateOrRange: lastValue.date_unix,
@@ -89,8 +94,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
         <TwoKpiSection>
           <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+            title={messageString('barscale:title')}
+            description={messageString('barscale:description')}
             metadata={{
               date: lastValue.date_unix,
               source: text.bronnen.rivm,
@@ -107,14 +112,14 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         </TwoKpiSection>
 
         <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
+          title={replaceVariablesInText(messageString('map:title'), {
             municipality: municipalityName,
           })}
           metadata={{
             date: lastValue.date_unix,
             source: text.bronnen.rivm,
           }}
-          description={text.map_toelichting}
+          description={messageString('map:description')}
           legend={{
             title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
             thresholds:
@@ -139,8 +144,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         </ChoroplethTile>
 
         <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_description}
+          title={messageString('linechart:title')}
+          description={messageString('linechart:description')}
           ariaDescription={graphDescriptions.ziekenhuis_opnames}
           metadata={{ source: text.bronnen.rivm }}
           timeframeOptions={['all', '5weeks', 'week']}
@@ -182,12 +187,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           legendItems={[
             {
               color: colors.data.primary,
-              label: text.linechart_legend_titel,
+              label: messageString('linechart:label_title'),
               shape: 'line',
             },
             {
               color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
+              label: messageString('linechart:label_underreported'),
               shape: 'square',
             },
           ]}

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -41,6 +41,7 @@ import {
   getLastGeneratedDate,
   getNlData,
   getText,
+  createGetMessages,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { assert } from '~/utils/assert';
@@ -49,6 +50,7 @@ import {
   formatDateFromSeconds,
 } from '~/utils/formatDate';
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
+import { formatMessages } from '~/utils/messages/format-messages';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
@@ -62,7 +64,8 @@ export const getStaticProps = createGetStaticProps(
   }),
   createGetContent<{
     articles?: ArticleSummary[];
-  }>(createPageArticlesQuery('positiveTestsPage'))
+  }>(createPageArticlesQuery('positiveTestsPage')),
+  createGetMessages(['positiveTestsPage'])
 );
 
 const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
@@ -70,6 +73,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
   choropleth,
   text: siteText,
   content,
+  messages,
 }) => {
   const text = siteText.positief_geteste_personen;
   const ggdText = siteText.positief_geteste_personen_ggd;
@@ -81,6 +85,8 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
   const dataInfectedDelta = data.tested_overall;
   const dataGgdAverageLastValue = data.tested_ggd_average.last_value;
   const dataGgdDailyValues = data.tested_ggd_daily.values;
+
+  const { messageString, messageBlock } = formatMessages(messages);
 
   const ageDemographicExampleData = getAgeDemographicExampleData(
     data.tested_per_age_group
@@ -94,13 +100,13 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
       />
       <TileList>
         <ContentHeader
-          category={siteText.nationaal_layout.headings.besmettingen}
+          category={messageString('intro:category')}
           screenReaderCategory={
             siteText.positief_geteste_personen.titel_sidebar
           }
-          title={text.titel}
+          title={messageString('intro:title')}
           icon={<Getest />}
-          subtitle={text.pagina_toelichting}
+          subtitle={messageString('intro:description')}
           metadata={{
             datumsText: text.datums,
             dateOrRange: dataInfectedDelta.last_value.date_unix,
@@ -115,7 +121,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
 
         <TwoKpiSection>
           <KpiTile
-            title={text.kpi_titel}
+            title={messageString('infected_delta_kpi:title')}
             metadata={{
               date: dataInfectedDelta.last_value.date_unix,
               source: text.bronnen.rivm,
@@ -127,10 +133,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
               difference={data.difference.tested_overall__infected}
             />
 
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
-            />
+            {messageBlock('infected_delta_kpi:description')}
             <Box>
               <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
                 <span
@@ -153,7 +156,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
             </Box>
           </KpiTile>
           <KpiTile
-            title={text.barscale_titel}
+            title={messageString('barscale:title')}
             data-cy="infected_per_100k"
             metadata={{
               date: dataInfectedDelta.last_value.date_unix,
@@ -169,7 +172,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
               differenceKey="tested_overall__infected_per_100k"
             />
 
-            <Text>{text.barscale_toelichting}</Text>
+            {messageBlock('barscale:description')}
           </KpiTile>
         </TwoKpiSection>
 

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -26,7 +26,9 @@ import {
   getLastGeneratedDate,
   getNlData,
   getText,
+  createGetMessages,
 } from '~/static-props/get-data';
+import { formatMessages } from '~/utils/messages/format-messages';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -37,7 +39,8 @@ export const getStaticProps = createGetStaticProps(
   }),
   createGetContent<{
     articles?: ArticleSummary[];
-  }>(createPageArticlesQuery('sewerPage'))
+  }>(createPageArticlesQuery('sewerPage')),
+  createGetMessages(['sewerPage'])
 );
 
 const SewerWater: FCWithLayout<typeof getStaticProps> = ({
@@ -45,11 +48,14 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = ({
   choropleth,
   content,
   text: siteText,
+  messages,
 }) => {
   const text = siteText.rioolwater_metingen;
   const graphDescriptions = siteText.accessibility.grafieken;
   const sewerAverages = data.sewer;
   const router = useRouter();
+
+  const { messageString, messageBlock } = formatMessages(messages);
 
   return (
     <>
@@ -64,6 +70,8 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = ({
           title={text.titel}
           icon={<RioolwaterMonitoring />}
           subtitle={text.pagina_toelichting}
+          title={messageString('intro:title')}
+          subtitle={messageString('intro:description')}
           metadata={{
             datumsText: text.datums,
             dateOrRange: {

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -32,6 +32,7 @@ import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
   createGetContent,
+  createGetMessages,
   getLastGeneratedDate,
   getNlData,
 } from '~/static-props/get-data';
@@ -45,6 +46,7 @@ import {
   DateRange,
   getTrailingDateRange,
 } from '~/utils/get-trailing-date-range';
+import { formatMessages } from '~/utils/messages/format-messages';
 
 const text = siteText.ziekenhuisopnames_per_dag;
 const graphDescriptions = siteText.accessibility.grafieken;
@@ -58,11 +60,12 @@ export const getStaticProps = createGetStaticProps(
   }),
   createGetContent<{
     articles?: ArticleSummary[];
-  }>(createPageArticlesQuery('hospitalPage'))
+  }>(createPageArticlesQuery('hospitalPage')),
+  createGetMessages(['hospitalPage'])
 );
 
 const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, content } = props;
+  const { data, choropleth, content, messages } = props;
   const router = useRouter();
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'region'
@@ -75,6 +78,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
   const underReportedRange = getTrailingDateRange(dataHospitalNice.values, 4);
 
   const bedsLastValue = getLastFilledValue(data.hospital_lcps);
+
+  const { messageString, messageBlock } = formatMessages(messages);
 
   const lcpsOldDataRange = [
     createDate(dataHospitalLcps.values[0].date_unix),
@@ -89,13 +94,13 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
       />
       <TileList>
         <ContentHeader
-          category={siteText.nationaal_layout.headings.ziekenhuizen}
+          category={messageString('intro:category')}
           screenReaderCategory={
             siteText.ziekenhuisopnames_per_dag.titel_sidebar
           }
-          title={text.titel}
+          title={messageString('intro:title')}
           icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
+          subtitle={messageBlock('intro:description')}
           metadata={{
             datumsText: text.datums,
             dateOrRange: lastValueNice.date_unix,
@@ -109,8 +114,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
         <TwoKpiSection>
           <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+            title={messageString('barscale:title')}
+            description={messageString('barscale:description')}
             metadata={{
               date: lastValueNice.date_unix,
               source: text.bronnen.nice,
@@ -127,8 +132,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           </KpiTile>
 
           <KpiTile
-            title={text.kpi_bedbezetting.title}
-            description={text.kpi_bedbezetting.description}
+            title={messageString('badbezetting_kpi:title')}
+            description={messageString('badbezetting_kpi:description')}
             metadata={{
               date: lastValueLcps.date_unix,
               source: text.bronnen.lnaz,
@@ -145,8 +150,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         </TwoKpiSection>
 
         <ChoroplethTile
-          title={text.map_titel}
-          description={text.map_toelichting}
+          title={messageString('map:title')}
+          description={messageString('map:description')}
           onChartRegionChange={setSelectedMap}
           chartRegion={selectedMap}
           legend={{
@@ -156,7 +161,7 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
                     .admissions_on_date_of_reporting
                 : regionThresholds.hospital_nice
                     .admissions_on_date_of_reporting,
-            title: text.chloropleth_legenda.titel,
+            title: messageString('map:legenda_title'),
           }}
           metadata={{
             date: lastValueNice.date_unix,
@@ -196,8 +201,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         </ChoroplethTile>
 
         <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_description}
+          title={messageString('linechart:title')}
+          description={messageString('linechart:description')}
           ariaDescription={graphDescriptions.ziekenhuisopnames}
           values={dataHospitalNice.values}
           signaalwaarde={40}
@@ -241,12 +246,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           legendItems={[
             {
               color: colors.data.primary,
-              label: text.linechart_legend_titel,
+              label: messageString('linechart:label_title'),
               shape: 'line',
             },
             {
               color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
+              label: messageString('linechart:label_underreported'),
               shape: 'square',
             },
           ]}
@@ -254,8 +259,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         />
 
         <LineChartTile
-          title={text.chart_bedbezetting.title}
-          description={text.chart_bedbezetting.description}
+          title={messageString('bedbezetting_chart:title')}
+          description={messageString('bedbezetting_chart:description')}
           values={dataHospitalLcps.values}
           linesConfig={[
             {
@@ -293,12 +298,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           legendItems={[
             {
               color: colors.data.primary,
-              label: text.chart_bedbezetting.legend_trend_label,
+              label: messageString('bedbezetting_chart:label_trend'),
               shape: 'line',
             },
             {
               color: colors.data.underReported,
-              label: text.chart_bedbezetting.legend_inaccurate_label,
+              label: messageString('bedbezetting_chart:label_underreported'),
               shape: 'square',
             },
           ]}

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -27,12 +27,14 @@ import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
   createGetContent,
+  createGetMessages,
   getLastGeneratedDate,
   getVrData,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { formatDateFromMilliseconds } from '~/utils/formatDate';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { formatMessages } from '~/utils/messages/format-messages';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
 export { getStaticPaths } from '~/static-paths/vr';
@@ -45,20 +47,23 @@ export const getStaticProps = createGetStaticProps(
   }),
   createGetContent<{
     articles?: ArticleSummary[];
-  }>(createPageArticlesQuery('hospitalPage'))
+  }>(createPageArticlesQuery('hospitalPage')),
+  createGetMessages(['hospitalPage'])
 );
 
 const text = siteText.veiligheidsregio_ziekenhuisopnames_per_dag;
 const graphDescriptions = siteText.accessibility.grafieken;
 
 const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, safetyRegionName, choropleth, content } = props;
+  const { data, safetyRegionName, choropleth, content, messages } = props;
   const router = useRouter();
 
   const lastValue = data.hospital_nice.last_value;
 
   const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
+
+  const { messageString, messageBlock } = formatMessages(messages);
 
   const underReportedRange = getTrailingDateRange(data.hospital_nice.values, 4);
 
@@ -75,12 +80,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
       <TileList>
         <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.ziekenhuizen}
-          title={replaceVariablesInText(text.titel, {
+          category={messageString('intro:category')}
+          title={replaceVariablesInText(messageString('intro:title'), {
             safetyRegion: safetyRegionName,
           })}
           icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
+          subtitle={messageBlock('intro:description')}
           metadata={{
             datumsText: text.datums,
             dateOrRange: lastValue.date_unix,
@@ -94,8 +99,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
         <TwoKpiSection>
           <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+            title={messageString('barscale:title')}
+            description={messageString('barscale:description')}
             metadata={{
               date: lastValue.date_unix,
               source: text.bronnen.rivm,
@@ -112,14 +117,14 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
         </TwoKpiSection>
 
         <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
+          title={replaceVariablesInText(messageString('map:title'), {
             safetyRegion: safetyRegionName,
           })}
-          description={text.map_toelichting}
+          description={messageString('map:description')}
           legend={{
             thresholds:
               municipalThresholds.hospital_nice.admissions_on_date_of_reporting,
-            title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
+            title: messageString('map:legenda_title'),
           }}
           metadata={{
             date: lastValue.date_unix,
@@ -146,8 +151,8 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
         <LineChartTile
           metadata={{ source: text.bronnen.rivm }}
-          title={text.linechart_titel}
-          description={text.linechart_description}
+          title={messageString('linechart:title')}
+          description={messageString('linechart:description')}
           ariaDescription={graphDescriptions.ziekenhuis_opnames}
           values={data.hospital_nice.values}
           formatTooltip={(values) => {
@@ -189,12 +194,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           legendItems={[
             {
               color: colors.data.primary,
-              label: text.linechart_legend_titel,
+              label: messageString('linechart:label_title'),
               shape: 'line',
             },
             {
               color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
+              label: messageString('linechart:label_underreported'),
               shape: 'square',
             },
           ]}

--- a/packages/app/src/test.ts
+++ b/packages/app/src/test.ts
@@ -1,0 +1,18 @@
+import { defineMessages, defineMessage } from 'react-intl';
+
+function foo(name: string) {
+  const msg = defineMessage({
+    defaultMessage: 'Foo bar ' + name,
+    description: 'Foo desc ' + name,
+  });
+  return msg.defaultMessage;
+}
+
+console.log(foo('Arjan'));
+console.log(foo('Martier'));
+console.log(foo('Norriz'));
+
+defineMessage({
+  defaultMessage: 'Foo bar kmewk',
+  description: 'Foo bar lols',
+});

--- a/packages/app/src/utils/messages/format-messages.tsx
+++ b/packages/app/src/utils/messages/format-messages.tsx
@@ -1,0 +1,16 @@
+import { RichContent } from '~/components-styled/cms/rich-content';
+
+export function formatMessages(messages: any[]) {
+  console.log(messages);
+  return {
+    messageString: (id: string) => {
+      const safeKey: any = id.replace(/\:/g, '_');
+      return messages[safeKey] ?? id;
+    },
+    messageBlock: (id: string) => {
+      const safeKey: any = id.replace(/\:/g, '_');
+      const components = <RichContent blocks={messages[safeKey]} />;
+      return components ?? <>{id}</>;
+    },
+  };
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,9 +22,13 @@
     "validate-json": "ts-node src/validate-schema/validate-all.ts",
     "validate-single": "ts-node src/validate-schema/validate-single.ts",
     "validate-last-values": "ts-node src/validate-last-values/index.ts",
-    "generate-typescript": "ts-node src/generate-typescript.ts"
+    "generate-typescript": "ts-node src/generate-typescript.ts",
+    "messages:interfaces": "ts-node src/messages/generate-typescript-interfaces.ts",
+    "messages:schemas": "ts-node src/messages/generate-sanity-schemas.ts",
+    "messages": "yarn messages:interfaces && yarn messages:schemas"
   },
   "devDependencies": {
-    "@types/meow": "^5.0.0"
+    "@types/meow": "^5.0.0",
+    "file-set": "^4.0.1"
   }
 }

--- a/packages/cli/src/messages/generate-sanity-schemas.ts
+++ b/packages/cli/src/messages/generate-sanity-schemas.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+
+// The directory where the resulting data.d.ts file will be saved
+const outputDirectory = path.join(
+  __dirname,
+  '..', // messages
+  '..', // cli
+  '..', // packages
+  'cms',
+  'src',
+  'schemas',
+  'messages'
+);
+
+const appBasePath = path.join(
+  __dirname,
+  '..',
+  '..', // cli
+  '..', // packages
+  'app'
+);
+
+interface RawMessage {
+  type: 'String' | 'Block';
+  name: string;
+}
+
+const appMessagesDirectory = path.join(appBasePath, 'src', 'messages');
+
+const messageInterfaces = fs.readdirSync(appMessagesDirectory);
+
+const promisedOperations = messageInterfaces.map((fileName) =>
+  generateSchemaForInterface(appMessagesDirectory, fileName)
+);
+
+Promise.all(promisedOperations).then(writeDefinitionsToFile, (err) => {
+  console.error(err.message);
+  process.exit(1);
+});
+
+function generateSchemaForInterface(dir: string, fileName: string) {
+  const contents = fs.readFileSync(path.join(dir, fileName), {
+    encoding: 'utf8',
+  });
+  const PATTERN = /([a-zA-Z_]+|'[a-zA-Z0-9:_]+')(?::\sMessage(String|Block))/g;
+  const matches = [...contents.matchAll(PATTERN)];
+  const messages = matches.map((m) => ({
+    type: m[2] as 'String' | 'Block',
+    name: m[1],
+  }));
+
+  const schema = getSchemaCode(messages);
+
+  const newFileName = fileName.split('.')[0] + '.ts';
+
+  const outputFile = path.join(outputDirectory, newFileName);
+  fs.writeFileSync(outputFile, schema, {
+    encoding: 'utf8',
+  });
+  console.log(`Written: ${newFileName}`);
+  return Promise.resolve(schema);
+}
+
+function writeDefinitionsToFile(a: any) {}
+
+function getSchemaCode(messages: RawMessage[]) {
+  const fieldsetNames = getFieldsetNames(messages);
+  const fields = getSchemaFields(messages);
+  const fieldsets = getSchemaFieldssets(fieldsetNames);
+
+  return `
+  /* AUTO GENERATED ; DO NOT EDIT MANUALLY*/
+  const MESSAGES = {
+    name: 'messages',
+    type: 'object',
+    fieldsets: [
+      ${fieldsets.join(',')}
+    ] ,
+    fields: [
+
+      ${fields.join(',')}
+    ]
+  }
+  export default MESSAGES;
+    `;
+}
+
+function getSchemaFields(messages: RawMessage[]) {
+  return messages.map((m) => {
+    return `        {
+      fieldset: '${m.name
+        .replace(/'/g, '')
+        .split(':')[0]
+        .replace(/[^a-zA-Z0-9_]/g, '_')}',
+      name: '${m.name.replace(/'/g, '').replace(/[^a-zA-Z0-9_]/g, '_')}',
+      type: 'locale${m.type}',
+    }`;
+  });
+}
+function getSchemaFieldssets(fieldsetNames: string[]) {
+  return fieldsetNames.map((f) => {
+    return `{
+      title: '${f.replace(/[^a-zA-Z0-9_]/g, ' ')}',
+      name: '${f.replace(/[^a-zA-Z0-9_]/g, '_')}',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    }`;
+  });
+}
+
+function getFieldsetNames(messages: RawMessage[]) {
+  return messages
+    .map((m) => {
+      return m.name.replace(/'/g, '').split(':')[0];
+    })
+    .filter((elm, i, arr) => {
+      return arr.indexOf(elm) === i;
+    });
+}

--- a/packages/cli/src/messages/generate-typescript-interfaces.ts
+++ b/packages/cli/src/messages/generate-typescript-interfaces.ts
@@ -1,0 +1,112 @@
+const FileSet = require('file-set');
+import fs from 'fs';
+import path from 'path';
+
+interface RawMessage {
+  type: 'String' | 'Block';
+  capture: string;
+}
+
+const appBasePath = path.join(
+  __dirname,
+  '..',
+  '..', // cli
+  '..', // packages
+  'app'
+);
+
+const interfaceDir = path.join(appBasePath, 'src', 'messages');
+
+const typescriptFiles = new FileSet(
+  path.join(appBasePath, 'src', 'pages', '**', '*.tsx')
+);
+
+processFiles();
+
+function processFiles() {
+  const rawBuckerts = typescriptFiles.files.map(processFile);
+  const buckets: Record<string, RawMessage[]> = {};
+
+  rawBuckerts.filter(Boolean).forEach((rawBucket: any) => {
+    if (buckets[rawBucket.bucket]) {
+      buckets[rawBucket.bucket].push(...rawBucket.messages);
+      return;
+    }
+    buckets[rawBucket.bucket] = rawBucket.messages;
+  });
+
+  Object.keys(buckets).forEach((bucketName) => {
+    writeFileForBucket(bucketName, buckets[bucketName]);
+  });
+}
+
+function processFile(filePath: string) {
+  const contents = fs.readFileSync(filePath, {
+    encoding: 'utf8',
+  });
+
+  const bucket = contents.match(/createGetMessages\(\['([^\]]+)'\]\)/)?.[1];
+
+  if (!bucket) {
+    return false;
+  }
+
+  const PATTERN = /message(String|Block)\(([^)]+)/g;
+  const matches = [...contents.matchAll(PATTERN)];
+  const messages: RawMessage[] = matches.map((m) => ({
+    type: m[1] as 'String' | 'Block',
+    capture: m[2],
+  }));
+
+  return {
+    bucket,
+    messages,
+  };
+}
+
+function writeFileForBucket(name: string, messages: RawMessage[]) {
+  const uniqueMessages = messages.filter(
+    (x, i) => messages.findIndex((y) => x.capture === y.capture) === i
+  );
+
+  const banner = `/* Auto generated! */
+type MessageString = string;
+type MessageBlock = any[];`;
+
+  // de-dupe
+  const formattedName = name[0].toUpperCase() + name.substr(1);
+  const interfaces = formatInterfaces(formattedName, uniqueMessages);
+  const stringKeys = formatStringKeys(formattedName, uniqueMessages);
+  const blockKeys = formatBlockKeys(formattedName, uniqueMessages);
+
+  const contents = [banner, interfaces, stringKeys, blockKeys].join('\n\n\n');
+
+  const outputFile = path.join(interfaceDir, `${name}.type.ts`);
+
+  fs.writeFileSync(outputFile, contents, {
+    encoding: 'utf8',
+  });
+  console.log(`Written: ${name}.type.ts`);
+}
+
+function formatInterfaces(name: string, messages: RawMessage[]) {
+  const lines = messages.map((m) => {
+    return `${m.capture}: Message${m.type};`;
+  });
+  return [`export interface ${name} {`, ...lines, `}`].join('\n');
+}
+
+function formatStringKeys(name: string, messages: RawMessage[]) {
+  const keys = messages
+    .filter((x) => x.type === 'String')
+    .map((x) => x.capture);
+  return [`export const ${name}StringKeys = [`, keys.join(',\n'), `]`].join(
+    '\n'
+  );
+}
+function formatBlockKeys(name: string, messages: RawMessage[]) {
+  const keys = messages.filter((x) => x.type === 'Block').map((x) => x.capture);
+  return [`export const ${name}BlockKeys = [`, keys.join(',\n'), `]`].join(
+    '\n'
+  );
+}

--- a/packages/cms/src/plugins/translate/select-language.js
+++ b/packages/cms/src/plugins/translate/select-language.js
@@ -88,5 +88,7 @@ function findLocaleFields(documentId, schema) {
   if (!docSchema) {
     return true;
   }
+  return true;
+  // @TODO fix
   return docSchema.fields.some((field) => field.type.startsWith('locale'));
 }

--- a/packages/cms/src/schemas/documents/pages/hospital-page.ts
+++ b/packages/cms/src/schemas/documents/pages/hospital-page.ts
@@ -1,8 +1,17 @@
 import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
+import MESSAGES from '../../messages/hospitalPage';
 
 export default {
   title: 'Ziekenhuis opnames',
   name: 'hospitalPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLES],
+  fields: [
+    HIGHLIGHTED_ARTICLES,
+    MESSAGES,
+    {
+      name: 'messageExceptions',
+      type: 'array',
+      of: [{ type: 'messageException' }],
+    },
+  ],
 };

--- a/packages/cms/src/schemas/documents/pages/positive-tests-page.ts
+++ b/packages/cms/src/schemas/documents/pages/positive-tests-page.ts
@@ -1,8 +1,9 @@
 import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
+import MESSAGES from '../../messages/positiveTestsPage';
 
 export default {
   title: 'Positieve testen',
   name: 'positiveTestsPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLES],
+  fields: [HIGHLIGHTED_ARTICLES, MESSAGES],
 };

--- a/packages/cms/src/schemas/documents/pages/sewer-page.ts
+++ b/packages/cms/src/schemas/documents/pages/sewer-page.ts
@@ -1,8 +1,9 @@
 import { HIGHLIGHTED_ARTICLES } from '../fields/highlighted-articles';
+import MESSAGES from '../../messages/sewerPage';
 
 export default {
   title: 'Rioolwater pagina',
   name: 'sewerPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLES],
+  fields: [HIGHLIGHTED_ARTICLES, MESSAGES],
 };

--- a/packages/cms/src/schemas/messages/hospitalPage.ts
+++ b/packages/cms/src/schemas/messages/hospitalPage.ts
@@ -1,0 +1,129 @@
+
+  /* AUTO GENERATED ; DO NOT EDIT MANUALLY*/
+  const MESSAGES = {
+    name: 'messages',
+    type: 'object',
+    fieldsets: [
+      {
+      title: 'intro',
+      name: 'intro',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'barscale',
+      name: 'barscale',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'map',
+      name: 'map',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'linechart',
+      name: 'linechart',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'badbezetting_kpi',
+      name: 'badbezetting_kpi',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'bedbezetting_chart',
+      name: 'bedbezetting_chart',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    }
+    ] ,
+    fields: [
+
+              {
+      fieldset: 'intro',
+      name: 'intro_category',
+      type: 'localeString',
+    },        {
+      fieldset: 'intro',
+      name: 'intro_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'intro',
+      name: 'intro_description',
+      type: 'localeBlock',
+    },        {
+      fieldset: 'barscale',
+      name: 'barscale_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'barscale',
+      name: 'barscale_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'map',
+      name: 'map_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'map',
+      name: 'map_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'linechart',
+      name: 'linechart_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'linechart',
+      name: 'linechart_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'linechart',
+      name: 'linechart_label_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'linechart',
+      name: 'linechart_label_underreported',
+      type: 'localeString',
+    },        {
+      fieldset: 'badbezetting_kpi',
+      name: 'badbezetting_kpi_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'badbezetting_kpi',
+      name: 'badbezetting_kpi_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'map',
+      name: 'map_legenda_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'bedbezetting_chart',
+      name: 'bedbezetting_chart_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'bedbezetting_chart',
+      name: 'bedbezetting_chart_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'bedbezetting_chart',
+      name: 'bedbezetting_chart_label_trend',
+      type: 'localeString',
+    },        {
+      fieldset: 'bedbezetting_chart',
+      name: 'bedbezetting_chart_label_underreported',
+      type: 'localeString',
+    }
+    ]
+  }
+  export default MESSAGES;
+    

--- a/packages/cms/src/schemas/messages/index.ts
+++ b/packages/cms/src/schemas/messages/index.ts
@@ -1,0 +1,15 @@
+
+  /* AUTO GENERATED ; DO NOT EDIT MANUALLY*/
+  const MESSAGES = {
+    name: 'messages',
+    type: 'object',
+    fieldsets: [
+      
+    ] ,
+    fields: [
+
+      
+    ]
+  }
+  export default MESSAGES;
+    

--- a/packages/cms/src/schemas/messages/positiveTestsPage.ts
+++ b/packages/cms/src/schemas/messages/positiveTestsPage.ts
@@ -1,0 +1,64 @@
+
+  /* AUTO GENERATED ; DO NOT EDIT MANUALLY*/
+  const MESSAGES = {
+    name: 'messages',
+    type: 'object',
+    fieldsets: [
+      {
+      title: 'intro',
+      name: 'intro',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'infected_delta_kpi',
+      name: 'infected_delta_kpi',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },{
+      title: 'barscale',
+      name: 'barscale',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    }
+    ] ,
+    fields: [
+
+              {
+      fieldset: 'intro',
+      name: 'intro_category',
+      type: 'localeString',
+    },        {
+      fieldset: 'intro',
+      name: 'intro_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'intro',
+      name: 'intro_description',
+      type: 'localeString',
+    },        {
+      fieldset: 'infected_delta_kpi',
+      name: 'infected_delta_kpi_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'infected_delta_kpi',
+      name: 'infected_delta_kpi_description',
+      type: 'localeBlock',
+    },        {
+      fieldset: 'barscale',
+      name: 'barscale_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'barscale',
+      name: 'barscale_description',
+      type: 'localeBlock',
+    }
+    ]
+  }
+  export default MESSAGES;
+    

--- a/packages/cms/src/schemas/messages/sewerPage.ts
+++ b/packages/cms/src/schemas/messages/sewerPage.ts
@@ -1,0 +1,30 @@
+
+  /* AUTO GENERATED ; DO NOT EDIT MANUALLY*/
+  const MESSAGES = {
+    name: 'messages',
+    type: 'object',
+    fieldsets: [
+      {
+      title: 'intro',
+      name: 'intro',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    }
+    ] ,
+    fields: [
+
+              {
+      fieldset: 'intro',
+      name: 'intro_title',
+      type: 'localeString',
+    },        {
+      fieldset: 'intro',
+      name: 'intro_description',
+      type: 'localeString',
+    }
+    ]
+  }
+  export default MESSAGES;
+    

--- a/packages/cms/src/schemas/objects/message-exception.ts
+++ b/packages/cms/src/schemas/objects/message-exception.ts
@@ -1,0 +1,16 @@
+export default {
+  title: 'Default',
+  name: 'messageException',
+  type: 'object',
+  fields: [
+    { name: 'match', type: 'string', title: 'Match' },
+    { name: 'field', type: 'string', title: 'Veld' },
+    { name: 'value', type: 'localeString', title: 'Waarde' },
+  ],
+  preview: {
+    select: {
+      title: 'match',
+      subtitle: 'field',
+    },
+  },
+};

--- a/packages/cms/src/schemas/objects/message-string-exception.ts
+++ b/packages/cms/src/schemas/objects/message-string-exception.ts
@@ -1,0 +1,14 @@
+export default {
+  title: 'Default',
+  name: 'messageStringException',
+  type: 'object',
+  fields: [
+    { name: 'match', type: 'string', title: 'Match' },
+    { name: 'value', type: 'localeString', title: 'Waarde' },
+  ],
+  preview: {
+    select: {
+      title: 'match',
+    },
+  },
+};

--- a/packages/cms/src/schemas/objects/message-string.ts
+++ b/packages/cms/src/schemas/objects/message-string.ts
@@ -1,0 +1,19 @@
+export default {
+  title: 'Default',
+  name: 'messageString',
+  type: 'object',
+  fields: [
+    { name: 'value', type: 'localeString', title: 'Waarde' },
+    {
+      name: 'exceptions',
+      type: 'array',
+      title: 'Overschrijvingen',
+      of: [{ type: 'messageStringException' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'value.nl',
+    },
+  },
+};

--- a/packages/cms/src/schemas/schema.ts
+++ b/packages/cms/src/schemas/schema.ts
@@ -31,7 +31,11 @@ import localeText from './locale/locale-text';
 //objects are building blocks, but not queryable in itself
 import collapsible from './objects/collapsible';
 import lineChart from './objects/line-chart';
+<<<<<<< HEAD
 import milestone from './objects/milestone';
+=======
+import messageException from './objects/message-exception';
+>>>>>>> b0c91b00... poc messages
 import lockdown from './restrictions/lockdown';
 import restriction from './restrictions/restriction';
 import restrictionCategory from './restrictions/restriction-category';
@@ -77,7 +81,11 @@ export default createSchema({
     /* OBJECTS */
     lineChart,
     collapsible,
+<<<<<<< HEAD
     milestone,
+=======
+    messageException,
+>>>>>>> b0c91b00... poc messages
 
     /* LOCALE HELPERS */
     localeString,

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0":
   version "7.13.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.4.tgz#340211b0da94a351a6f10e63671fa727333d13ab"
   integrity sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
@@ -1012,7 +1012,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.12.6", "@babel/types@^7.13.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.12.6", "@babel/types@^7.13.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.0.tgz#74424d2816f0171b4100f0ab34e9a374efdf7f80"
   integrity sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==
@@ -1126,11 +1126,49 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/cli@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@formatjs/cli/-/cli-3.1.6.tgz#a5547c919e36032811a86f82d84fa681ce23a0aa"
+  integrity sha512-r2GDGlmlGfXI3pv7/IrK9iSOwvNir9gVINNvyvP8mTZ5+px/WbXGn/79gB/q6DXYoeMkoi7k7Lp8DPhRrKxwfg==
+  dependencies:
+    "@formatjs/ts-transformer" "3.2.0"
+    "@types/json-stable-stringify" "^1.0.32"
+    "@types/lodash" "^4.14.150"
+    "@types/loud-rejection" "^2.0.0"
+    "@types/node" "14"
+    "@vue/compiler-core" "^3.0.0"
+    "@vue/compiler-sfc" "^3.0.5"
+    chalk "^4.0.0"
+    commander "7"
+    fast-glob "^3.2.4"
+    fs-extra "^9.0.0"
+    intl-messageformat-parser "6.4.2"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.15"
+    loud-rejection "^2.2.0"
+    tslib "^2.1.0"
+    typescript "^4.0"
+
 "@formatjs/ecma402-abstract@1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.1.tgz#05eb0d879a00509525818e89ef2a0a833aa52b27"
   integrity sha512-GQJ+mK4rrbpdXjFzwK/5NIalxBOjCLI4ZuCCvReLQGwq1ICViIIgLQw1wP95doZFjH5Y9WaQ8Zzl8+A9IkxAsQ==
   dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/ecma402-abstract@1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.2.tgz#9d064a2cf790769aa6721e074fb5d5c357084bb9"
+  integrity sha512-aLBODrSRhHaL/0WdQ0T2UsGqRbdtRRHqqrs4zwNQoRsGBEtEAvlj/rgr6Uea4PSymVJrbZBoAyECM2Z3Pq4i0g==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/intl-datetimeformat@3.2.12":
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-datetimeformat/-/intl-datetimeformat-3.2.12.tgz#c9b2e85f0267ee13ea615a8991995da3075e3b13"
+  integrity sha512-qvY5+dl3vlgH0iWRXwl8CG9UkSVB5uP2+HH//fyZZ01G4Ww5rxMJmia1SbUqatpoe/dX+Z+aLejCqUUyugyL2g==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
     tslib "^2.1.0"
 
 "@formatjs/intl-datetimeformat@^3.2.7":
@@ -1141,12 +1179,28 @@
     "@formatjs/ecma402-abstract" "1.6.1"
     tslib "^2.1.0"
 
+"@formatjs/intl-displaynames@4.0.10":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-4.0.10.tgz#5bbd1bbcd64a036b4be27798b650c864dcf4466a"
+  integrity sha512-KmYJQHynGnnMeqIWVXhbzCMcEC8lg1TfGVdcO9May6paDT+dksZoOBQc741t7iXi/YVO/wXEZdmXhUNX7ODZug==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
+    tslib "^2.1.0"
+
 "@formatjs/intl-getcanonicallocales@1.5.5", "@formatjs/intl-getcanonicallocales@^1.4.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.5.tgz#fd92b7d38b013c5ea505c0db011126e17aa56b40"
   integrity sha512-Q8nhZcA8hjtQiHukvNON5HK9vJOe9f55mv18qpRA9fy/5IHD8N0khEfWiC0TzYVK0pvhkL0x2W+gJjn4JeqSuw==
   dependencies:
     cldr-core "38"
+    tslib "^2.1.0"
+
+"@formatjs/intl-listformat@5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-5.0.10.tgz#9f8c4ad5e8a925240e151ba794c41fba01f742cc"
+  integrity sha512-FLtrtBPfBoeteRlYcHvThYbSW2YdJTllR0xEnk6cr/6FRArbfPRYMzDpFYlESzb5g8bpQMKZy+kFQ6V2Z+5KaA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
     tslib "^2.1.0"
 
 "@formatjs/intl-locale@^2.4.14":
@@ -1158,6 +1212,38 @@
     "@formatjs/intl-getcanonicallocales" "1.5.5"
     cldr-core "38"
     tslib "^2.1.0"
+
+"@formatjs/intl-relativetimeformat@8.1.2":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-8.1.2.tgz#119f3dce97458991f86bf34a736880e4a7bc1697"
+  integrity sha512-LZUxbc9GHVGmDc4sqGAXugoxhvZV7EG2lG2c0aKERup2ixvmDMbbEN3iEEr5aKkP7YyGxXxgqDn2dwg7QCPR6Q==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
+    tslib "^2.1.0"
+
+"@formatjs/intl@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl/-/intl-1.8.2.tgz#6090e6c1826a92e70668dfe08b4ba30127ea3a85"
+  integrity sha512-9xHoNKPv4qQIQ5AVfpQbIPZanz50i7oMtZWrd6Fz7Q2GM/5uhBr9mrCrY1tz/+diP7uguKmhj1IweLYaxY3DTQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
+    "@formatjs/intl-datetimeformat" "3.2.12"
+    "@formatjs/intl-displaynames" "4.0.10"
+    "@formatjs/intl-listformat" "5.0.10"
+    "@formatjs/intl-relativetimeformat" "8.1.2"
+    fast-memoize "^2.5.2"
+    intl-messageformat "9.5.2"
+    intl-messageformat-parser "6.4.2"
+    tslib "^2.1.0"
+
+"@formatjs/ts-transformer@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/ts-transformer/-/ts-transformer-3.2.0.tgz#fdd3617347f023cbe3dad91713240d39bb139eca"
+  integrity sha512-T1mf72VaqPcARMSbAxRogXTd58gBF3R87oApCvMtXLJR2AIuSX7fnia/2A//f4dmq4qDetcvEmetlvwz0b5dbw==
+  dependencies:
+    intl-messageformat-parser "6.4.2"
+    tslib "^2.1.0"
+    typescript "^4.0"
 
 "@hapi/accept@5.0.1":
   version "5.0.1"
@@ -2765,7 +2851,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/hoist-non-react-statics@*":
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -2810,6 +2896,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-stable-stringify@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
+  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
+
 "@types/linkifyjs@^2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@types/linkifyjs/-/linkifyjs-2.1.3.tgz#80195c3c88c5e75d9f660e3046ce4a42be2c2fa4"
@@ -2817,10 +2908,17 @@
   dependencies:
     "@types/react" "*"
 
-"@types/lodash@^4.14.146", "@types/lodash@^4.14.149", "@types/lodash@^4.14.160", "@types/lodash@^4.14.165":
+"@types/lodash@^4.14.146", "@types/lodash@^4.14.149", "@types/lodash@^4.14.150", "@types/lodash@^4.14.160", "@types/lodash@^4.14.165":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
+"@types/loud-rejection@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/loud-rejection/-/loud-rejection-2.0.0.tgz#271bb21c63f51776e1156604cda3b21a2d3f60f3"
+  integrity sha512-oTHISsIybJGoh3b3Ay/10csbAd2k0su7G7DGrE1QWciC+IdydPm0WMw1+Gr9YMYjPiJ5poB3g5Ev73IlLoavLw==
+  dependencies:
+    loud-rejection "*"
 
 "@types/match-sorter@^6.0.0":
   version "6.0.0"
@@ -2873,7 +2971,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.14.25":
+"@types/node@*", "@types/node@14", "@types/node@^14.14.25":
   version "14.14.31"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
   integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
@@ -3333,6 +3431,60 @@
     classnames "^2.2.5"
     d3-voronoi "^1.1.2"
     prop-types "^15.6.1"
+
+"@vue/compiler-core@3.0.6", "@vue/compiler-core@^3.0.0":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.6.tgz#265bbe0711a81ab4c1344f8294e22e2d08ca167d"
+  integrity sha512-O7QzQ39DskOoPpEDWRvKwDX7Py9UNT7SvLHvBdIfckGA3OsAEBdiAtuYQNcVmUDeBajm+08v5wyvHWBbWgkilQ==
+  dependencies:
+    "@babel/parser" "^7.12.0"
+    "@babel/types" "^7.12.0"
+    "@vue/shared" "3.0.6"
+    estree-walker "^2.0.1"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.6.tgz#f94c3959320a1252915bd02b943f96a7ee3fc951"
+  integrity sha512-q1wfHzYwvDRAhBlx+Qa+n3Bu5nHr1qL/j0UbpNlbQDwIlt9zpvmXUrUCL+i55Bh5lLKvSe+mNo0qlwNEApm+jA==
+  dependencies:
+    "@vue/compiler-core" "3.0.6"
+    "@vue/shared" "3.0.6"
+
+"@vue/compiler-sfc@^3.0.5":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.6.tgz#3945f73a93d52868799f1e332a75bb8849976ac9"
+  integrity sha512-g1tkswnhtiJpj4ELQ3SzeGxtOd0t8E5GkT+n2VlElEnTI1BzueSvr41D5QthnUS+TNWZd52ZnPtdaNz+Lfum1w==
+  dependencies:
+    "@babel/parser" "^7.12.0"
+    "@babel/types" "^7.12.0"
+    "@vue/compiler-core" "3.0.6"
+    "@vue/compiler-dom" "3.0.6"
+    "@vue/compiler-ssr" "3.0.6"
+    "@vue/shared" "3.0.6"
+    consolidate "^0.16.0"
+    estree-walker "^2.0.1"
+    hash-sum "^2.0.0"
+    lru-cache "^5.1.1"
+    magic-string "^0.25.7"
+    merge-source-map "^1.1.0"
+    postcss "^8.1.10"
+    postcss-modules "^4.0.0"
+    postcss-selector-parser "^6.0.4"
+    source-map "^0.6.1"
+
+"@vue/compiler-ssr@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.6.tgz#7156361e4c465cbee2723275edc61e940678e47c"
+  integrity sha512-Y4amPwRevUiiNQDho0cq1Ith9q6UU5N6CD6YiXkHIboFPeXEiGvH3ULJWjFzlGqn1eUV1AReNJpFJrhjtQNc7g==
+  dependencies:
+    "@vue/compiler-dom" "3.0.6"
+    "@vue/shared" "3.0.6"
+
+"@vue/shared@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.6.tgz#d65576430fc4ad383dc7c829118798e5169178d4"
+  integrity sha512-c37C60HpelUZIx+SNZVEINSxkFzQYhIXFg5AynnIA4QDBmY4iSPoACfGSwSUTCTKImukPeCgY2oqRJVP3R1Mnw==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -3863,6 +4015,11 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.1.tgz#9b80312935a52062e1a233a9c7abeb5481b30e90"
+  integrity sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -5330,6 +5487,11 @@ commander@2, commander@^2.20.0, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@7:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
 commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
@@ -5436,6 +5598,13 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+consolidate@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.16.0.tgz#a11864768930f2f19431660a65906668f5fbdc16"
+  integrity sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==
+  dependencies:
+    bluebird "^3.7.2"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -7214,6 +7383,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -7548,7 +7722,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3, fast-glob@^3.1.1:
+fast-glob@^3.0.3, fast-glob@^3.1.1, fast-glob@^3.2.4:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
   integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
@@ -7569,6 +7743,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-memoize@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
+  integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
 
 fastparse@^1.1.2:
   version "1.1.2"
@@ -7662,6 +7841,14 @@ file-loader@^1.1.4:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
+
+file-set@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/file-set/-/file-set-4.0.1.tgz#d8a4485a89c8db7ca414f05a043bce44a2d6a913"
+  integrity sha512-tRzX4kGPmxS2HDK2q2L4qcPopTl/gcyahve2/O8l8hHNJgJ7m+r/ZncCJ1MmFWEMp1yHxJGIU9gAcsWu5jPMpg==
+  dependencies:
+    array-back "^4.0.1"
+    glob "^7.1.6"
 
 file-type@5.2.0, file-type@^5.2.0:
   version "5.2.0"
@@ -7998,7 +8185,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -8098,6 +8285,13 @@ generic-names@^1.0.1:
   integrity sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=
   dependencies:
     loader-utils "^0.2.16"
+
+generic-names@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
+  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
+  dependencies:
+    loader-utils "^1.1.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -8583,6 +8777,11 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
+hash-sum@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
+  integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
+
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
@@ -8694,7 +8893,7 @@ hoist-non-react-statics@^2.1.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8891,6 +9090,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+icss-utils@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
 identity-obj-proxy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
@@ -9074,6 +9278,23 @@ intl-messageformat-parser@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz#b43d45a97468cadbe44331d74bb1e8dea44fc075"
   integrity sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU=
+
+intl-messageformat-parser@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-6.4.2.tgz#e2d28c3156c27961ead9d613ca55b6a155078d7d"
+  integrity sha512-IVNGy24lNEYr/KPWId5tF3KXRHFFbMgzIMI4kUonNa/ide2ywUYyBuOUro1IBGZJqjA2ncBVUyXdYKlMfzqpAA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
+    tslib "^2.1.0"
+
+intl-messageformat@9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-9.5.2.tgz#e72d32152c760b7411e413780e462909987c005a"
+  integrity sha512-sBGXcSQLyBuBA/kzAYhTpzhzkOGfSwGIau2W6FuwLZk0JE+VF3C+y0077FhVDOcRSi60iSfWzT8QC3Z7//dFxw==
+  dependencies:
+    fast-memoize "^2.5.2"
+    intl-messageformat-parser "6.4.2"
+    tslib "^2.1.0"
 
 intl-messageformat@^2.0.0, intl-messageformat@^2.1.0:
   version "2.2.0"
@@ -10278,6 +10499,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -10317,6 +10545,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -10837,6 +11070,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loud-rejection@*, loud-rejection@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-2.2.0.tgz#4255eb6e9c74045b0edc021fa7397ab655a8517c"
+  integrity sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.2"
+
 loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -10888,6 +11129,13 @@ lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -11136,6 +11384,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -11426,7 +11681,7 @@ nano-pubsub@^2.0.0:
   resolved "https://registry.yarnpkg.com/nano-pubsub/-/nano-pubsub-2.0.0.tgz#de291f170ce54ea3e3b39f0b53296d322cd9c540"
   integrity sha512-tDJdYcRD4CIHAxB6kAWO7HWSGWODxL0buzcJHazIIrmHYDH2t7DcTN0vV7dIr39oPwZo5WawULp9CHhtYdhm0A==
 
-nanoid@^3.1.12, nanoid@^3.1.16, nanoid@^3.1.9:
+nanoid@^3.1.12, nanoid@^3.1.16, nanoid@^3.1.20, nanoid@^3.1.9:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
@@ -13085,6 +13340,11 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
+postcss-modules-extract-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
+  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+
 postcss-modules-local-by-default@^1.0.1, postcss-modules-local-by-default@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
@@ -13100,6 +13360,15 @@ postcss-modules-local-by-default@^3.0.3:
   dependencies:
     icss-utils "^4.1.1"
     postcss "^7.0.32"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-local-by-default@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
+  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+  dependencies:
+    icss-utils "^5.0.0"
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
@@ -13128,6 +13397,13 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
+postcss-modules-scope@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
+  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
 postcss-modules-values@^1.1.1, postcss-modules-values@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
@@ -13143,6 +13419,27 @@ postcss-modules-values@^3.0.0:
   dependencies:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
+
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
+
+postcss-modules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.0.0.tgz#2bc7f276ab88f3f1b0fadf6cbd7772d43b5f3b9b"
+  integrity sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==
+  dependencies:
+    generic-names "^2.0.1"
+    icss-replace-symbols "^1.1.0"
+    lodash.camelcase "^4.3.0"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
+    string-hash "^1.1.1"
 
 postcss-nesting@^4.0.1:
   version "4.2.1"
@@ -13436,7 +13733,7 @@ postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
+postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
   integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
@@ -13559,6 +13856,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.1.10:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.6.tgz#5d69a974543b45f87e464bc4c3e392a97d6be9fe"
+  integrity sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==
+  dependencies:
+    colorette "^1.2.1"
+    nanoid "^3.1.20"
+    source-map "^0.6.1"
 
 prebuild-install@^6.0.0:
   version "6.0.1"
@@ -14055,6 +14361,23 @@ react-intl@^2.2.2:
     intl-messageformat "^2.1.0"
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
+
+react-intl@^5.13.2:
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-5.13.2.tgz#b0f49c301504bed380a8468e83d28494cdb073db"
+  integrity sha512-5NbfIjmA1+35dM4pusDj3xCgc5YgN4uAQealDW32M7IC2PykPmiQy8IZbTya/hYIZGFYpFSnvU3rUVGatqokFQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.6.2"
+    "@formatjs/intl" "1.8.2"
+    "@formatjs/intl-displaynames" "4.0.10"
+    "@formatjs/intl-listformat" "5.0.10"
+    "@formatjs/intl-relativetimeformat" "8.1.2"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    fast-memoize "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    intl-messageformat "9.5.2"
+    intl-messageformat-parser "6.4.2"
+    tslib "^2.1.0"
 
 react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -15428,6 +15751,11 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
@@ -15636,7 +15964,7 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-string-hash@1.1.3:
+string-hash@1.1.3, string-hash@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
   integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
@@ -16604,7 +16932,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.2:
+typescript@^4.0, typescript@^4.1.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
   integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==


### PR DESCRIPTION
For inspiration

Noteworthy to looks at:

In `cli`:
* `yarn run messages:interfaces` creates a Typescript interface and an array of keys it has found, based on uses of `formatString(...)` and `formatBlock(...)`
* `yarn run messages:schemas` creates Sanity schema's from the interfaces created by `yarn run messages:interfaces`
* Extracting interfaces/keys now happens using rudimentary regex work, but can work well by walking through the AST using certain typescript functions.
* `yarn run messages` combines both

In `app`:
* `createGetMessages` generates a query for the provided interface / name of 'bucket' of messages.
* `formatMessages` transforms the returned messages into strings/components (for the blocks). This could be expanded later into a bit more powerful formatting, such as string replacements (for GM/VR names)
* with adjustments/naming conventions we could opt to make the use of the name `messages` solemnly for this; we could then extract replace `formatString('foo')` for `messages.foo`. (Important when extracting keys.)

In `cms`:
* Generated blocks of field configs are in `schemas/messages` and are then imported where needed.

## Adding new files / bucket


1. Include the needed code (formatString, formatBlock, createGetMessages, formatMessages) using a new name
2. `yarn run messages` in cli
3. include the generated schema on the desired page

## Adding new strings  files / bucket

1. Include the needed code (formatString, formatBlock) using an existing bucket name
2. `yarn run messages` in cli

(Also needed with this hacky code, but can be fixed to eliminate: fix interfaces import, fix empty sanity response)
