### PR TITLE
Add internationalized routing to next.config.js

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -38,7 +38,7 @@ const nextConfig = {
     // your application
     locales: ['nl', 'en'],
     // This is the default locale you want to be used when visiting
-    // a non-locale prefixed path e.g. `/hello`
+    // a non-locale prefixed path e.g. `/hello` or a (sub)domain that's not mapped to a locale.
     defaultLocale: 'nl',
     // When localeDetection is set to false Next.js will no longer automatically
     // redirect based on the user's preferred locale and will only provide locale information

--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -33,6 +33,56 @@ const nextConfig = {
    */
   reactStrictMode: true,
 
+  i18n: {
+    // These are all the locales you want to support in
+    // your application
+    locales: ['nl', 'en'],
+    // This is the default locale you want to be used when visiting
+    // a non-locale prefixed path e.g. `/hello`
+    defaultLocale: 'nl',
+    // When localeDetection is set to false Next.js will no longer automatically
+    // redirect based on the user's preferred locale and will only provide locale information
+    // detected from either the locale based domain or locale path as described above.
+    localeDetection: false,
+    // This is a list of locale domains and the default locale they
+    // should handle (these are only required when setting up domain routing)
+    // Note: subdomains must be included in the domain value to be matched e.g. "fr.example.com".
+    domains: [
+      //Production environments
+      {
+        domain: 'coronadashboard.nl',
+        defaultLocale: 'nl',
+      },
+      {
+        domain: 'coronadashboard.rijksoverheid.nl',
+        defaultLocale: 'nl',
+      },
+      {
+        domain: 'coronadashboard.government.com',
+        defaultLocale: 'en',
+      },
+      // For convenience, the deploy previews are configured as well
+      { domain: 'nl-covid19-data-dashboard.vercel.app', defaultLocale: 'nl' },
+      { domain: 'en-covid19-data-dashboard.vercel.app', defaultLocale: 'en' },
+      {
+        domain: 'develop-en-covid19-data-dashboard.vercel.app',
+        defaultLocale: 'en',
+      },
+      {
+        domain: 'master-en-covid19-data-dashboard.vercel.app',
+        defaultLocale: 'en',
+      },
+      {
+        domain: 'develop-nl-covid19-data-dashboard.vercel.app',
+        defaultLocale: 'nl',
+      },
+      {
+        domain: 'master-nl-covid19-data-dashboard.vercel.app',
+        defaultLocale: 'nl',
+      },
+    ],
+  },
+
   webpack(config, { isServer, webpack, defaultLoaders }) {
     if (
       isServer &&


### PR DESCRIPTION
## Summary

This PR adds the internationalized routing configuration to the application. In other words, if you go to coronadashboard.rijksoverheid.nl it will configure the router to use the Dutch locale. For coronadashboard.government.nl it will configure itself to use the English locale.

## Motivation

This is a preparation of a bigger refactor where we use locale information from `next/router` to configure the apps translations and date formatting. This part is easy to review, and follows [Next.js conventions](https://nextjs.org/docs/advanced-features/i18n-routing). I expect more discussions around the other implementation details so I want to get this out of the way first.

## Detailed design

Read the comments I left in the configuration file. They should be crystal clear. If not, let me know and I will change them.