### PR TITLE
Fix LinkWithIcon when icon is positioned on the left

### DIFF
--- a/packages/app/src/components-styled/link-with-icon.tsx
+++ b/packages/app/src/components-styled/link-with-icon.tsx
@@ -59,11 +59,8 @@ export function LinkWithIcon({
         )}
         {iconPlacement === 'left' && !headingLink && (
           <>
-            {!words.length ? children : firstWords}
-            <IconWrapper>
-              <IconSmall icon={icon} width={11} height={10} />
-              {words[words.length - 1]}
-            </IconWrapper>
+            <IconSmall icon={icon} width={11} height={10} />
+            {children}
           </>
         )}
         {headingLink && (


### PR DESCRIPTION
## Summary

Accidentally applied the icon wrapping logic to links with the icon on the left where the issue doesn't apply. This reverts that change for this icon positioning


