### PR TITLE
Collapsable button

### DIFF
--- a/packages/app/src/components-styled/collapsible-button.tsx
+++ b/packages/app/src/components-styled/collapsible-button.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import css from '@styled-system/css';
 import styled from 'styled-components';
 
@@ -11,18 +11,34 @@ interface CollapsibleButtonProps {
 }
 
 export function CollapsibleButton({ label, children }: CollapsibleButtonProps) {
-  const [expanded, setExpanded] = useState(false);
   const { ref, height: contentHeight } = useResizeObserver();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [initialWidth, setInitialWidth] = useState(0);
+
+  useEffect(() => {
+    if (buttonRef.current) {
+      setInitialWidth(buttonRef.current.offsetWidth);
+    }
+  }, [buttonRef.current]);
 
   return (
     <Box css={css({ textAlign: 'center' })}>
-      <Container css={css({ minWidth: expanded ? '100%' : 0 })}>
-        <ExpandButton color="link" onClick={() => setExpanded(!expanded)}>
+      <Container
+        maxWidth={initialWidth ? initialWidth : undefined}
+        minWidth={expanded ? '100%' : 0}
+      >
+        <ExpandButton ref={buttonRef} onClick={() => setExpanded(!expanded)}>
           {label}
           <Chevron expanded={expanded} />
         </ExpandButton>
 
-        <Content css={css({ height: expanded ? contentHeight : 0 })}>
+        <Content
+          css={css({
+            height: expanded ? contentHeight : 0,
+            width: expanded ? '100%' : 0,
+          })}
+        >
           <div ref={ref}>{children}</div>
         </Content>
       </Container>

--- a/packages/app/src/components-styled/collapsible-button.tsx
+++ b/packages/app/src/components-styled/collapsible-button.tsx
@@ -1,6 +1,11 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import css from '@styled-system/css';
 import styled from 'styled-components';
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@reach/disclosure';
 
 import useResizeObserver from 'use-resize-observer';
 import { Box } from './base';
@@ -11,58 +16,25 @@ interface CollapsibleButtonProps {
 }
 
 export function CollapsibleButton({ label, children }: CollapsibleButtonProps) {
-  const { ref: containerRef, width: containerWidth } = useResizeObserver();
   const { ref: contentRef, height: contentHeight } = useResizeObserver();
-  const {
-    ref: buttonRef,
-    width: buttonWidth,
-    height: buttonHeight,
-  } = useResizeObserver();
-  // const buttonRef = useRef<HTMLButtonElement>(null);
-  const [expanded, setExpanded] = useState(false);
-  // const [initialWidth, setInitialWidth] = useState(0);
+  const { ref: buttonRef, height: buttonHeight } = useResizeObserver();
+  const [open, setOpen] = useState(false);
 
-  // useEffect(() => {
-  //   if (buttonRef.current) {
-  //     setInitialWidth(buttonRef.current.offsetWidth);
-  //   }
-  // }, [buttonRef.current]);
-
-  const expandedHeight =
+  const openHeight =
     buttonHeight && contentHeight ? buttonHeight + contentHeight : 0;
   return (
-    <Box
-      ref={containerRef}
-      css={css({
-        textAlign: 'center',
-        position: 'relative',
-        overflow: 'hidden',
-      })}
-    >
-      <Container
-        // maxWidth={buttonWidth ? buttonWidth : undefined}
-        minHeight={expanded ? expandedHeight : 0}
-        width="100%"
-        // minWidth={expanded ? '100%' : 0}
-      >
-        <ExpandButton ref={buttonRef} onClick={() => setExpanded(!expanded)}>
+    <Container minHeight={open ? openHeight : 0}>
+      <Disclosure open={open} onChange={() => setOpen(!open)}>
+        <ExpandButton ref={buttonRef}>
           {label}
-          <Chevron expanded={expanded} />
+          <Chevron open={open} />
         </ExpandButton>
-        <Content
-          css={css({
-            // position: 'absolute',
-            top: buttonHeight,
-            // bottom: 0,
-            // zIndex: 1,
-            // right: '0%',
-            // width: containerWidth,
-          })}
-        >
+
+        <Content style={{ height: open ? contentHeight : 0 }}>
           <div ref={contentRef}>{children}</div>
         </Content>
-      </Container>
-    </Box>
+      </Disclosure>
+    </Container>
   );
 }
 
@@ -76,30 +48,24 @@ const Container = styled(Box).attrs({ as: 'section' })(
     transitionProperty: 'min-width, min-height',
     transitionDuration: '0.5s',
     bg: 'tileGray',
-    // overflow: 'hidden',
+    width: '100%',
   })
 );
 
