### PR TITLE
Fix time series chart timeframe handling

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
@@ -6,6 +6,7 @@ import {
 import { localPoint } from '@visx/event';
 import { bisectCenter } from 'd3-array';
 import { ScaleLinear } from 'd3-scale';
+import { isEmpty } from 'lodash';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { isDefined } from 'ts-is-present';
 import { TimespanAnnotationConfig } from './common';
@@ -101,6 +102,10 @@ export function useHoverState<T extends TimestampedValue>({
 
   const handleHover = useCallback(
     (event: Event, __trendIndex?: number) => {
+      if (isEmpty(values)) {
+        return;
+      }
+
       if (event.type === 'mouseleave') {
         /**
          * Here a timeout is used on the clear hover state to prevent the

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -10,7 +10,6 @@ import { ScaleLinear } from 'd3-scale';
 import { first, last } from 'lodash';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
-import { TimeframeOption } from '~/utils/timeframe';
 import { Bounds } from './common';
 import { SeriesDoubleValue, SeriesItem, SeriesSingleValue } from './series';
 
@@ -34,7 +33,6 @@ export function useScales<T extends TimestampedValue>(args: {
   maximumValue: number;
   bounds: Bounds;
   numTicks: number;
-  timeframe: TimeframeOption;
 }) {
   const { maximumValue, bounds, numTicks, values } = args;
 

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -10,6 +10,7 @@ import { ScaleLinear } from 'd3-scale';
 import { first, last } from 'lodash';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
+import { TimeframeOption } from '~/utils/timeframe';
 import { Bounds } from './common';
 import { SeriesDoubleValue, SeriesItem, SeriesSingleValue } from './series';
 
@@ -33,6 +34,7 @@ export function useScales<T extends TimestampedValue>(args: {
   maximumValue: number;
   bounds: Bounds;
   numTicks: number;
+  timeframe: TimeframeOption;
 }) {
   const { maximumValue, bounds, numTicks, values } = args;
 

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -38,9 +38,16 @@ export function useScales<T extends TimestampedValue>(args: {
 
   return useMemo(() => {
     if (isEmpty(values)) {
+      const today = Date.now() / 1000;
       return {
-        xScale: scaleLinear({ domain: [0, 0], range: [0, 0] }),
-        yScale: scaleLinear({ domain: [0, 0], range: [0, 0] }),
+        xScale: scaleLinear({
+          domain: [today, today + ONE_DAY_IN_SECONDS],
+          range: [0, bounds.width],
+        }),
+        yScale: scaleLinear({
+          domain: [0, maximumValue],
+          range: [bounds.height, 0],
+        }),
         getX: (_x: SeriesItem) => 0,
         getY: (_x: SeriesSingleValue) => 0,
         getY0: (_x: SeriesDoubleValue) => 0,

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -7,7 +7,7 @@ import {
 } from '@corona-dashboard/common';
 import { scaleLinear } from '@visx/scale';
 import { ScaleLinear } from 'd3-scale';
-import { first, last } from 'lodash';
+import { first, isEmpty, last } from 'lodash';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Bounds } from './common';
@@ -37,6 +37,18 @@ export function useScales<T extends TimestampedValue>(args: {
   const { maximumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
+    if (isEmpty(values)) {
+      return {
+        xScale: scaleLinear({ domain: [0, 0], range: [0, 0] }),
+        yScale: scaleLinear({ domain: [0, 0], range: [0, 0] }),
+        getX: (_x: SeriesItem) => 0,
+        getY: (_x: SeriesSingleValue) => 0,
+        getY0: (_x: SeriesDoubleValue) => 0,
+        getY1: (_x: SeriesDoubleValue) => 0,
+        dateSpanWidth: 0,
+      };
+    }
+
     const [start, end] = getTimeDomain(values);
 
     const xScale = scaleLinear({

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -46,12 +46,20 @@ export type AreaSeriesDefinition<T extends TimestampedValue> = {
 
 export function useSeriesList<T extends TimestampedValue>(
   values: T[],
-  seriesConfig: SeriesConfig<T>,
-  timeframe: TimeframeOption
+  seriesConfig: SeriesConfig<T>
 ) {
-  return useMemo(() => getSeriesList(values, seriesConfig, timeframe), [
+  return useMemo(() => getSeriesList(values, seriesConfig), [
     values,
     seriesConfig,
+  ]);
+}
+
+export function useValuesInTimeframe<T extends TimestampedValue>(
+  values: T[],
+  timeframe: TimeframeOption
+) {
+  return useMemo(() => getValuesInTimeframe(values, timeframe), [
+    values,
     timeframe,
   ]);
 }
@@ -120,20 +128,17 @@ export function isSeriesValue(
 export type SeriesList = (SeriesSingleValue[] | SeriesDoubleValue[])[];
 
 export function getSeriesList<T extends TimestampedValue>(
-  values: T[],
-  seriesConfig: SeriesConfig<T>,
-  timeframe: TimeframeOption
+  valuesInTimeframe: T[],
+  seriesConfig: SeriesConfig<T>
 ): SeriesList {
-  const series = getValuesInTimeframe(values, timeframe);
-
   return seriesConfig.map((config) =>
     config.type === 'range'
       ? getRangeSeriesData(
-          series,
+          valuesInTimeframe,
           config.metricPropertyLow,
           config.metricPropertyHigh
         )
-      : getSeriesData(series, config.metricProperty)
+      : getSeriesData(valuesInTimeframe, config.metricProperty)
   );
 }
 

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -128,17 +128,17 @@ export function isSeriesValue(
 export type SeriesList = (SeriesSingleValue[] | SeriesDoubleValue[])[];
 
 export function getSeriesList<T extends TimestampedValue>(
-  valuesInTimeframe: T[],
+  values: T[],
   seriesConfig: SeriesConfig<T>
 ): SeriesList {
   return seriesConfig.map((config) =>
     config.type === 'range'
       ? getRangeSeriesData(
-          valuesInTimeframe,
+          values,
           config.metricPropertyLow,
           config.metricPropertyHigh
         )
-      : getSeriesData(valuesInTimeframe, config.metricProperty)
+      : getSeriesData(values, config.metricProperty)
   );
 }
 

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -149,11 +149,16 @@ export function TimeSeriesChart<T extends TimestampedValue>({
   const legendItems = useLegendItems(seriesConfig, dataOptions);
 
   const values = useValuesInTimeframe(allValues, timeframe);
+
   const seriesList = useSeriesList(values, seriesConfig);
 
+  /**
+   * The maximum is calculated over all values, because you don't want the
+   * y-axis scaling to change when toggling the timeframe setting.
+   */
   const calculatedSeriesMax = useMemo(
-    () => calculateSeriesMaximum(values, seriesConfig, benchmark?.value),
-    [values, seriesConfig, benchmark]
+    () => calculateSeriesMaximum(allValues, seriesConfig, benchmark?.value),
+    [allValues, seriesConfig, benchmark]
   );
 
   const seriesMax = isDefined(forcedMaximumValue)

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -166,7 +166,6 @@ export function TimeSeriesChart<T extends TimestampedValue>({
       maximumValue: seriesMax,
       bounds,
       numTicks: tickValues?.length || numGridLines,
-      timeframe,
     }
   );
 

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -28,6 +28,7 @@ import {
   useScales,
   useSeriesList,
   DataOptions,
+  useValuesInTimeframe,
 } from './logic';
 import { useDimensions } from './logic/dimensions';
 import { Bar } from '@visx/shape';
@@ -112,7 +113,7 @@ export type TimeSeriesChartProps<T extends TimestampedValue> = {
 };
 
 export function TimeSeriesChart<T extends TimestampedValue>({
-  values,
+  values: allValues,
   seriesConfig,
   width,
   height = 250,
@@ -147,7 +148,8 @@ export function TimeSeriesChart<T extends TimestampedValue>({
 
   const legendItems = useLegendItems(seriesConfig, dataOptions);
 
-  const seriesList = useSeriesList(values, seriesConfig, timeframe);
+  const values = useValuesInTimeframe(allValues, timeframe);
+  const seriesList = useSeriesList(values, seriesConfig);
 
   const calculatedSeriesMax = useMemo(
     () => calculateSeriesMaximum(values, seriesConfig, benchmark?.value),
@@ -164,6 +166,7 @@ export function TimeSeriesChart<T extends TimestampedValue>({
       maximumValue: seriesMax,
       bounds,
       numTicks: tickValues?.length || numGridLines,
+      timeframe,
     }
   );
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -364,7 +364,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
             {({ width }) => (
               <TimeSeriesChart
                 title={text.grafiek_draagvlak.titel}
-                timeframe="all"
+                timeframe="week"
                 width={width}
                 ariaLabelledBy="chart_vaccine_support"
                 values={data.vaccine_support.values}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -364,7 +364,6 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
             {({ width }) => (
               <TimeSeriesChart
                 title={text.grafiek_draagvlak.titel}
-                timeframe="week"
                 width={width}
                 ariaLabelledBy="chart_vaccine_support"
                 values={data.vaccine_support.values}

--- a/packages/common/src/data-sorting.ts
+++ b/packages/common/src/data-sorting.ts
@@ -108,7 +108,7 @@ export function isDateSeries(
   timeSeries: TimestampedValue[]
 ): timeSeries is DateValue[] {
   const firstValue = (timeSeries as DateValue[])[0];
-  return isDefined(firstValue.date_unix);
+  return isDefined(firstValue?.date_unix);
 }
 
 export function isDateSpanSeries(
@@ -116,6 +116,7 @@ export function isDateSpanSeries(
 ): timeSeries is DateSpanValue[] {
   const firstValue = (timeSeries as DateSpanValue[])[0];
   return (
-    isDefined(firstValue.date_end_unix) && isDefined(firstValue.date_start_unix)
+    isDefined(firstValue?.date_end_unix) &&
+    isDefined(firstValue?.date_start_unix)
   );
 }


### PR DESCRIPTION
## Summary

It turned out that TimeSeriesChart was not yet handling the timeframe setting properly. The scales would not adjust to the range of used values. This PR solves it.

When testing this it also raised an interesting question. How to deal with an empty array when you selected a timeframe that has no values. This should not happen on production with a proper dataset so I'm leaving it as is. I've made it so that it doesn't crash at least, see screenshot below.

![image](https://user-images.githubusercontent.com/71320230/110669896-20975700-81cd-11eb-8553-999a58f49c5f.png)

