### PR TITLE
Add date range GGD positive tested

### DIFF
--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -63,7 +63,6 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
   const router = useRouter();
 
   const lastValue = data.tested_overall.last_value;
-
   const ggdAverageLastValue = data.tested_ggd_average.last_value;
   const ggdDailyValues = data.tested_ggd_daily.values;
 
@@ -266,7 +265,10 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
           <KpiTile
             title={ggdText.totaal_getest_week_titel}
             metadata={{
-              date: ggdAverageLastValue.date_end_unix,
+              date: [
+                ggdAverageLastValue.date_start_unix,
+                ggdAverageLastValue.date_end_unix,
+              ],
               source: ggdText.bronnen.rivm,
             }}
           >


### PR DESCRIPTION
Use both the start and the end key to create a date range for the tiles.