### PR TITLE
Display sum of administered vaccins in tooltip

### DIFF
--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -10,6 +10,7 @@ import { Fragment } from 'react';
 import styled from 'styled-components';
 import { HoverPoint } from '~/components-styled/area-chart/components/marker';
 import { TimestampedTrendValue } from '~/components-styled/area-chart/logic';
+import { Spacer } from '~/components-styled/base';
 import { InlineText, Text } from '~/components-styled/typography';
 import { AllLanguages } from '~/locale/APP_LOCALE';
 import { formatDateFromSeconds } from '~/utils/formatDate';
@@ -90,9 +91,31 @@ function formatVaccinationsTooltip(
             )}
           </Fragment>
         ))}
+        <Spacer mb={1} />
+        <TooltipListItem color="transparent">
+          <TooltipValueContainer>
+            {text.vaccinaties.data.vaccination_chart
+              .doses_administered_total}:{' '}
+            <strong>{formatNumber(sumSubCategories(values))}</strong>
+          </TooltipValueContainer>
+        </TooltipListItem>
       </TooltipList>
     </>
   );
+}
+
+function sumSubCategories(values: HoverPoint<TooltipValue>[]) {
+  return values.reduce((acc, currentValue) => {
+    const data: any = currentValue.data;
+    if (!data.total) {
+      /**
+       * We're only interested in values with a `data` since
+       * they make up the subcategories, hence this if-statement.
+       */
+      return acc + data[currentValue.label as string];
+    }
+    return 0;
+  }, 0)
 }
 
 function formatLabel(labelKey: string | undefined, text: AllLanguages) {

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2233,7 +2233,8 @@
         },
         "legend_label": "Number of {{name}} doses administered",
         "doses_administered": "Number of doses administered",
-        "doses_administered_estimated": "Expected number of doses administered"
+        "doses_administered_estimated": "Expected number of doses administered",
+        "doses_administered_total": "Total"
       }
     },
     "current_amount_of_administrations_text": "So far approximately {{amount}} vaccine doses have been administered.",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -2233,7 +2233,8 @@
         },
         "legend_label": "Aantal gezette prikken {{name}}",
         "doses_administered": "Aantal gezette prikken",
-        "doses_administered_estimated": "Verwacht aantal gezette prikken"
+        "doses_administered_estimated": "Verwacht aantal gezette prikken",
+        "doses_administered_total": "Totaal"
       }
     },
     "current_amount_of_administrations_text": "Tot nu toe zijn er ongeveer {{amount}} prikken gezet.",


### PR DESCRIPTION
## Summary

This change displays the total amount of vaccines administered in the graph on the `/landelijk/vaccinaties` page.

![image](https://user-images.githubusercontent.com/19948032/110370501-0aae5880-804c-11eb-9299-0f213532b271.png)

## Motivation

When hovering over the graph, for each point in time the amount of either estimated or actual available vaccins is shown (yellow line). In addition the tooltip also displays the amount of vaccins actually administered, but not the total amount, just the amount _per vaccine supplier_. It would be better if the user could immediately determine the total amount of vaccines administered, across all suppliers.

## Detailed design

To implement this, I first took a look at the "willingness"-graph just under the graph this PR is about. That tooltip first shows the willingness per age category and then the overall average willingness so I think that is a good starting point. One difference with how the two graphs are implemented is that in this case the information we need (the sum of the vaccines) isn't separately provided in the data; therefore we'll have to dynamically calculate it. I added a new function to do this (`sumSubCategories()`) inside of the tooltip formatter. Just as in `formatValue()` I use the fact that the subcategories we're looking for have no `total`, and count those up. I placed a comment explaining why we only need the `total`-less values. Another way to achieve this would be to use the `values[1].data.__value` property but that may be a bit hacky too. Then I added the extra entry to the list using a spacer just as in the example graph. I labeled it as `Total`/`Totaal` and added the string to the JSON files.

## Drawbacks

I don't really see any major drawbacks but some noteworthy points:

- We shouldn't confuse the user into thinking the total listed there counts for every entry in the tooltip (e.g. the supplied vaccines as well), however I believe the bold header in the middle of the tooltip already takes care of this.
- From the other code I noticed many values aren't calculated on the spot even if it would be possible to do so, therefore this approach may be a bit different than usual. However I don't see any value in adding the total as an entire new data point (as is the case wit the example graph), but I may be missing something there.

## Alternatives

_See section above._

## Unresolved questions

_Not applicable, I believe._

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
