### PR TITLE
Update data-driven text postive tested people regional

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -1054,7 +1054,7 @@
   },
   "positief_geteste_personen_ggd": {
     "titel": "Percentage of positive test results at GGD test locations ",
-    "summary_title": "{{percentage}} of the test results at GGD test locations had a positive result",
+    "summary_text": "{{percentage}} of the test results at GGD test locations had a positive result from {{dateFrom}} to {{dateTo}}.",
     "summary_link_cta": "More about the percentage of positive test results from GGD test locations only",
     "datums": "Last values obtained on {{dateOfInsertion}}. Is updated on a weekly basis.",
     "bron": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -1054,7 +1054,7 @@
   },
   "positief_geteste_personen_ggd": {
     "titel": "Percentage positief geteste personen via GGD-teststraten",
-    "summary_title": "{{percentage}} van de GGD-testen was positief",
+    "summary_text": "{{percentage}} van de GGD testen was positief in de periode van {{dateFrom}} tot en met {{dateTo}}.",
     "summary_link_cta": "Meer over het percentage positieve testen via alleen de GGD",
     "datums": "Laatste waardes verkregen op {{dateOfInsertion}}. Wordt wekelijks bijgewerkt.",
     "bron": {

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -51,6 +51,7 @@ import {
 import { formatNumber, formatPercentage } from '~/utils/formatNumber';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -129,24 +130,31 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
 
             <Text
               as="div"
+              css={css({ mb: 4 })}
               dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
             />
             <Box>
-              <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
-                <span
-                  css={css({ '& > span': { color: 'data.primary' } })}
-                  dangerouslySetInnerHTML={{
-                    __html: replaceKpisInText(ggdText.summary_title, [
-                      {
-                        name: 'percentage',
-                        value: `${formatPercentage(
-                          dataGgdAverageLastValue.infected_percentage
-                        )}%`,
-                      },
-                    ]),
-                  }}
-                />
+              <Heading level={4} fontSize={'1.2em'} mb={0}>
+                {replaceComponentsInText(ggdText.summary_text, {
+                  percentage: (
+                    <span css={css({ color: 'data.primary' })}>
+                      {formatPercentage(
+                        dataGgdAverageLastValue.infected_percentage
+                      )}
+                      %
+                    </span>
+                  ),
+                  dateFrom: formatDateFromSeconds(
+                    dataGgdAverageLastValue.date_start_unix,
+                    'weekday-medium'
+                  ),
+                  dateTo: formatDateFromSeconds(
+                    dataGgdAverageLastValue.date_end_unix,
+                    'weekday-medium'
+                  ),
+                })}
               </Heading>
+
               <Text mt={0} lineHeight={1}>
                 <Anchor name="ggd" text={ggdText.summary_link_cta} />
               </Text>


### PR DESCRIPTION
Update the data-driven text in the KPI tile on a regional level and added the form - to dates to inform the user about a 7 days calculation. It should now show:

<img width="471" alt="Screenshot 2021-03-11 at 11 24 27" src="https://user-images.githubusercontent.com/76471292/110772879-63544000-825c-11eb-90c5-ad2f5bc50cbe.png">
