### PR TITLE
Add tooltips for undereported sections

### DIFF
--- a/packages/app/src/domain/underreported/under-reported-tooltip.tsx
+++ b/packages/app/src/domain/underreported/under-reported-tooltip.tsx
@@ -1,0 +1,34 @@
+import { formatNumber } from '@corona-dashboard/common';
+import { Box } from '~/components-styled/base';
+import { TrendValue } from '~/components-styled/line-chart/logic';
+import { Text } from '~/components-styled/typography';
+import { colors } from '~/style/theme';
+import { formatDateFromMilliseconds } from '~/utils/formatDate';
+
+type UnderReportedTooltipProps<T extends TrendValue> = {
+  value: T;
+  isInUnderReportedRange: boolean;
+  underReportedText: string;
+};
+
+export function UnderReportedTooltip<T extends TrendValue>(
+  props: UnderReportedTooltipProps<T>
+) {
+  const { value, isInUnderReportedRange, underReportedText } = props;
+
+  return (
+    <Box display="flex" alignItems="center" flexDirection="column">
+      {isInUnderReportedRange && (
+        <Text as="span" fontSize={0} color={colors.annotation}>
+          ({underReportedText})
+        </Text>
+      )}
+      <Box>
+        <Text as="span" fontWeight="bold">
+          {`${formatDateFromMilliseconds(value.__date.getTime(), 'medium')}: `}
+        </Text>
+        {formatNumber(value.__value)}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/app/src/domain/underreported/under-reported-tooltip.tsx
+++ b/packages/app/src/domain/underreported/under-reported-tooltip.tsx
@@ -1,7 +1,7 @@
 import { formatNumber } from '@corona-dashboard/common';
 import { Box } from '~/components-styled/base';
 import { TrendValue } from '~/components-styled/line-chart/logic';
-import { Text } from '~/components-styled/typography';
+import { InlineText } from '~/components-styled/typography';
 import { colors } from '~/style/theme';
 import { formatDateFromMilliseconds } from '~/utils/formatDate';
 
@@ -19,14 +19,14 @@ export function UnderReportedTooltip<T extends TrendValue>(
   return (
     <Box display="flex" alignItems="center" flexDirection="column">
       {isInUnderReportedRange && (
-        <Text as="span" fontSize={0} color={colors.annotation}>
+        <InlineText fontSize={0} color={colors.annotation}>
           ({underReportedText})
-        </Text>
+        </InlineText>
       )}
       <Box>
-        <Text as="span" fontWeight="bold">
+        <InlineText fontWeight="bold">
           {`${formatDateFromMilliseconds(value.__date.getTime(), 'medium')}: `}
-        </Text>
+        </InlineText>
         {formatNumber(value.__value)}
       </Box>
     </Box>

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -1,9 +1,7 @@
-import { formatNumber } from '@corona-dashboard/common';
 import { useRouter } from 'next/router';
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { ArticleStrip } from '~/components-styled/article-strip';
 import { ArticleSummary } from '~/components-styled/article-teaser';
-import { Box } from '~/components-styled/base';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
@@ -13,13 +11,13 @@ import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/l
 import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { Text } from '~/components-styled/typography';
 import { municipalThresholds } from '~/components/choropleth/municipal-thresholds';
 import { MunicipalityChoropleth } from '~/components/choropleth/municipality-choropleth';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -30,7 +28,6 @@ import {
   getLastGeneratedDate,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
-import { formatDateFromMilliseconds } from '~/utils/formatDate';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
@@ -149,24 +146,11 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
             const value = values[0];
             const isInrange = value.__date >= underReportedRange[0];
             return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInrange && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromMilliseconds(
-                        value.__date.getTime(),
-                        'medium'
-                      )}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
-                  </Box>
-                </Box>
-              </>
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInrange}
+                underReportedText={siteText.common.incomplete}
+              />
             );
           }}
           linesConfig={[

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -18,6 +18,7 @@ import { createSelectRegionHandler } from '~/components/choropleth/select-handle
 import { createDisablityInfectedLocationsRegionalTooltip } from '~/components/choropleth/tooltips/region/create-disability-infected-locations-regional-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -103,6 +104,18 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty: 'newly_infected_people',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue = value.__date >= underReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             underReportedValues,
             {
@@ -255,6 +268,18 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty: 'deceased_daily',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue = value.__date >= underReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             underReportedValues,
             {

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -16,6 +16,7 @@ import { createSelectRegionHandler } from '~/components/choropleth/select-handle
 import { createRegionElderlyAtHomeTooltip } from '~/components/choropleth/tooltips/region/create-region-elderly-at-home-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -123,6 +124,19 @@ const ElderlyAtHomeNationalPage: FCWithLayout<typeof getStaticProps> = ({
             },
           ]}
           metadata={{ source: text.section_positive_tested.bronnen.rivm }}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= elderlyAtHomeInfectedUnderReportedRange[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             elderlyAtHomeInfectedUnderReportedRange,
             {
@@ -220,6 +234,19 @@ const ElderlyAtHomeNationalPage: FCWithLayout<typeof getStaticProps> = ({
               fill: colors.data.underReported,
             }
           )}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           legendItems={[
             {
               color: colors.data.primary,

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -18,6 +18,7 @@ import { createSelectRegionHandler } from '~/components/choropleth/select-handle
 import { createInfectedLocationsRegionalTooltip } from '~/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -112,6 +113,19 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = ({
               fill: colors.data.underReported,
             }
           )}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= nursinghomeDataUnderReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           legendItems={[
             {
               color: colors.data.primary,
@@ -263,6 +277,19 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = ({
               metricProperty: 'deceased_daily',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= nursinghomeDataUnderReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             nursinghomeDataUnderReportedValues,
             {

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -1,10 +1,9 @@
-import { formatNumber, getLastFilledValue } from '@corona-dashboard/common';
+import { getLastFilledValue } from '@corona-dashboard/common';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { ArticleStrip } from '~/components-styled/article-strip';
 import { ArticleSummary } from '~/components-styled/article-teaser';
-import { Box } from '~/components-styled/base';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
@@ -15,7 +14,6 @@ import { PageBarScale } from '~/components-styled/page-barscale';
 import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { Text } from '~/components-styled/typography';
 import { municipalThresholds } from '~/components/choropleth/municipal-thresholds';
 import { MunicipalityChoropleth } from '~/components/choropleth/municipality-choropleth';
 import { regionThresholds } from '~/components/choropleth/region-thresholds';
@@ -26,6 +24,7 @@ import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choroplet
 import { createRegionHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/region/create-region-hospital-admissions-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -37,10 +36,6 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/createDate';
-import {
-  formatDateFromMilliseconds,
-  formatDateFromSeconds,
-} from '~/utils/formatDate';
 import {
   DateRange,
   getTrailingDateRange,
@@ -203,26 +198,12 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
           signaalwaarde={40}
           formatTooltip={(values) => {
             const value = values[0];
-            const isInrange = value.__date >= underReportedRange[0];
             return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInrange && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromMilliseconds(
-                        value.__date.getTime(),
-                        'medium'
-                      )}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
-                  </Box>
-                </Box>
-              </>
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={value.__date >= underReportedRange[0]}
+                underReportedText={siteText.common.incomplete}
+              />
             );
           }}
           linesConfig={[
@@ -274,21 +255,11 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
             const isInaccurateValue = value.__date < lcpsOldDataRange[1];
 
             return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInaccurateValue && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromSeconds(value.date_unix, 'medium')}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
-                  </Box>
-                </Box>
-              </>
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
             );
           }}
           legendItems={[

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -12,6 +12,7 @@ import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate, getVrData } from '~/static-props/get-data';
@@ -107,6 +108,18 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty: 'newly_infected_people',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue = value.__date >= underReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             underReportedValues,
             {
@@ -239,6 +252,18 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty: 'deceased_daily',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue = value.__date >= underReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             underReportedValues,
             {

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -10,6 +10,7 @@ import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate, getVrData } from '~/static-props/get-data';
@@ -128,6 +129,19 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<typeof getStaticProps> = (
               fill: colors.data.underReported,
             }
           )}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= elderlyAtHomeUnderReportedRange[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           legendItems={[
             {
               color: colors.data.primary,
@@ -195,6 +209,19 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<typeof getStaticProps> = (
               fill: colors.data.underReported,
             }
           )}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           legendItems={[
             {
               color: colors.data.primary,

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -12,6 +12,7 @@ import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate, getVrData } from '~/static-props/get-data';
@@ -106,6 +107,19 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = (props) => {
               metricProperty: 'newly_infected_people',
             },
           ]}
+          formatTooltip={(values) => {
+            const value = values[0];
+            const isInaccurateValue =
+              value.__date >= nursinghomeDataUnderReportedValues[0];
+
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInaccurateValue}
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             nursinghomeDataUnderReportedValues,
             {
@@ -242,6 +256,19 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = (props) => {
                 metricProperty: 'deceased_daily',
               },
             ]}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= nursinghomeDataUnderReportedValues[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
             componentCallback={addBackgroundRectangleCallback(
               nursinghomeDataUnderReportedValues,
               {

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -1,9 +1,7 @@
-import { formatNumber } from '@corona-dashboard/common';
 import { useRouter } from 'next/router';
 import Ziekenhuis from '~/assets/ziekenhuis.svg';
 import { ArticleStrip } from '~/components-styled/article-strip';
 import { ArticleSummary } from '~/components-styled/article-teaser';
-import { Box } from '~/components-styled/base';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
@@ -13,7 +11,6 @@ import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/l
 import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
-import { Text } from '~/components-styled/typography';
 import { municipalThresholds } from '~/components/choropleth/municipal-thresholds';
 import { MunicipalityChoropleth } from '~/components/choropleth/municipality-choropleth';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
@@ -21,6 +18,7 @@ import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choroplet
 import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -31,7 +29,6 @@ import {
   getVrData,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
-import { formatDateFromMilliseconds } from '~/utils/formatDate';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
@@ -156,24 +153,11 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
               value.__date >= underReportedRange[0] &&
               value.__date <= underReportedRange[1];
             return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInrange && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromMilliseconds(
-                        value.__date.getTime(),
-                        'medium'
-                      )}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
-                  </Box>
-                </Box>
-              </>
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={isInrange}
+                underReportedText={siteText.common.incomplete}
+              />
             );
           }}
           linesConfig={[


### PR DESCRIPTION
## Summary

Add tooltip that displays optional 'incomplete data' text when hovering over an 'underreported' section.

## Motivation

Feature request

## Detailed design

`UnderReportedTooltip` component was added to display the tooltip

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
