### PR TITLE
Test build times with all getStaticPaths emptied

### DIFF
--- a/packages/app/infra/download.js
+++ b/packages/app/infra/download.js
@@ -5,5 +5,6 @@ const API_URL =
 (async () => {
   await download(API_URL, './public/json', {
     extract: true,
+    strip: 1,
   });
 })();

--- a/packages/app/src/static-paths/gm.ts
+++ b/packages/app/src/static-paths/gm.ts
@@ -1,16 +1,17 @@
-import municipalities from '~/data/municipalSearchData';
+// import municipalities from '~/data/municipalSearchData';
 
 /**
  * getStaticPaths creates an array of all the allowed `/gemeente/[code]` routes.
  */
 export function getStaticPaths() {
-  const paths = municipalities.map((municipality) => ({
-    params: { code: municipality.gemcode },
-  }));
+  // const paths = municipalities.map((municipality) => ({
+  //   params: { code: municipality.gemcode },
+  // }));
+
+  const paths = [] as any[];
 
   return {
     paths,
-    // other routes should 404
-    fallback: false,
+    fallback: 'blocking',
   };
 }

--- a/packages/app/src/static-paths/vr.ts
+++ b/packages/app/src/static-paths/vr.ts
@@ -1,20 +1,22 @@
-import safetyRegions from '~/data/index';
+// import safetyRegions from '~/data/index';
 
 /**
  * getStaticPaths creates an array of all the allowed `/veiligheidsregio/[code]`
  * routes.
  */
 export function getStaticPaths() {
-  const filteredRegions = safetyRegions.filter(
-    (region) => region.code.indexOf('VR') === 0
-  );
-  const paths = filteredRegions.map((region) => ({
-    params: { code: region.code },
-  }));
+  // const filteredRegions = safetyRegions.filter(
+  //   (region) => region.code.indexOf('VR') === 0
+  // );
+  // const paths = filteredRegions.map((region) => ({
+  //   params: { code: region.code },
+  // }));
+
+  const paths = [] as any[];
 
   return {
     paths,
     // other routes should 404
-    fallback: false,
+    fallback: 'blocking',
   };
 }


### PR DESCRIPTION
## Summary

Reduce build times by loading municipality and safety region pages on first demand instead of on build-time.

With these changes, a build takes 5 minutes to complete.
We can further reduce this by lazy loading images though an image CDN instead of resizing them all on build-time.

## Motivation

Faster build times leads to a shorter feedback loop.
Building less pages on every build potentially means lower bandwidth/CDN usage.