### PR TITLE
Make language switcher use international routing

### DIFF
--- a/packages/app/src/components-styled/layout/components/language-switcher.tsx
+++ b/packages/app/src/components-styled/layout/components/language-switcher.tsx
@@ -1,36 +1,32 @@
 import css from '@styled-system/css';
 import { useRouter } from 'next/router';
+import { Link } from '~/utils/link';
 import styled from 'styled-components';
 import { Box } from '~/components-styled/base';
-import { getLocale } from '~/utils/getLocale';
 
 export function LanguageSwitcher() {
   const router = useRouter();
-  const locale = getLocale();
+
+  const { locale } = router;
 
   return (
     <Box height={55} mt={-55} textAlign="right">
-      <LanguageLink
-        href={`https://coronadashboard.rijksoverheid.nl${router.asPath}`}
-        lang="nl"
-        hrefLang="nl"
-        isActive={locale === 'nl'}
-        title="Website in het Nederlands"
-      >
-        NL
-      </LanguageLink>
+      <Link href={`${router.asPath}`} locale="nl" passHref>
+        <LanguageLink
+          isActive={locale === 'nl'}
+          title="Website in het Nederlands"
+        >
+          NL
+        </LanguageLink>
+      </Link>
 
       <Separator />
 
-      <LanguageLink
-        href={`https://coronadashboard.government.nl${router.asPath}`}
-        lang="en-GB"
-        hrefLang="en-GB"
-        isActive={locale === 'en-GB'}
-        title="Website in English"
-      >
-        EN
-      </LanguageLink>
+      <Link href={`${router.asPath}`} locale="en" passHref>
+        <LanguageLink isActive={locale === 'en'} title="Website in English">
+          EN
+        </LanguageLink>
+      </Link>
     </Box>
   );
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -6,5 +6,6 @@ import NextLink, { LinkProps } from 'next/link';
  */
 
 export function Link(props: LinkProps & { children?: React.ReactNode }) {
-  return <NextLink {...props} scroll={props.scroll ?? false} />;
+  const { locale = false } = props;
+  return <NextLink {...props} scroll={props.scroll ?? false} locale={locale} />;
 }


### PR DESCRIPTION
## Summary

In this PR we change the language switcher to use International Routing. 
Reference document: https://nextjs.org/docs/advanced-features/i18n-routing#transition-between-locales

## Motivation

This will allow us to switch languages on both preview and production servers. E.g. the language switcher does not always redirect to production anymore, which is a step up from where we're at currently.

What could still be improved: It does not work on localhost environments... but neither does the current codebase. Instead of switching `NEXT_PUBLIC_LOCALE` you can now switch the `defaultLanguage` in `next.config.js` if you need to test the english version locally.