-const Content = styled(Box)(
+const Content = styled(DisclosurePanel)(
   css({
-    position: 'absolute',
-    transitionProperty: 'height',
+    transitionProperty: 'height, opacity',
     transitionDuration: '0.5s',
-    // overflow: 'hidden',
-
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bg: 'lightGray',
-      height: '1px',
+    width: '100%',
+    overflow: 'hidden',
+    opacity: 0,
+    '&[data-state="open"]': {
+      opacity: 1,
     },
   })
 );
 
-const ExpandButton = styled.button(
+const ExpandButton = styled(DisclosureButton)(
   css({
     position: 'relative',
     px: 4,
@@ -111,18 +77,27 @@ const ExpandButton = styled.button(
     cursor: 'pointer',
     fontWeight: 'bold',
     zIndex: 1,
-    boxSizing: 'border-box',
 
     '&:focus': {
       outlineWidth: '1px',
       outlineStyle: 'dashed',
       outlineColor: 'blue',
     },
+
+    '&[data-state="open"]:after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      bg: 'lightGray',
+      height: '1px',
+    },
   })
 );
 
 const Chevron = styled.div<{
-  expanded: boolean;
+  open: boolean;
 }>((x) =>
   css({
     ml: 2,
@@ -135,6 +110,6 @@ const Chevron = styled.div<{
     display: 'inline-block',
     transitionProperty: 'transform',
     transitionDuration: '0.5s',
-    transform: x.expanded ? 'rotate(-180deg)' : '',
+    transform: x.open ? 'rotate(-180deg)' : '',
   })
 );

--- a/packages/app/src/components-styled/collapsible-button.tsx
+++ b/packages/app/src/components-styled/collapsible-button.tsx
@@ -23,44 +23,61 @@ export function CollapsibleButton({ label, children }: CollapsibleButtonProps) {
   const openHeight =
     buttonHeight && contentHeight ? buttonHeight + contentHeight : 0;
   return (
-    <Container minHeight={open ? openHeight : 0}>
+    <Box as="section">
       <Disclosure open={open} onChange={() => setOpen(!open)}>
-        <ExpandButton ref={buttonRef}>
-          {label}
-          <Chevron open={open} />
-        </ExpandButton>
-
+        <Box display="flex" alignItems="center">
+          <Background
+            minWidth={open ? '100%' : 0}
+            css={css({
+              '&::after': {
+                content: '""',
+                position: 'absolute',
+                zIndex: 0,
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+                bg: 'tileGray',
+                minHeight: open ? openHeight : 0,
+                transitionProperty: 'min-height',
+                transitionDuration: '0.5s',
+              },
+            })}
+          >
+            <ExpandButton ref={buttonRef}>
+              {label}
+              <Chevron open={open} />
+            </ExpandButton>
+          </Background>
+        </Box>
         <Content style={{ height: open ? contentHeight : 0 }}>
           <div ref={contentRef}>{children}</div>
         </Content>
       </Disclosure>
-    </Container>
+    </Box>
   );
 }
 
-const Container = styled(Box).attrs({ as: 'section' })(
+const Background = styled(Box)(
   css({
     position: 'relative',
-    display: 'inline-flex',
-    flexDirection: 'column',
     padding: 0,
     margin: '0 auto',
     transitionProperty: 'min-width, min-height',
     transitionDuration: '0.5s',
-    bg: 'tileGray',
-    width: '100%',
   })
 );
 
 const Content = styled(DisclosurePanel)(
   css({
-    transitionProperty: 'height, opacity',
-    transitionDuration: '0.5s',
-    width: '100%',
+    display: 'block',
     overflow: 'hidden',
+    transition: 'height .3s, opacity 0.5s',
+    width: '100%',
     opacity: 0,
     '&[data-state="open"]': {
       opacity: 1,
+      transition: 'height .5s, opacity 1s 0.2s',
     },
   })
 );
@@ -77,6 +94,7 @@ const ExpandButton = styled(DisclosureButton)(
     cursor: 'pointer',
     fontWeight: 'bold',
     zIndex: 1,
+    width: '100%',
 
     '&:focus': {
       outlineWidth: '1px',

--- a/packages/app/src/components-styled/collapsible-button.tsx
+++ b/packages/app/src/components-styled/collapsible-button.tsx
@@ -11,35 +11,55 @@ interface CollapsibleButtonProps {
 }
 
 export function CollapsibleButton({ label, children }: CollapsibleButtonProps) {
-  const { ref, height: contentHeight } = useResizeObserver();
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const { ref: containerRef, width: containerWidth } = useResizeObserver();
+  const { ref: contentRef, height: contentHeight } = useResizeObserver();
+  const {
+    ref: buttonRef,
+    width: buttonWidth,
+    height: buttonHeight,
+  } = useResizeObserver();
+  // const buttonRef = useRef<HTMLButtonElement>(null);
   const [expanded, setExpanded] = useState(false);
-  const [initialWidth, setInitialWidth] = useState(0);
+  // const [initialWidth, setInitialWidth] = useState(0);
 
-  useEffect(() => {
-    if (buttonRef.current) {
-      setInitialWidth(buttonRef.current.offsetWidth);
-    }
-  }, [buttonRef.current]);
+  // useEffect(() => {
+  //   if (buttonRef.current) {
+  //     setInitialWidth(buttonRef.current.offsetWidth);
+  //   }
+  // }, [buttonRef.current]);
 
+  const expandedHeight =
+    buttonHeight && contentHeight ? buttonHeight + contentHeight : 0;
   return (
-    <Box css={css({ textAlign: 'center' })}>
+    <Box
+      ref={containerRef}
+      css={css({
+        textAlign: 'center',
+        position: 'relative',
+        overflow: 'hidden',
+      })}
+    >
       <Container
-        maxWidth={initialWidth ? initialWidth : undefined}
-        minWidth={expanded ? '100%' : 0}
+        // maxWidth={buttonWidth ? buttonWidth : undefined}
+        minHeight={expanded ? expandedHeight : 0}
+        width="100%"
+        // minWidth={expanded ? '100%' : 0}
       >
         <ExpandButton ref={buttonRef} onClick={() => setExpanded(!expanded)}>
           {label}
           <Chevron expanded={expanded} />
         </ExpandButton>
-
         <Content
           css={css({
-            height: expanded ? contentHeight : 0,
-            width: expanded ? '100%' : 0,
+            // position: 'absolute',
+            top: buttonHeight,
+            // bottom: 0,
+            // zIndex: 1,
+            // right: '0%',
+            // width: containerWidth,
           })}
         >
-          <div ref={ref}>{children}</div>
+          <div ref={contentRef}>{children}</div>
         </Content>
       </Container>
     </Box>
@@ -53,18 +73,19 @@ const Container = styled(Box).attrs({ as: 'section' })(
     flexDirection: 'column',
     padding: 0,
     margin: '0 auto',
-    transitionProperty: 'min-width',
+    transitionProperty: 'min-width, min-height',
     transitionDuration: '0.5s',
     bg: 'tileGray',
+    // overflow: 'hidden',
   })
 );
 
 const Content = styled(Box)(
   css({
-    position: 'relative',
+    position: 'absolute',
     transitionProperty: 'height',
     transitionDuration: '0.5s',
-    overflow: 'hidden',
+    // overflow: 'hidden',
 
     '&::after': {
       content: '""',
@@ -90,6 +111,7 @@ const ExpandButton = styled.button(
     cursor: 'pointer',
     fontWeight: 'bold',
     zIndex: 1,
+    boxSizing: 'border-box',
 
     '&:focus': {
       outlineWidth: '1px',

--- a/packages/app/src/components-styled/collapsible-button.tsx
+++ b/packages/app/src/components-styled/collapsible-button.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import css from '@styled-system/css';
+import styled from 'styled-components';
+
+import useResizeObserver from 'use-resize-observer';
+import { Box } from './base';
+
+interface CollapsibleButtonProps {
+  children: React.ReactNode;
+  label: string;
+}
+
+export function CollapsibleButton({ label, children }: CollapsibleButtonProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { ref, height: contentHeight } = useResizeObserver();
+
+  return (
+    <Box css={css({ textAlign: 'center' })}>
+      <Container css={css({ minWidth: expanded ? '100%' : 0 })}>
+        <ExpandButton color="link" onClick={() => setExpanded(!expanded)}>
+          {label}
+          <Chevron expanded={expanded} />
+        </ExpandButton>
+
+        <Content css={css({ height: expanded ? contentHeight : 0 })}>
+          <div ref={ref}>{children}</div>
+        </Content>
+      </Container>
+    </Box>
+  );
+}
+
+const Container = styled(Box).attrs({ as: 'section' })(
+  css({
+    position: 'relative',
+    display: 'inline-flex',
+    flexDirection: 'column',
+    padding: 0,
+    margin: '0 auto',
+    transitionProperty: 'min-width',
+    transitionDuration: '0.5s',
+    bg: 'tileGray',
+  })
+);
+
+const Content = styled(Box)(
+  css({
+    position: 'relative',
+    transitionProperty: 'height',
+    transitionDuration: '0.5s',
+    overflow: 'hidden',
+
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bg: 'lightGray',
+      height: '1px',
+    },
+  })
+);
+
+const ExpandButton = styled.button(
+  css({
+    position: 'relative',
+    px: 4,
+    py: 3,
+    border: 'none',
+    background: 'none',
+    font: 'inherit',
+    color: 'blue',
+    cursor: 'pointer',
+    fontWeight: 'bold',
+    zIndex: 1,
+
+    '&:focus': {
+      outlineWidth: '1px',
+      outlineStyle: 'dashed',
+      outlineColor: 'blue',
+    },
+  })
+);
+
+const Chevron = styled.div<{
+  expanded: boolean;
+}>((x) =>
+  css({
+    ml: 2,
+    backgroundImage: 'url("/images/chevron-down.svg")',
+    backgroundSize: '0.9em 0.5em',
+    backgroundPosition: '0 50%',
+    backgroundRepeat: 'no-repeat',
+    height: '0.5em',
+    width: '1em',
+    display: 'inline-block',
+    transitionProperty: 'transform',
+    transitionDuration: '0.5s',
+    transform: x.expanded ? 'rotate(-180deg)' : '',
+  })
+);

--- a/packages/app/src/components-styled/collapsible.tsx
+++ b/packages/app/src/components-styled/collapsible.tsx
@@ -91,7 +91,7 @@ const Panel = styled(DisclosurePanel)(
   })
 );
 
-interface CollapsableProps extends BoxProps {
+interface CollapsibleProps extends BoxProps {
   summary: string;
   children: ReactNode;
   id?: string;
@@ -103,7 +103,7 @@ export const Collapsible = ({
   children,
   id,
   hideBorder,
-}: CollapsableProps) => {
+}: CollapsibleProps) => {
   const [open, setOpen] = useState(true);
   const panelReference = useRef<HTMLDivElement>(null);
 

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -31,105 +31,109 @@ export function DataSitemap() {
           justifyContent={{ lg: 'space-between' }}
           flexWrap={{ md: 'wrap', lg: 'nowrap' }}
         >
-          <Box width={{ md: '25%', lg: 'auto' }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.vaccinaties}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/vaccinaties"
-                text={siteText.vaccinaties.titel_sidebar}
-              />
-            </List>
-          </Box>
-          <Box width={{ md: '25%', lg: 'auto' }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.besmettingen}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/positief-geteste-mensen"
-                text={siteText.positief_geteste_personen.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/besmettelijke-mensen"
-                text={siteText.besmettelijke_personen.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/reproductiegetal"
-                text={siteText.reproductiegetal.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/sterfte"
-                text={siteText.sterfte.titel_sidebar}
-              />
-            </List>
-          </Box>
-          <Box width={{ md: '25%', lg: 'auto' }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.ziekenhuizen}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/ziekenhuis-opnames"
-                text={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/intensive-care-opnames"
-                text={siteText.ic_opnames_per_dag.titel_sidebar}
-              />
-            </List>
-          </Box>
-          <Box width={{ md: '25%', lg: 'auto' }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.kwetsbare_groepen}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/verpleeghuiszorg"
-                text={siteText.verpleeghuis_besmette_locaties.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/gehandicaptenzorg"
-                text={
-                  siteText.gehandicaptenzorg_besmette_locaties.titel_sidebar
-                }
-              />
-              <SitemapItem
-                href="/landelijk/thuiswonende-ouderen"
-                text={siteText.thuiswonende_ouderen.titel_sidebar}
-              />
-            </List>
-          </Box>
-          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.vroege_signalen}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/rioolwater"
-                text={siteText.rioolwater_metingen.titel_sidebar}
-              />
-              <SitemapItem
-                href="/landelijk/verdenkingen-huisartsen"
-                text={siteText.verdenkingen_huisartsen.titel_sidebar}
-              />
-            </List>
-          </Box>
-          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
-            <StyledHeader>
-              {siteText.nationaal_layout.headings.gedrag}
-            </StyledHeader>
-            <List>
-              <SitemapItem
-                href="/landelijk/gedrag"
-                text={siteText.nl_gedrag.sidebar.titel}
-              />
-            </List>
-          </Box>
+          <SitemapItems />
         </Box>
       </Box>
     </Box>
+  );
+}
+
+export function SitemapItems() {
+  return (
+    <>
+      <Box width={{ md: '25%', lg: 'auto' }}>
+        <StyledHeader>
+          {siteText.nationaal_layout.headings.vaccinaties}
+        </StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/vaccinaties"
+            text={siteText.vaccinaties.titel_sidebar}
+          />
+        </List>
+      </Box>
+      <Box width={{ md: '25%', lg: 'auto' }}>
+        <StyledHeader>
+          {siteText.nationaal_layout.headings.besmettingen}
+        </StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/positief-geteste-mensen"
+            text={siteText.positief_geteste_personen.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/besmettelijke-mensen"
+            text={siteText.besmettelijke_personen.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/reproductiegetal"
+            text={siteText.reproductiegetal.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/sterfte"
+            text={siteText.sterfte.titel_sidebar}
+          />
+        </List>
+      </Box>
+      <Box width={{ md: '25%', lg: 'auto' }}>
+        <StyledHeader>
+          {siteText.nationaal_layout.headings.ziekenhuizen}
+        </StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/ziekenhuis-opnames"
+            text={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/intensive-care-opnames"
+            text={siteText.ic_opnames_per_dag.titel_sidebar}
+          />
+        </List>
+      </Box>
+      <Box width={{ md: '25%', lg: 'auto' }}>
+        <StyledHeader>
+          {siteText.nationaal_layout.headings.kwetsbare_groepen}
+        </StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/verpleeghuiszorg"
+            text={siteText.verpleeghuis_besmette_locaties.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/gehandicaptenzorg"
+            text={siteText.gehandicaptenzorg_besmette_locaties.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/thuiswonende-ouderen"
+            text={siteText.thuiswonende_ouderen.titel_sidebar}
+          />
+        </List>
+      </Box>
+      <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
+        <StyledHeader>
+          {siteText.nationaal_layout.headings.vroege_signalen}
+        </StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/rioolwater"
+            text={siteText.rioolwater_metingen.titel_sidebar}
+          />
+          <SitemapItem
+            href="/landelijk/verdenkingen-huisartsen"
+            text={siteText.verdenkingen_huisartsen.titel_sidebar}
+          />
+        </List>
+      </Box>
+      <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
+        <StyledHeader>{siteText.nationaal_layout.headings.gedrag}</StyledHeader>
+        <List>
+          <SitemapItem
+            href="/landelijk/gedrag"
+            text={siteText.nl_gedrag.sidebar.titel}
+          />
+        </List>
+      </Box>
+    </>
   );
 }
 

--- a/packages/app/src/domain/topical/data-sitemap.tsx
+++ b/packages/app/src/domain/topical/data-sitemap.tsx
@@ -31,109 +31,105 @@ export function DataSitemap() {
           justifyContent={{ lg: 'space-between' }}
           flexWrap={{ md: 'wrap', lg: 'nowrap' }}
         >
-          <SitemapItems />
+          <Box width={{ md: '25%', lg: 'auto' }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.vaccinaties}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/vaccinaties"
+                text={siteText.vaccinaties.titel_sidebar}
+              />
+            </List>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.besmettingen}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/positief-geteste-mensen"
+                text={siteText.positief_geteste_personen.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/besmettelijke-mensen"
+                text={siteText.besmettelijke_personen.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/reproductiegetal"
+                text={siteText.reproductiegetal.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/sterfte"
+                text={siteText.sterfte.titel_sidebar}
+              />
+            </List>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.ziekenhuizen}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/ziekenhuis-opnames"
+                text={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/intensive-care-opnames"
+                text={siteText.ic_opnames_per_dag.titel_sidebar}
+              />
+            </List>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.kwetsbare_groepen}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/verpleeghuiszorg"
+                text={siteText.verpleeghuis_besmette_locaties.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/gehandicaptenzorg"
+                text={
+                  siteText.gehandicaptenzorg_besmette_locaties.titel_sidebar
+                }
+              />
+              <SitemapItem
+                href="/landelijk/thuiswonende-ouderen"
+                text={siteText.thuiswonende_ouderen.titel_sidebar}
+              />
+            </List>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.vroege_signalen}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/rioolwater"
+                text={siteText.rioolwater_metingen.titel_sidebar}
+              />
+              <SitemapItem
+                href="/landelijk/verdenkingen-huisartsen"
+                text={siteText.verdenkingen_huisartsen.titel_sidebar}
+              />
+            </List>
+          </Box>
+          <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
+            <StyledHeader>
+              {siteText.nationaal_layout.headings.gedrag}
+            </StyledHeader>
+            <List>
+              <SitemapItem
+                href="/landelijk/gedrag"
+                text={siteText.nl_gedrag.sidebar.titel}
+              />
+            </List>
+          </Box>
         </Box>
       </Box>
     </Box>
-  );
-}
-
-export function SitemapItems() {
-  return (
-    <>
-      <Box width={{ md: '25%', lg: 'auto' }}>
-        <StyledHeader>
-          {siteText.nationaal_layout.headings.vaccinaties}
-        </StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/vaccinaties"
-            text={siteText.vaccinaties.titel_sidebar}
-          />
-        </List>
-      </Box>
-      <Box width={{ md: '25%', lg: 'auto' }}>
-        <StyledHeader>
-          {siteText.nationaal_layout.headings.besmettingen}
-        </StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/positief-geteste-mensen"
-            text={siteText.positief_geteste_personen.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/besmettelijke-mensen"
-            text={siteText.besmettelijke_personen.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/reproductiegetal"
-            text={siteText.reproductiegetal.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/sterfte"
-            text={siteText.sterfte.titel_sidebar}
-          />
-        </List>
-      </Box>
-      <Box width={{ md: '25%', lg: 'auto' }}>
-        <StyledHeader>
-          {siteText.nationaal_layout.headings.ziekenhuizen}
-        </StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/ziekenhuis-opnames"
-            text={siteText.ziekenhuisopnames_per_dag.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/intensive-care-opnames"
-            text={siteText.ic_opnames_per_dag.titel_sidebar}
-          />
-        </List>
-      </Box>
-      <Box width={{ md: '25%', lg: 'auto' }}>
-        <StyledHeader>
-          {siteText.nationaal_layout.headings.kwetsbare_groepen}
-        </StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/verpleeghuiszorg"
-            text={siteText.verpleeghuis_besmette_locaties.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/gehandicaptenzorg"
-            text={siteText.gehandicaptenzorg_besmette_locaties.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/thuiswonende-ouderen"
-            text={siteText.thuiswonende_ouderen.titel_sidebar}
-          />
-        </List>
-      </Box>
-      <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
-        <StyledHeader>
-          {siteText.nationaal_layout.headings.vroege_signalen}
-        </StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/rioolwater"
-            text={siteText.rioolwater_metingen.titel_sidebar}
-          />
-          <SitemapItem
-            href="/landelijk/verdenkingen-huisartsen"
-            text={siteText.verdenkingen_huisartsen.titel_sidebar}
-          />
-        </List>
-      </Box>
-      <Box width={{ md: '25%', lg: 'auto' }} marginTop={{ md: 4, lg: 0 }}>
-        <StyledHeader>{siteText.nationaal_layout.headings.gedrag}</StyledHeader>
-        <List>
-          <SitemapItem
-            href="/landelijk/gedrag"
-            text={siteText.nl_gedrag.sidebar.titel}
-          />
-        </List>
-      </Box>
-    </>
   );
 }
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -170,25 +170,22 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               />
             </MiniTrendTileLayout>
 
-            <QuickLinks
-              header={text.quick_links.header}
-              links={[
-                {
-                  href: '/landelijk/vaccinaties',
-                  text: text.quick_links.links.nationaal,
-                },
-                {
-                  href: '/veiligheidsregio',
-                  text: text.quick_links.links.veiligheidsregio,
-                },
-                { href: '/gemeente', text: text.quick_links.links.gemeente },
-              ]}
-            />
-
-            <CollapsibleButton
-              label={text.quick_links.header}
-              children="hello"
-            />
+            <CollapsibleButton label={text.quick_links.header}>
+              <QuickLinks
+                header={text.quick_links.header}
+                links={[
+                  {
+                    href: '/landelijk/vaccinaties',
+                    text: text.quick_links.links.nationaal,
+                  },
+                  {
+                    href: '/veiligheidsregio',
+                    text: text.quick_links.links.veiligheidsregio,
+                  },
+                  { href: '/gemeente', text: text.quick_links.links.gemeente },
+                ]}
+              />
+            </CollapsibleButton>
 
             {content.editorial && content.highlight && (
               <Box pt={3}>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -188,6 +188,24 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               <DataSitemap />
             </CollapsibleButton>
 
+            <Collapsible>
+              <QuickLinks
+                header={text.quick_links.header}
+                links={[
+                  {
+                    href: '/landelijk/vaccinaties',
+                    text: text.quick_links.links.nationaal,
+                  },
+                  {
+                    href: '/veiligheidsregio',
+                    text: text.quick_links.links.veiligheidsregio,
+                  },
+                  { href: '/gemeente', text: text.quick_links.links.gemeente },
+                ]}
+              />
+              <DataSitemap />
+            </Collapsible>
+
             {content.editorial && content.highlight && (
               <Box pt={3}>
                 <TopicalSectionHeader

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -188,24 +188,6 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               <DataSitemap />
             </CollapsibleButton>
 
-            <Collapsible>
-              <QuickLinks
-                header={text.quick_links.header}
-                links={[
-                  {
-                    href: '/landelijk/vaccinaties',
-                    text: text.quick_links.links.nationaal,
-                  },
-                  {
-                    href: '/veiligheidsregio',
-                    text: text.quick_links.links.veiligheidsregio,
-                  },
-                  { href: '/gemeente', text: text.quick_links.links.gemeente },
-                ]}
-              />
-              <DataSitemap />
-            </Collapsible>
-
             {content.editorial && content.highlight && (
               <Box pt={3}>
                 <TopicalSectionHeader

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -185,6 +185,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                   { href: '/gemeente', text: text.quick_links.links.gemeente },
                 ]}
               />
+              <DataSitemap />
             </CollapsibleButton>
 
             {content.editorial && content.highlight && (
@@ -244,8 +245,6 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 </Box>
               </TopicalTile>
             </Box>
-
-            <DataSitemap />
 
             <Box pb={4}>
               <TopicalSectionHeader

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -5,6 +5,8 @@ import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box } from '~/components-styled/base';
 import { DataDrivenText } from '~/components-styled/data-driven-text';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
+import { CollapsibleButton } from '~/components-styled/collapsible-button';
+import { Collapsible } from '~/components-styled/collapsible';
 import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { MaxWidth } from '~/components-styled/max-width';
 import { QuickLinks } from '~/components-styled/quick-links';
@@ -181,6 +183,11 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
                 },
                 { href: '/gemeente', text: text.quick_links.links.gemeente },
               ]}
+            />
+
+            <CollapsibleButton
+              label={text.quick_links.header}
+              children="hello"
             />
 
             {content.editorial && content.highlight && (


### PR DESCRIPTION
## Summary

Created a collapsable button that will hold links in the Actueel page

## Motivation

Redesign 

## Detailed design

Created a `CollapsibleButton` component that uses reach/disclosure components and and elements of the existing `Collapsible` component. The animation uses a pseudo element to render the "background" so that the div wrapping the button can utilize the shape of the button independent from the expanded body.

One glitch that i'm running into is shown the following video. Does anyone know what might be causing this?

https://user-images.githubusercontent.com/75375917/110440335-d58c1f80-80b8-11eb-8160-8a7b7148010a.mov

## Alternatives

Open to alternative ways of styling this! Struggled with the animation and this was the best I had been able to achieve

## Unresolved questions

`CollapsibleButton` and `Collapsible` share the `setLinkTabability` callback that needed to be implemented due to some styling applied to the DisclosurePanel however it appears the `Collapsible` component is not being used. Should I remove the `Collapsible` component entirely or move them both into a `Collapsible` folder with shared utils?

