### PR TITLE
Fix an infinite render loop in the time series chart

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/logic/legend.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/legend.ts
@@ -9,7 +9,7 @@ import { SeriesConfig } from './series';
 
 export function useLegendItems<T extends TimestampedValue>(
   config: SeriesConfig<T>,
-  dataOptions: DataOptions
+  dataOptions?: DataOptions
 ) {
   const legendItems = useMemo(() => {
     const items = config
@@ -40,7 +40,7 @@ export function useLegendItems<T extends TimestampedValue>(
     /**
      * Add annotations to the legend
      */
-    if (dataOptions.timespanAnnotations) {
+    if (dataOptions?.timespanAnnotations) {
       for (const annotation of dataOptions.timespanAnnotations) {
         items.push({
           color: annotation.color

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -118,7 +118,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   height = 250,
   timeframe = 'all',
   formatTooltip,
-  dataOptions = {},
+  dataOptions,
   numGridLines = 3,
   tickValues,
   showDateMarker,
@@ -141,7 +141,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
     forcedMaximumValue,
     benchmark,
     timespanAnnotations,
-  } = dataOptions;
+  } = dataOptions || {};
 
   const { padding, bounds } = useDimensions(width, height, paddingLeft);
 
@@ -196,14 +196,14 @@ export function TimeSeriesChart<T extends TimestampedValue>({
           value: values[valuesIndex],
           valueKey: nearestPoint.metricProperty as keyof T,
           config: seriesConfig,
-          options: dataOptions,
+          options: dataOptions || {},
           /**
            * Pass the full annotation data. We could just pass the index because
            * dataOptions is already being passed, but it's cumbersome to have to
            * dig up the annotation from the array in the tooltip logic.
            */
           timespanAnnotation:
-            isDefined(dataOptions.timespanAnnotations) &&
+            dataOptions?.timespanAnnotations &&
             isDefined(timespanAnnotationIndex)
               ? dataOptions.timespanAnnotations[timespanAnnotationIndex]
               : undefined,


### PR DESCRIPTION
## Summary

The time series chart had an infinite render loop due to an effect dependent on an object created during rendering. This effect mutated state and so the loop started again.

edit:

I just think of another approach:

```diff
diff --git a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
index 3e1a2c51..07c2450e 100644
--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -111,6 +111,8 @@ export type TimeSeriesChartProps<T extends TimestampedValue> = {
   dataOptions?: DataOptions;
 };
 
+const EMPTY_OBJECT = {};
+
 export function TimeSeriesChart<T extends TimestampedValue>({
   values,
   seriesConfig,
@@ -118,7 +120,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   height = 250,
   timeframe = 'all',
   formatTooltip,
-  dataOptions = {},
+  dataOptions = EMPTY_OBJECT,
   numGridLines = 3,
   tickValues,
   showDateMarker,
```

What would have our preference?