### PR TITLE
Update bug percentage dividing

### DIFF
--- a/packages/app/src/components-styled/line-chart/components/marker.tsx
+++ b/packages/app/src/components-styled/line-chart/components/marker.tsx
@@ -155,7 +155,7 @@ export function Marker<T extends TimestampedValue>(props: MarkerProps<T>) {
           <Point
             indicatorColor={d.color ?? colors.data.primary}
             style={{ top: d.y - index * MARKER_POINT_SIZE }}
-            key={d.y}
+            key={index}
           />
         ))}
       </DateSpanMarker>

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -357,13 +357,11 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
             source: ggdText.bronnen.rivm,
           }}
           formatTooltip={(x) => {
-            const valueOne = x[0].__value;
-            const valueTwo = x[1].__value;
+            const numerator = x[0].__value;
+            const denominator = x[1].__value;
 
             const percentage =
-              valueTwo === 0 && valueOne === 0
-                ? 0
-                : (valueTwo * 100) / valueOne;
+              numerator === 0 ? 0 : (denominator * 100) / numerator;
 
             return (
               <>
@@ -378,7 +376,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
                     display: 'inline-block',
                   }}
                 />{' '}
-                {formatNumber(valueOne)}
+                {formatNumber(numerator)}
                 <br />
                 <span
                   style={{
@@ -389,7 +387,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
                     display: 'inline-block',
                   }}
                 />{' '}
-                {formatNumber(valueTwo)} ({formatPercentage(percentage)}%)
+                {formatNumber(denominator)} ({formatPercentage(percentage)}%)
               </>
             );
           }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -357,7 +357,13 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
             source: ggdText.bronnen.rivm,
           }}
           formatTooltip={(x) => {
-            const percentage = (x[1].__value * 100) / x[0].__value;
+            const valueOne = x[0].__value;
+            const valueTwo = x[1].__value;
+
+            const percentage =
+              valueTwo === 0 && valueOne === 0
+                ? 0
+                : (valueTwo * 100) / valueOne;
 
             return (
               <>
@@ -372,7 +378,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
                     display: 'inline-block',
                   }}
                 />{' '}
-                {formatNumber(x[0].__value)}
+                {formatNumber(valueOne)}
                 <br />
                 <span
                   style={{
@@ -383,7 +389,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
                     display: 'inline-block',
                   }}
                 />{' '}
-                {formatNumber(x[1].__value)} ({formatPercentage(percentage)}%)
+                {formatNumber(valueTwo)} ({formatPercentage(percentage)}%)
               </>
             );
           }}


### PR DESCRIPTION
At https://coronadashboard.rijksoverheid.nl/veiligheidsregio/VR14/positief-geteste-mensen
The graph "Aantal testen door de tijd heen" was showing a Nan in the tooltip, caused by dividing 0 to 0.

Also changed the key of DateSpanMarker since both of the Y values were the same it yielded an error and created duplicating markers in the graph. 
Error: `Encountered two children with the same key, `210`.`