### PR TITLE
Add obtained on to kpi tile on the reproduction page

### DIFF
--- a/packages/app/src/components-styled/metadata.tsx
+++ b/packages/app/src/components-styled/metadata.tsx
@@ -9,6 +9,7 @@ export interface MetadataProps {
     text: string;
     href: string;
   };
+  obtained?: number;
 }
 
 function formatMetadataDate(date: number | [number, number]): string {
@@ -24,13 +25,20 @@ function formatMetadataDate(date: number | [number, number]): string {
   });
 }
 
-export function Metadata({ date, source }: MetadataProps) {
+export function Metadata({ date, source, obtained }: MetadataProps) {
   const dateString = date ? formatMetadataDate(date) : null;
 
   return (
     <Box as="footer" mt={3} mb={{ _: 0, sm: -3 }} gridArea="metadata">
       <Text my={0} color="annotation" fontSize={1}>
         {dateString}
+        {obtained && (
+          <>
+            {` ${replaceVariablesInText(locale.common.metadata.obtained, {
+              date: formatDateFromSeconds(obtained, 'weekday-medium'),
+            })}`}
+          </>
+        )}
         {dateString && source ? ' · ' : null}
         {source ? `${locale.common.metadata.source}: ${source.text}` : null}
       </Text>

--- a/packages/app/src/components-styled/metadata.tsx
+++ b/packages/app/src/components-styled/metadata.tsx
@@ -32,13 +32,10 @@ export function Metadata({ date, source, obtained }: MetadataProps) {
     <Box as="footer" mt={3} mb={{ _: 0, sm: -3 }} gridArea="metadata">
       <Text my={0} color="annotation" fontSize={1}>
         {dateString}
-        {obtained && (
-          <>
-            {` ${replaceVariablesInText(locale.common.metadata.obtained, {
-              date: formatDateFromSeconds(obtained, 'weekday-medium'),
-            })}`}
-          </>
-        )}
+        {obtained &&
+          ` ${replaceVariablesInText(locale.common.metadata.obtained, {
+            date: formatDateFromSeconds(obtained, 'weekday-medium'),
+          })}`}
         {dateString && source ? ' · ' : null}
         {source ? `${locale.common.metadata.source}: ${source.text}` : null}
       </Text>

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -631,7 +631,8 @@
       "source": "Source",
       "date": "Value of {{date}}",
       "dateFromTo": "Value from {{startDate}} - {{endDate}}",
-      "download": "Download data"
+      "download": "Download data",
+      "obtained": "obtained on {{date}}"
     },
     "barScale": {
       "signaalwaarde": "Alert value"

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -631,7 +631,8 @@
       "source": "Bron",
       "date": "Waarde van {{date}}",
       "dateFromTo": "Waarde van {{startDate}} - {{endDate}}",
-      "download": "Download data"
+      "download": "Download data",
+      "obtained": "verkregen op {{date}}"
     },
     "barScale": {
       "signaalwaarde": "Signaalwaarde"

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -69,6 +69,7 @@ const ReproductionIndex: FCWithLayout<typeof getStaticProps> = (props) => {
             metadata={{
               date: lastFilledValue.date_unix,
               source: text.bronnen.rivm,
+              obtained: lastFilledValue.date_of_insertion_unix,
             }}
             illustration={{
               image: '/images/reproductie-explainer.svg',


### PR DESCRIPTION
On the reproduction page the KPI tile should yield now:
`Waarde van maandag 22 februari verkregen op dinsdag 9 maart · Bron: RIVM`