### PR TITLE
Render years in chart x-axis when it spans multiple years

### DIFF
--- a/packages/app/src/components-styled/line-chart-tile.tsx
+++ b/packages/app/src/components-styled/line-chart-tile.tsx
@@ -1,5 +1,4 @@
 import { ParentSize } from '@visx/responsive';
-import { AxisBottom } from '@visx/axis';
 import {
   LineChart,
   LineChartProps,
@@ -7,7 +6,6 @@ import {
 import { TimestampedValue } from '@corona-dashboard/common';
 import { TimeframeOption } from '~/utils/timeframe';
 import { ChartTileWithTimeframe } from './chart-tile';
-import { ComponentCallbackInfo } from '~/components-styled/line-chart/components';
 import { MetadataProps } from './metadata';
 import { assert } from '~/utils/assert';
 import slugify from 'slugify';
@@ -57,7 +55,6 @@ export function LineChartTile<T extends TimestampedValue>({
                 width={parent.width}
                 timeframe={timeframe}
                 ariaLabelledBy={ariaLabelledBy}
-                componentCallback={componentCallback}
               />
             )}
           </ParentSize>
@@ -66,32 +63,4 @@ export function LineChartTile<T extends TimestampedValue>({
       )}
     </ChartTileWithTimeframe>
   );
-}
-
-function componentCallback(callbackInfo: ComponentCallbackInfo) {
-  switch (callbackInfo.type) {
-    case 'AxisBottom': {
-      const domain = callbackInfo.props.scale.domain();
-      const tickFormat = callbackInfo.props.tickFormat;
-
-      const tickLabelProps = (value: Date, index: number) => {
-        const labelProps = callbackInfo.props.tickLabelProps
-          ? callbackInfo.props.tickLabelProps(value, index)
-          : {};
-        labelProps.textAnchor = value === domain[0] ? 'start' : 'end';
-        labelProps.dx = 0;
-        labelProps.dy = -4;
-        return labelProps;
-      };
-
-      return (
-        <AxisBottom
-          {...(callbackInfo.props as any)}
-          tickLabelProps={tickLabelProps}
-          tickFormat={tickFormat}
-          tickValues={domain}
-        />
-      );
-    }
-  }
 }

--- a/packages/app/src/components-styled/line-chart/line-chart.tsx
+++ b/packages/app/src/components-styled/line-chart/line-chart.tsx
@@ -33,9 +33,6 @@ import { TimeframeOption } from '~/utils/timeframe';
 import { HoverPoint, Marker, Tooltip, Trend } from './components';
 import { calculateYMax, getTrendData, TrendValue } from './logic';
 
-const dateToValue = (d: Date) => d.valueOf() / 1000;
-const formatXAxis = (date: Date) =>
-  formatDateFromSeconds(dateToValue(date), 'axis');
 const formatYAxisFn = (y: number) => formatNumber(y);
 const formatYAxisPercentageFn = (y: number) => `${formatPercentage(y)}%`;
 
@@ -334,7 +331,6 @@ export function LineChart<T extends TimestampedValue>({
               ? formatYAxisPercentageFn
               : formatYAxisFn
           }
-          formatXAxis={formatXAxis}
           onHover={handleHover}
           benchmark={benchmark}
           componentCallback={componentCallback}

--- a/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/components-styled/sewer-chart/sewer-chart.tsx
@@ -99,7 +99,7 @@ export function SewerChart(props: SewerChartProps) {
   const dimensions = useMemo<Dimensions>(() => {
     const padding = {
       top: 20,
-      right: 35,
+      right: 10,
       bottom: 30,
       left: 50,
     };

--- a/packages/app/src/domain/behavior/components/behavior-line-chart.tsx
+++ b/packages/app/src/domain/behavior/components/behavior-line-chart.tsx
@@ -82,7 +82,7 @@ function getChartOptions<T>(values: Value[][], linesConfig: LineConfig<T>[]) {
         rotation: '0' as any,
         formatter: function () {
           return this.isFirst || this.isLast
-            ? formatDateFromSeconds(this.value, 'axis')
+            ? formatDateFromSeconds(this.value, 'axis-with-year')
             : '';
         },
       },

--- a/packages/app/src/domain/deceased/deceased-monitor-section.tsx
+++ b/packages/app/src/domain/deceased/deceased-monitor-section.tsx
@@ -43,6 +43,7 @@ export function DeceasedMonitorSection({
               width={width}
               values={data.values}
               ariaLabelledBy=""
+              showDateMarker
               seriesConfig={[
                 {
                   type: 'range',

--- a/packages/app/src/utils/formatDate.ts
+++ b/packages/app/src/utils/formatDate.ts
@@ -42,6 +42,7 @@ type formatStyle =
   | 'relative'
   | 'iso'
   | 'axis'
+  | 'axis-with-year'
   | 'weekday-medium'
   | 'day-month';
 
@@ -68,18 +69,16 @@ const DayMonth = new Intl.DateTimeFormat(locale, {
   timeZone: 'Europe/Amsterdam',
 });
 
-const MonthShort = new Intl.DateTimeFormat(locale, {
+const DayMonthShort = new Intl.DateTimeFormat(locale, {
   month: 'short',
-  timeZone: 'Europe/Amsterdam',
-});
-
-const Year = new Intl.DateTimeFormat(locale, {
-  year: 'numeric',
-  timeZone: 'Europe/Amsterdam',
-});
-
-const Day = new Intl.DateTimeFormat(locale, {
   day: 'numeric',
+  timeZone: 'Europe/Amsterdam',
+});
+
+const DayMonthShortYear = new Intl.DateTimeFormat(locale, {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
   timeZone: 'Europe/Amsterdam',
 });
 
@@ -157,10 +156,11 @@ function getFormattedDate(date: Date, style: formatStyle) {
     case 'medium': // '23 juli 2020'
       return Medium.format(date);
 
-    case 'axis': // '23 jul.'
-      return `${Day.format(date)} ${MonthShort.format(date)} ${Year.format(
-        date
-      )}`;
+    case 'axis': // '23 jul'
+      return DayMonthShort.format(date).replace(/\./g, '');
+
+    case 'axis-with-year': // '23 jul. 2021'
+      return DayMonthShortYear.format(date);
 
     case 'weekday-medium':
       return WeekdayMedium.format(date);
@@ -176,6 +176,7 @@ function getFormattedDate(date: Date, style: formatStyle) {
         ? siteText.utils.date_day_before_yesterday
         : DayMonth.format(date);
 
+    case 'day-month':
     default:
       return DayMonth.format(date);
   }


### PR DESCRIPTION
## Summary

- Only render years on the x-axis when it spans multiple years
- align dates on the "inside" of the chart, preventing long dates being cut off
- Fix a regression with missing background rectangles