### PR TITLE
Add vaccin delivery date of report

### DIFF
--- a/packages/app/schema/nl/vaccine_delivery.json
+++ b/packages/app/schema/nl/vaccine_delivery.json
@@ -6,6 +6,7 @@
       "required": [
         "total",
         "date_of_insertion_unix",
+        "date_of_report_unix",
         "date_start_unix",
         "date_end_unix"
       ],
@@ -15,6 +16,9 @@
           "type": "number"
         },
         "date_of_insertion_unix": {
+          "type": "integer"
+        },
+        "date_of_report_unix": {
           "type": "integer"
         },
         "date_start_unix": {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -480,6 +480,7 @@ export interface NlVaccineDelivery {
 export interface NlVaccineDeliveryValue {
   total: number;
   date_of_insertion_unix: number;
+  date_of_report_unix: number;
   date_start_unix: number;
   date_end_unix: number;
 }


### PR DESCRIPTION
## Summary

We are missing a timestamp to indicate when the data was last reported/calculated. This is different from our regular date_unix timestamp (= date of statistic) or date_of_insertion (last data insertion in dashboard)