### PR TITLE
Fix sewer date rendering

### DIFF
--- a/packages/app/src/components-styled/sewer-chart/components/tooltip.tsx
+++ b/packages/app/src/components-styled/sewer-chart/components/tooltip.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import useResizeObserver from 'use-resize-observer';
 import { Box } from '~/components-styled/base';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
+import { useIsMounted } from '~/utils/use-is-mounted';
 
 type Bounds = {
   left: number;
@@ -32,19 +33,40 @@ const TooltipContainer = styled.div(
 );
 
 export function Tooltip({ children, title, x, y, bounds }: TooltipProps) {
+  const isMounted = useIsMounted({ delayMs: 1 });
   const { width = 0, height = 0, ref } = useResizeObserver<HTMLDivElement>();
 
   const left = Math.min(bounds.right - width, Math.max(0, x - width / 2));
-  const top = y - height - 20;
+  const top = y - height - 30;
+
+  /**
+   * Alternative algorithm to position the tooltip next to the point, instead
+   * of above the point. Might be useful in the future.
+   *
+   * let left = x + 20;
+   * let top = y - height / 2;
+   *
+   * left = left + width >= bounds.right ? x - width - 20 : left;
+   *
+   * if (left < bounds.left) {
+   *   left =
+   *     left < bounds.left
+   *       ? Math.min(bounds.right - width, Math.max(0, x - width / 2))
+   *       : left;
+   *
+   *   top = y - height - 20;
+   * }
+   */
 
   return (
     <TooltipContainer
       ref={ref}
       style={{
         top: 0,
+        opacity: isMounted ? 1 : 0,
         transform: `translate(${left}px,${top}px)`,
         willChange: 'transform',
-        transition: 'transform 75ms ease-out',
+        transition: `transform ${isMounted ? '75ms' : '0ms'} ease-out`,
         maxWidth: bounds.right - bounds.left,
       }}
     >

--- a/packages/app/src/components-styled/sewer-chart/logic.ts
+++ b/packages/app/src/components-styled/sewer-chart/logic.ts
@@ -13,12 +13,15 @@ export interface Dimensions {
   padding: Record<'top' | 'right' | 'bottom' | 'left', number>;
 }
 
-export interface SewerChartValue {
+export type SewerChartValue = {
   id: string;
   name: string;
   value: number;
   dateMs: number;
-}
+} & (
+  | { dateStartMs: number; dateEndMs: number }
+  | { dateStartMs?: never; dateEndMs?: never }
+);
 
 export function useSewerChartValues(
   data: Regionaal | Municipal,
@@ -38,7 +41,12 @@ export function useSewerChartValues(
             .map((x) => ({
               name: '__average',
               value: x.average,
-              dateMs: x.date_end_unix * 1000,
+              dateMs:
+                (x.date_start_unix +
+                  (x.date_end_unix - x.date_start_unix) / 2) *
+                1000,
+              dateStartMs: x.date_start_unix * 1000,
+              dateEndMs: x.date_end_unix * 1000,
             }))
             .map((x) => ({
               ...x,
@@ -269,7 +277,13 @@ export function useLineTooltip({
     });
   }
 
-  return { datum, point, findClosest: setInputPoint, clear } as const;
+  return { datum, point, findClosest: setInputPoint, clear } as {
+    findClosest: typeof setInputPoint;
+    clear: typeof clear;
+  } & (
+    | { datum: undefined; point: undefined }
+    | { datum: SewerChartValue; point: Point }
+  );
 }
 
 /**

--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -283,8 +283,17 @@ export function SewerChart(props: SewerChartProps) {
 
             {lineTooltip.point && (
               <Bar
-                x={lineTooltip.point.x - 4}
-                width={8}
+                x={
+                  lineTooltip.datum.dateStartMs
+                    ? scales.xScale(lineTooltip.datum.dateStartMs)
+                    : lineTooltip.point.x - 4
+                }
+                width={
+                  lineTooltip.datum.dateStartMs
+                    ? scales.xScale(lineTooltip.datum.dateEndMs) -
+                      scales.xScale(lineTooltip.datum.dateStartMs)
+                    : 8
+                }
                 height={dimensions.bounds.height}
                 fill="rgba(192, 232, 252, 0.5)"
                 css={css({
@@ -384,13 +393,21 @@ export function SewerChart(props: SewerChartProps) {
           </Group>
         </svg>
 
-        {lineTooltip.datum && lineTooltip.point && (
+        {lineTooltip.datum && (
           <DateTooltip
             bounds={{ left: 0, top: 0, right: width, bottom: height }}
             x={lineTooltip.point.x + dimensions.padding.left}
             y={dimensions.bounds.height + dimensions.padding.top + 2}
           >
-            {formatDate(lineTooltip.datum?.dateMs)}
+            {lineTooltip.datum.dateStartMs ? (
+              <>
+                {formatDate(lineTooltip.datum.dateStartMs, 'axis')}
+                {' – '}
+                {formatDate(lineTooltip.datum.dateEndMs, 'axis')}
+              </>
+            ) : (
+              formatDate(lineTooltip.datum.dateMs, 'axis')
+            )}
           </DateTooltip>
         )}
 
@@ -406,7 +423,10 @@ export function SewerChart(props: SewerChartProps) {
             y={lineTooltip.point.y + dimensions.padding.top}
           >
             <Box display="inline-block">
-              <b>{lineTooltip.datum.value} per 100.000</b>
+              <b>
+                {formatNumber(lineTooltip.datum.value)} per{' '}
+                {formatNumber(100_000)}
+              </b>
             </Box>{' '}
             {siteText.common.inwoners}
           </Tooltip>


### PR DESCRIPTION
## Summary

- Render the date range in the sewer chart x-axis tooltip.
- Render the vertical "hover-bar" using the start- and end date.
- Visually display tooltip after tiny delay to process dimensions and positioning of the tooltip (prevents the initial "jump" of the tooltip)
- Use number formatter when displaying numbers