### PR TITLE
update reproduction digits

### DIFF
--- a/packages/app/src/components-styled/difference-indicator.tsx
+++ b/packages/app/src/components-styled/difference-indicator.tsx
@@ -27,20 +27,32 @@ interface DifferenceIndicatorProps {
   isDecimal?: boolean;
   context?: 'sidebar' | 'tile' | 'inline';
   staticTimespan?: string;
+  differenceFractionDigits?: number;
 }
 
 export function DifferenceIndicator(props: DifferenceIndicatorProps) {
-  const { value, isDecimal, context, staticTimespan } = props;
+  const {
+    value,
+    isDecimal,
+    context,
+    staticTimespan,
+    differenceFractionDigits,
+  } = props;
 
   if (context === 'sidebar') {
     return renderSidebarIndicator(value);
   }
 
   if (context === 'inline') {
-    return renderInlineIndicator(value, isDecimal);
+    return renderInlineIndicator(value, isDecimal, differenceFractionDigits);
   }
 
-  return renderTileIndicator(value, isDecimal, staticTimespan);
+  return renderTileIndicator(
+    value,
+    isDecimal,
+    staticTimespan,
+    differenceFractionDigits
+  );
 }
 
 function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
@@ -77,12 +89,13 @@ function renderSidebarIndicator(value: DifferenceDecimal | DifferenceInteger) {
 
 function renderInlineIndicator(
   value: DifferenceDecimal | DifferenceInteger,
-  isDecimal?: boolean
+  isDecimal?: boolean,
+  differenceFractionDigits?: number
 ) {
   const { difference } = value;
 
   const differenceFormattedString = isDecimal
-    ? formatPercentage(Math.abs(difference))
+    ? formatPercentage(Math.abs(difference), differenceFractionDigits)
     : formatNumber(Math.abs(difference));
 
   if (difference > 0) {
@@ -126,12 +139,13 @@ function renderInlineIndicator(
 function renderTileIndicator(
   value: DifferenceDecimal | DifferenceInteger,
   isDecimal?: boolean,
-  staticTimespan?: string
+  staticTimespan?: string,
+  maximumFractionDigits?: number
 ) {
   const { difference } = value;
 
   const differenceFormattedString = isDecimal
-    ? formatPercentage(Math.abs(difference))
+    ? formatPercentage(Math.abs(difference), maximumFractionDigits)
     : formatNumber(Math.abs(difference));
 
   const timespanTextNode = staticTimespan ?? text.vorige_waarde;

--- a/packages/app/src/components-styled/page-barscale.tsx
+++ b/packages/app/src/components-styled/page-barscale.tsx
@@ -30,6 +30,7 @@ interface PageBarScaleProps<T> {
   metricProperty: string;
   differenceKey?: string;
   differenceStaticTimespan?: string;
+  differenceFractionDigits?: number;
 }
 
 export function PageBarScale<T>({
@@ -40,6 +41,7 @@ export function PageBarScale<T>({
   localeTextKey,
   differenceKey,
   differenceStaticTimespan,
+  differenceFractionDigits,
 }: PageBarScaleProps<T>) {
   const text = siteText[localeTextKey] as Record<string, string>;
 
@@ -128,6 +130,7 @@ export function PageBarScale<T>({
           value={differenceValue}
           isDecimal={config.isDecimal}
           staticTimespan={differenceStaticTimespan}
+          differenceFractionDigits={differenceFractionDigits}
         />
       )}
     </Box>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -83,6 +83,7 @@ const ReproductionIndex: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty="index_average"
               localeTextKey="reproductiegetal"
               differenceKey="reproduction__index_average"
+              differenceFractionDigits={2}
             />
             <Text>{text.barscale_toelichting}</Text>
           </KpiWithIllustrationTile>


### PR DESCRIPTION
Duplicate of https://github.com/minvws/nl-covid19-data-dashboard/pull/2121, there went something wrong with merging so I thought it would be better to just create a new pull request instead of spending some time undoing my mistake.

Update to 2 digits in the percentage on the reproduction page
<img width="441" alt="Screenshot 2021-03-10 at 16 25 42" src="https://user-images.githubusercontent.com/76471292/110653466-91367780-81bd-11eb-841d-81183666b01c.png">
