### PR TITLE
Add date of report to vaccine delivery schema

### DIFF
--- a/packages/app/schema/nl/vaccine_delivery.json
+++ b/packages/app/schema/nl/vaccine_delivery.json
@@ -6,6 +6,7 @@
       "required": [
         "total",
         "date_of_insertion_unix",
+        "date_of_report_unix",
         "date_start_unix",
         "date_end_unix"
       ],
@@ -15,6 +16,9 @@
           "type": "number"
         },
         "date_of_insertion_unix": {
+          "type": "integer"
+        },
+        "date_of_report_unix": {
           "type": "integer"
         },
         "date_start_unix": {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -233,7 +233,7 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
           title={text.grafiek.titel}
           description={text.grafiek.omschrijving}
           metadata={{
-            date: vaccineDeliveryValues[0].date_of_insertion_unix,
+            date: data.vaccine_delivery.last_value.date_of_report_unix,
             source: text.bronnen.rivm,
           }}
         >

--- a/packages/common/src/data-sorting.ts
+++ b/packages/common/src/data-sorting.ts
@@ -18,6 +18,15 @@ export function sortTimeSeriesInDataInPlace<T>(data: T) {
     const nestedSeries = (data as UnknownObject)
       .sewer_per_installation as SewerPerInstallationData;
 
+    if (!nestedSeries.values) {
+      /**
+       * It can happen that we get incomplete json data and assuming that values
+       * exists here might crash the app
+       */
+      console.error('sewer_per_installation.values does not exist');
+      return;
+    }
+
     nestedSeries.values = nestedSeries.values.map((x) => {
       x.values = sortTimeSeriesValues(x.values);
       return x;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -478,6 +478,7 @@ export interface NlVaccineDelivery {
 export interface NlVaccineDeliveryValue {
   total: number;
   date_of_insertion_unix: number;
+  date_of_report_unix: number;
   date_start_unix: number;
   date_end_unix: number;
 }


### PR DESCRIPTION

## Summary

Add date of report to vaccine delivery schema and apply to chart metadata display.
