### PR TITLE
Add grouping to FAQ

### DIFF
--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -1,3 +1,4 @@
+import groupBy from 'lodash/groupBy';
 import Head from 'next/head';
 import { Box } from '~/components-styled/base';
 import { RichContent } from '~/components-styled/cms/rich-content';
@@ -58,15 +59,10 @@ export const getStaticProps = createGetStaticProps(
 const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
   const { content } = props;
 
-  const groups = content.questions.reduce<
-    Record<string, FAQuestionAndAnswer[]>
-  >((groupsAggr, question) => {
-    if (!groupsAggr[question.group]) {
-      groupsAggr[question.group] = [];
-    }
-    groupsAggr[question.group].push(question);
-    return groupsAggr;
-  }, {});
+  const groups = groupBy<FAQuestionAndAnswer>(
+    content.questions,
+    (x) => x.group
+  );
 
   return (
     <>

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -87,13 +87,15 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
       <Box fontSize={2} bg={'white'} pt={6} pb={4}>
         <MaxWidth>
           <Box maxWidth="39em" margin="auto" mt={0} px={{ _: 4, md: 0 }}>
-            {content.title && <Heading level={2}>{content.title}</Heading>}
+            {content.title && <Heading level={1}>{content.title}</Heading>}
             {content.description && (
               <RichContent blocks={content.description} />
             )}
             {Object.entries(groups).map(([group, questions]) => (
               <Box as="article" mt={5} key={group}>
-                <Heading level={3}>{group}</Heading>
+                <Heading level={2} fontSize={3}>
+                  {group}
+                </Heading>
                 {questions.map((item) => {
                   const id = getSkipLinkId(item.title);
                   return (

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -1,7 +1,9 @@
 import Head from 'next/head';
+import { Box } from '~/components-styled/base';
 import { RichContent } from '~/components-styled/cms/rich-content';
 import { CollapsibleSection } from '~/components-styled/collapsible';
 import { MaxWidth } from '~/components-styled/max-width';
+import { Heading } from '~/components-styled/typography';
 import { FCWithLayout, getLayoutWithMetadata } from '~/domain/layout/layout';
 import siteText, { targetLanguage } from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -9,14 +11,12 @@ import {
   createGetContent,
   getLastGeneratedDate,
 } from '~/static-props/get-data';
-import { CollapsibleList, RichContentBlock } from '~/types/cms';
+import { FAQQuestion, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
-import styles from './over.module.scss';
-import { Box } from '~/components-styled/base';
 interface VeelgesteldeVragenData {
   title: string | null;
   description: RichContentBlock[] | null;
-  questions: CollapsibleList[];
+  questions: FAQQuestion[];
 }
 
 const query = `*[_type == 'veelgesteldeVragen']{
@@ -35,7 +35,7 @@ const query = `*[_type == 'veelgesteldeVragen']{
     ...questions[]
     {
       ...,
-                
+      "group": group->group.${targetLanguage},
       "content": {
         ...content,
         "${targetLanguage}": [...content.${targetLanguage}[]
@@ -58,6 +58,17 @@ export const getStaticProps = createGetStaticProps(
 const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
   const { content } = props;
 
+  const groups = content.questions.reduce<Record<string, FAQQuestion[]>>(
+    (groupsAggr, question) => {
+      if (!groupsAggr[question.group]) {
+        groupsAggr[question.group] = [];
+      }
+      groupsAggr[question.group].push(question);
+      return groupsAggr;
+    },
+    {}
+  );
+
   return (
     <>
       <Head>
@@ -74,16 +85,17 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
         />
       </Head>
 
-      <div className={styles.container}>
+      <Box fontSize={2} bg={'white'} pt={6} pb={4}>
         <MaxWidth>
-          <div className={styles.maxwidth}>
-            {content.title && <h2>{content.title}</h2>}
+          <Box maxWidth="39em" margin="auto" mt={0} px={{ _: 4, md: 0 }}>
+            {content.title && <Heading level={2}>{content.title}</Heading>}
             {content.description && (
               <RichContent blocks={content.description} />
             )}
-            {content.questions && (
-              <article>
-                {content.questions.map((item) => {
+            {Object.entries(groups).map(([group, questions]) => (
+              <Box as="article" mt={5} key={group}>
+                <Heading level={3}>{group}</Heading>
+                {questions.map((item) => {
                   const id = getSkipLinkId(item.title);
                   return (
                     <CollapsibleSection key={id} id={id} summary={item.title}>
@@ -95,11 +107,11 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
                     </CollapsibleSection>
                   );
                 })}
-              </article>
-            )}
-          </div>
+              </Box>
+            ))}
+          </Box>
         </MaxWidth>
-      </div>
+      </Box>
     </>
   );
 };

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -11,12 +11,12 @@ import {
   createGetContent,
   getLastGeneratedDate,
 } from '~/static-props/get-data';
-import { FAQQuestion, RichContentBlock } from '~/types/cms';
+import { FAQuestionAndAnswer, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 interface VeelgesteldeVragenData {
   title: string | null;
   description: RichContentBlock[] | null;
-  questions: FAQQuestion[];
+  questions: FAQuestionAndAnswer[];
 }
 
 const query = `*[_type == 'veelgesteldeVragen']{
@@ -58,16 +58,15 @@ export const getStaticProps = createGetStaticProps(
 const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
   const { content } = props;
 
-  const groups = content.questions.reduce<Record<string, FAQQuestion[]>>(
-    (groupsAggr, question) => {
-      if (!groupsAggr[question.group]) {
-        groupsAggr[question.group] = [];
-      }
-      groupsAggr[question.group].push(question);
-      return groupsAggr;
-    },
-    {}
-  );
+  const groups = content.questions.reduce<
+    Record<string, FAQuestionAndAnswer[]>
+  >((groupsAggr, question) => {
+    if (!groupsAggr[question.group]) {
+      groupsAggr[question.group] = [];
+    }
+    groupsAggr[question.group].push(question);
+    return groupsAggr;
+  }, {});
 
   return (
     <>

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -1,6 +1,6 @@
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 
-export type FAQQuestion = {
+export type FAQuestionAndAnswer = {
   content: RichContentBlock[] | null;
   title: string;
   group: string;

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -1,5 +1,11 @@
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 
+export type FAQQuestion = {
+  content: RichContentBlock[] | null;
+  title: string;
+  group: string;
+};
+
 export type CollapsibleList = {
   content: RichContentBlock[] | null;
   title: string;

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -15,13 +15,13 @@
     "format": "prettier --write \"src/**/*.{js,ts,tsx}\" \"*.{js,json,md,yml}\""
   },
   "dependencies": {
-    "@sanity/base": "^2.4.3",
+    "@sanity/base": "^2.6.0",
     "@sanity/components": "^2.2.6",
-    "@sanity/core": "^2.4.0",
+    "@sanity/core": "^2.6.1",
     "@sanity/dashboard": "^2.2.6",
-    "@sanity/default-layout": "^2.4.3",
+    "@sanity/default-layout": "^2.6.0",
     "@sanity/default-login": "^2.2.6",
-    "@sanity/desk-tool": "^2.4.3",
+    "@sanity/desk-tool": "^2.6.1",
     "@sanity/production-preview": "^2.2.6",
     "@sanity/ui": "^0.33.7",
     "@sanity/vision": "^2.2.6",
@@ -38,11 +38,12 @@
     "sanity-plugin-tabs": "^2.0.1"
   },
   "devDependencies": {
-    "@sanity/cli": "^2.4.0",
+    "@sanity/cli": "^2.6.0",
     "@types/download": "^6.2.4",
     "@types/fs-extra": "^9.0.6",
     "@types/prompts": "^2.0.9",
     "@types/react-world-flags": "^1.4.1",
-    "dotenv-flow": "^3.2.0"
+    "dotenv-flow": "^3.2.0",
+    "ts-node": "^9.1.1"
   }
 }

--- a/packages/cms/src/desk-structure.ts
+++ b/packages/cms/src/desk-structure.ts
@@ -1,5 +1,4 @@
 import { StructureBuilder } from '@sanity/structure';
-import { ReactNode } from 'react';
 // import StructureBuilder from '@sanity/desk-tool/structure-builder';
 import { BsCardChecklist, BsLockFill, BsMap, BsTable } from 'react-icons/bs';
 import { GrCircleInformation, GrDashboard } from 'react-icons/gr';
@@ -47,6 +46,7 @@ const hiddenDocTypes = [
   'siteSettings',
   'topicalPage',
   'veelgesteldeVragen',
+  'veelgesteldeVragenGroups',
   'cijferVerantwoording',
   'overDitDashboard',
   'overRisicoNiveaus',
@@ -92,12 +92,24 @@ export default () =>
         'Over de risiconiveaus',
         'overRisicoNiveaus'
       ),
-      addListItem(
-        StructureBuilder,
-        MdQuestionAnswer,
-        'Veelgestelde vragen',
-        'veelgesteldeVragen'
-      ),
+      StructureBuilder.listItem()
+        .title('Veelgestelde vragen')
+        .icon(MdQuestionAnswer)
+        .child(
+          StructureBuilder.list()
+            .title('Groepen en Vragen')
+            .items([
+              ...StructureBuilder.documentTypeListItems().filter(
+                (item) => item.getId() === 'veelgesteldeVragenGroups'
+              ),
+              addListItem(
+                StructureBuilder,
+                MdQuestionAnswer,
+                'Veelgestelde vragen',
+                'veelgesteldeVragen'
+              ),
+            ])
+        ),
       addListItem(
         StructureBuilder,
         BsCardChecklist,

--- a/packages/cms/src/migrations/sprint18/index.ts
+++ b/packages/cms/src/migrations/sprint18/index.ts
@@ -19,29 +19,24 @@ const fetchDefaultGroup = () =>
 
 const buildPatches = (docs: any[], group: any) =>
   docs
-    .map((doc) => {
-      if (doc.questions.every((x: any) => x._type === 'faqQuestion')) {
-        return;
-      }
-      return {
-        id: doc._id,
-        patch: {
-          set: {
-            questions: doc.questions.map((x: any) => ({
-              ...x,
-              _type: 'faqQuestion',
-              group: {
-                _type: 'reference',
-                _ref: group._id,
-              },
-            })),
-          },
-          // this will cause the transaction to fail if the documents has been
-          // modified since it was fetched.
-          ifRevisionID: doc._rev,
+    .map((doc) => ({
+      id: doc._id,
+      patch: {
+        set: {
+          questions: doc.questions.map((x: any) => ({
+            ...x,
+            _type: 'faqQuestion',
+            group: {
+              _type: 'reference',
+              _ref: group._id,
+            },
+          })),
         },
-      };
-    })
+        // this will cause the transaction to fail if the documents has been
+        // modified since it was fetched.
+        ifRevisionID: doc._rev,
+      },
+    }))
     .filter((x) => x !== undefined);
 
 const createTransaction = (patches: any[]) =>

--- a/packages/cms/src/migrations/sprint18/index.ts
+++ b/packages/cms/src/migrations/sprint18/index.ts
@@ -1,0 +1,83 @@
+import client from 'part:@sanity/base/client';
+
+const fetchFAQ = () => client.fetch(`*[_type == 'veelgesteldeVragen']`);
+const fetchDefaultGroup = () =>
+  client.fetch(`*[_type == 'veelgesteldeVragenGroups'][0]`);
+
+const buildPatches = (docs: any[], group: any) =>
+  docs
+    .map((doc) => {
+      if (doc.questions.every((x: any) => x._type === 'faqQuestion')) {
+        return;
+      }
+      return {
+        id: doc._id,
+        patch: {
+          set: {
+            questions: doc.questions.map((x: any) => ({
+              ...x,
+              _type: 'faqQuestion',
+              group: {
+                _type: 'reference',
+                _ref: group._id,
+              },
+            })),
+          },
+          // this will cause the transaction to fail if the documents has been
+          // modified since it was fetched.
+          ifRevisionID: doc._rev,
+        },
+      };
+    })
+    .filter((x) => x !== undefined);
+
+const createTransaction = (patches: any[]) =>
+  patches.reduce(
+    (tx, patch) => tx.patch(patch.id, patch.patch),
+    client.transaction()
+  );
+
+const commitTransaction = (tx: any) => tx.commit();
+
+const createDefaultGroup = async () => {
+  const doc = {
+    _type: 'veelgesteldeVragenGroups',
+    group: {
+      _type: 'localeString',
+      nl: 'Algemeen',
+      en: 'General',
+    },
+  };
+
+  return client.create(doc);
+};
+
+const migrateNextBatch = async (): Promise<any> => {
+  let group = await fetchDefaultGroup();
+  if (group === null) {
+    group = await createDefaultGroup();
+  }
+  const documents = (await fetchFAQ()).filter((x: any) =>
+    x.questions.some((x: any) => x._type === 'collapsible')
+  );
+  const patches = buildPatches(documents, group);
+  if (patches.length === 0) {
+    console.log('No more documents to migrate!');
+    return null;
+  }
+  console.dir(patches);
+  console.log(
+    `Migrating batch:\n %s`,
+    patches
+      .map((patch: any) => `${patch.id} => ${JSON.stringify(patch.patch)}`)
+      .join('\n')
+  );
+  const transaction = createTransaction(patches);
+  await commitTransaction(transaction);
+  return migrateNextBatch();
+};
+
+migrateNextBatch().catch((err: any) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cms/src/migrations/sprint18/index.ts
+++ b/packages/cms/src/migrations/sprint18/index.ts
@@ -7,6 +7,10 @@ import client from 'part:@sanity/base/client';
  * Then it changes the '_type' field for all 'veelgesteldeVragen.question' documents from 'collapsible' to 'faqQuestion' and
  * assigns the veelgesteldeVragenGroups document to the 'group' field.
  *
+ * This migration can be run by executing the following command from the packages/cms directory:
+ * sanity exec src/migrations/sprint18 --with-user-token
+ *
+ * (Don't forget to run 'sanity login' first and choose the 'Google' option to login with)
  */
 
 const fetchFAQ = () => client.fetch(`*[_type == 'veelgesteldeVragen']`);

--- a/packages/cms/src/plugins/translate/datastore.js
+++ b/packages/cms/src/plugins/translate/datastore.js
@@ -1,9 +1,9 @@
 import { intersection } from 'lodash';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { map, publishReplay, refCount, startWith, tap } from 'rxjs/operators';
 import config from './config.js';
 
-const onSelect$ = new Subject();
+const onSelect$ = new BehaviorSubject();
 
 export const setLangs = (langs) => onSelect$.next(langs);
 

--- a/packages/cms/src/plugins/translate/prepareLocalized.ts
+++ b/packages/cms/src/plugins/translate/prepareLocalized.ts
@@ -1,0 +1,35 @@
+import { selectedLanguages$ } from '../../plugins/translate/datastore';
+
+let selectedLanguage = 'nl';
+selectedLanguages$.subscribe((selected: any[]) => {
+  selectedLanguage = selected.length ? selected[0] : 'nl';
+});
+
+export function prepareLocalized(selection: any) {
+  const result: any = {};
+  for (let prop in selection) {
+    const value = selection[prop];
+    if (isLocaleObject(value)) {
+      if (isLocaleBlock(value)) {
+        result[prop] = localeBlockToString(value, selectedLanguage);
+      } else {
+        result[prop] = value[selectedLanguage];
+      }
+    } else {
+      result[prop] = value;
+    }
+  }
+  return result;
+}
+
+function isLocaleObject(obj: any) {
+  return typeof obj === 'object' && obj._type?.startsWith('locale');
+}
+
+function isLocaleBlock(obj: any) {
+  return obj._type === 'localeBlock';
+}
+
+function localeBlockToString(block: any, lang: string) {
+  return block[lang][0]?.children[0]?.text;
+}

--- a/packages/cms/src/plugins/translate/select-language-provider.js
+++ b/packages/cms/src/plugins/translate/select-language-provider.js
@@ -5,13 +5,15 @@ import { selectedLanguages$, setLangs } from './datastore';
 import SelectLanguage from './select-language';
 
 export default function SelectLanguageProvider() {
-  const [selected, setSelected] = useState('nl');
+  const [selected, setSelected] = useState(['nl']);
   const langSubscription = useRef();
   const document = useCurrentDocument();
 
   useEffect(() => {
     langSubscription.current = selectedLanguages$.subscribe((selected) => {
-      setSelected(selected);
+      if (selected?.length) {
+        setSelected(selected);
+      }
     });
     return () => {
       langSubscription.current.unsubscribe();

--- a/packages/cms/src/plugins/translate/select-language.js
+++ b/packages/cms/src/plugins/translate/select-language.js
@@ -88,5 +88,10 @@ function findLocaleFields(documentId, schema) {
   if (!docSchema) {
     return true;
   }
-  return docSchema.fields.some((field) => field.type.startsWith('locale'));
+  return docSchema.fields.some(
+    (field) =>
+      field.type.startsWith('locale') ||
+      (field.type === 'array' &&
+        field.of.some((x) => x.type.startsWith('locale')))
+  );
 }

--- a/packages/cms/src/sanity.d.ts
+++ b/packages/cms/src/sanity.d.ts
@@ -2,6 +2,8 @@ declare module 'part:@sanity/form-builder/patch-event' {
   export * from '@sanity/form-builder/lib/PatchEvent';
 }
 
+declare module 'part:@sanity/base/client';
+
 declare module 'all:part:@sanity/base/schema-type' {
   let types: any[];
   export default types;

--- a/packages/cms/src/schemas/documents/pages/veelgestelde-vragen-groepen-page.ts
+++ b/packages/cms/src/schemas/documents/pages/veelgestelde-vragen-groepen-page.ts
@@ -1,0 +1,26 @@
+import { selectedLanguages$ } from '../../../plugins/translate/datastore';
+import { prepareLocalized } from '../../../plugins/translate/prepareLocalized';
+
+let selectedLanguage = 'nl';
+selectedLanguages$.subscribe((selected) => {
+  selectedLanguage = selected.length ? selected[0] : 'nl';
+});
+
+export default {
+  name: 'veelgesteldeVragenGroups',
+  type: 'document',
+  title: 'Veelgestelde vragen groepen',
+  fields: [
+    {
+      name: 'group',
+      type: 'localeString',
+      title: 'Groepsnaam',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'group',
+    },
+    prepare: prepareLocalized,
+  },
+};

--- a/packages/cms/src/schemas/documents/pages/veelgestelde-vragen-page.ts
+++ b/packages/cms/src/schemas/documents/pages/veelgestelde-vragen-page.ts
@@ -19,7 +19,7 @@ export default {
       title: 'Vragen',
       description:
         'Je kan veel gestelde vragen toevoegen, de volgorde veranderen, de tekst bijwerken of verwijderen',
-      of: [{ type: 'collapsible' }],
+      of: [{ type: 'faqQuestion' }],
     },
   ],
   preview: {

--- a/packages/cms/src/schemas/locale/locale-string.ts
+++ b/packages/cms/src/schemas/locale/locale-string.ts
@@ -4,17 +4,9 @@ export default {
   name: 'localeString',
   type: 'object',
   title: 'Locale String Content',
-  // fieldsets: [
-  //   {
-  //     title: "Vertalingen",
-  //     name: "translations",
-  //     options: { collapsible: true },
-  //   },
-  // ],
   fields: supportedLanguages.map((lang) => ({
     title: lang.title,
     name: lang.id,
     type: 'string',
-    // fieldset: lang.isDefault ? null : "translations",
   })),
 };

--- a/packages/cms/src/schemas/objects/faq-question.ts
+++ b/packages/cms/src/schemas/objects/faq-question.ts
@@ -23,7 +23,7 @@ export default {
   preview: {
     select: {
       title: 'title',
-      subtitle: 'content',
+      subtitle: 'group.group',
     },
     prepare: prepareLocalized,
   },

--- a/packages/cms/src/schemas/objects/faq-question.ts
+++ b/packages/cms/src/schemas/objects/faq-question.ts
@@ -1,0 +1,30 @@
+import { selectedLanguages$ } from '../../plugins/translate/datastore';
+import { prepareLocalized } from '../../plugins/translate/prepareLocalized';
+
+let selectedLanguage = 'nl';
+selectedLanguages$.subscribe((selected: any[]) => {
+  selectedLanguage = selected.length ? selected[0] : 'nl';
+});
+
+export default {
+  title: 'Veelgestelde vraag',
+  name: 'faqQuestion',
+  type: 'object',
+  fields: [
+    { name: 'title', type: 'localeString', title: 'Titel' },
+    { name: 'content', type: 'localeBlock', title: 'Inhoud' },
+    {
+      name: 'group',
+      type: 'reference',
+      to: [{ type: 'veelgesteldeVragenGroups' }],
+      title: 'Groep',
+    },
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'content',
+    },
+    prepare: prepareLocalized,
+  },
+};

--- a/packages/cms/src/schemas/schema.ts
+++ b/packages/cms/src/schemas/schema.ts
@@ -20,6 +20,7 @@ import reproductionPage from './documents/pages/reproduction-page';
 import sewerPage from './documents/pages/sewer-page';
 import topicalPage from './documents/pages/topical-page';
 import vaccinationsPage from './documents/pages/vaccinations-page';
+import veelgesteldeVragenGroepen from './documents/pages/veelgestelde-vragen-groepen-page';
 import veelgesteldeVragen from './documents/pages/veelgestelde-vragen-page';
 import toegankelijkheid from './documents/toegankelijkheid';
 import localeBlock from './locale/locale-block';
@@ -30,6 +31,7 @@ import localeString from './locale/locale-string';
 import localeText from './locale/locale-text';
 //objects are building blocks, but not queryable in itself
 import collapsible from './objects/collapsible';
+import faqQuestion from './objects/faq-question';
 import lineChart from './objects/line-chart';
 import milestone from './objects/milestone';
 import lockdown from './restrictions/lockdown';
@@ -51,6 +53,7 @@ export default createSchema({
     article,
     editorial,
     veelgesteldeVragen,
+    veelgesteldeVragenGroepen,
     cijferVerantwoording,
     overRisicoNiveaus,
     overDitDashboard,
@@ -78,6 +81,7 @@ export default createSchema({
     lineChart,
     collapsible,
     milestone,
+    faqQuestion,
 
     /* LOCALE HELPERS */
     localeString,

--- a/packages/cms/tsconfig.json
+++ b/packages/cms/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "@types/sanity.d.ts"],
   "compilerOptions": {
     "jsx": "react",
     "allowJs": true

--- a/packages/cms/tsconfig.json
+++ b/packages/cms/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src", "@types/sanity.d.ts"],
+  "include": ["src"],
   "compilerOptions": {
     "jsx": "react",
     "allowJs": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,7 +1563,7 @@
   resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.1.2.tgz#d6b4b875bee4189cb56f274a7fb5494174463cb2"
   integrity sha512-wVNhZ/W0ktlvHUzUrCuJMY9YtSls3PU+p5iQko8+P2R0HhEJfBCeTMTdqCe4BY/AfzVb4tn3/xr6XRRBKEL+AA==
 
-"@sanity/base@2.6.0", "@sanity/base@^2.4.3":
+"@sanity/base@2.6.0", "@sanity/base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@sanity/base/-/base-2.6.0.tgz#98f2816ba8d6fd7b3d5f6c608e26eae819cb83d0"
   integrity sha512-HT13hy07xGBnwmyezVTRZkk7FdGaJ1raZE0qq7FwtzhT7d1+4rNu2rkfY4uNrpEAnI0+BgkX5LvEikUDeNFzfQ==
@@ -1652,7 +1652,7 @@
     get-random-values "^1.2.0"
     lodash "^4.17.15"
 
-"@sanity/cli@^2.4.0":
+"@sanity/cli@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@sanity/cli/-/cli-2.6.0.tgz#ffc0ba15cf6e34627538fe8ba655369f5a655a48"
   integrity sha512-lZFSF9ahk67YI/hYXP7RpQv1iubw5N/OA8+X7CjiLqoBe0C7kQ/B7hPnw3TyMz4r67Mwt5ApnsKd5466S5M3/A==
@@ -1685,7 +1685,7 @@
   resolved "https://registry.yarnpkg.com/@sanity/components/-/components-2.2.6.tgz#d1d6d1017a53ebb413ef026eabd5dd0b4a1bcdad"
   integrity sha512-KK+6eJgrgHEd9Hq+LbRamdAI64cNXYoVn/f/Dn3ES1GA55AvQyKQUay4T/zZ1yEITKSyIZgETQjpAl/Hg+72eQ==
 
-"@sanity/core@^2.4.0":
+"@sanity/core@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@sanity/core/-/core-2.6.1.tgz#abdebe2e9dc62a9a198e477963be35f008aad581"
   integrity sha512-OljJZvehYZktf35auusKcfZL3ewMeg6BkJ5kmK7mc7OGBIcTaT0q8o4PAYMc63TZ5aPvjljbn2ONyATnTrjIPw==
@@ -1777,7 +1777,7 @@
     "@sanity/generate-help-url" "2.2.6"
     lodash "^4.17.15"
 
-"@sanity/default-layout@^2.4.3":
+"@sanity/default-layout@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@sanity/default-layout/-/default-layout-2.6.0.tgz#2f5b7d5a54016a1b632d4dafc103aa0f4aa6838e"
   integrity sha512-bGIHaDZzI5BJlLAJ21XMhUm3zR8vJsKURcbqOK/moDuBvbOfbrmTvnadTljV8KEubCnRFZMw446qZQqY1b6uFQ==
@@ -1803,7 +1803,7 @@
     prop-types "^15.6.0"
     rxjs "^6.5.3"
 
-"@sanity/desk-tool@^2.4.3":
+"@sanity/desk-tool@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@sanity/desk-tool/-/desk-tool-2.6.1.tgz#b6e09c8ab53675e06e8535f1a9746be9151b7dcc"
   integrity sha512-0pItzqRzVq7ZnwdamQm3/A2RZQwqqrIU/RwdcGe5Gx3Q87u5k9uvW8UBWdGbdfA+PfjGZ9mSrhyyWigOWjDF9w==


### PR DESCRIPTION
## Summary

This PR adds a grouping to the FAQ questions:

![image](https://user-images.githubusercontent.com/69849293/111193268-48fec700-85ba-11eb-8d89-34cbeeb0cea9.png)

Since the schema had to be changed for this feature a data migration was also added.
Previews are now also, more or less, localized in the Sanity Studio.

## Motivation

Feature request

## Detailed design

The frontend changes are quite minimal all that was added is an H3 between all the questions indicating the assigned group.

A `veelgesteldeVragenGroups` schema was added in order to define the localized group names and the `question` fields in `veelgesteldeVragen ` schema are now of type `faqQuestion`.

In order to migrate those field types a migration was created in `packages/cms/src/migrations/sprint18`, my proposal is keep that naming scheme for future migrations. I've added a big comment header to the migration script that, hopefully, clarifies exactly what the migration does and how to run it.

Lastly, Sanity was upgraded to the latest version, so don't forget to run `yarn` once this is merged.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
