### PR TITLE
Fix: point 'yarn download' to right path and URL

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -134,7 +134,7 @@
     "lint": "eslint .",
     "type-check": "yarn compile",
     "compile": "tsc --pretty --noEmit",
-    "download": "download https://coronadashboard.rijksoverheid.nl/latest-data.zip -e -o public/",
+    "download": "download https://coronadashboard.rijksoverheid.nl/json/latest-data.zip -e -o public/json/",
     "clean": "rimraf .next"
   },
   "browserslist": [


### PR DESCRIPTION
## Summary

Either I did something very wrong, or the path and URL used in the `yarn download` script were outdated. If that is the case I believe this PR fixes it.

To test: remove local `public/json` folder, run `yarn download`
Expected output on `develop`: JSON files are not downloaded, since rijksoverheid.nl will return a 404
Expected output on this branch: JSON files will download correctly and get placed in correct directory

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
