### PR TITLE
Allow y-axis to start from a non-zero value

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/logic/common.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/common.ts
@@ -1,6 +1,7 @@
 export interface DataOptions {
   valueAnnotation?: string;
   forcedMaximumValue?: number;
+  forcedMinimumValue?: number;
   isPercentage?: boolean;
   benchmark?: {
     value: number;

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -30,11 +30,12 @@ interface UseScalesResult {
 
 export function useScales<T extends TimestampedValue>(args: {
   values: T[];
+  minimumValue: number;
   maximumValue: number;
   bounds: Bounds;
   numTicks: number;
 }) {
-  const { maximumValue, bounds, numTicks, values } = args;
+  const { minimumValue, maximumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
     const [start, end] = getTimeDomain(values);
@@ -45,7 +46,7 @@ export function useScales<T extends TimestampedValue>(args: {
     });
 
     const yScale = scaleLinear({
-      domain: [0, maximumValue],
+      domain: [minimumValue, maximumValue],
       range: [bounds.height, 0],
       nice: numTicks,
     });
@@ -61,7 +62,14 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [values, maximumValue, bounds, numTicks]);
+  }, [
+    values,
+    maximumValue,
+    minimumValue,
+    bounds.width,
+    bounds.height,
+    numTicks,
+  ]);
 }
 
 /**

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -62,7 +62,7 @@ export function useSeriesList<T extends TimestampedValue>(
  * render lines, so that the axis scales with whatever key contains the highest
  * values.
  */
-export function calculateSeriesMaximum<T extends TimestampedValue>(
+export function calculateSeriesRange<T extends TimestampedValue>(
   values: T[],
   seriesConfig: SeriesConfig<T>,
   benchmarkValue = -Infinity
@@ -81,6 +81,15 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
     return Math.max(...trendValues.filter(isPresent));
   });
 
+  const bottomValues = values.map((x) => {
+    const trendValues = Object.values(pick(x, metricProperties)) as (
+      | number
+      | null
+    )[];
+    return Math.min(...trendValues.filter(isPresent));
+  });
+
+  const overallMinimum = Math.min(...bottomValues);
   const overallMaximum = Math.max(...peakValues);
 
   /**
@@ -91,7 +100,10 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
   const artificialMax =
     overallMaximum < benchmarkValue ? benchmarkValue * 2 : 0;
 
-  return Math.max(overallMaximum, artificialMax);
+  const min = overallMinimum;
+  const max = Math.max(overallMaximum, artificialMax);
+
+  return [min, max] as const;
 }
 
 export type SeriesItem = {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -375,6 +375,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                 dataOptions={{
                   isPercentage: true,
                   forcedMaximumValue: 100,
+                  forcedMinimumValue: 0,
                 }}
                 seriesConfig={[
                   {


### PR DESCRIPTION
## Summary

This PR allows the Y-axis to start from an automatically determined nice and round value instead of always using `0`.

old:
![image](https://user-images.githubusercontent.com/73584448/110623152-bff02600-819c-11eb-8315-10c02c7ea6b5.png)

new:
![image](https://user-images.githubusercontent.com/73584448/110623129-b8308180-819c-11eb-958f-051054672240.png)