### PR TITLE
Refactor page layouts to a simper implementation

### DIFF
--- a/packages/app/src/domain/layout/layout.tsx
+++ b/packages/app/src/domain/layout/layout.tsx
@@ -5,7 +5,6 @@ import { SEOHead } from '~/components-styled/seo-head';
 import { AppFooter } from '~/components-styled/layout/app-footer';
 import { AppHeader } from '~/components-styled/layout/app-header';
 import { SkipLinkMenu } from '~/components-styled/skip-link-menu';
-import { useIntl } from '~/intl';
 
 interface LayoutProps {
   title: string;
@@ -26,47 +25,7 @@ export type FCWithLayout<
   ) => Promise<{ props: any }>
     ? StaticProps<PropsOrGetStaticProps>
     : PropsOrGetStaticProps
-> = React.FC<Props> & {
-  getLayout: (page: React.ReactNode, pageProps: Props) => React.ReactNode;
-};
-
-export function GetLayoutWithMetadata(metadata: LayoutProps) {
-  return function (page: React.ReactNode, pageProps: any) {
-    const lastGenerated = pageProps.lastGenerated;
-    return getLayout(metadata, lastGenerated)(<>{page}</>);
-  };
-}
-
-export function GetLayoutWithMetadataKey(metadatakey: string) {
-  const { siteText } = useIntl();
-  const metadata = siteText[metadatakey] as LayoutProps;
-
-  return function (page: React.ReactNode, pageProps: any) {
-    const lastGenerated = pageProps.lastGenerated;
-    return getLayout(metadata, lastGenerated)(<>{page}</>);
-  };
-}
-
-export function getDefaultLayout() {
-  return function <T extends { lastGenerated: string }>(
-    page: React.ReactNode,
-    pageProps: T
-  ) {
-    const { siteText } = useIntl();
-    const lastGenerated = pageProps.lastGenerated;
-    return getLayout(siteText?.metadata, lastGenerated)(<>{page}</>);
-  };
-}
-
-export function getLayout(layoutProps: LayoutProps, lastGenerated: string) {
-  return function (page: React.ReactNode): React.ReactNode {
-    return (
-      <Layout {...layoutProps} lastGenerated={lastGenerated}>
-        {page}
-      </Layout>
-    );
-  };
-}
+> = React.FC<Props>;
 
 export function Layout(
   props: LayoutProps & { lastGenerated: string; children: React.ReactNode }

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -16,7 +16,6 @@ import { AppContent } from '~/components-styled/layout/app-content';
 import { SidebarMetric } from '~/components-styled/sidebar-metric';
 import { Text } from '~/components-styled/typography';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
-import { getLayout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import { getSafetyRegionForMunicipalityCode } from '~/utils/getSafetyRegionForMunicipalityCode';
 import { Link } from '~/utils/link';
@@ -28,20 +27,6 @@ interface MunicipalityLayoutProps {
   data?: Municipal;
   municipalityName?: string;
   children?: React.ReactNode;
-}
-
-export function getMunicipalityLayout() {
-  return function (
-    page: React.ReactNode,
-    pageProps: MunicipalityLayoutProps
-  ): React.ReactNode {
-    const lastGenerated = pageProps.lastGenerated;
-
-    return getLayout(
-      siteText?.gemeente_metadata,
-      lastGenerated
-    )(<MunicipalityLayout {...pageProps}>{page}</MunicipalityLayout>);
-  };
 }
 
 /**
@@ -60,7 +45,7 @@ export function getMunicipalityLayout() {
  * More info on persistent layouts:
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function MunicipalityLayout(props: MunicipalityLayoutProps) {
+export function MunicipalityLayout(props: MunicipalityLayoutProps) {
   const { children, data, municipalityName } = props;
 
   const { siteText } = useIntl();

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -20,7 +20,6 @@ import {
 } from '~/components-styled/aside/menu';
 import { AppContent } from '~/components-styled/layout/app-content';
 import { SidebarMetric } from '~/components-styled/sidebar-metric';
-import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { Box } from '~/components-styled/base';
@@ -31,20 +30,6 @@ interface NationalLayoutProps {
   children?: React.ReactNode;
 }
 
-export function getNationalLayout(
-  page: React.ReactNode,
-  pageProps: NationalLayoutProps
-) {
-  return (
-    <Layout
-      //@TODO HOW DO I GET METADATA HERE?
-      // {...siteText?.nationaal_metadata}
-      lastGenerated={pageProps.lastGenerated}
-    >
-      <NationalLayout {...pageProps}>{page}</NationalLayout>
-    </Layout>
-  );
-}
 /**
  * NationalLayout is a composition of persistent layouts.
  *
@@ -61,7 +46,7 @@ export function getNationalLayout(
  * More info on persistent layouts:
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function NationalLayout(props: NationalLayoutProps) {
+export function NationalLayout(props: NationalLayoutProps) {
   const { children, data } = props;
   const router = useRouter();
   const breakpoints = useBreakpoints();

--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -19,7 +19,6 @@ import { AppContent } from '~/components-styled/layout/app-content';
 import { SidebarMetric } from '~/components-styled/sidebar-metric';
 import { Text } from '~/components-styled/typography';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
-import { getLayout as getSiteLayout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { SafetyRegionComboBox } from './components/safety-region-combo-box';
@@ -31,18 +30,6 @@ interface SafetyRegionLayoutProps {
   data?: Regionaal;
   safetyRegionName?: string;
   children?: React.ReactNode;
-}
-
-export function getSafetyRegionLayout() {
-  return function (page: React.ReactNode, pageProps: SafetyRegionLayoutProps) {
-    //@TODO WHY IS THIS NULL
-
-    return getSiteLayout(
-      //@TODO HOW DO I GET METADATA HERE?
-      // siteText?.veiligheidsregio_metadata,
-      pageProps.lastGenerated
-    )(<SafetyRegionLayout {...pageProps}>{page}</SafetyRegionLayout>);
-  };
 }
 
 /**
@@ -61,7 +48,7 @@ export function getSafetyRegionLayout() {
  * More info on persistent layouts:
  * https:adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
-function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
+export function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
   const { children, data, safetyRegionName } = props;
 
   const breakpoints = useBreakpoints();

--- a/packages/app/src/intl/hooks/useIntl.ts
+++ b/packages/app/src/intl/hooks/useIntl.ts
@@ -52,9 +52,6 @@ export function useIntl() {
   const { locale } = useRouter();
   const { messages } = useContext(IntlContext);
 
-  console.log('useIntl');
-  console.log({ locale });
-
   // Number formatting
   const NumberFormat = new Intl.NumberFormat(locale);
 

--- a/packages/app/src/pages/404.tsx
+++ b/packages/app/src/pages/404.tsx
@@ -1,27 +1,28 @@
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { MaxWidth } from '~/components-styled/max-width';
 import styles from './over.module.scss';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
-const NotFound: FCWithLayout = () => {
+const NotFound = (props) => {
+  const { lastGenerated } = props;
   const { siteText } = useIntl();
 
   return (
-    <div className={styles.container}>
-      <MaxWidth>
-        <div className={styles.maxwidth}>
-          <h2>{siteText.notfound_titel.text}</h2>
-          <p>{siteText.notfound_beschrijving.text}</p>
-        </div>
-      </MaxWidth>
-    </div>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <div className={styles.container}>
+        <MaxWidth>
+          <div className={styles.maxwidth}>
+            <h2>{siteText.notfound_titel.text}</h2>
+            <p>{siteText.notfound_beschrijving.text}</p>
+          </div>
+        </MaxWidth>
+      </div>
+    </Layout>
   );
 };
-
-NotFound.getLayout = GetLayoutWithMetadataKey('notfound_metadata');
 
 export default NotFound;

--- a/packages/app/src/pages/404.tsx
+++ b/packages/app/src/pages/404.tsx
@@ -12,7 +12,7 @@ const NotFound = (props) => {
   const { siteText } = useIntl();
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...siteText.notfound_metadata} lastGenerated={lastGenerated}>
       <div className={styles.container}>
         <MaxWidth>
           <div className={styles.maxwidth}>

--- a/packages/app/src/pages/500.tsx
+++ b/packages/app/src/pages/500.tsx
@@ -13,7 +13,7 @@ const ErrorPage = (props) => {
   const { siteText } = useIntl();
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...siteText.error_metadata} lastGenerated={lastGenerated}>
       <div className={styles.container}>
         <MaxWidth>
           <div className={styles.maxwidth}>

--- a/packages/app/src/pages/500.tsx
+++ b/packages/app/src/pages/500.tsx
@@ -1,27 +1,29 @@
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
 import styles from './error.module.scss';
+import { Layout } from '~/domain/layout/layout';
+
 import { useIntl } from '~/intl';
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
-const ErrorPage: FCWithLayout = () => {
+const ErrorPage = (props) => {
+  const { lastGenerated } = props;
   const { siteText } = useIntl();
 
   return (
-    <div className={styles.container}>
-      <MaxWidth>
-        <div className={styles.maxwidth}>
-          <h2>{siteText.error_titel.text}</h2>
-          <p>{siteText.error_beschrijving.text}</p>
-        </div>
-      </MaxWidth>
-    </div>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <div className={styles.container}>
+        <MaxWidth>
+          <div className={styles.maxwidth}>
+            <h2>{siteText.error_titel.text}</h2>
+            <p>{siteText.error_beschrijving.text}</p>
+          </div>
+        </MaxWidth>
+      </div>
+    </Layout>
   );
 };
-
-ErrorPage.getLayout = GetLayoutWithMetadataKey('error_metadata');
 
 export default ErrorPage;

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -4,7 +4,6 @@ import Router, { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import '~/components-styled/combo-box/combo-box.scss';
-import { FCWithLayout } from '~/domain/layout/layout';
 import { IntlContext } from '~/intl';
 import * as piwik from '~/lib/piwik';
 import { GlobalStyle } from '~/style/global-style';
@@ -26,14 +25,8 @@ if (typeof window !== 'undefined') {
   }
 }
 
-type AppPropsWithLayout = AppProps & {
-  Component: FCWithLayout;
-};
-
-export default function App(props: AppPropsWithLayout) {
+export default function App(props: AppProps) {
   const { Component, pageProps } = props;
-  const page = (page: React.ReactNode) => page;
-  const getLayout = Component.getLayout || page;
 
   const { locale } = useRouter();
 
@@ -56,13 +49,11 @@ export default function App(props: AppPropsWithLayout) {
     };
   }, []);
 
-  const pageWithLayout = getLayout(<Component {...pageProps} />, pageProps);
-
   return (
     <ThemeProvider theme={theme}>
       <IntlContext.Provider value={intlState}>
         <GlobalStyle />
-        {pageWithLayout}
+        <Component {...pageProps} />
       </IntlContext.Provider>
     </ThemeProvider>
   );

--- a/packages/app/src/pages/_error.tsx
+++ b/packages/app/src/pages/_error.tsx
@@ -1,35 +1,36 @@
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
-import styles from './error.module.scss';
+import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
+import styles from './error.module.scss';
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
-const ErrorPage: FCWithLayout = () => {
+const ErrorPage = (props) => {
+  const { lastGenerated } = props;
   const { siteText } = useIntl();
 
   return (
-    <div className={styles.container}>
-      <MaxWidth>
-        <div className={styles.maxwidth}>
-          <h2>{siteText.error_titel.text}</h2>
-          <p>{siteText.error_beschrijving.text}</p>
-          <button
-            className={styles.button}
-            onClick={() => {
-              location.reload();
-            }}
-          >
-            {siteText.error_probeer_opnieuw.text}
-          </button>
-        </div>
-      </MaxWidth>
-    </div>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <div className={styles.container}>
+        <MaxWidth>
+          <div className={styles.maxwidth}>
+            <h2>{siteText.error_titel.text}</h2>
+            <p>{siteText.error_beschrijving.text}</p>
+            <button
+              className={styles.button}
+              onClick={() => {
+                location.reload();
+              }}
+            >
+              {siteText.error_probeer_opnieuw.text}
+            </button>
+          </div>
+        </MaxWidth>
+      </div>
+    </Layout>
   );
 };
-
-ErrorPage.getLayout = GetLayoutWithMetadataKey('error_metadata');
 
 export default ErrorPage;

--- a/packages/app/src/pages/_error.tsx
+++ b/packages/app/src/pages/_error.tsx
@@ -12,7 +12,7 @@ const ErrorPage = (props) => {
   const { siteText } = useIntl();
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...siteText.error_metadata} lastGenerated={lastGenerated}>
       <div className={styles.container}>
         <MaxWidth>
           <div className={styles.maxwidth}>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -9,7 +9,6 @@ import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { MaxWidth } from '~/components-styled/max-width';
 import { CollapsibleButton } from '~/components-styled/collapsible';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
@@ -85,16 +84,17 @@ const TopicalMunicipality = (props) => {
     `Could not find a "vrcode" to match with the region: ${safetyRegionForMunicipality?.code} to get the the current "level" of it.`
   );
 
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      municipalityName,
+    }),
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          municipalityName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          municipalityName,
-        })}
-      />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <Box bg="white" pb={4}>
         <MaxWidth id="content">
           <TileList>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -15,7 +15,6 @@ import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout, getDefaultLayout } from '~/domain/layout/layout';
 import { ArticleList } from '~/domain/topical/article-list';
 import { Sitemap } from '~/domain/topical/sitemap';
 import { EditorialSummary } from '~/domain/topical/editorial-teaser';
@@ -42,6 +41,7 @@ import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/gm';
 import { useDataSitemap } from '~/domain/topical/sitemap/utils';
+import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 
 export const getStaticProps = createGetStaticProps(
@@ -57,8 +57,8 @@ export const getStaticProps = createGetStaticProps(
   }>(getTopicalPageQuery)
 );
 
-const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { municipalityName, choropleth, data, content } = props;
+const TopicalMunicipality = (props) => {
+  const { municipalityName, choropleth, data, content, lastGenerated } = props;
 
   const { siteText } = useIntl();
   const router = useRouter();
@@ -86,7 +86,7 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
   );
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <SEOHead
         title={replaceVariablesInText(text.metadata.title, {
           municipalityName,
@@ -300,10 +300,8 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
           </TileList>
         </MaxWidth>
       </Box>
-    </>
+    </Layout>
   );
 };
-
-TopicalMunicipality.getLayout = getDefaultLayout();
 
 export default TopicalMunicipality;

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -17,7 +17,6 @@ import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout, getDefaultLayout } from '~/domain/layout/layout';
 import { ArticleList } from '~/domain/topical/article-list';
 import { Sitemap } from '~/domain/topical/sitemap';
 import { EditorialSummary } from '~/domain/topical/editorial-teaser';
@@ -42,6 +41,7 @@ import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/vr';
 import { useDataSitemap } from '~/domain/topical/sitemap/utils';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -56,8 +56,8 @@ export const getStaticProps = createGetStaticProps(
   }>(getTopicalPageQuery)
 );
 
-const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { choropleth, data, content } = props;
+const TopicalSafetyRegion = (props) => {
+  const { choropleth, data, content, lastGenerated } = props;
   const router = useRouter();
   const { siteText } = useIntl();
 
@@ -71,7 +71,7 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
   const dataSitemap = useDataSitemap('veiligheidsregio', vrCode);
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <SEOHead
         title={replaceVariablesInText(text.metadata.title, {
           safetyRegionName: props.safetyRegionName,
@@ -281,10 +281,8 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
           </TileList>
         </MaxWidth>
       </Box>
-    </>
+    </Layout>
   );
 };
-
-TopicalSafetyRegion.getLayout = getDefaultLayout();
 
 export default TopicalSafetyRegion;

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -9,7 +9,6 @@ import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { MaxWidth } from '~/components-styled/max-width';
 import { CollapsibleButton } from '~/components-styled/collapsible';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
@@ -70,17 +69,17 @@ const TopicalSafetyRegion = (props) => {
 
   const dataSitemap = useDataSitemap('veiligheidsregio', vrCode);
 
-  return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName: props.safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName: props.safetyRegionName,
-        })}
-      />
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName: props.safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegionName: props.safetyRegionName,
+    }),
+  };
 
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <Box bg="white" pb={4}>
         {/**
          * Since now the sections have a H2 heading I think we need to include

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -1,6 +1,5 @@
 import { ArticleDetail } from '~/components-styled/article-detail';
 import { Box } from '~/components-styled/base';
-import { FCWithLayout, GetLayoutWithMetadata } from '~/domain/layout/layout';
 import { client, getImageSrc, localize } from '~/lib/sanity';
 import { targetLanguage } from '~/locale/index';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -10,6 +9,7 @@ import {
 } from '~/static-props/get-data';
 import { Article, Block, RichContentBlock } from '~/types/cms';
 import { assert } from '~/utils/assert';
+import { Layout } from '~/domain/layout/layout';
 
 const articlesQuery = `*[_type == 'article'] {"slug":slug.current}`;
 
@@ -67,32 +67,28 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
-const ArticleDetailPage: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const ArticleDetailPage = (props) => {
+  const { content, lastGenerated } = props;
 
-  return (
-    <Box backgroundColor="white">
-      <ArticleDetail article={content} />
-    </Box>
-  );
-};
-
-/**
- *  @TODO this implementation below is not very sexy yet, its hacked together
- * to simply have _something_
- */
-ArticleDetailPage.getLayout = (page, props) => {
-  const { cover } = props.content;
+  const { cover } = content;
   const { asset } = cover;
 
   const imgPath = getImageSrc(asset, 1200);
 
-  return GetLayoutWithMetadata({
+  const metadata = {
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
     openGraphImage: imgPath,
     twitterImage: imgPath,
-  })(page, props);
+  };
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <Box backgroundColor="white">
+        <ArticleDetail article={content} />
+      </Box>
+    </Layout>
+  );
 };
 
 export default ArticleDetailPage;

--- a/packages/app/src/pages/artikelen/index.tsx
+++ b/packages/app/src/pages/artikelen/index.tsx
@@ -1,13 +1,14 @@
 import { ArticleSummary } from '~/components-styled/article-teaser';
 import { Box } from '~/components-styled/base';
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { ArticleList } from '~/domain/topical/article-list';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetContent,
   getLastGeneratedDate,
 } from '~/static-props/get-data';
+import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
 
 //@TODO THIS NEEDS TO COME FROM CONTEXT
 const locale = 'nl';
@@ -27,18 +28,19 @@ export const getStaticProps = createGetStaticProps(
   )
 );
 
-const ArticlesOverview: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const ArticlesOverview = (props) => {
+  const { content, lastGenerated } = props;
+  const { siteText } = useIntl();
 
   return (
-    <Box backgroundColor="white" py={{ _: 4, md: 5 }}>
-      <MaxWidth px={{ _: 3, lg: 4 }}>
-        <ArticleList articleSummaries={content} hideLink={true} />
-      </MaxWidth>
-    </Box>
+    <Layout {...siteText.articles_metadata} lastGenerated={lastGenerated}>
+      <Box backgroundColor="white" py={{ _: 4, md: 5 }}>
+        <MaxWidth px={{ _: 3, lg: 4 }}>
+          <ArticleList articleSummaries={content} hideLink={true} />
+        </MaxWidth>
+      </Box>
+    </Layout>
   );
 };
-
-ArticlesOverview.getLayout = GetLayoutWithMetadataKey('articles_metadata');
 
 export default ArticlesOverview;

--- a/packages/app/src/pages/gemeente/[code]/index.tsx
+++ b/packages/app/src/pages/gemeente/[code]/index.tsx
@@ -1,7 +1,8 @@
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { getGmData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -10,7 +11,15 @@ export const getStaticProps = createGetStaticProps(
   getGmData
 );
 
-const Municipality: FCWithLayout<typeof getStaticProps> = () => null;
-Municipality.getLayout = getMunicipalityLayout();
+const Municipality = (props) => {
+  const { lastGenerated } = props;
+  const { siteText } = useIntl();
+
+  return (
+    <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated} />
+    </Layout>
+  );
+};
 
 export default Municipality;

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -51,6 +51,7 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
   const router = useRouter();
 
   const metadata = {
+    ...siteText.gemeente_index.metadata,
     title: replaceVariablesInText(text.metadata.title, {
       municipalityName,
     }),

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -7,7 +7,6 @@ import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -16,7 +15,6 @@ import { MunicipalityChoropleth } from '~/components/choropleth/municipality-cho
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { createPositiveTestedPeopleMunicipalTooltip } from '~/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -29,6 +27,8 @@ import { colors } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/gm';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -42,7 +42,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, municipalityName, content } = props;
+  const { data, choropleth, municipalityName, content, lastGenerated } = props;
 
   const { siteText, formatDateFromMilliseconds, formatNumber } = useIntl();
   const text = siteText.gemeente_positief_geteste_personen;
@@ -50,153 +50,158 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const router = useRouter();
 
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      municipalityName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          municipalityName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          municipalityName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.gemeente_layout.headings.besmettingen}
-          title={replaceVariablesInText(text.titel, {
-            municipality: municipalityName,
-          })}
-          icon={<Getest />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.kpi_titel}
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.gemeente_layout.headings.besmettingen}
+            title={replaceVariablesInText(text.titel, {
+              municipality: municipalityName,
+            })}
+            icon={<Getest />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: lastValue.date_unix,
-              source: text.bronnen.rivm,
+              datumsText: text.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="infected"
-              absolute={lastValue.infected}
-              difference={data.difference.tested_overall__infected}
-            />
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
-            />
-          </KpiTile>
-
-          <KpiTile
-            title={text.barscale_titel}
-            metadata={{
-              date: lastValue.date_unix,
-              source: text.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="infected_per_100k"
-              absolute={lastValue.infected_per_100k}
-              difference={data.difference.tested_overall__infected_per_100k}
-            />
-            <Text>{text.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_toelichting}
-          values={data.tested_overall.values}
-          linesConfig={[
-            {
-              metricProperty: 'infected_per_100k',
-            },
-          ]}
-          metadata={{
-            source: text.bronnen.rivm,
-          }}
-          formatTooltip={(values) => {
-            const value = values[0];
-            return (
-              <Text textAlign="center" m={0}>
-                <span style={{ fontWeight: 'bold' }}>
-                  {formatDateFromMilliseconds(value.__date.getTime(), 'medium')}
-                </span>
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    marginBottom: '0.5px',
-                    backgroundColor: colors.data.primary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_value,
-                  {
-                    totalPositiveValue: formatNumber(value.__value),
-                  }
-                )}
-                <br />
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_people,
-                  {
-                    totalPositiveTestedPeople: formatNumber(value.infected),
-                  }
-                )}
-              </Text>
-            );
-          }}
-        />
-
-        <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
-            municipality: municipalityName,
-          })}
-          description={text.map_toelichting}
-          legend={{
-            thresholds: municipalThresholds.tested_overall.infected_per_100k,
-            title: siteText.positief_geteste_personen.chloropleth_legenda.titel,
-          }}
-          metadata={{
-            date: lastValue.date_unix,
-            source: text.bronnen.rivm,
-          }}
-        >
-          <MunicipalityChoropleth
-            selectedCode={data.code}
-            data={choropleth.gm}
-            metricName="tested_overall"
-            metricProperty="infected_per_100k"
-            tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-              siteText.choropleth_tooltip.positive_tested_people,
-              municipalThresholds.tested_overall.infected_per_100k,
-              createSelectMunicipalHandler(router, 'positief-geteste-mensen')
-            )}
-            onSelect={createSelectMunicipalHandler(
-              router,
-              'positief-geteste-mensen'
-            )}
+            reference={text.reference}
           />
-        </ChoroplethTile>
-      </TileList>
-    </>
+
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.kpi_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected"
+                absolute={lastValue.infected}
+                difference={data.difference.tested_overall__infected}
+              />
+              <Text
+                as="div"
+                dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
+              />
+            </KpiTile>
+
+            <KpiTile
+              title={text.barscale_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected_per_100k"
+                absolute={lastValue.infected_per_100k}
+                difference={data.difference.tested_overall__infected_per_100k}
+              />
+              <Text>{text.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            title={text.linechart_titel}
+            description={text.linechart_toelichting}
+            values={data.tested_overall.values}
+            linesConfig={[
+              {
+                metricProperty: 'infected_per_100k',
+              },
+            ]}
+            metadata={{
+              source: text.bronnen.rivm,
+            }}
+            formatTooltip={(values) => {
+              const value = values[0];
+              return (
+                <Text textAlign="center" m={0}>
+                  <span style={{ fontWeight: 'bold' }}>
+                    {formatDateFromMilliseconds(
+                      value.__date.getTime(),
+                      'medium'
+                    )}
+                  </span>
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      marginBottom: '0.5px',
+                      backgroundColor: colors.data.primary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_value,
+                    {
+                      totalPositiveValue: formatNumber(value.__value),
+                    }
+                  )}
+                  <br />
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_people,
+                    {
+                      totalPositiveTestedPeople: formatNumber(value.infected),
+                    }
+                  )}
+                </Text>
+              );
+            }}
+          />
+
+          <ChoroplethTile
+            title={replaceVariablesInText(text.map_titel, {
+              municipality: municipalityName,
+            })}
+            description={text.map_toelichting}
+            legend={{
+              thresholds: municipalThresholds.tested_overall.infected_per_100k,
+              title:
+                siteText.positief_geteste_personen.chloropleth_legenda.titel,
+            }}
+            metadata={{
+              date: lastValue.date_unix,
+              source: text.bronnen.rivm,
+            }}
+          >
+            <MunicipalityChoropleth
+              selectedCode={data.code}
+              data={choropleth.gm}
+              metricName="tested_overall"
+              metricProperty="infected_per_100k"
+              tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
+                siteText.choropleth_tooltip.positive_tested_people,
+                municipalThresholds.tested_overall.infected_per_100k,
+                createSelectMunicipalHandler(router, 'positief-geteste-mensen')
+              )}
+              onSelect={createSelectMunicipalHandler(
+                router,
+                'positief-geteste-mensen'
+              )}
+            />
+          </ChoroplethTile>
+        </TileList>
+      </MunicipalityLayout>
+    </Layout>
   );
 };
-
-PositivelyTestedPeople.getLayout = getMunicipalityLayout();
 
 export default PositivelyTestedPeople;

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -10,18 +10,14 @@ import {
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
-import { SEOHead } from '~/components-styled/seo-head';
 import { SewerChart } from '~/components-styled/sewer-chart';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { WarningTile } from '~/components-styled/warning-tile';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { useIntl } from '~/intl';
-
 import {
   createGetContent,
   getGmData,
@@ -30,6 +26,8 @@ import {
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { useSewerWaterBarChartData } from '~/utils/sewer-water/municipality-sewer-water.util';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
+import { Layout } from '~/domain/layout/layout';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -41,8 +39,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('sewerPage'))
 );
 
-const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, municipalityName, content } = props;
+const SewerWater = (props) => {
+  const { data, municipalityName, content, lastGenerated } = props;
   const { siteText } = useIntl();
 
   const text = siteText.gemeente_rioolwater_metingen;
@@ -61,145 +59,146 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
     return null;
   }
 
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      municipalityName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          municipalityName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          municipalityName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.gemeente_layout.headings.vroege_signalen}
-          title={replaceVariablesInText(text.titel, {
-            municipality: municipalityName,
-          })}
-          icon={<RioolwaterMonitoring />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: {
-              start: sewerAverages.last_value.date_start_unix,
-              end: sewerAverages.last_value.date_end_unix,
-            },
-            dateOfInsertionUnix:
-              sewerAverages.last_value.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <WarningTile message={text.warning_method} icon={ExperimenteelIcon} />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
-            metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="barscale_value"
-              absolute={sewerAverages.last_value.average}
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
-              difference={data.difference.sewer__average}
-            />
-          </KpiTile>
-
-          <KpiTile
-            title={text.total_measurements_title}
-            description={text.total_measurements_description}
-            metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="total_number_of_samples"
-              absolute={sewerAverages.last_value.total_number_of_samples}
-            />
-            <Text>
-              {replaceComponentsInText(text.total_measurements_locations, {
-                sampled_installation_count: (
-                  <strong>
-                    {sewerAverages.last_value.sampled_installation_count}
-                  </strong>
-                ),
-                total_installation_count: (
-                  <strong>
-                    {sewerAverages.last_value.total_installation_count}
-                  </strong>
-                ),
-              })}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChartTileWithTimeframe
-          title={text.linechart_titel}
-          metadata={{ source: text.bronnen.rivm }}
-          timeframeOptions={['all', '5weeks']}
-        >
-          {(timeframe) => (
-            <SewerChart
-              data={data}
-              timeframe={timeframe}
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
-              text={{
-                select_station_placeholder:
-                  text.graph_selected_rwzi_placeholder,
-                average_label_text: text.graph_average_label_text,
-                secondary_label_text: text.graph_secondary_label_text,
-                daily_label_text: text.graph_daily_label_text_rwzi,
-                range_description: text.graph_range_description,
-                display_outliers: text.display_outliers,
-                hide_outliers: text.hide_outliers,
-              }}
-            />
-          )}
-        </ChartTileWithTimeframe>
-
-        {barChartData && (
-          <ChartTile
-            title={replaceVariablesInText(text.bar_chart_title, {
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.gemeente_layout.headings.vroege_signalen}
+            title={replaceVariablesInText(text.titel, {
               municipality: municipalityName,
             })}
-            ariaDescription={graphDescriptions.rioolwater_meetwaarde}
+            icon={<RioolwaterMonitoring />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
+              datumsText: text.datums,
+              dateOrRange: {
+                start: sewerAverages.last_value.date_start_unix,
+                end: sewerAverages.last_value.date_end_unix,
+              },
+              dateOfInsertionUnix:
+                sewerAverages.last_value.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
+            reference={text.reference}
+          />
+
+          <WarningTile message={text.warning_method} icon={ExperimenteelIcon} />
+
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              description={text.extra_uitleg}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="barscale_value"
+                absolute={sewerAverages.last_value.average}
+                valueAnnotation={siteText.waarde_annotaties.riool_normalized}
+                difference={data.difference.sewer__average}
+              />
+            </KpiTile>
+
+            <KpiTile
+              title={text.total_measurements_title}
+              description={text.total_measurements_description}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="total_number_of_samples"
+                absolute={sewerAverages.last_value.total_number_of_samples}
+              />
+              <Text>
+                {replaceComponentsInText(text.total_measurements_locations, {
+                  sampled_installation_count: (
+                    <strong>
+                      {sewerAverages.last_value.sampled_installation_count}
+                    </strong>
+                  ),
+                  total_installation_count: (
+                    <strong>
+                      {sewerAverages.last_value.total_installation_count}
+                    </strong>
+                  ),
+                })}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChartTileWithTimeframe
+            title={text.linechart_titel}
+            metadata={{ source: text.bronnen.rivm }}
+            timeframeOptions={['all', '5weeks']}
           >
-            <BarChart
-              values={barChartData.values}
-              xAxisTitle={text.bar_chart_axis_title}
-              accessibilityDescription={
-                text.bar_chart_accessibility_description
-              }
-            />
-          </ChartTile>
-        )}
-      </TileList>
-    </>
+            {(timeframe) => (
+              <SewerChart
+                data={data}
+                timeframe={timeframe}
+                valueAnnotation={siteText.waarde_annotaties.riool_normalized}
+                text={{
+                  select_station_placeholder:
+                    text.graph_selected_rwzi_placeholder,
+                  average_label_text: text.graph_average_label_text,
+                  secondary_label_text: text.graph_secondary_label_text,
+                  daily_label_text: text.graph_daily_label_text_rwzi,
+                  range_description: text.graph_range_description,
+                  display_outliers: text.display_outliers,
+                  hide_outliers: text.hide_outliers,
+                }}
+              />
+            )}
+          </ChartTileWithTimeframe>
+
+          {barChartData && (
+            <ChartTile
+              title={replaceVariablesInText(text.bar_chart_title, {
+                municipality: municipalityName,
+              })}
+              ariaDescription={graphDescriptions.rioolwater_meetwaarde}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <BarChart
+                values={barChartData.values}
+                xAxisTitle={text.bar_chart_axis_title}
+                accessibilityDescription={
+                  text.bar_chart_accessibility_description
+                }
+              />
+            </ChartTile>
+          )}
+        </TileList>
+      </MunicipalityLayout>
+    </Layout>
   );
 };
-
-SewerWater.getLayout = getMunicipalityLayout();
 
 export default SewerWater;

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -60,6 +60,7 @@ const SewerWater = (props) => {
   }
 
   const metadata = {
+    ...siteText.gemeente_index.metadata,
     title: replaceVariablesInText(text.metadata.title, {
       municipalityName,
     }),

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -42,6 +42,7 @@ const DeceasedMunicipalPage = (props) => {
   const text = siteText.gemeente_sterfte;
 
   const metadata = {
+    ...siteText.gemeente_index.metadata,
     title: replaceVariablesInText(text.metadata.title, {
       municipalityName,
     }),

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -5,12 +5,9 @@ import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -20,6 +17,8 @@ import {
   getGmData,
 } from '~/static-props/get-data';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { Layout } from '~/domain/layout/layout';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -31,99 +30,100 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('deceasedPage'))
 );
 
-const DeceasedMunicipalPage: FCWithLayout<typeof getStaticProps> = (props) => {
+const DeceasedMunicipalPage = (props) => {
   const {
     municipalityName,
     data: { deceased_rivm: dataRivm, difference },
     content,
+    lastGenerated,
   } = props;
 
   const { siteText } = useIntl();
   const text = siteText.gemeente_sterfte;
 
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      municipalityName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          municipalityName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          municipalityName,
-        })}
-      />
-
-      <TileList>
-        <ContentHeader
-          category={siteText.gemeente_layout.headings.besmettingen}
-          title={replaceVariablesInText(text.section_deceased_rivm.title, {
-            municipalityName,
-          })}
-          icon={<CoronaVirusIcon />}
-          subtitle={text.section_deceased_rivm.description}
-          reference={text.section_deceased_rivm.reference}
-          metadata={{
-            datumsText: text.section_deceased_rivm.datums,
-            dateOrRange: dataRivm.last_value.date_unix,
-            dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
-            dataSources: [text.section_deceased_rivm.bronnen.rivm],
-          }}
-        />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_daily_title}
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.gemeente_layout.headings.besmettingen}
+            title={replaceVariablesInText(text.section_deceased_rivm.title, {
+              municipalityName,
+            })}
+            icon={<CoronaVirusIcon />}
+            subtitle={text.section_deceased_rivm.description}
+            reference={text.section_deceased_rivm.reference}
             metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
+              datumsText: text.section_deceased_rivm.datums,
+              dateOrRange: dataRivm.last_value.date_unix,
+              dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
+              dataSources: [text.section_deceased_rivm.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="covid_daily"
-              absolute={dataRivm.last_value.covid_daily}
-              difference={difference.deceased_rivm__covid_daily}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_daily_description}
-            </Text>
-          </KpiTile>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_total_title}
-            metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="covid_total"
-              absolute={dataRivm.last_value.covid_total}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_total_description}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
+          />
 
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_deceased_rivm.line_chart_covid_daily_title}
-          description={
-            text.section_deceased_rivm.line_chart_covid_daily_description
-          }
-          values={dataRivm.values}
-          linesConfig={[
-            {
-              metricProperty: 'covid_daily',
-            },
-          ]}
-          metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
-        />
-      </TileList>
-    </>
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_daily_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_daily"
+                absolute={dataRivm.last_value.covid_daily}
+                difference={difference.deceased_rivm__covid_daily}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_daily_description}
+              </Text>
+            </KpiTile>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_total_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_total"
+                absolute={dataRivm.last_value.covid_total}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_total_description}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_deceased_rivm.line_chart_covid_daily_title}
+            description={
+              text.section_deceased_rivm.line_chart_covid_daily_description
+            }
+            values={dataRivm.values}
+            linesConfig={[
+              {
+                metricProperty: 'covid_daily',
+              },
+            ]}
+            metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
+          />
+        </TileList>
+      </MunicipalityLayout>
+    </Layout>
   );
 };
-
-DeceasedMunicipalPage.getLayout = getMunicipalityLayout();
 
 export default DeceasedMunicipalPage;

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -8,15 +8,12 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic/background-rectangle';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { municipalThresholds } from '~/components/choropleth/municipal-thresholds';
 import { MunicipalityChoropleth } from '~/components/choropleth/municipality-choropleth';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
@@ -30,6 +27,8 @@ import {
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
+import { Layout } from '~/domain/layout/layout';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -44,8 +43,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('hospitalPage'))
 );
 
-const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, municipalityName, content } = props;
+const IntakeHospital = (props) => {
+  const { data, choropleth, municipalityName, content, lastGenerated } = props;
   const router = useRouter();
   const { siteText } = useIntl();
 
@@ -56,134 +55,138 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const underReportedRange = getTrailingDateRange(data.hospital_nice.values, 4);
 
+  const metadata = {
+    title: replaceVariablesInText(text.metadata.title, {
+      municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      municipalityName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          municipalityName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          municipalityName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.gemeente_layout.headings.ziekenhuizen}
-          title={replaceVariablesInText(text.titel, {
-            municipality: municipalityName,
-          })}
-          icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.gemeente_layout.headings.ziekenhuizen}
+            title={replaceVariablesInText(text.titel, {
+              municipality: municipalityName,
+            })}
+            icon={<Ziekenhuis />}
+            subtitle={text.pagina_toelichting}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
+            }}
+            reference={text.reference}
+          />
 
-        <ArticleStrip articles={content.articles} />
+          <ArticleStrip articles={content.articles} />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              description={text.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="admissions_on_date_of_reporting"
+                absolute={lastValue.admissions_on_date_of_reporting}
+                difference={
+                  data.difference.hospital_nice__admissions_on_date_of_reporting
+                }
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChoroplethTile
+            title={replaceVariablesInText(text.map_titel, {
+              municipality: municipalityName,
+            })}
             metadata={{
               date: lastValue.date_unix,
               source: text.bronnen.rivm,
             }}
+            description={text.map_toelichting}
+            legend={{
+              title:
+                siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
+              thresholds:
+                municipalThresholds.hospital_nice
+                  .admissions_on_date_of_reporting,
+            }}
           >
-            <KpiValue
-              data-cy="admissions_on_date_of_reporting"
-              absolute={lastValue.admissions_on_date_of_reporting}
-              difference={
-                data.difference.hospital_nice__admissions_on_date_of_reporting
-              }
+            <MunicipalityChoropleth
+              selectedCode={data.code}
+              data={choropleth.gm}
+              metricName="hospital_nice"
+              metricProperty="admissions_on_date_of_reporting"
+              tooltipContent={createMunicipalHospitalAdmissionsTooltip(
+                siteText.choropleth_tooltip.hospital_admissions,
+                municipalThresholds.hospital_nice
+                  .admissions_on_date_of_reporting,
+                createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
+              )}
+              onSelect={createSelectMunicipalHandler(
+                router,
+                'ziekenhuis-opnames'
+              )}
             />
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
-            municipality: municipalityName,
-          })}
-          metadata={{
-            date: lastValue.date_unix,
-            source: text.bronnen.rivm,
-          }}
-          description={text.map_toelichting}
-          legend={{
-            title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
-            thresholds:
-              municipalThresholds.hospital_nice.admissions_on_date_of_reporting,
-          }}
-        >
-          <MunicipalityChoropleth
-            selectedCode={data.code}
-            data={choropleth.gm}
-            metricName="hospital_nice"
-            metricProperty="admissions_on_date_of_reporting"
-            tooltipContent={createMunicipalHospitalAdmissionsTooltip(
-              siteText.choropleth_tooltip.hospital_admissions,
-              municipalThresholds.hospital_nice.admissions_on_date_of_reporting,
-              createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
+          <LineChartTile
+            title={text.linechart_titel}
+            description={text.linechart_description}
+            ariaDescription={graphDescriptions.ziekenhuis_opnames}
+            metadata={{ source: text.bronnen.rivm }}
+            timeframeOptions={['all', '5weeks', 'week']}
+            values={data.hospital_nice.values}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInrange = value.__date >= underReportedRange[0];
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInrange}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            linesConfig={[
+              {
+                metricProperty: 'admissions_on_date_of_admission',
+              },
+            ]}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
             )}
-            onSelect={createSelectMunicipalHandler(
-              router,
-              'ziekenhuis-opnames'
-            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.linechart_legend_titel,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.linechart_legend_underreported_titel,
+                shape: 'square',
+              },
+            ]}
+            showLegend
           />
-        </ChoroplethTile>
-
-        <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_description}
-          ariaDescription={graphDescriptions.ziekenhuis_opnames}
-          metadata={{ source: text.bronnen.rivm }}
-          timeframeOptions={['all', '5weeks', 'week']}
-          values={data.hospital_nice.values}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInrange = value.__date >= underReportedRange[0];
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInrange}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          linesConfig={[
-            {
-              metricProperty: 'admissions_on_date_of_admission',
-            },
-          ]}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.linechart_legend_titel,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+        </TileList>
+      </MunicipalityLayout>
+    </Layout>
   );
 };
-
-IntakeHospital.getLayout = getMunicipalityLayout();
 
 export default IntakeHospital;

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -56,6 +56,7 @@ const IntakeHospital = (props) => {
   const underReportedRange = getTrailingDateRange(data.hospital_nice.values, 4);
 
   const metadata = {
+    ...siteText.gemeente_index.metadata,
     title: replaceVariablesInText(text.metadata.title, {
       municipalityName,
     }),

--- a/packages/app/src/pages/gemeente/index.tsx
+++ b/packages/app/src/pages/gemeente/index.tsx
@@ -45,8 +45,12 @@ const Municipality = (props) => {
     !breakpoints.md
   );
 
+  const metadata = {
+    ...siteText.gemeente_index.metadata,
+  };
+
   return (
-    <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout lastGenerated={lastGenerated}>
         {!breakpoints.md && (
           <Box bg="white">

--- a/packages/app/src/pages/gemeente/index.tsx
+++ b/packages/app/src/pages/gemeente/index.tsx
@@ -9,14 +9,13 @@ import {
 } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { MunicipalityProperties } from '@corona-dashboard/common';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
-import { SEOHead } from '~/components-styled/seo-head';
 import { MunicipalityComboBox } from '~/domain/layout/components/municipality-combo-box';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getMunicipalityLayout } from '~/domain/layout/municipality-layout';
-import text from '~/locale/index';
 import { getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { useBreakpoints } from '~/utils/useBreakpoints';
+import { Layout } from '~/domain/layout/layout';
+import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
+import { useIntl } from '~/intl';
 
 const tooltipContent = (selectedHandler: MunicipalitySelectionHandler) => {
   return (context: MunicipalityProperties): ReactNode => {
@@ -33,7 +32,10 @@ const tooltipContent = (selectedHandler: MunicipalitySelectionHandler) => {
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
-const Municipality: FCWithLayout<typeof getStaticProps> = () => {
+const Municipality = (props) => {
+  const { siteText } = useIntl();
+  const { lastGenerated } = props;
+
   const router = useRouter();
   const breakpoints = useBreakpoints();
 
@@ -44,43 +46,38 @@ const Municipality: FCWithLayout<typeof getStaticProps> = () => {
   );
 
   return (
-    <>
-      <SEOHead
-        title={text.gemeente_index.metadata.title}
-        description={text.gemeente_index.metadata.description}
-      />
+    <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>
+      <MunicipalityLayout lastGenerated={lastGenerated}>
+        {!breakpoints.md && (
+          <Box bg="white">
+            <MunicipalityComboBox onSelect={goToMunicipal} />
+          </Box>
+        )}
 
-      {!breakpoints.md && (
-        <Box bg="white">
-          <MunicipalityComboBox onSelect={goToMunicipal} />
+        <Box as="article" p={4}>
+          <Heading level={3} as="h1">
+            {siteText.gemeente_index.selecteer_titel}
+          </Heading>
+          <Text>{siteText.gemeente_index.selecteer_toelichting}</Text>
+
+          <Box
+            display="flex"
+            justifyContent="center"
+            width="100%"
+            height="120vw"
+            maxWidth={750}
+            maxHeight={960}
+            margin="0 auto"
+          >
+            <MunicipalityNavigationMap
+              tooltipContent={tooltipContent(goToMunicipal)}
+              onSelect={goToMunicipal}
+            />
+          </Box>
         </Box>
-      )}
-
-      <Box as="article" p={4}>
-        <Heading level={3} as="h1">
-          {text.gemeente_index.selecteer_titel}
-        </Heading>
-        <Text>{text.gemeente_index.selecteer_toelichting}</Text>
-
-        <Box
-          display="flex"
-          justifyContent="center"
-          width="100%"
-          height="120vw"
-          maxWidth={750}
-          maxHeight={960}
-          margin="0 auto"
-        >
-          <MunicipalityNavigationMap
-            tooltipContent={tooltipContent(goToMunicipal)}
-            onSelect={goToMunicipal}
-          />
-        </Box>
-      </Box>
-    </>
+      </MunicipalityLayout>
+    </Layout>
   );
 };
-
-Municipality.getLayout = getMunicipalityLayout();
 
 export default Municipality;

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -9,7 +9,6 @@ import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda
 import { HighlightTeaserProps } from '~/components-styled/highlight-teaser';
 import { Sitemap } from '~/domain/topical/sitemap';
 import { MaxWidth } from '~/components-styled/max-width';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
@@ -89,12 +88,14 @@ const Home = (props) => {
   const { siteText, formatDate } = useIntl();
   const text = siteText.nationaal_actueel;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <Box bg="white" pb={4}>
         {/**
          * Since now the sections have a H2 heading I think we need to include

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -17,7 +17,6 @@ import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
-import { FCWithLayout, getDefaultLayout } from '~/domain/layout/layout';
 import { ArticleList } from '~/domain/topical/article-list';
 import { Search } from '~/domain/topical/components/search';
 import { EditorialSummary } from '~/domain/topical/editorial-teaser';
@@ -43,6 +42,8 @@ import { useIntl } from '~/intl';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { useDataSitemap } from '~/domain/topical/sitemap/utils';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+
+import { Layout } from '~/domain/layout/layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -77,7 +78,7 @@ export const getStaticProps = createGetStaticProps(
   }
 );
 
-const Home: FCWithLayout<typeof getStaticProps> = (props) => {
+const Home = (props) => {
   const { data, choropleth, content, lastGenerated } = props;
   const router = useRouter();
 
@@ -89,7 +90,7 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
   const text = siteText.nationaal_actueel;
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <SEOHead
         title={text.metadata.title}
         description={text.metadata.description}
@@ -275,10 +276,8 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
           </TileList>
         </MaxWidth>
       </Box>
-    </>
+    </Layout>
   );
 };
-
-Home.getLayout = getDefaultLayout();
 
 export default Home;

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -8,108 +8,108 @@ import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { AreaChart } from '~/components/charts/index';
 import { SEOHead } from '~/components-styled/seo-head';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { getNlData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { getLastFilledValue } from '@corona-dashboard/common';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   getNlData
 );
 
-const InfectiousPeople: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data } = props;
+const InfectiousPeople = (props) => {
+  const { data, lastGenerated } = props;
 
   const lastFullValue = getLastFilledValue(data.infectious_people);
   const values = data.infectious_people.values;
   const { siteText } = useIntl();
   const text = siteText.besmettelijke_personen;
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.besmettingen}
-          screenReaderCategory={text.titel_sidebar}
-          title={text.title}
-          icon={<Ziektegolf />}
-          subtitle={text.toelichting_pagina}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastFullValue.date_unix,
-            dateOfInsertionUnix: lastFullValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.cijfer_titel}
-            description={text.cijfer_toelichting}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.besmettingen}
+            screenReaderCategory={text.titel_sidebar}
+            title={text.title}
+            icon={<Ziektegolf />}
+            subtitle={text.toelichting_pagina}
             metadata={{
-              date: lastFullValue.date_unix,
-              source: text.bronnen.rivm,
+              datumsText: text.datums,
+              dateOrRange: lastFullValue.date_unix,
+              dateOfInsertionUnix: lastFullValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="estimate"
-              /**
-               * Somehow non-null assertion via ! was not allowed. At this point
-               * we can be sure that estimate exists
-               */
-              absolute={lastFullValue.estimate || 0}
-              difference={data.difference.infectious_people__estimate}
-            />
-          </KpiTile>
-        </TwoKpiSection>
+            reference={text.reference}
+          />
 
-        <ChartTileWithTimeframe
-          metadata={{ source: text.bronnen.rivm }}
-          title={text.linechart_titel}
-          timeframeOptions={['all', '5weeks']}
-        >
-          {(timeframe) => (
-            <>
-              <AreaChart
-                timeframe={timeframe}
-                data={values.map((value) => ({
-                  avg: value.estimate,
-                  min: value.margin_low,
-                  max: value.margin_high,
-                  date: value.date_unix,
-                }))}
-                rangeLegendLabel={text.rangeLegendLabel}
-                lineLegendLabel={text.lineLegendLabel}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.cijfer_titel}
+              description={text.cijfer_toelichting}
+              metadata={{
+                date: lastFullValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="estimate"
+                /**
+                 * Somehow non-null assertion via ! was not allowed. At this point
+                 * we can be sure that estimate exists
+                 */
+                absolute={lastFullValue.estimate || 0}
+                difference={data.difference.infectious_people__estimate}
               />
-              <Legend
-                items={[
-                  {
-                    label: text.legenda_line,
-                    color: 'data.primary',
-                    shape: 'line',
-                  },
-                  {
-                    label: text.legenda_marge,
-                    color: 'data.margin',
-                    shape: 'square',
-                  },
-                ]}
-              />
-            </>
-          )}
-        </ChartTileWithTimeframe>
-      </TileList>
-    </>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChartTileWithTimeframe
+            metadata={{ source: text.bronnen.rivm }}
+            title={text.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
+          >
+            {(timeframe) => (
+              <>
+                <AreaChart
+                  timeframe={timeframe}
+                  data={values.map((value) => ({
+                    avg: value.estimate,
+                    min: value.margin_low,
+                    max: value.margin_high,
+                    date: value.date_unix,
+                  }))}
+                  rangeLegendLabel={text.rangeLegendLabel}
+                  lineLegendLabel={text.lineLegendLabel}
+                />
+                <Legend
+                  items={[
+                    {
+                      label: text.legenda_line,
+                      color: 'data.primary',
+                      shape: 'line',
+                    },
+                    {
+                      label: text.legenda_marge,
+                      color: 'data.margin',
+                      shape: 'square',
+                    },
+                  ]}
+                />
+              </>
+            )}
+          </ChartTileWithTimeframe>
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-InfectiousPeople.getLayout = GetNationalLayout;
 
 export default InfectiousPeople;

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -7,7 +7,6 @@ import { Legend } from '~/components-styled/legend';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { AreaChart } from '~/components/charts/index';
-import { SEOHead } from '~/components-styled/seo-head';
 import { useIntl } from '~/intl';
 import { getNlData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -27,13 +26,16 @@ const InfectiousPeople = (props) => {
   const values = data.infectious_people.values;
   const { siteText } = useIntl();
   const text = siteText.besmettelijke_personen;
+
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.besmettingen}

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -17,8 +17,6 @@ import { BehaviorChoroplethTile } from '~/domain/behavior/behavior-choropleth-ti
 import { BehaviorLineChartTile } from '~/domain/behavior/behavior-line-chart-tile';
 import { BehaviorTableTile } from '~/domain/behavior/behavior-table-tile';
 import { MoreInformation } from '~/domain/behavior/components/more-information';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -30,6 +28,8 @@ import {
 } from '~/static-props/get-data';
 import { Link } from '~/utils/link';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -42,11 +42,7 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('behaviorPage'))
 );
 
-const BehaviorPage: FCWithLayout<typeof getStaticProps> = ({
-  data,
-  choropleth,
-  content,
-}) => {
+const BehaviorPage = ({ data, choropleth, content, lastGenerated }) => {
   const behaviorLastValue = data.behavior.last_value;
 
   const { siteText, formatNumber } = useIntl();
@@ -54,137 +50,140 @@ const BehaviorPage: FCWithLayout<typeof getStaticProps> = ({
   const { nl_gedrag, corona_melder_app } = siteText;
 
   return (
-    <>
-      <SEOHead
-        title={nl_gedrag.metadata.title}
-        description={nl_gedrag.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.gedrag}
-          title={nl_gedrag.pagina.titel}
-          icon={<Gedrag />}
-          subtitle={nl_gedrag.pagina.toelichting}
-          metadata={{
-            datumsText: nl_gedrag.datums,
-            dateOrRange: {
-              start: behaviorLastValue.date_start_unix,
-              end: behaviorLastValue.date_end_unix,
-            },
-            dateOfInsertionUnix: behaviorLastValue.date_of_insertion_unix,
-            dataSources: [nl_gedrag.bronnen.rivm],
-          }}
-          reference={nl_gedrag.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={nl_gedrag.metadata.title}
+          description={nl_gedrag.metadata.description}
         />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <Tile height="100%">
-            <Heading level={3}>{nl_gedrag.onderzoek_uitleg.titel}</Heading>
-            <Text>{nl_gedrag.onderzoek_uitleg.toelichting}</Text>
-          </Tile>
-
-          <KpiTile
-            title={nl_gedrag.kpi.aantal_respondenten.titel}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.gedrag}
+            title={nl_gedrag.pagina.titel}
+            icon={<Gedrag />}
+            subtitle={nl_gedrag.pagina.toelichting}
             metadata={{
-              source: nl_gedrag.kpi.aantal_respondenten.bron,
-              date: [
-                behaviorLastValue.date_start_unix,
-                behaviorLastValue.date_end_unix,
-              ],
+              datumsText: nl_gedrag.datums,
+              dateOrRange: {
+                start: behaviorLastValue.date_start_unix,
+                end: behaviorLastValue.date_end_unix,
+              },
+              dateOfInsertionUnix: behaviorLastValue.date_of_insertion_unix,
+              dataSources: [nl_gedrag.bronnen.rivm],
             }}
-          >
-            <KpiValue absolute={behaviorLastValue.number_of_participants} />
-            <Text>{nl_gedrag.kpi.aantal_respondenten.toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
+            reference={nl_gedrag.reference}
+          />
 
-        <BehaviorTableTile
-          behavior={behaviorLastValue}
-          title={nl_gedrag.basisregels.title}
-          introduction={nl_gedrag.basisregels.intro}
-          footer={nl_gedrag.basisregels.voetnoot}
-          footerAsterisk={nl_gedrag.basisregels.voetnoot_asterisk}
-        />
+          <ArticleStrip articles={content.articles} />
 
-        <BehaviorLineChartTile
-          values={data.behavior.values}
-          title={nl_gedrag.basisregels_over_tijd.title}
-          introduction={nl_gedrag.basisregels_over_tijd.intro}
-        />
+          <TwoKpiSection>
+            <Tile height="100%">
+              <Heading level={3}>{nl_gedrag.onderzoek_uitleg.titel}</Heading>
+              <Text>{nl_gedrag.onderzoek_uitleg.toelichting}</Text>
+            </Tile>
 
-        <BehaviorChoroplethTile data={choropleth.vr} />
+            <KpiTile
+              title={nl_gedrag.kpi.aantal_respondenten.titel}
+              metadata={{
+                source: nl_gedrag.kpi.aantal_respondenten.bron,
+                date: [
+                  behaviorLastValue.date_start_unix,
+                  behaviorLastValue.date_end_unix,
+                ],
+              }}
+            >
+              <KpiValue absolute={behaviorLastValue.number_of_participants} />
+              <Text>{nl_gedrag.kpi.aantal_respondenten.toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
 
-        <MoreInformation />
+          <BehaviorTableTile
+            behavior={behaviorLastValue}
+            title={nl_gedrag.basisregels.title}
+            introduction={nl_gedrag.basisregels.intro}
+            footer={nl_gedrag.basisregels.voetnoot}
+            footerAsterisk={nl_gedrag.basisregels.voetnoot_asterisk}
+          />
 
-        <ContentHeader
-          category={corona_melder_app.header.category}
-          title={corona_melder_app.header.title}
-          icon={<Phone />}
-          subtitle={corona_melder_app.header.description}
-          metadata={{
-            datumsText: corona_melder_app.header.datums,
-            dateOrRange: data.corona_melder_app.last_value.date_unix,
-            dateOfInsertionUnix:
-              data.corona_melder_app.last_value.date_of_insertion_unix,
-            dataSources: [corona_melder_app.header.bronnen.rivm],
-          }}
-          reference={corona_melder_app.header.reference}
-        />
+          <BehaviorLineChartTile
+            values={data.behavior.values}
+            title={nl_gedrag.basisregels_over_tijd.title}
+            introduction={nl_gedrag.basisregels_over_tijd.intro}
+          />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={corona_melder_app.waarschuwingen.title}
+          <BehaviorChoroplethTile data={choropleth.vr} />
+
+          <MoreInformation />
+
+          <ContentHeader
+            category={corona_melder_app.header.category}
+            title={corona_melder_app.header.title}
+            icon={<Phone />}
+            subtitle={corona_melder_app.header.description}
             metadata={{
-              date: data.corona_melder_app.last_value.date_unix,
-              source: corona_melder_app.header.bronnen.rivm,
+              datumsText: corona_melder_app.header.datums,
+              dateOrRange: data.corona_melder_app.last_value.date_unix,
+              dateOfInsertionUnix:
+                data.corona_melder_app.last_value.date_of_insertion_unix,
+              dataSources: [corona_melder_app.header.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="infected"
-              absolute={data.corona_melder_app.last_value.warned_daily}
-              difference={data.difference.corona_melder_app__warned_daily}
-            />
+            reference={corona_melder_app.header.reference}
+          />
 
-            <Text>{corona_melder_app.waarschuwingen.description}</Text>
-            <Text>
-              {replaceComponentsInText(corona_melder_app.waarschuwingen.total, {
-                totalDownloads: (
-                  <span
-                    css={css({ color: 'data.primary', fontWeight: 'bold' })}
-                  >
-                    {formatNumber(
-                      data.corona_melder_app?.last_value.downloaded_total
-                    )}
+          <TwoKpiSection>
+            <KpiTile
+              title={corona_melder_app.waarschuwingen.title}
+              metadata={{
+                date: data.corona_melder_app.last_value.date_unix,
+                source: corona_melder_app.header.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected"
+                absolute={data.corona_melder_app.last_value.warned_daily}
+                difference={data.difference.corona_melder_app__warned_daily}
+              />
+
+              <Text>{corona_melder_app.waarschuwingen.description}</Text>
+              <Text>
+                {replaceComponentsInText(
+                  corona_melder_app.waarschuwingen.total,
+                  {
+                    totalDownloads: (
+                      <span
+                        css={css({ color: 'data.primary', fontWeight: 'bold' })}
+                      >
+                        {formatNumber(
+                          data.corona_melder_app?.last_value.downloaded_total
+                        )}
+                      </span>
+                    ),
+                  }
+                )}
+              </Text>
+            </KpiTile>
+
+            <Tile>
+              <Heading level={3}>{corona_melder_app.rapport.title}</Heading>
+              <Text>{corona_melder_app.rapport.description}</Text>
+
+              <Link href={corona_melder_app.rapport.link.href} passHref>
+                <a target="_blank" css={css({ display: 'flex' })}>
+                  <IconContainer>
+                    <ExternalLinkIcon />
+                  </IconContainer>
+                  <span css={css({ maxWidth: 200 })}>
+                    {corona_melder_app.rapport.link.text}
                   </span>
-                ),
-              })}
-            </Text>
-          </KpiTile>
-
-          <Tile>
-            <Heading level={3}>{corona_melder_app.rapport.title}</Heading>
-            <Text>{corona_melder_app.rapport.description}</Text>
-
-            <Link href={corona_melder_app.rapport.link.href} passHref>
-              <a target="_blank" css={css({ display: 'flex' })}>
-                <IconContainer>
-                  <ExternalLinkIcon />
-                </IconContainer>
-                <span css={css({ maxWidth: 200 })}>
-                  {corona_melder_app.rapport.link.text}
-                </span>
-              </a>
-            </Link>
-          </Tile>
-        </TwoKpiSection>
-      </TileList>
-    </>
+                </a>
+              </Link>
+            </Tile>
+          </TwoKpiSection>
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-BehaviorPage.getLayout = GetNationalLayout;
 
 export default BehaviorPage;
 

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -8,7 +8,7 @@ import { ArticleSummary } from '~/components-styled/article-teaser';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
-import { SEOHead } from '~/components-styled/seo-head';
+
 import { Tile } from '~/components-styled/tile';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
@@ -49,13 +49,15 @@ const BehaviorPage = ({ data, choropleth, content, lastGenerated }) => {
 
   const { nl_gedrag, corona_melder_app } = siteText;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: nl_gedrag.metadata.title,
+    description: nl_gedrag.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={nl_gedrag.metadata.title}
-          description={nl_gedrag.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.gedrag}

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -17,7 +17,6 @@ import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-ch
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createDisablityInfectedLocationsRegionalTooltip } from '~/components/choropleth/tooltips/region/create-disability-infected-locations-regional-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -28,6 +27,8 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -38,7 +39,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth } = props;
+  const { data, choropleth, lastGenerated } = props;
   const lastValue = data.disability_care.last_value;
   const values = data.disability_care.values;
   const underReportedValues = getTrailingDateRange(values, 7);
@@ -53,260 +54,262 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
   const graphDescriptions = siteText.accessibility.grafieken;
 
   return (
-    <>
-      <SEOHead
-        title={infectedLocationsText.metadata.title}
-        description={infectedLocationsText.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={
-            siteText.verpleeghuis_positief_geteste_personen.titel_sidebar
-          }
-          title={positiveTestedPeopleText.titel}
-          icon={<Gehandicaptenzorg />}
-          subtitle={positiveTestedPeopleText.pagina_toelichting}
-          metadata={{
-            datumsText: positiveTestedPeopleText.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [positiveTestedPeopleText.bronnen.rivm],
-          }}
-          reference={positiveTestedPeopleText.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={infectedLocationsText.metadata.title}
+          description={infectedLocationsText.metadata.description}
         />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={positiveTestedPeopleText.barscale_titel}
-            description={positiveTestedPeopleText.extra_uitleg}
-            metadata={{
-              date: lastValue.date_unix,
-              source: positiveTestedPeopleText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_people"
-              absolute={lastValue.newly_infected_people}
-              difference={
-                data.difference.disability_care__newly_infected_people
-              }
-            />
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
-          title={positiveTestedPeopleText.linechart_titel}
-          ariaDescription={graphDescriptions.gehandicaptenzorg_positief_getest}
-          values={values}
-          linesConfig={[
-            {
-              metricProperty: 'newly_infected_people',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date >= underReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedValues,
-            {
-              fill: colors.data.underReported,
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.kwetsbare_groepen}
+            screenReaderCategory={
+              siteText.verpleeghuis_positief_geteste_personen.titel_sidebar
             }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: positiveTestedPeopleText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                positiveTestedPeopleText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ContentHeader
-          id="besmette-locaties"
-          skipLinkAnchor={true}
-          title={infectedLocationsText.titel}
-          icon={<Locatie />}
-          subtitle={infectedLocationsText.pagina_toelichting}
-          metadata={{
-            datumsText: infectedLocationsText.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [infectedLocationsText.bronnen.rivm],
-          }}
-          reference={infectedLocationsText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={infectedLocationsText.kpi_titel}
+            title={positiveTestedPeopleText.titel}
+            icon={<Gehandicaptenzorg />}
+            subtitle={positiveTestedPeopleText.pagina_toelichting}
             metadata={{
-              date: lastValue.date_unix,
-              source: infectedLocationsText.bronnen.rivm,
+              datumsText: positiveTestedPeopleText.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [positiveTestedPeopleText.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="infected_locations_total"
-              absolute={lastValue.infected_locations_total}
-              percentage={lastValue.infected_locations_percentage}
-              difference={
-                data.difference.disability_care__infected_locations_total
-              }
-            />
-            <Text>{infectedLocationsText.kpi_toelichting}</Text>
-          </KpiTile>
-
-          <KpiTile
-            title={infectedLocationsText.barscale_titel}
-            metadata={{
-              date: lastValue.date_unix,
-              source: infectedLocationsText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_locations"
-              absolute={lastValue.newly_infected_locations}
-            />
-            <Text>{infectedLocationsText.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChoroplethTile
-          title={infectedLocationsText.map_titel}
-          description={infectedLocationsText.map_toelichting}
-          metadata={{
-            date: lastValue.date_unix,
-            source: infectedLocationsText.bronnen.rivm,
-          }}
-          legend={{
-            thresholds:
-              regionThresholds.nursing_home.infected_locations_percentage,
-            title: infectedLocationsText.chloropleth_legenda.titel,
-          }}
-        >
-          <SafetyRegionChoropleth
-            data={choropleth.vr}
-            metricName="disability_care"
-            metricProperty="infected_locations_percentage"
-            tooltipContent={createDisablityInfectedLocationsRegionalTooltip(
-              siteText.choropleth_tooltip.infected_locations,
-              regionThresholds.nursing_home.infected_locations_percentage,
-              createSelectRegionHandler(router, 'gehandicaptenzorg')
-            )}
-            onSelect={createSelectRegionHandler(router, 'gehandicaptenzorg')}
+            reference={positiveTestedPeopleText.reference}
           />
-        </ChoroplethTile>
 
-        <LineChartTile
-          metadata={{ source: infectedLocationsText.bronnen.rivm }}
-          title={infectedLocationsText.linechart_titel}
-          values={values}
-          ariaDescription={
-            graphDescriptions.gehandicaptenzorg_besmette_locaties
-          }
-          linesConfig={[
-            {
-              metricProperty: 'infected_locations_total',
-            },
-          ]}
-        />
+          <TwoKpiSection>
+            <KpiTile
+              title={positiveTestedPeopleText.barscale_titel}
+              description={positiveTestedPeopleText.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: positiveTestedPeopleText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_people"
+                absolute={lastValue.newly_infected_people}
+                difference={
+                  data.difference.disability_care__newly_infected_people
+                }
+              />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <ContentHeader
-          id="sterfte"
-          skipLinkAnchor={true}
-          title={locationDeaths.titel}
-          icon={<CoronaVirus />}
-          subtitle={locationDeaths.pagina_toelichting}
-          metadata={{
-            datumsText: locationDeaths.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [locationDeaths.bronnen.rivm],
-          }}
-          reference={locationDeaths.reference}
-        />
+          <LineChartTile
+            metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
+            title={positiveTestedPeopleText.linechart_titel}
+            ariaDescription={
+              graphDescriptions.gehandicaptenzorg_positief_getest
+            }
+            values={values}
+            linesConfig={[
+              {
+                metricProperty: 'newly_infected_people',
+              },
+            ]}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date >= underReportedValues[0];
 
-        <TwoKpiSection>
-          <KpiTile
-            title={locationDeaths.barscale_titel}
-            description={locationDeaths.extra_uitleg}
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: positiveTestedPeopleText.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  positiveTestedPeopleText.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <ContentHeader
+            id="besmette-locaties"
+            skipLinkAnchor={true}
+            title={infectedLocationsText.titel}
+            icon={<Locatie />}
+            subtitle={infectedLocationsText.pagina_toelichting}
+            metadata={{
+              datumsText: infectedLocationsText.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [infectedLocationsText.bronnen.rivm],
+            }}
+            reference={infectedLocationsText.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={infectedLocationsText.kpi_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: infectedLocationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected_locations_total"
+                absolute={lastValue.infected_locations_total}
+                percentage={lastValue.infected_locations_percentage}
+                difference={
+                  data.difference.disability_care__infected_locations_total
+                }
+              />
+              <Text>{infectedLocationsText.kpi_toelichting}</Text>
+            </KpiTile>
+
+            <KpiTile
+              title={infectedLocationsText.barscale_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: infectedLocationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_locations"
+                absolute={lastValue.newly_infected_locations}
+              />
+              <Text>{infectedLocationsText.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChoroplethTile
+            title={infectedLocationsText.map_titel}
+            description={infectedLocationsText.map_toelichting}
             metadata={{
               date: lastValue.date_unix,
-              source: locationDeaths.bronnen.rivm,
+              source: infectedLocationsText.bronnen.rivm,
+            }}
+            legend={{
+              thresholds:
+                regionThresholds.nursing_home.infected_locations_percentage,
+              title: infectedLocationsText.chloropleth_legenda.titel,
             }}
           >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={lastValue.deceased_daily}
+            <SafetyRegionChoropleth
+              data={choropleth.vr}
+              metricName="disability_care"
+              metricProperty="infected_locations_percentage"
+              tooltipContent={createDisablityInfectedLocationsRegionalTooltip(
+                siteText.choropleth_tooltip.infected_locations,
+                regionThresholds.nursing_home.infected_locations_percentage,
+                createSelectRegionHandler(router, 'gehandicaptenzorg')
+              )}
+              onSelect={createSelectRegionHandler(router, 'gehandicaptenzorg')}
             />
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <LineChartTile
-          metadata={{ source: locationDeaths.bronnen.rivm }}
-          title={locationDeaths.linechart_titel}
-          ariaDescription={graphDescriptions.gehandicaptenzorg_overleden}
-          values={values}
-          linesConfig={[
-            {
-              metricProperty: 'deceased_daily',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date >= underReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedValues,
-            {
-              fill: colors.data.underReported,
+          <LineChartTile
+            metadata={{ source: infectedLocationsText.bronnen.rivm }}
+            title={infectedLocationsText.linechart_titel}
+            values={values}
+            ariaDescription={
+              graphDescriptions.gehandicaptenzorg_besmette_locaties
             }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: positiveTestedPeopleText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                positiveTestedPeopleText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+            linesConfig={[
+              {
+                metricProperty: 'infected_locations_total',
+              },
+            ]}
+          />
+
+          <ContentHeader
+            id="sterfte"
+            skipLinkAnchor={true}
+            title={locationDeaths.titel}
+            icon={<CoronaVirus />}
+            subtitle={locationDeaths.pagina_toelichting}
+            metadata={{
+              datumsText: locationDeaths.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [locationDeaths.bronnen.rivm],
+            }}
+            reference={locationDeaths.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={locationDeaths.barscale_titel}
+              description={locationDeaths.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: locationDeaths.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={lastValue.deceased_daily}
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            metadata={{ source: locationDeaths.bronnen.rivm }}
+            title={locationDeaths.linechart_titel}
+            ariaDescription={graphDescriptions.gehandicaptenzorg_overleden}
+            values={values}
+            linesConfig={[
+              {
+                metricProperty: 'deceased_daily',
+              },
+            ]}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date >= underReportedValues[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: positiveTestedPeopleText.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  positiveTestedPeopleText.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-DisabilityCare.getLayout = GetNationalLayout;
 
 export default DisabilityCare;

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -8,7 +8,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -53,13 +52,15 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
   const locationDeaths = siteText.gehandicaptenzorg_oversterfte;
   const graphDescriptions = siteText.accessibility.grafieken;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: infectedLocationsText.metadata.title,
+    description: infectedLocationsText.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={infectedLocationsText.metadata.title}
-          description={infectedLocationsText.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.kwetsbare_groepen}

--- a/packages/app/src/pages/landelijk/index.tsx
+++ b/packages/app/src/pages/landelijk/index.tsx
@@ -1,14 +1,22 @@
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { getNlData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
+import { useIntl } from '~/intl';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   getNlData
 );
 
-const National: FCWithLayout<typeof getStaticProps> = () => null;
-National.getLayout = GetNationalLayout;
+const National = (props) => {
+  const { siteText } = useIntl();
+  const { data, lastGenerated } = props;
+  return (
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated} />
+    </Layout>
+  );
+};
 
 export default National;

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -9,7 +9,6 @@ import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
 import { PageBarScale } from '~/components-styled/page-barscale';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -57,13 +56,15 @@ const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
   const text = siteText.ic_opnames_per_dag;
   const graphDescriptions = siteText.accessibility.grafieken;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.ziekenhuizen}

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -14,7 +14,6 @@ import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -29,6 +28,8 @@ import {
   DateRange,
   getTrailingDateRange,
 } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -39,7 +40,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, content } = props;
+  const { data, content, lastGenerated } = props;
 
   const dataIntake = data.intensive_care_nice;
 
@@ -57,156 +58,166 @@ const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
   const graphDescriptions = siteText.accessibility.grafieken;
 
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.ziekenhuizen}
-          screenReaderCategory={siteText.ic_opnames_per_dag.titel_sidebar}
-          title={text.titel}
-          icon={<Arts />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: dataIntake.last_value.date_unix,
-            dateOfInsertionUnix: dataIntake.last_value.date_of_insertion_unix,
-            dataSources: [text.bronnen.nice, text.bronnen.lnaz],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <ArticleStrip articles={content?.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.ziekenhuizen}
+            screenReaderCategory={siteText.ic_opnames_per_dag.titel_sidebar}
+            title={text.titel}
+            icon={<Arts />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: dataIntake.last_value.date_unix,
-              source: text.bronnen.nice,
+              datumsText: text.datums,
+              dateOrRange: dataIntake.last_value.date_unix,
+              dateOfInsertionUnix: dataIntake.last_value.date_of_insertion_unix,
+              dataSources: [text.bronnen.nice, text.bronnen.lnaz],
             }}
-          >
-            <PageBarScale
-              data={data}
-              scope="nl"
-              metricName="intensive_care_nice"
-              metricProperty="admissions_moving_average"
-              localeTextKey="ic_opnames_per_dag"
-              differenceKey="intensive_care_nice__admissions_moving_average"
-            />
-            <Text>{text.extra_uitleg}</Text>
-          </KpiTile>
+            reference={text.reference}
+          />
 
-          <KpiTile
-            title={text.kpi_bedbezetting.title}
-            metadata={{
-              date: bedsLastValue.date_unix,
-              source: text.bronnen.lnaz,
-            }}
-          >
-            {bedsLastValue.beds_occupied_covid !== null &&
-              bedsLastValue.beds_occupied_covid_percentage !== null && (
-                <KpiValue
-                  data-cy="beds_occupied_covid"
-                  absolute={bedsLastValue.beds_occupied_covid}
-                  percentage={bedsLastValue.beds_occupied_covid_percentage}
-                  difference={
-                    data.difference.intensive_care_lcps__beds_occupied_covid
-                  }
-                />
-              )}
-            <Text>{text.kpi_bedbezetting.description}</Text>
-          </KpiTile>
-        </TwoKpiSection>
+          <ArticleStrip articles={content?.articles} />
 
-        <LineChartTile
-          title={text.linechart_titel}
-          values={dataIntake.values}
-          ariaDescription={graphDescriptions.intensive_care_opnames}
-          linesConfig={[
-            {
-              metricProperty: 'admissions_moving_average',
-            },
-          ]}
-          signaalwaarde={10}
-          metadata={{ source: text.bronnen.nice }}
-          componentCallback={addBackgroundRectangleCallback(
-            intakeUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.linechart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.linechart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              metadata={{
+                date: dataIntake.last_value.date_unix,
+                source: text.bronnen.nice,
+              }}
+            >
+              <PageBarScale
+                data={data}
+                scope="nl"
+                metricName="intensive_care_nice"
+                metricProperty="admissions_moving_average"
+                localeTextKey="ic_opnames_per_dag"
+                differenceKey="intensive_care_nice__admissions_moving_average"
+              />
+              <Text>{text.extra_uitleg}</Text>
+            </KpiTile>
 
-        <LineChartTile
-          title={text.chart_bedbezetting.title}
-          description={text.chart_bedbezetting.description}
-          values={data.intensive_care_lcps.values}
-          linesConfig={[
-            {
-              metricProperty: 'beds_occupied_covid',
-            },
-          ]}
-          metadata={{ source: text.bronnen.lnaz }}
-          componentCallback={addBackgroundRectangleCallback(lcpsOldDataRange, {
-            fill: colors.data.underReported,
-          })}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date < lcpsOldDataRange[1];
+            <KpiTile
+              title={text.kpi_bedbezetting.title}
+              metadata={{
+                date: bedsLastValue.date_unix,
+                source: text.bronnen.lnaz,
+              }}
+            >
+              {bedsLastValue.beds_occupied_covid !== null &&
+                bedsLastValue.beds_occupied_covid_percentage !== null && (
+                  <KpiValue
+                    data-cy="beds_occupied_covid"
+                    absolute={bedsLastValue.beds_occupied_covid}
+                    percentage={bedsLastValue.beds_occupied_covid_percentage}
+                    difference={
+                      data.difference.intensive_care_lcps__beds_occupied_covid
+                    }
+                  />
+                )}
+              <Text>{text.kpi_bedbezetting.description}</Text>
+            </KpiTile>
+          </TwoKpiSection>
 
-            return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInaccurateValue && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromSeconds(value.date_unix, 'medium')}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
+          <LineChartTile
+            title={text.linechart_titel}
+            values={dataIntake.values}
+            ariaDescription={graphDescriptions.intensive_care_opnames}
+            linesConfig={[
+              {
+                metricProperty: 'admissions_moving_average',
+              },
+            ]}
+            signaalwaarde={10}
+            metadata={{ source: text.bronnen.nice }}
+            componentCallback={addBackgroundRectangleCallback(
+              intakeUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.linechart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.linechart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <LineChartTile
+            title={text.chart_bedbezetting.title}
+            description={text.chart_bedbezetting.description}
+            values={data.intensive_care_lcps.values}
+            linesConfig={[
+              {
+                metricProperty: 'beds_occupied_covid',
+              },
+            ]}
+            metadata={{ source: text.bronnen.lnaz }}
+            componentCallback={addBackgroundRectangleCallback(
+              lcpsOldDataRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date < lcpsOldDataRange[1];
+
+              return (
+                <>
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    flexDirection="column"
+                  >
+                    {isInaccurateValue && (
+                      <Text as="span" fontSize={0} color={colors.annotation}>
+                        ({siteText.common.incomplete})
+                      </Text>
+                    )}
+                    <Box>
+                      <Text as="span" fontWeight="bold">
+                        {`${formatDateFromSeconds(
+                          value.date_unix,
+                          'medium'
+                        )}: `}
+                      </Text>
+                      {formatNumber(value.__value)}
+                    </Box>
                   </Box>
-                </Box>
-              </>
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.chart_bedbezetting.legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.chart_bedbezetting.legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+                </>
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.chart_bedbezetting.legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.chart_bedbezetting.legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-IntakeIntensiveCare.getLayout = GetNationalLayout;
 
 export default IntakeIntensiveCare;

--- a/packages/app/src/pages/landelijk/maatregelen.tsx
+++ b/packages/app/src/pages/landelijk/maatregelen.tsx
@@ -1,13 +1,13 @@
 import css from '@styled-system/css';
 import { ContentHeader } from '~/components-styled/content-header';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { Heading } from '~/components-styled/typography';
 import { KpiSection } from '~/components-styled/kpi-section';
 import { LockdownTable } from '~/domain/restrictions/lockdown-table';
 import { SEOHead } from '~/components-styled/seo-head';
 import { Box } from '~/components-styled/base/box';
 import { TileList } from '~/components-styled/tile-list';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 import { useIntl } from '~/intl';
 import {
@@ -56,10 +56,10 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<MaatregelenData>(query)
 );
 
-const NationalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
+const NationalRestrictions = (props) => {
   const { siteText } = useIntl();
 
-  const { content } = props;
+  const { content, lastGenerated, data } = props;
   const { lockdown } = content;
 
   const { showLockdown } = lockdown;
@@ -72,42 +72,42 @@ const NationalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
   // const effectiveEscalationLevel: EscalationLevel = escalationLevel > 4 ? 4 : (escalationLevel as EscalationLevel);
 
   return (
-    <>
-      <SEOHead
-        title={siteText.nationaal_metadata.title}
-        description={siteText.nationaal_metadata.description}
-      />
-      <TileList>
-        <ContentHeader title={siteText.nationaal_maatregelen.titel} />
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={siteText.nationaal_metadata.title}
+          description={siteText.nationaal_metadata.description}
+        />
+        <TileList>
+          <ContentHeader title={siteText.nationaal_maatregelen.titel} />
 
-        {showLockdown && (
-          <KpiSection flexDirection="column">
-            <Box
-              css={css({
-                'p:last-child': {
-                  margin: '0',
-                },
-              })}
-            >
-              <Heading level={3}>{lockdown.message.title}</Heading>
-              {lockdown.message.description ? (
-                <RichContent blocks={lockdown.message.description} />
-              ) : null}
-            </Box>
-          </KpiSection>
-        )}
+          {showLockdown && (
+            <KpiSection flexDirection="column">
+              <Box
+                css={css({
+                  'p:last-child': {
+                    margin: '0',
+                  },
+                })}
+              >
+                <Heading level={3}>{lockdown.message.title}</Heading>
+                {lockdown.message.description ? (
+                  <RichContent blocks={lockdown.message.description} />
+                ) : null}
+              </Box>
+            </KpiSection>
+          )}
 
-        {showLockdown && (
-          <KpiSection display="flex" flexDirection="column">
-            <Heading level={3}>{lockdown.title}</Heading>
-            <LockdownTable data={lockdown} />
-          </KpiSection>
-        )}
-      </TileList>
-    </>
+          {showLockdown && (
+            <KpiSection display="flex" flexDirection="column">
+              <Heading level={3}>{lockdown.title}</Heading>
+              <LockdownTable data={lockdown} />
+            </KpiSection>
+          )}
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-NationalRestrictions.getLayout = GetNationalLayout;
 
 export default NationalRestrictions;

--- a/packages/app/src/pages/landelijk/maatregelen.tsx
+++ b/packages/app/src/pages/landelijk/maatregelen.tsx
@@ -3,12 +3,10 @@ import { ContentHeader } from '~/components-styled/content-header';
 import { Heading } from '~/components-styled/typography';
 import { KpiSection } from '~/components-styled/kpi-section';
 import { LockdownTable } from '~/domain/restrictions/lockdown-table';
-import { SEOHead } from '~/components-styled/seo-head';
 import { Box } from '~/components-styled/base/box';
 import { TileList } from '~/components-styled/tile-list';
 import { Layout } from '~/domain/layout/layout';
 import { NationalLayout } from '~/domain/layout/national-layout';
-
 import { useIntl } from '~/intl';
 import {
   getNlData,
@@ -71,13 +69,13 @@ const NationalRestrictions = (props) => {
    */
   // const effectiveEscalationLevel: EscalationLevel = escalationLevel > 4 ? 4 : (escalationLevel as EscalationLevel);
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={siteText.nationaal_metadata.title}
-          description={siteText.nationaal_metadata.description}
-        />
         <TileList>
           <ContentHeader title={siteText.nationaal_maatregelen.titel} />
 

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -20,7 +20,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { PageBarScale } from '~/components-styled/page-barscale';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Heading, Text } from '~/components-styled/typography';
@@ -87,13 +86,15 @@ const PositivelyTestedPeople = ({
     data.tested_per_age_group
   );
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.besmettingen}

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -31,8 +31,6 @@ import { createSelectMunicipalHandler } from '~/components/choropleth/select-han
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createPositiveTestedPeopleMunicipalTooltip } from '~/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip';
 import { createPositiveTestedPeopleRegionalTooltip } from '~/components/choropleth/tooltips/region/create-positive-tested-people-regional-tooltip';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -46,6 +44,8 @@ import { assert } from '~/utils/assert';
 import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -59,10 +59,11 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('positiveTestsPage'))
 );
 
-const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
+const PositivelyTestedPeople = ({
   data,
   choropleth,
   content,
+  lastGenerated,
 }) => {
   const {
     siteText,
@@ -87,370 +88,377 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = ({
   );
 
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.besmettingen}
-          screenReaderCategory={
-            siteText.positief_geteste_personen.titel_sidebar
-          }
-          title={text.titel}
-          icon={<Getest />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: dataInfectedDelta.last_value.date_unix,
-            dateOfInsertionUnix:
-              dataInfectedDelta.last_value.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.besmettingen}
+            screenReaderCategory={
+              siteText.positief_geteste_personen.titel_sidebar
+            }
+            title={text.titel}
+            icon={<Getest />}
+            subtitle={text.pagina_toelichting}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: dataInfectedDelta.last_value.date_unix,
+              dateOfInsertionUnix:
+                dataInfectedDelta.last_value.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
+            }}
+            reference={text.reference}
+          />
 
-        <ArticleStrip articles={content.articles} />
+          <ArticleStrip articles={content.articles} />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.kpi_titel}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.kpi_titel}
+              metadata={{
+                date: dataInfectedDelta.last_value.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected"
+                absolute={data.tested_overall.last_value.infected}
+                difference={data.difference.tested_overall__infected}
+              />
+
+              <Text
+                as="div"
+                dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
+              />
+              <Box>
+                <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
+                  <span
+                    css={css({ '& > span': { color: 'data.primary' } })}
+                    dangerouslySetInnerHTML={{
+                      __html: replaceKpisInText(ggdText.summary_title, [
+                        {
+                          name: 'percentage',
+                          value: `${formatPercentage(
+                            dataGgdAverageLastValue.infected_percentage
+                          )}%`,
+                        },
+                      ]),
+                    }}
+                  />
+                </Heading>
+                <Text mt={0} lineHeight={1}>
+                  <Anchor name="ggd" text={ggdText.summary_link_cta} />
+                </Text>
+              </Box>
+            </KpiTile>
+            <KpiTile
+              title={text.barscale_titel}
+              data-cy="infected_per_100k"
+              metadata={{
+                date: dataInfectedDelta.last_value.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <PageBarScale
+                data={data}
+                scope="nl"
+                metricName="tested_overall"
+                metricProperty="infected_per_100k"
+                localeTextKey="positief_geteste_personen"
+                differenceKey="tested_overall__infected_per_100k"
+              />
+
+              <Text>{text.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChoroplethTile
+            data-cy="choropleths"
+            title={text.map_titel}
+            metadata={{
+              date: dataInfectedDelta.last_value.date_unix,
+              source: text.bronnen.rivm,
+            }}
+            description={text.map_toelichting}
+            onChartRegionChange={setSelectedMap}
+            chartRegion={selectedMap}
+            legend={{
+              title: text.chloropleth_legenda.titel,
+              thresholds: regionThresholds.tested_overall.infected_per_100k,
+            }}
+          >
+            {/**
+             * It's probably a good idea to abstract this even further, so that
+             * the switching of charts, and the state involved, are all handled by
+             * the component. The page does not have to be bothered with this.
+             *
+             * Ideally the ChoroplethTile would receive some props with the data
+             * it needs to render either Choropleth without it caring about
+             * MunicipalityChloropleth or SafetyRegionChloropleth, that data would
+             * make the chart and define the tooltip layout for each, but maybe for
+             * now that is a bridge too far. Let's take it one step at a time.
+             */}
+            {selectedMap === 'municipal' && (
+              <MunicipalityChoropleth
+                data={choropleth.gm}
+                metricName="tested_overall"
+                metricProperty="infected_per_100k"
+                tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
+                  siteText.choropleth_tooltip.positive_tested_people,
+                  regionThresholds.tested_overall.infected_per_100k,
+                  createSelectMunicipalHandler(
+                    router,
+                    'positief-geteste-mensen'
+                  )
+                )}
+                onSelect={createSelectMunicipalHandler(
+                  router,
+                  'positief-geteste-mensen'
+                )}
+              />
+            )}
+            {selectedMap === 'region' && (
+              <SafetyRegionChoropleth
+                data={choropleth.vr}
+                metricName="tested_overall"
+                metricProperty="infected_per_100k"
+                tooltipContent={createPositiveTestedPeopleRegionalTooltip(
+                  siteText.choropleth_tooltip.positive_tested_people,
+                  regionThresholds.tested_overall.infected_per_100k,
+                  createSelectRegionHandler(router, 'positief-geteste-mensen')
+                )}
+                onSelect={createSelectRegionHandler(
+                  router,
+                  'positief-geteste-mensen'
+                )}
+              />
+            )}
+          </ChoroplethTile>
+
+          <LineChartTile
+            title={text.linechart_titel}
+            description={text.linechart_toelichting}
+            signaalwaarde={7}
+            values={dataInfectedDelta.values}
+            linesConfig={[{ metricProperty: 'infected_per_100k' }]}
+            metadata={{
+              source: text.bronnen.rivm,
+            }}
+            formatTooltip={(values) => {
+              const value = values[0];
+
+              return (
+                <Text textAlign="center" m={0}>
+                  <span style={{ fontWeight: 'bold' }}>
+                    {formatDateFromMilliseconds(
+                      value.__date.getTime(),
+                      'medium'
+                    )}
+                  </span>
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      marginBottom: '0.5px',
+                      backgroundColor: colors.data.primary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_value,
+                    {
+                      totalPositiveValue: formatNumber(value.__value),
+                    }
+                  )}
+                  <br />
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_people,
+                    {
+                      totalPositiveTestedPeople: formatNumber(value.infected),
+                    }
+                  )}
+                </Text>
+              );
+            }}
+          />
+
+          <ChartTile
+            title={siteText.infected_age_groups.title}
+            description={replaceVariablesInText(
+              siteText.infected_age_groups.description,
+              ageDemographicExampleData
+            )}
             metadata={{
               date: dataInfectedDelta.last_value.date_unix,
               source: text.bronnen.rivm,
             }}
           >
-            <KpiValue
-              data-cy="infected"
-              absolute={data.tested_overall.last_value.infected}
-              difference={data.difference.tested_overall__infected}
+            <AgeDemographic
+              data={data.tested_per_age_group}
+              metricProperty="infected_percentage"
+              text={siteText.infected_age_groups.graph}
             />
+          </ChartTile>
 
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
-            />
-            <Box>
-              <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
-                <span
+          <ContentHeader
+            title={ggdText.titel}
+            skipLinkAnchor={true}
+            id="ggd"
+            icon={<Afname />}
+            subtitle={ggdText.toelichting}
+            metadata={{
+              datumsText: ggdText.datums,
+              dateOrRange: {
+                start: dataGgdAverageLastValue.date_start_unix,
+                end: dataGgdAverageLastValue.date_end_unix,
+              },
+              dateOfInsertionUnix:
+                dataGgdAverageLastValue.date_of_insertion_unix,
+              dataSources: [ggdText.bronnen.rivm],
+            }}
+            reference={text.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={ggdText.totaal_getest_week_titel}
+              metadata={{
+                date: [
+                  dataGgdAverageLastValue.date_start_unix,
+                  dataGgdAverageLastValue.date_end_unix,
+                ],
+                source: ggdText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="ggd_tested_total"
+                absolute={dataGgdAverageLastValue.tested_total}
+                difference={data.difference.tested_ggd_average__tested_total}
+              />
+              <Text>{ggdText.totaal_getest_week_uitleg}</Text>
+            </KpiTile>
+            <KpiTile
+              title={ggdText.positief_getest_week_titel}
+              metadata={{
+                date: [
+                  dataGgdAverageLastValue.date_start_unix,
+                  dataGgdAverageLastValue.date_end_unix,
+                ],
+                source: ggdText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="ggd_infected"
+                percentage={dataGgdAverageLastValue.infected_percentage}
+                difference={
+                  data.difference.tested_ggd_average__infected_percentage
+                }
+              />
+              <Text>{ggdText.positief_getest_week_uitleg}</Text>
+              <Text>
+                <strong
                   css={css({ '& > span': { color: 'data.primary' } })}
                   dangerouslySetInnerHTML={{
-                    __html: replaceKpisInText(ggdText.summary_title, [
-                      {
-                        name: 'percentage',
-                        value: `${formatPercentage(
-                          dataGgdAverageLastValue.infected_percentage
-                        )}%`,
-                      },
-                    ]),
+                    __html: replaceKpisInText(
+                      ggdText.positief_getest_getest_week_uitleg,
+                      [
+                        {
+                          name: 'numerator',
+                          value: formatNumber(dataGgdAverageLastValue.infected),
+                        },
+                        {
+                          name: 'denominator',
+                          value: formatNumber(
+                            dataGgdAverageLastValue.tested_total
+                          ),
+                        },
+                      ]
+                    ),
                   }}
                 />
-              </Heading>
-              <Text mt={0} lineHeight={1}>
-                <Anchor name="ggd" text={ggdText.summary_link_cta} />
               </Text>
-            </Box>
-          </KpiTile>
-          <KpiTile
-            title={text.barscale_titel}
-            data-cy="infected_per_100k"
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={ggdText.linechart_percentage_titel}
+            description={ggdText.linechart_percentage_toelichting}
+            values={dataGgdDailyValues}
+            linesConfig={[{ metricProperty: 'infected_percentage' }]}
+            isPercentage
             metadata={{
-              date: dataInfectedDelta.last_value.date_unix,
-              source: text.bronnen.rivm,
+              source: ggdText.bronnen.rivm,
             }}
-          >
-            <PageBarScale
-              data={data}
-              scope="nl"
-              metricName="tested_overall"
-              metricProperty="infected_per_100k"
-              localeTextKey="positief_geteste_personen"
-              differenceKey="tested_overall__infected_per_100k"
-            />
-
-            <Text>{text.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChoroplethTile
-          data-cy="choropleths"
-          title={text.map_titel}
-          metadata={{
-            date: dataInfectedDelta.last_value.date_unix,
-            source: text.bronnen.rivm,
-          }}
-          description={text.map_toelichting}
-          onChartRegionChange={setSelectedMap}
-          chartRegion={selectedMap}
-          legend={{
-            title: text.chloropleth_legenda.titel,
-            thresholds: regionThresholds.tested_overall.infected_per_100k,
-          }}
-        >
-          {/**
-           * It's probably a good idea to abstract this even further, so that
-           * the switching of charts, and the state involved, are all handled by
-           * the component. The page does not have to be bothered with this.
-           *
-           * Ideally the ChoroplethTile would receive some props with the data
-           * it needs to render either Choropleth without it caring about
-           * MunicipalityChloropleth or SafetyRegionChloropleth, that data would
-           * make the chart and define the tooltip layout for each, but maybe for
-           * now that is a bridge too far. Let's take it one step at a time.
-           */}
-          {selectedMap === 'municipal' && (
-            <MunicipalityChoropleth
-              data={choropleth.gm}
-              metricName="tested_overall"
-              metricProperty="infected_per_100k"
-              tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-                siteText.choropleth_tooltip.positive_tested_people,
-                regionThresholds.tested_overall.infected_per_100k,
-                createSelectMunicipalHandler(router, 'positief-geteste-mensen')
-              )}
-              onSelect={createSelectMunicipalHandler(
-                router,
-                'positief-geteste-mensen'
-              )}
-            />
-          )}
-          {selectedMap === 'region' && (
-            <SafetyRegionChoropleth
-              data={choropleth.vr}
-              metricName="tested_overall"
-              metricProperty="infected_per_100k"
-              tooltipContent={createPositiveTestedPeopleRegionalTooltip(
-                siteText.choropleth_tooltip.positive_tested_people,
-                regionThresholds.tested_overall.infected_per_100k,
-                createSelectRegionHandler(router, 'positief-geteste-mensen')
-              )}
-              onSelect={createSelectRegionHandler(
-                router,
-                'positief-geteste-mensen'
-              )}
-            />
-          )}
-        </ChoroplethTile>
-
-        <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_toelichting}
-          signaalwaarde={7}
-          values={dataInfectedDelta.values}
-          linesConfig={[{ metricProperty: 'infected_per_100k' }]}
-          metadata={{
-            source: text.bronnen.rivm,
-          }}
-          formatTooltip={(values) => {
-            const value = values[0];
-
-            return (
-              <Text textAlign="center" m={0}>
-                <span style={{ fontWeight: 'bold' }}>
-                  {formatDateFromMilliseconds(value.__date.getTime(), 'medium')}
-                </span>
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    marginBottom: '0.5px',
-                    backgroundColor: colors.data.primary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_value,
-                  {
-                    totalPositiveValue: formatNumber(value.__value),
-                  }
-                )}
-                <br />
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_people,
-                  {
-                    totalPositiveTestedPeople: formatNumber(value.infected),
-                  }
-                )}
-              </Text>
-            );
-          }}
-        />
-
-        <ChartTile
-          title={siteText.infected_age_groups.title}
-          description={replaceVariablesInText(
-            siteText.infected_age_groups.description,
-            ageDemographicExampleData
-          )}
-          metadata={{
-            date: dataInfectedDelta.last_value.date_unix,
-            source: text.bronnen.rivm,
-          }}
-        >
-          <AgeDemographic
-            data={data.tested_per_age_group}
-            metricProperty="infected_percentage"
-            text={siteText.infected_age_groups.graph}
           />
-        </ChartTile>
 
-        <ContentHeader
-          title={ggdText.titel}
-          skipLinkAnchor={true}
-          id="ggd"
-          icon={<Afname />}
-          subtitle={ggdText.toelichting}
-          metadata={{
-            datumsText: ggdText.datums,
-            dateOrRange: {
-              start: dataGgdAverageLastValue.date_start_unix,
-              end: dataGgdAverageLastValue.date_end_unix,
-            },
-            dateOfInsertionUnix: dataGgdAverageLastValue.date_of_insertion_unix,
-            dataSources: [ggdText.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={ggdText.totaal_getest_week_titel}
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={ggdText.linechart_totaltests_titel}
+            description={ggdText.linechart_totaltests_toelichting}
+            hideFill={true}
+            showLegend
+            padding={{
+              left: 50,
+            }}
+            values={dataGgdDailyValues}
+            linesConfig={[
+              {
+                metricProperty: 'tested_total',
+                color: colors.data.secondary,
+                legendLabel: ggdText.linechart_totaltests_legend_label,
+              },
+              {
+                metricProperty: 'infected',
+                color: colors.data.primary,
+                legendLabel: ggdText.linechart_positivetests_legend_label,
+              },
+            ]}
             metadata={{
-              date: [
-                dataGgdAverageLastValue.date_start_unix,
-                dataGgdAverageLastValue.date_end_unix,
-              ],
               source: ggdText.bronnen.rivm,
             }}
-          >
-            <KpiValue
-              data-cy="ggd_tested_total"
-              absolute={dataGgdAverageLastValue.tested_total}
-              difference={data.difference.tested_ggd_average__tested_total}
-            />
-            <Text>{ggdText.totaal_getest_week_uitleg}</Text>
-          </KpiTile>
-          <KpiTile
-            title={ggdText.positief_getest_week_titel}
-            metadata={{
-              date: [
-                dataGgdAverageLastValue.date_start_unix,
-                dataGgdAverageLastValue.date_end_unix,
-              ],
-              source: ggdText.bronnen.rivm,
+            formatTooltip={(x) => {
+              const percentage = (x[1].__value * 100) / x[0].__value;
+
+              return (
+                <>
+                  {formatDateFromSeconds(x[0].date_unix, 'medium')}
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      backgroundColor: colors.data.secondary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {formatNumber(x[0].__value)}
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      backgroundColor: colors.data.primary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {formatNumber(x[1].__value)} ({formatPercentage(percentage)}%)
+                </>
+              );
             }}
-          >
-            <KpiValue
-              data-cy="ggd_infected"
-              percentage={dataGgdAverageLastValue.infected_percentage}
-              difference={
-                data.difference.tested_ggd_average__infected_percentage
-              }
-            />
-            <Text>{ggdText.positief_getest_week_uitleg}</Text>
-            <Text>
-              <strong
-                css={css({ '& > span': { color: 'data.primary' } })}
-                dangerouslySetInnerHTML={{
-                  __html: replaceKpisInText(
-                    ggdText.positief_getest_getest_week_uitleg,
-                    [
-                      {
-                        name: 'numerator',
-                        value: formatNumber(dataGgdAverageLastValue.infected),
-                      },
-                      {
-                        name: 'denominator',
-                        value: formatNumber(
-                          dataGgdAverageLastValue.tested_total
-                        ),
-                      },
-                    ]
-                  ),
-                }}
-              />
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_percentage_titel}
-          description={ggdText.linechart_percentage_toelichting}
-          values={dataGgdDailyValues}
-          linesConfig={[{ metricProperty: 'infected_percentage' }]}
-          isPercentage
-          metadata={{
-            source: ggdText.bronnen.rivm,
-          }}
-        />
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_totaltests_titel}
-          description={ggdText.linechart_totaltests_toelichting}
-          hideFill={true}
-          showLegend
-          padding={{
-            left: 50,
-          }}
-          values={dataGgdDailyValues}
-          linesConfig={[
-            {
-              metricProperty: 'tested_total',
-              color: colors.data.secondary,
-              legendLabel: ggdText.linechart_totaltests_legend_label,
-            },
-            {
-              metricProperty: 'infected',
-              color: colors.data.primary,
-              legendLabel: ggdText.linechart_positivetests_legend_label,
-            },
-          ]}
-          metadata={{
-            source: ggdText.bronnen.rivm,
-          }}
-          formatTooltip={(x) => {
-            const percentage = (x[1].__value * 100) / x[0].__value;
-
-            return (
-              <>
-                {formatDateFromSeconds(x[0].date_unix, 'medium')}
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    backgroundColor: colors.data.secondary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {formatNumber(x[0].__value)}
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    backgroundColor: colors.data.primary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {formatNumber(x[1].__value)} ({formatPercentage(percentage)}%)
-              </>
-            );
-          }}
-        />
-      </TileList>
-    </>
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-PositivelyTestedPeople.getLayout = GetNationalLayout;
 
 export default PositivelyTestedPeople;
 

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -12,8 +12,6 @@ import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -22,6 +20,8 @@ import {
   getLastGeneratedDate,
   getNlData,
 } from '~/static-props/get-data';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -31,8 +31,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('reproductionPage'))
 );
 
-const ReproductionIndex: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, content } = props;
+const ReproductionIndex = (props) => {
+  const { data, content, lastGenerated } = props;
 
   const lastFilledValue = getLastFilledValue(data.reproduction);
 
@@ -41,90 +41,90 @@ const ReproductionIndex: FCWithLayout<typeof getStaticProps> = (props) => {
   const graphDescriptions = siteText.accessibility.grafieken;
 
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.besmettingen}
-          screenReaderCategory={siteText.reproductiegetal.titel_sidebar}
-          title={text.titel}
-          icon={<Repro />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastFilledValue.date_unix,
-            dateOfInsertionUnix: lastFilledValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiWithIllustrationTile
-            title={text.barscale_titel}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.besmettingen}
+            screenReaderCategory={siteText.reproductiegetal.titel_sidebar}
+            title={text.titel}
+            icon={<Repro />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: lastFilledValue.date_unix,
-              source: text.bronnen.rivm,
-              obtained: lastFilledValue.date_of_insertion_unix,
+              datumsText: text.datums,
+              dateOrRange: lastFilledValue.date_unix,
+              dateOfInsertionUnix: lastFilledValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
-            illustration={{
-              image: '/images/reproductie-explainer.svg',
-              alt: text.reproductie_explainer_alt,
-              description: text.extra_uitleg,
-            }}
-          >
-            <PageBarScale
-              data={data}
-              scope="nl"
-              metricName="reproduction"
-              metricProperty="index_average"
-              localeTextKey="reproductiegetal"
-              differenceKey="reproduction__index_average"
-              differenceFractionDigits={2}
-            />
-            <Text>{text.barscale_toelichting}</Text>
-          </KpiWithIllustrationTile>
-        </TwoKpiSection>
-
-        {data.reproduction.values && (
-          <LineChartTile
-            metadata={{ source: text.bronnen.rivm }}
-            title={text.linechart_titel}
-            values={data.reproduction.values}
-            ariaDescription={graphDescriptions.reproductiegetal_verloop}
-            linesConfig={[
-              {
-                metricProperty: 'index_average',
-              },
-            ]}
-            signaalwaarde={1}
-            timeframeOptions={['all', '5weeks']}
-            hideFill={true}
-            footer={
-              <Box pl="30px">
-                <Legend
-                  items={[
-                    {
-                      label: text.legenda_r,
-                      color: 'data.primary',
-                      shape: 'line',
-                    },
-                  ]}
-                />
-              </Box>
-            }
+            reference={text.reference}
           />
-        )}
-      </TileList>
-    </>
+
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiWithIllustrationTile
+              title={text.barscale_titel}
+              metadata={{
+                date: lastFilledValue.date_unix,
+                source: text.bronnen.rivm,
+                obtained: lastFilledValue.date_of_insertion_unix,
+              }}
+              illustration={{
+                image: '/images/reproductie-explainer.svg',
+                alt: text.reproductie_explainer_alt,
+                description: text.extra_uitleg,
+              }}
+            >
+              <PageBarScale
+                data={data}
+                scope="nl"
+                metricName="reproduction"
+                metricProperty="index_average"
+                localeTextKey="reproductiegetal"
+                differenceKey="reproduction__index_average"
+                differenceFractionDigits={2}
+              />
+              <Text>{text.barscale_toelichting}</Text>
+            </KpiWithIllustrationTile>
+          </TwoKpiSection>
+
+          {data.reproduction.values && (
+            <LineChartTile
+              metadata={{ source: text.bronnen.rivm }}
+              title={text.linechart_titel}
+              values={data.reproduction.values}
+              ariaDescription={graphDescriptions.reproductiegetal_verloop}
+              linesConfig={[
+                {
+                  metricProperty: 'index_average',
+                },
+              ]}
+              signaalwaarde={1}
+              timeframeOptions={['all', '5weeks']}
+              hideFill={true}
+              footer={
+                <Box pl="30px">
+                  <Legend
+                    items={[
+                      {
+                        label: text.legenda_r,
+                        color: 'data.primary',
+                        shape: 'line',
+                      },
+                    ]}
+                  />
+                </Box>
+              }
+            />
+          )}
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-ReproductionIndex.getLayout = GetNationalLayout;
 
 export default ReproductionIndex;

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -8,7 +8,6 @@ import { KpiWithIllustrationTile } from '~/components-styled/kpi-with-illustrati
 import { Legend } from '~/components-styled/legend';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { PageBarScale } from '~/components-styled/page-barscale';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -40,13 +39,15 @@ const ReproductionIndex = (props) => {
   const text = siteText.reproductiegetal;
   const graphDescriptions = siteText.accessibility.grafieken;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.besmettingen}

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -10,7 +10,6 @@ import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -58,13 +57,15 @@ const SewerWater = ({ data, choropleth, content, lastGenerated }) => {
     'municipal'
   );
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.vroege_signalen}

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -13,8 +13,6 @@ import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { DeceasedMonitorSection } from '~/domain/deceased/deceased-monitor-section';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -25,6 +23,8 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -34,7 +34,9 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('deceasedPage'))
 );
 
-const DeceasedNationalPage: FCWithLayout<typeof getStaticProps> = (props) => {
+const DeceasedNationalPage = (props) => {
+  const { data, lastGenerated } = props;
+
   const dataCbs = props.data.deceased_cbs;
   const dataRivm = props.data.deceased_rivm;
   const dataDeceasedPerAgeGroup = props.data.deceased_rivm_per_age_group;
@@ -46,138 +48,138 @@ const DeceasedNationalPage: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const text = siteText.sterfte;
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.besmettingen}
-          title={text.section_deceased_rivm.title}
-          icon={<CoronaVirusIcon />}
-          subtitle={text.section_deceased_rivm.description}
-          reference={text.section_deceased_rivm.reference}
-          metadata={{
-            datumsText: text.section_deceased_rivm.datums,
-            dateOrRange: dataRivm.last_value.date_unix,
-            dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
-            dataSources: [text.section_deceased_rivm.bronnen.rivm],
-          }}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_daily_title}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.besmettingen}
+            title={text.section_deceased_rivm.title}
+            icon={<CoronaVirusIcon />}
+            subtitle={text.section_deceased_rivm.description}
+            reference={text.section_deceased_rivm.reference}
             metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
+              datumsText: text.section_deceased_rivm.datums,
+              dateOrRange: dataRivm.last_value.date_unix,
+              dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
+              dataSources: [text.section_deceased_rivm.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="covid_daily"
-              absolute={dataRivm.last_value.covid_daily}
-              difference={props.data.difference.deceased_rivm__covid_daily}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_daily_description}
-            </Text>
-          </KpiTile>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_total_title}
-            metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="covid_total"
-              absolute={dataRivm.last_value.covid_total}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_total_description}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_deceased_rivm.line_chart_covid_daily_title}
-          description={
-            text.section_deceased_rivm.line_chart_covid_daily_description
-          }
-          values={dataRivm.values}
-          linesConfig={[
-            {
-              metricProperty: 'covid_daily',
-            },
-          ]}
-          metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
-          componentCallback={addBackgroundRectangleCallback(
-            dataRivmUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label:
-                text.section_deceased_rivm
-                  .line_chart_covid_daily_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                text.section_deceased_rivm
-                  .line_chart_covid_daily_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ChartTile
-          title={siteText.deceased_age_groups.title}
-          description={siteText.deceased_age_groups.description}
-          metadata={{
-            date: dataRivm.last_value.date_unix,
-            source: siteText.deceased_age_groups.bronnen.rivm,
-          }}
-        >
-          <AgeDemographic
-            data={dataDeceasedPerAgeGroup}
-            metricProperty="covid_percentage"
-            displayMaxPercentage={45}
-            text={siteText.deceased_age_groups.graph}
           />
-        </ChartTile>
 
-        <ContentHeader
-          title={siteText.section_sterftemonitor.title}
-          icon={<CoronaVirusIcon />}
-          subtitle={siteText.section_sterftemonitor.description}
-          reference={siteText.section_sterftemonitor.reference}
-          metadata={{
-            datumsText: siteText.section_sterftemonitor.datums,
-            dateOrRange: {
-              start: dataCbs.last_value.date_start_unix,
-              end: dataCbs.last_value.date_end_unix,
-            },
-            dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
-            dataSources: [siteText.section_sterftemonitor.bronnen.cbs],
-          }}
-        />
+          <ArticleStrip articles={content.articles} />
 
-        <DeceasedMonitorSection data={dataCbs} showDataMessage />
-      </TileList>
-    </>
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_daily_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_daily"
+                absolute={dataRivm.last_value.covid_daily}
+                difference={props.data.difference.deceased_rivm__covid_daily}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_daily_description}
+              </Text>
+            </KpiTile>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_total_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_total"
+                absolute={dataRivm.last_value.covid_total}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_total_description}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_deceased_rivm.line_chart_covid_daily_title}
+            description={
+              text.section_deceased_rivm.line_chart_covid_daily_description
+            }
+            values={dataRivm.values}
+            linesConfig={[
+              {
+                metricProperty: 'covid_daily',
+              },
+            ]}
+            metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
+            componentCallback={addBackgroundRectangleCallback(
+              dataRivmUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label:
+                  text.section_deceased_rivm
+                    .line_chart_covid_daily_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  text.section_deceased_rivm
+                    .line_chart_covid_daily_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <ChartTile
+            title={siteText.deceased_age_groups.title}
+            description={siteText.deceased_age_groups.description}
+            metadata={{
+              date: dataRivm.last_value.date_unix,
+              source: siteText.deceased_age_groups.bronnen.rivm,
+            }}
+          >
+            <AgeDemographic
+              data={dataDeceasedPerAgeGroup}
+              metricProperty="covid_percentage"
+              displayMaxPercentage={45}
+              text={siteText.deceased_age_groups.graph}
+            />
+          </ChartTile>
+
+          <ContentHeader
+            title={siteText.section_sterftemonitor.title}
+            icon={<CoronaVirusIcon />}
+            subtitle={siteText.section_sterftemonitor.description}
+            reference={siteText.section_sterftemonitor.reference}
+            metadata={{
+              datumsText: siteText.section_sterftemonitor.datums,
+              dateOrRange: {
+                start: dataCbs.last_value.date_start_unix,
+                end: dataCbs.last_value.date_end_unix,
+              },
+              dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
+              dataSources: [siteText.section_sterftemonitor.bronnen.cbs],
+            }}
+          />
+
+          <DeceasedMonitorSection data={dataCbs} showDataMessage />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-DeceasedNationalPage.getLayout = GetNationalLayout;
 
 export default DeceasedNationalPage;

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -8,7 +8,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -47,13 +46,16 @@ const DeceasedNationalPage = (props) => {
   const { siteText } = useIntl();
 
   const text = siteText.sterfte;
+
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.besmettingen}

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -6,7 +6,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -52,13 +51,16 @@ const ElderlyAtHomeNationalPage = ({ data, choropleth, lastGenerated }) => {
 
   const text = siteText.thuiswonende_ouderen;
   const graphDescriptions = siteText.accessibility.grafieken;
+
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.kwetsbare_groepen}

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -14,8 +14,6 @@ import { regionThresholds } from '~/components/choropleth/region-thresholds';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createRegionElderlyAtHomeTooltip } from '~/components/choropleth/tooltips/region/create-region-elderly-at-home-tooltip';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -26,6 +24,8 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -35,10 +35,7 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
-const ElderlyAtHomeNationalPage: FCWithLayout<typeof getStaticProps> = ({
-  data,
-  choropleth,
-}) => {
+const ElderlyAtHomeNationalPage = ({ data, choropleth, lastGenerated }) => {
   const router = useRouter();
   const elderlyAtHomeData = data.elderly_at_home;
 
@@ -56,217 +53,224 @@ const ElderlyAtHomeNationalPage: FCWithLayout<typeof getStaticProps> = ({
   const text = siteText.thuiswonende_ouderen;
   const graphDescriptions = siteText.accessibility.grafieken;
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={siteText.thuiswonende_ouderen.titel_sidebar}
-          title={text.section_positive_tested.title}
-          icon={<ElderlyIcon />}
-          subtitle={text.section_positive_tested.description}
-          metadata={{
-            datumsText: text.section_positive_tested.datums,
-            dateOrRange: elderlyAtHomeData.last_value.date_unix,
-            dateOfInsertionUnix:
-              elderlyAtHomeData.last_value.date_of_insertion_unix,
-            dataSources: [text.section_positive_tested.bronnen.rivm],
-          }}
-          reference={text.section_positive_tested.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_positive_tested.kpi_daily_title}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.kwetsbare_groepen}
+            screenReaderCategory={siteText.thuiswonende_ouderen.titel_sidebar}
+            title={text.section_positive_tested.title}
+            icon={<ElderlyIcon />}
+            subtitle={text.section_positive_tested.description}
             metadata={{
-              date: elderlyAtHomeData.last_value.date_unix,
-              source: text.section_positive_tested.bronnen.rivm,
+              datumsText: text.section_positive_tested.datums,
+              dateOrRange: elderlyAtHomeData.last_value.date_unix,
+              dateOfInsertionUnix:
+                elderlyAtHomeData.last_value.date_of_insertion_unix,
+              dataSources: [text.section_positive_tested.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="positive_tested_daily"
-              absolute={elderlyAtHomeData.last_value.positive_tested_daily}
-              difference={
-                data.difference.elderly_at_home__positive_tested_daily
-              }
-            />
-            <Text>{text.section_positive_tested.kpi_daily_description}</Text>
-          </KpiTile>
-          <KpiTile
-            title={text.section_positive_tested.kpi_daily_per_100k_title}
-            metadata={{
-              date: elderlyAtHomeData.last_value.date_unix,
-              source: text.section_positive_tested.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="positive_tested_daily_per_100k"
-              absolute={
-                elderlyAtHomeData.last_value.positive_tested_daily_per_100k
-              }
-            />
-            <Text>
-              {text.section_positive_tested.kpi_daily_per_100k_description}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_positive_tested.line_chart_daily_title}
-          values={elderlyAtHomeData.values}
-          ariaDescription={graphDescriptions.thuiswonende_ouderen_besmettingen}
-          linesConfig={[
-            {
-              metricProperty: 'positive_tested_daily',
-            },
-          ]}
-          metadata={{ source: text.section_positive_tested.bronnen.rivm }}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= elderlyAtHomeInfectedUnderReportedRange[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            elderlyAtHomeInfectedUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.section_positive_tested.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                text.section_positive_tested.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ChoroplethTile
-          title={text.section_positive_tested.choropleth_daily_title}
-          description={
-            text.section_positive_tested.choropleth_daily_description
-          }
-          metadata={{
-            date: elderlyAtHomeData.last_value.date_unix,
-            source: text.section_positive_tested.bronnen.rivm,
-          }}
-          legend={{
-            thresholds:
-              regionThresholds.elderly_at_home.positive_tested_daily_per_100k,
-            title: text.section_positive_tested.choropleth_daily_legenda,
-          }}
-        >
-          <SafetyRegionChoropleth
-            data={choropleth.vr}
-            metricName="elderly_at_home"
-            metricProperty="positive_tested_daily_per_100k"
-            tooltipContent={createRegionElderlyAtHomeTooltip(
-              siteText.choropleth_tooltip.elderly_at_home,
-              regionThresholds.elderly_at_home.positive_tested_daily_per_100k,
-              createSelectRegionHandler(router, 'thuiswonende-ouderen')
-            )}
-            onSelect={createSelectRegionHandler(router, 'thuiswonende-ouderen')}
+            reference={text.section_positive_tested.reference}
           />
-        </ChoroplethTile>
 
-        <ContentHeader
-          title={text.section_deceased.title}
-          icon={<ElderlyIcon />}
-          subtitle={text.section_deceased.description}
-          metadata={{
-            datumsText: text.section_deceased.datums,
-            dateOrRange: elderlyAtHomeData.last_value.date_unix,
-            dateOfInsertionUnix:
-              elderlyAtHomeData.last_value.date_of_insertion_unix,
-            dataSources: [text.section_deceased.bronnen.rivm],
-          }}
-          reference={text.section_deceased.reference}
-        />
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_positive_tested.kpi_daily_title}
+              metadata={{
+                date: elderlyAtHomeData.last_value.date_unix,
+                source: text.section_positive_tested.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="positive_tested_daily"
+                absolute={elderlyAtHomeData.last_value.positive_tested_daily}
+                difference={
+                  data.difference.elderly_at_home__positive_tested_daily
+                }
+              />
+              <Text>{text.section_positive_tested.kpi_daily_description}</Text>
+            </KpiTile>
+            <KpiTile
+              title={text.section_positive_tested.kpi_daily_per_100k_title}
+              metadata={{
+                date: elderlyAtHomeData.last_value.date_unix,
+                source: text.section_positive_tested.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="positive_tested_daily_per_100k"
+                absolute={
+                  elderlyAtHomeData.last_value.positive_tested_daily_per_100k
+                }
+              />
+              <Text>
+                {text.section_positive_tested.kpi_daily_per_100k_description}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_deceased.kpi_daily_title}
-            description={text.section_deceased.kpi_daily_description}
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_positive_tested.line_chart_daily_title}
+            values={elderlyAtHomeData.values}
+            ariaDescription={
+              graphDescriptions.thuiswonende_ouderen_besmettingen
+            }
+            linesConfig={[
+              {
+                metricProperty: 'positive_tested_daily',
+              },
+            ]}
+            metadata={{ source: text.section_positive_tested.bronnen.rivm }}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= elderlyAtHomeInfectedUnderReportedRange[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              elderlyAtHomeInfectedUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label:
+                  text.section_positive_tested.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  text.section_positive_tested
+                    .line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <ChoroplethTile
+            title={text.section_positive_tested.choropleth_daily_title}
+            description={
+              text.section_positive_tested.choropleth_daily_description
+            }
             metadata={{
               date: elderlyAtHomeData.last_value.date_unix,
-              source: text.section_deceased.bronnen.rivm,
+              source: text.section_positive_tested.bronnen.rivm,
+            }}
+            legend={{
+              thresholds:
+                regionThresholds.elderly_at_home.positive_tested_daily_per_100k,
+              title: text.section_positive_tested.choropleth_daily_legenda,
             }}
           >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={elderlyAtHomeData.last_value.deceased_daily}
+            <SafetyRegionChoropleth
+              data={choropleth.vr}
+              metricName="elderly_at_home"
+              metricProperty="positive_tested_daily_per_100k"
+              tooltipContent={createRegionElderlyAtHomeTooltip(
+                siteText.choropleth_tooltip.elderly_at_home,
+                regionThresholds.elderly_at_home.positive_tested_daily_per_100k,
+                createSelectRegionHandler(router, 'thuiswonende-ouderen')
+              )}
+              onSelect={createSelectRegionHandler(
+                router,
+                'thuiswonende-ouderen'
+              )}
             />
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_deceased.line_chart_daily_title}
-          values={elderlyAtHomeData.values}
-          ariaDescription={graphDescriptions.thuiswonende_ouderen_overleden}
-          linesConfig={[
-            {
-              metricProperty: 'deceased_daily',
-            },
-          ]}
-          metadata={{ source: text.section_positive_tested.bronnen.rivm }}
-          componentCallback={addBackgroundRectangleCallback(
-            elderlyAtHomeDeceasedUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
+          <ContentHeader
+            title={text.section_deceased.title}
+            icon={<ElderlyIcon />}
+            subtitle={text.section_deceased.description}
+            metadata={{
+              datumsText: text.section_deceased.datums,
+              dateOrRange: elderlyAtHomeData.last_value.date_unix,
+              dateOfInsertionUnix:
+                elderlyAtHomeData.last_value.date_of_insertion_unix,
+              dataSources: [text.section_deceased.bronnen.rivm],
+            }}
+            reference={text.section_deceased.reference}
+          />
 
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_deceased.kpi_daily_title}
+              description={text.section_deceased.kpi_daily_description}
+              metadata={{
+                date: elderlyAtHomeData.last_value.date_unix,
+                source: text.section_deceased.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={elderlyAtHomeData.last_value.deceased_daily}
               />
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.section_deceased.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.section_deceased.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_deceased.line_chart_daily_title}
+            values={elderlyAtHomeData.values}
+            ariaDescription={graphDescriptions.thuiswonende_ouderen_overleden}
+            linesConfig={[
+              {
+                metricProperty: 'deceased_daily',
+              },
+            ]}
+            metadata={{ source: text.section_positive_tested.bronnen.rivm }}
+            componentCallback={addBackgroundRectangleCallback(
+              elderlyAtHomeDeceasedUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.section_deceased.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.section_deceased.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-ElderlyAtHomeNationalPage.getLayout = GetNationalLayout;
 
 export default ElderlyAtHomeNationalPage;

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -16,7 +16,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { Legend } from '~/components-styled/legend';
 import { RadioGroup } from '~/components-styled/radio-group';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
@@ -84,13 +83,15 @@ const VaccinationPage = ({ content, data, lastGenerated }) => {
     vaccineAdministeredEstimateValues,
   ] = useVaccineDeliveryData(data);
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <VaccinePageIntroduction data={data} text={text} />
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -21,8 +21,6 @@ import { TileList } from '~/components-styled/tile-list';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { InlineText, Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { VaccineSupportTooltip } from '~/domain/vaccine/components/vaccine-support-tooltip';
 import { createDeliveryTooltipFormatter } from '~/domain/vaccine/create-delivery-tooltip-formatter';
 import {
@@ -44,6 +42,9 @@ import {
 import { colors } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
+
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   getNlData,
@@ -61,10 +62,7 @@ export const getStaticProps = createGetStaticProps(
   )
 );
 
-const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
-  content,
-  data,
-}) => {
+const VaccinationPage = ({ content, data, lastGenerated }) => {
   const { siteText } = useIntl();
   const text = siteText.vaccinaties;
   const [selectedTab, setSelectedTab] = useState(
@@ -87,371 +85,393 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
   ] = useVaccineDeliveryData(data);
 
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <VaccinePageIntroduction data={data} text={text} />
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
+        />
+        <TileList>
+          <VaccinePageIntroduction data={data} text={text} />
 
-        <ArticleStrip articles={content.highlight.articles} />
+          <ArticleStrip articles={content.highlight.articles} />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.gezette_prikken.title}
-            metadata={{
-              date:
-                data.vaccine_administered_total.last_value
-                  .date_of_insertion_unix,
-              source: text.bronnen.all_left,
-            }}
-          >
-            <Box
-              css={css({ '& div': { justifyContent: 'flex-start' } })}
-              mb={3}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.gezette_prikken.title}
+              metadata={{
+                date:
+                  data.vaccine_administered_total.last_value
+                    .date_of_insertion_unix,
+                source: text.bronnen.all_left,
+              }}
             >
-              <RadioGroup
-                value={selectedTab}
-                onChange={(value) => setSelectedTab(value)}
-                items={[
-                  {
-                    label: text.gezette_prikken.tab_first.title,
-                    value: text.gezette_prikken.tab_first.title,
-                  },
-                  {
-                    label: text.gezette_prikken.tab_second.title,
-                    value: text.gezette_prikken.tab_second.title,
-                  },
-                ]}
-              />
-            </Box>
-            {selectedTab == text.gezette_prikken.tab_first.title && (
-              <>
-                <KpiValue
-                  absolute={
-                    data.vaccine_administered_total.last_value.estimated
-                  }
+              <Box
+                css={css({ '& div': { justifyContent: 'flex-start' } })}
+                mb={3}
+              >
+                <RadioGroup
+                  value={selectedTab}
+                  onChange={(value) => setSelectedTab(value)}
+                  items={[
+                    {
+                      label: text.gezette_prikken.tab_first.title,
+                      value: text.gezette_prikken.tab_first.title,
+                    },
+                    {
+                      label: text.gezette_prikken.tab_second.title,
+                      value: text.gezette_prikken.tab_second.title,
+                    },
+                  ]}
                 />
-                <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
-                  <Box flex={{ lg: '1 1 50%' }}>
-                    <Box
-                      mb={3}
-                      dangerouslySetInnerHTML={{
-                        __html: text.gezette_prikken.tab_first.description,
-                      }}
-                    />
-                  </Box>
-                  <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
-                    <VaccineAdministeredItem
-                      value={data.vaccine_administered_ggd.last_value.estimated}
-                      description={text.gezette_prikken.estimated.ggd}
-                      date={data.vaccine_administered_ggd.last_value.date_unix}
-                      isReported
-                    />
-
-                    <VaccineAdministeredItem
-                      value={
-                        data.vaccine_administered_hospitals.last_value.estimated
-                      }
-                      description={text.gezette_prikken.estimated.hospitals}
-                      date={
-                        data.vaccine_administered_hospitals.last_value.date_unix
-                      }
-                      isReported
-                    />
-
-                    <VaccineAdministeredItem
-                      value={
-                        data.vaccine_administered_care_institutions.last_value
-                          .estimated
-                      }
-                      description={
-                        text.gezette_prikken.estimated.care_institutions
-                      }
-                      date={
-                        data.vaccine_administered_care_institutions.last_value
-                          .date_unix
-                      }
-                    />
-
-                    <VaccineAdministeredItem
-                      value={
-                        data.vaccine_administered_doctors.last_value.estimated
-                      }
-                      description={text.gezette_prikken.estimated.doctors}
-                      date={
-                        data.vaccine_administered_doctors.last_value.date_unix
-                      }
-                    />
-                  </Box>
-                </Box>
-              </>
-            )}
-            {selectedTab == text.gezette_prikken.tab_second.title && (
-              <>
-                <KpiValue
-                  absolute={data.vaccine_administered_total.last_value.reported}
-                />
-                <Box display="flex" flexDirection={{ _: 'column', lg: 'row' }}>
-                  <Box flex={{ lg: '1 1 50%' }}>
-                    <Box
-                      dangerouslySetInnerHTML={{
-                        __html: text.gezette_prikken.tab_second.description,
-                      }}
-                    />
-                  </Box>
-                  <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
-                    <VaccineAdministeredItem
-                      value={
-                        data.vaccine_administered_ggd_ghor.last_value.reported
-                      }
-                      description={text.gezette_prikken.reported.ggd_ghor}
-                      date={
-                        data.vaccine_administered_ggd_ghor.last_value.date_unix
-                      }
-                      isReported
-                    />
-
-                    <VaccineAdministeredItem
-                      value={data.vaccine_administered_lnaz.last_value.reported}
-                      description={text.gezette_prikken.reported.lnaz}
-                      date={data.vaccine_administered_lnaz.last_value.date_unix}
-                      isReported
-                    />
-                  </Box>
-                </Box>
-              </>
-            )}
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChartTile
-          title={text.grafiek.titel}
-          description={text.grafiek.omschrijving}
-          metadata={{
-            date: vaccineDeliveryValues[0].date_of_insertion_unix,
-            source: text.bronnen.rivm,
-          }}
-        >
-          <Box>
-            <ParentSize>
-              {({ width }) => (
+              </Box>
+              {selectedTab == text.gezette_prikken.tab_first.title && (
                 <>
-                  <AreaChart<
-                    NlVaccineDeliveryValue | NlVaccineDeliveryEstimateValue,
-                    | NlVaccineAdministeredValue
-                    | NlVaccineAdministeredEstimateValue
+                  <KpiValue
+                    absolute={
+                      data.vaccine_administered_total.last_value.estimated
+                    }
+                  />
+                  <Box
+                    display="flex"
+                    flexDirection={{ _: 'column', lg: 'row' }}
                   >
-                    valueAnnotation={siteText.waarde_annotaties.x_miljoen}
-                    width={width}
-                    timeframe="all"
-                    formatTooltip={createDeliveryTooltipFormatter()}
-                    divider={{
-                      color: colors.annotation,
-                      leftLabel: text.data.vaccination_chart.left_divider_label,
-                      rightLabel:
-                        text.data.vaccination_chart.right_divider_label,
-                    }}
-                    trends={[
-                      {
-                        values: vaccineDeliveryValues,
-                        displays: [
-                          {
-                            metricProperty: 'total',
-                            strokeWidth: 3,
-                            color: colors.data.emphasis,
-                            legendLabel: text.data.vaccination_chart.delivered,
-                          },
-                        ],
-                      },
-                      {
-                        values: vaccineDeliveryEstimateValues,
-                        displays: [
-                          {
-                            metricProperty: 'total',
-                            style: 'dashed',
-                            strokeWidth: 3,
-                            legendLabel: text.data.vaccination_chart.estimated,
-                            color: colors.data.emphasis,
-                          },
-                        ],
-                      },
-                    ]}
-                    areas={[
-                      {
-                        values: vaccineAdministeredValues,
-                        displays: vaccineNames.map((key) => ({
-                          metricProperty: key as any,
-                          color: (colors.data.vaccines as any)[key],
-                          legendLabel: key,
-                        })),
-                      },
-                      {
-                        values: vaccineAdministeredEstimateValues,
-                        displays: vaccineNames.map((key) => ({
-                          metricProperty: key as any,
-                          pattern: 'hatched',
-                          color: (colors.data.vaccines as any)[key],
-                          legendLabel: key,
-                        })),
-                      },
-                    ]}
-                  />
-                  <Legend
-                    items={[
-                      {
-                        label: text.data.vaccination_chart.legend.available,
-                        color: 'data.emphasis',
-                        shape: 'line',
-                      },
-                      {
-                        label: text.data.vaccination_chart.legend.expected,
-                        color: 'black',
-                        shape: 'custom',
-                        shapeComponent: <HatchedSquare />,
-                      },
-                    ]}
-                  />
-                  <Legend
-                    items={vaccineNames.map((key) => ({
-                      label: replaceVariablesInText(
-                        text.data.vaccination_chart.legend_label,
-                        {
-                          name: (text.data.vaccination_chart
-                            .product_names as any)[key],
+                    <Box flex={{ lg: '1 1 50%' }}>
+                      <Box
+                        mb={3}
+                        dangerouslySetInnerHTML={{
+                          __html: text.gezette_prikken.tab_first.description,
+                        }}
+                      />
+                    </Box>
+                    <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_ggd.last_value.estimated
                         }
-                      ),
-                      color: `data.vaccines.${key}`,
-                      shape: 'square',
-                    }))}
-                  />
+                        description={text.gezette_prikken.estimated.ggd}
+                        date={
+                          data.vaccine_administered_ggd.last_value.date_unix
+                        }
+                        isReported
+                      />
+
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_hospitals.last_value
+                            .estimated
+                        }
+                        description={text.gezette_prikken.estimated.hospitals}
+                        date={
+                          data.vaccine_administered_hospitals.last_value
+                            .date_unix
+                        }
+                        isReported
+                      />
+
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_care_institutions.last_value
+                            .estimated
+                        }
+                        description={
+                          text.gezette_prikken.estimated.care_institutions
+                        }
+                        date={
+                          data.vaccine_administered_care_institutions.last_value
+                            .date_unix
+                        }
+                      />
+
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_doctors.last_value.estimated
+                        }
+                        description={text.gezette_prikken.estimated.doctors}
+                        date={
+                          data.vaccine_administered_doctors.last_value.date_unix
+                        }
+                      />
+                    </Box>
+                  </Box>
                 </>
               )}
-            </ParentSize>
-          </Box>
-        </ChartTile>
-
-        <MilestonesView
-          title={milestones.title}
-          description={milestones.description}
-          milestones={milestones.milestones}
-          expectedMilestones={milestones.expectedMilestones}
-        />
-
-        <ChartTile
-          title={text.grafiek_draagvlak.titel}
-          description={text.grafiek_draagvlak.omschrijving}
-          ariaDescription={
-            siteText.accessibility.grafieken.vaccinatie_draagvlak
-          }
-          metadata={{
-            date: data.vaccine_support.last_value.date_of_insertion_unix,
-            source: text.bronnen.rivm,
-          }}
-        >
-          <section>
-            <KpiValue
-              percentage={data.vaccine_support.last_value.percentage_average}
-            />
-            <Text mt={0}>{text.grafiek_draagvlak.kpi_omschrijving}</Text>
-          </section>
-
-          <ParentSize>
-            {({ width }) => (
-              <TimeSeriesChart
-                title={text.grafiek_draagvlak.titel}
-                width={width}
-                ariaLabelledBy="chart_vaccine_support"
-                values={data.vaccine_support.values}
-                showDateMarker
-                numGridLines={20}
-                tickValues={[0, 25, 50, 75, 100]}
-                dataOptions={{
-                  isPercentage: true,
-                  forcedMaximumValue: 100,
-                }}
-                seriesConfig={[
-                  {
-                    type: 'line',
-                    metricProperty: 'percentage_16_24',
-                    label: replaceVariablesInText(
-                      text.grafiek_draagvlak.leeftijd_jaar,
-                      { ageGroup: '16 - 24' }
-                    ),
-                    color: '#005082',
-                  },
-                  {
-                    type: 'line',
-                    metricProperty: 'percentage_25_39',
-                    label: replaceVariablesInText(
-                      text.grafiek_draagvlak.leeftijd_jaar,
-                      { ageGroup: '25 - 39' }
-                    ),
-                    color: '#00BBB5',
-                  },
-                  {
-                    type: 'line',
-                    metricProperty: 'percentage_40_54',
-                    label: replaceVariablesInText(
-                      text.grafiek_draagvlak.leeftijd_jaar,
-                      { ageGroup: '40 - 54' }
-                    ),
-                    color: '#FFC000',
-                  },
-                  {
-                    type: 'line',
-                    metricProperty: 'percentage_55_69',
-                    label: replaceVariablesInText(
-                      text.grafiek_draagvlak.leeftijd_jaar,
-                      { ageGroup: '55 - 69' }
-                    ),
-                    color: '#E28700',
-                  },
-                  {
-                    type: 'line',
-                    metricProperty: 'percentage_70_plus',
-                    label: replaceVariablesInText(
-                      text.grafiek_draagvlak.leeftijd_jaar,
-                      { ageGroup: '70+' }
-                    ),
-                    color: '#C252D4',
-                  },
-                ]}
-                formatTooltip={({ value, valueKey, config }) => (
-                  <VaccineSupportTooltip
-                    value={value}
-                    valueKey={valueKey}
-                    config={config}
+              {selectedTab == text.gezette_prikken.tab_second.title && (
+                <>
+                  <KpiValue
+                    absolute={
+                      data.vaccine_administered_total.last_value.reported
+                    }
                   />
-                )}
-              />
-            )}
-          </ParentSize>
-        </ChartTile>
+                  <Box
+                    display="flex"
+                    flexDirection={{ _: 'column', lg: 'row' }}
+                  >
+                    <Box flex={{ lg: '1 1 50%' }}>
+                      <Box
+                        dangerouslySetInnerHTML={{
+                          __html: text.gezette_prikken.tab_second.description,
+                        }}
+                      />
+                    </Box>
+                    <Box flex={{ lg: '1 1 50%' }} ml={{ lg: 4 }}>
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_ggd_ghor.last_value.reported
+                        }
+                        description={text.gezette_prikken.reported.ggd_ghor}
+                        date={
+                          data.vaccine_administered_ggd_ghor.last_value
+                            .date_unix
+                        }
+                        isReported
+                      />
 
-        <TwoKpiSection>
-          <KpiTile title={text.expected_page_additions.title}>
-            <Text mb={4}>{text.expected_page_additions.description}</Text>
-            {additions.length > 0 && (
-              <ul>
-                {text.expected_page_additions.additions
-                  .filter((x: any) => x.length)
-                  .map((addition: any) => (
-                    <li key={addition}>
-                      <InlineText>{addition}</InlineText>
-                    </li>
-                  ))}
-              </ul>
-            )}
-          </KpiTile>
-        </TwoKpiSection>
-      </TileList>
-    </>
+                      <VaccineAdministeredItem
+                        value={
+                          data.vaccine_administered_lnaz.last_value.reported
+                        }
+                        description={text.gezette_prikken.reported.lnaz}
+                        date={
+                          data.vaccine_administered_lnaz.last_value.date_unix
+                        }
+                        isReported
+                      />
+                    </Box>
+                  </Box>
+                </>
+              )}
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChartTile
+            title={text.grafiek.titel}
+            description={text.grafiek.omschrijving}
+            metadata={{
+              date: vaccineDeliveryValues[0].date_of_insertion_unix,
+              source: text.bronnen.rivm,
+            }}
+          >
+            <Box>
+              <ParentSize>
+                {({ width }) => (
+                  <>
+                    <AreaChart<
+                      NlVaccineDeliveryValue | NlVaccineDeliveryEstimateValue,
+                      | NlVaccineAdministeredValue
+                      | NlVaccineAdministeredEstimateValue
+                    >
+                      valueAnnotation={siteText.waarde_annotaties.x_miljoen}
+                      width={width}
+                      timeframe="all"
+                      formatTooltip={createDeliveryTooltipFormatter()}
+                      divider={{
+                        color: colors.annotation,
+                        leftLabel:
+                          text.data.vaccination_chart.left_divider_label,
+                        rightLabel:
+                          text.data.vaccination_chart.right_divider_label,
+                      }}
+                      trends={[
+                        {
+                          values: vaccineDeliveryValues,
+                          displays: [
+                            {
+                              metricProperty: 'total',
+                              strokeWidth: 3,
+                              color: colors.data.emphasis,
+                              legendLabel:
+                                text.data.vaccination_chart.delivered,
+                            },
+                          ],
+                        },
+                        {
+                          values: vaccineDeliveryEstimateValues,
+                          displays: [
+                            {
+                              metricProperty: 'total',
+                              style: 'dashed',
+                              strokeWidth: 3,
+                              legendLabel:
+                                text.data.vaccination_chart.estimated,
+                              color: colors.data.emphasis,
+                            },
+                          ],
+                        },
+                      ]}
+                      areas={[
+                        {
+                          values: vaccineAdministeredValues,
+                          displays: vaccineNames.map((key) => ({
+                            metricProperty: key as any,
+                            color: (colors.data.vaccines as any)[key],
+                            legendLabel: key,
+                          })),
+                        },
+                        {
+                          values: vaccineAdministeredEstimateValues,
+                          displays: vaccineNames.map((key) => ({
+                            metricProperty: key as any,
+                            pattern: 'hatched',
+                            color: (colors.data.vaccines as any)[key],
+                            legendLabel: key,
+                          })),
+                        },
+                      ]}
+                    />
+                    <Legend
+                      items={[
+                        {
+                          label: text.data.vaccination_chart.legend.available,
+                          color: 'data.emphasis',
+                          shape: 'line',
+                        },
+                        {
+                          label: text.data.vaccination_chart.legend.expected,
+                          color: 'black',
+                          shape: 'custom',
+                          shapeComponent: <HatchedSquare />,
+                        },
+                      ]}
+                    />
+                    <Legend
+                      items={vaccineNames.map((key) => ({
+                        label: replaceVariablesInText(
+                          text.data.vaccination_chart.legend_label,
+                          {
+                            name: (text.data.vaccination_chart
+                              .product_names as any)[key],
+                          }
+                        ),
+                        color: `data.vaccines.${key}`,
+                        shape: 'square',
+                      }))}
+                    />
+                  </>
+                )}
+              </ParentSize>
+            </Box>
+          </ChartTile>
+
+          <MilestonesView
+            title={milestones.title}
+            description={milestones.description}
+            milestones={milestones.milestones}
+            expectedMilestones={milestones.expectedMilestones}
+          />
+
+          <ChartTile
+            title={text.grafiek_draagvlak.titel}
+            description={text.grafiek_draagvlak.omschrijving}
+            ariaDescription={
+              siteText.accessibility.grafieken.vaccinatie_draagvlak
+            }
+            metadata={{
+              date: data.vaccine_support.last_value.date_of_insertion_unix,
+              source: text.bronnen.rivm,
+            }}
+          >
+            <section>
+              <KpiValue
+                percentage={data.vaccine_support.last_value.percentage_average}
+              />
+              <Text mt={0}>{text.grafiek_draagvlak.kpi_omschrijving}</Text>
+            </section>
+
+            <ParentSize>
+              {({ width }) => (
+                <TimeSeriesChart
+                  title={text.grafiek_draagvlak.titel}
+                  width={width}
+                  ariaLabelledBy="chart_vaccine_support"
+                  values={data.vaccine_support.values}
+                  showDateMarker
+                  numGridLines={20}
+                  tickValues={[0, 25, 50, 75, 100]}
+                  dataOptions={{
+                    isPercentage: true,
+                    forcedMaximumValue: 100,
+                  }}
+                  seriesConfig={[
+                    {
+                      type: 'line',
+                      metricProperty: 'percentage_16_24',
+                      label: replaceVariablesInText(
+                        text.grafiek_draagvlak.leeftijd_jaar,
+                        { ageGroup: '16 - 24' }
+                      ),
+                      color: '#005082',
+                    },
+                    {
+                      type: 'line',
+                      metricProperty: 'percentage_25_39',
+                      label: replaceVariablesInText(
+                        text.grafiek_draagvlak.leeftijd_jaar,
+                        { ageGroup: '25 - 39' }
+                      ),
+                      color: '#00BBB5',
+                    },
+                    {
+                      type: 'line',
+                      metricProperty: 'percentage_40_54',
+                      label: replaceVariablesInText(
+                        text.grafiek_draagvlak.leeftijd_jaar,
+                        { ageGroup: '40 - 54' }
+                      ),
+                      color: '#FFC000',
+                    },
+                    {
+                      type: 'line',
+                      metricProperty: 'percentage_55_69',
+                      label: replaceVariablesInText(
+                        text.grafiek_draagvlak.leeftijd_jaar,
+                        { ageGroup: '55 - 69' }
+                      ),
+                      color: '#E28700',
+                    },
+                    {
+                      type: 'line',
+                      metricProperty: 'percentage_70_plus',
+                      label: replaceVariablesInText(
+                        text.grafiek_draagvlak.leeftijd_jaar,
+                        { ageGroup: '70+' }
+                      ),
+                      color: '#C252D4',
+                    },
+                  ]}
+                  formatTooltip={({ value, valueKey, config }) => (
+                    <VaccineSupportTooltip
+                      value={value}
+                      valueKey={valueKey}
+                      config={config}
+                    />
+                  )}
+                />
+              )}
+            </ParentSize>
+          </ChartTile>
+
+          <TwoKpiSection>
+            <KpiTile title={text.expected_page_additions.title}>
+              <Text mb={4}>{text.expected_page_additions.description}</Text>
+              {additions.length > 0 && (
+                <ul>
+                  {text.expected_page_additions.additions
+                    .filter((x: any) => x.length)
+                    .map((addition: any) => (
+                      <li key={addition}>
+                        <InlineText>{addition}</InlineText>
+                      </li>
+                    ))}
+                </ul>
+              )}
+            </KpiTile>
+          </TwoKpiSection>
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-VaccinationPage.getLayout = GetNationalLayout;
 
 export default VaccinationPage;
 

--- a/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -5,7 +5,6 @@ import { KpiValue } from '~/components-styled/kpi-value';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { SEOHead } from '~/components-styled/seo-head';
 import { useIntl } from '~/intl';
 import { getNlData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -25,13 +24,16 @@ const SuspectedPatients = (props) => {
   const { siteText } = useIntl();
   const text = siteText.verdenkingen_huisartsen;
   const graphDescriptions = siteText.accessibility.grafieken;
+
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={text.metadata.title}
-          description={text.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.vroege_signalen}

--- a/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -6,95 +6,97 @@ import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { SEOHead } from '~/components-styled/seo-head';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { useIntl } from '~/intl';
 import { getNlData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   getNlData
 );
 
-const SuspectedPatients: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data } = props;
+const SuspectedPatients = (props) => {
+  const { data, lastGenerated } = props;
   const lastValue = data.doctor.last_value;
 
   const { siteText } = useIntl();
   const text = siteText.verdenkingen_huisartsen;
   const graphDescriptions = siteText.accessibility.grafieken;
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.vroege_signalen}
-          screenReaderCategory={siteText.verdenkingen_huisartsen.titel_sidebar}
-          title={text.titel}
-          icon={<Arts />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValue.date_end_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.nivel],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.kpi_titel}
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.vroege_signalen}
+            screenReaderCategory={
+              siteText.verdenkingen_huisartsen.titel_sidebar
+            }
+            title={text.titel}
+            icon={<Arts />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: [lastValue.date_start_unix, lastValue.date_end_unix],
-              source: text.bronnen.nivel,
+              datumsText: text.datums,
+              dateOrRange: lastValue.date_end_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.nivel],
             }}
-          >
-            <KpiValue
-              absolute={lastValue.covid_symptoms}
-              data-cy="covid_symptoms"
-              difference={data.difference.doctor__covid_symptoms}
-            />
-            <Text>{text.barscale_toelichting}</Text>
-          </KpiTile>
-          <KpiTile
-            title={text.normalized_kpi_titel}
-            metadata={{
-              date: [lastValue.date_start_unix, lastValue.date_end_unix],
-              source: text.bronnen.nivel,
-            }}
-          >
-            <KpiValue
-              absolute={lastValue.covid_symptoms_per_100k}
-              data-cy="covid_symptoms_per_100k"
-              difference={data.difference.doctor__covid_symptoms_per_100k}
-            />
-            <Text>{text.normalized_kpi_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
+            reference={text.reference}
+          />
 
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.linechart_titel}
-          values={data.doctor.values}
-          ariaDescription={graphDescriptions.verdenkingen_huisartsen}
-          linesConfig={[
-            {
-              metricProperty: 'covid_symptoms_per_100k',
-            },
-          ]}
-          metadata={{ source: text.bronnen.nivel }}
-        />
-      </TileList>
-    </>
+          <TwoKpiSection>
+            <KpiTile
+              title={text.kpi_titel}
+              metadata={{
+                date: [lastValue.date_start_unix, lastValue.date_end_unix],
+                source: text.bronnen.nivel,
+              }}
+            >
+              <KpiValue
+                absolute={lastValue.covid_symptoms}
+                data-cy="covid_symptoms"
+                difference={data.difference.doctor__covid_symptoms}
+              />
+              <Text>{text.barscale_toelichting}</Text>
+            </KpiTile>
+            <KpiTile
+              title={text.normalized_kpi_titel}
+              metadata={{
+                date: [lastValue.date_start_unix, lastValue.date_end_unix],
+                source: text.bronnen.nivel,
+              }}
+            >
+              <KpiValue
+                absolute={lastValue.covid_symptoms_per_100k}
+                data-cy="covid_symptoms_per_100k"
+                difference={data.difference.doctor__covid_symptoms_per_100k}
+              />
+              <Text>{text.normalized_kpi_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.linechart_titel}
+            values={data.doctor.values}
+            ariaDescription={graphDescriptions.verdenkingen_huisartsen}
+            linesConfig={[
+              {
+                metricProperty: 'covid_symptoms_per_100k',
+              },
+            ]}
+            metadata={{ source: text.bronnen.nivel }}
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-SuspectedPatients.getLayout = GetNationalLayout;
 
 export default SuspectedPatients;

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -8,7 +8,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
@@ -16,7 +15,6 @@ import { regionThresholds } from '~/components/choropleth/region-thresholds';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createInfectedLocationsRegionalTooltip } from '~/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip';
-import { FCWithLayout } from '~/domain/layout/layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -54,13 +52,15 @@ const NursingHomeCare = ({ data, choropleth, lastGenerated }) => {
   const locationDeaths = siteText.verpleeghuis_oversterfte;
   const graphDescriptions = siteText.accessibility.grafieken;
 
+  const metadata = {
+    ...siteText.nationaal_metadata,
+    title: infectedLocationsText.metadata.title,
+    description: infectedLocationsText.metadata.description,
+  };
+
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <SEOHead
-          title={infectedLocationsText.metadata.title}
-          description={infectedLocationsText.metadata.description}
-        />
         <TileList>
           <ContentHeader
             category={siteText.nationaal_layout.headings.kwetsbare_groepen}

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -17,7 +17,6 @@ import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-ch
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createInfectedLocationsRegionalTooltip } from '~/components/choropleth/tooltips/region/create-infected-locations-regional-tooltip';
 import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -28,6 +27,8 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -37,10 +38,7 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
-const NursingHomeCare: FCWithLayout<typeof getStaticProps> = ({
-  data,
-  choropleth,
-}) => {
+const NursingHomeCare = ({ data, choropleth, lastGenerated }) => {
   const nursinghomeData = data.nursing_home;
   const nursinghomeDataUnderReportedValues = getTrailingDateRange(
     nursinghomeData.values,
@@ -57,265 +55,269 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = ({
   const graphDescriptions = siteText.accessibility.grafieken;
 
   return (
-    <>
-      <SEOHead
-        title={infectedLocationsText.metadata.title}
-        description={infectedLocationsText.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={
-            siteText.verpleeghuis_besmette_locaties.titel_sidebar
-          }
-          title={positiveTestedPeopleText.titel}
-          icon={<Verpleeghuiszorg />}
-          subtitle={positiveTestedPeopleText.pagina_toelichting}
-          metadata={{
-            datumsText: positiveTestedPeopleText.datums,
-            dateOrRange: nursinghomeData.last_value.date_unix,
-            dateOfInsertionUnix:
-              nursinghomeData.last_value.date_of_insertion_unix,
-            dataSources: [positiveTestedPeopleText.bronnen.rivm],
-          }}
-          reference={positiveTestedPeopleText.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={infectedLocationsText.metadata.title}
+          description={infectedLocationsText.metadata.description}
         />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={positiveTestedPeopleText.barscale_titel}
-            description={positiveTestedPeopleText.extra_uitleg}
-            metadata={{
-              date: nursinghomeData.last_value.date_unix,
-              source: positiveTestedPeopleText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_people"
-              absolute={nursinghomeData.last_value.newly_infected_people}
-              difference={data.difference.nursing_home__newly_infected_people}
-            />
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
-          title={positiveTestedPeopleText.linechart_titel}
-          values={nursinghomeData.values}
-          ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
-          linesConfig={[
-            {
-              metricProperty: 'newly_infected_people',
-            },
-          ]}
-          componentCallback={addBackgroundRectangleCallback(
-            nursinghomeDataUnderReportedValues,
-            {
-              fill: colors.data.underReported,
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.kwetsbare_groepen}
+            screenReaderCategory={
+              siteText.verpleeghuis_besmette_locaties.titel_sidebar
             }
-          )}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= nursinghomeDataUnderReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: positiveTestedPeopleText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                positiveTestedPeopleText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ContentHeader
-          id="besmette-locaties"
-          skipLinkAnchor={true}
-          title={infectedLocationsText.titel}
-          icon={<Locatie />}
-          subtitle={infectedLocationsText.pagina_toelichting}
-          metadata={{
-            datumsText: infectedLocationsText.datums,
-            dateOrRange: nursinghomeData.last_value.date_unix,
-            dateOfInsertionUnix:
-              nursinghomeData.last_value.date_of_insertion_unix,
-            dataSources: [infectedLocationsText.bronnen.rivm],
-          }}
-          reference={infectedLocationsText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={infectedLocationsText.kpi_titel}
+            title={positiveTestedPeopleText.titel}
+            icon={<Verpleeghuiszorg />}
+            subtitle={positiveTestedPeopleText.pagina_toelichting}
             metadata={{
-              date: nursinghomeData.last_value.date_unix,
-              source: infectedLocationsText.bronnen.rivm,
+              datumsText: positiveTestedPeopleText.datums,
+              dateOrRange: nursinghomeData.last_value.date_unix,
+              dateOfInsertionUnix:
+                nursinghomeData.last_value.date_of_insertion_unix,
+              dataSources: [positiveTestedPeopleText.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="infected_locations_total"
-              absolute={nursinghomeData.last_value.infected_locations_total}
-              percentage={
-                nursinghomeData.last_value.infected_locations_percentage
-              }
-              difference={
-                data.difference.nursing_home__infected_locations_total
-              }
-            />
-            <Text>{infectedLocationsText.kpi_toelichting}</Text>
-          </KpiTile>
-
-          <KpiTile
-            title={infectedLocationsText.barscale_titel}
-            metadata={{
-              date: nursinghomeData.last_value.date_unix,
-              source: infectedLocationsText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_locations"
-              absolute={nursinghomeData.last_value.newly_infected_locations}
-            />
-            <Text>{infectedLocationsText.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChoroplethTile
-          title={infectedLocationsText.map_titel}
-          description={infectedLocationsText.map_toelichting}
-          metadata={{
-            date: nursinghomeData.last_value.date_unix,
-            source: infectedLocationsText.bronnen.rivm,
-          }}
-          legend={{
-            thresholds:
-              regionThresholds.nursing_home.infected_locations_percentage,
-            title: infectedLocationsText.chloropleth_legenda.titel,
-          }}
-        >
-          <SafetyRegionChoropleth
-            data={choropleth.vr}
-            metricName="nursing_home"
-            metricProperty="infected_locations_percentage"
-            tooltipContent={createInfectedLocationsRegionalTooltip(
-              siteText.choropleth_tooltip.infected_locations,
-              regionThresholds.nursing_home.infected_locations_percentage,
-              createSelectRegionHandler(router, 'verpleeghuiszorg')
-            )}
-            onSelect={createSelectRegionHandler(router, 'verpleeghuiszorg')}
+            reference={positiveTestedPeopleText.reference}
           />
-        </ChoroplethTile>
 
-        <LineChartTile
-          metadata={{ source: infectedLocationsText.bronnen.rivm }}
-          title={infectedLocationsText.linechart_titel}
-          values={nursinghomeData.values}
-          ariaDescription={graphDescriptions.verpleeghuiszorg_besmette_locaties}
-          linesConfig={[
-            {
-              metricProperty: 'infected_locations_total',
-            },
-          ]}
-          padding={{
-            left: 35,
-          }}
-        />
+          <TwoKpiSection>
+            <KpiTile
+              title={positiveTestedPeopleText.barscale_titel}
+              description={positiveTestedPeopleText.extra_uitleg}
+              metadata={{
+                date: nursinghomeData.last_value.date_unix,
+                source: positiveTestedPeopleText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_people"
+                absolute={nursinghomeData.last_value.newly_infected_people}
+                difference={data.difference.nursing_home__newly_infected_people}
+              />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <ContentHeader
-          id="sterfte"
-          skipLinkAnchor={true}
-          title={locationDeaths.titel}
-          icon={<CoronaVirus />}
-          subtitle={locationDeaths.pagina_toelichting}
-          metadata={{
-            datumsText: locationDeaths.datums,
-            dateOrRange: nursinghomeData.last_value.date_unix,
-            dateOfInsertionUnix:
-              nursinghomeData.last_value.date_of_insertion_unix,
-            dataSources: [locationDeaths.bronnen.rivm],
-          }}
-          reference={locationDeaths.reference}
-        />
+          <LineChartTile
+            metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
+            title={positiveTestedPeopleText.linechart_titel}
+            values={nursinghomeData.values}
+            ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
+            linesConfig={[
+              {
+                metricProperty: 'newly_infected_people',
+              },
+            ]}
+            componentCallback={addBackgroundRectangleCallback(
+              nursinghomeDataUnderReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= nursinghomeDataUnderReportedValues[0];
 
-        <TwoKpiSection>
-          <KpiTile
-            title={locationDeaths.barscale_titel}
-            description={locationDeaths.extra_uitleg}
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: positiveTestedPeopleText.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  positiveTestedPeopleText.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <ContentHeader
+            id="besmette-locaties"
+            skipLinkAnchor={true}
+            title={infectedLocationsText.titel}
+            icon={<Locatie />}
+            subtitle={infectedLocationsText.pagina_toelichting}
+            metadata={{
+              datumsText: infectedLocationsText.datums,
+              dateOrRange: nursinghomeData.last_value.date_unix,
+              dateOfInsertionUnix:
+                nursinghomeData.last_value.date_of_insertion_unix,
+              dataSources: [infectedLocationsText.bronnen.rivm],
+            }}
+            reference={infectedLocationsText.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={infectedLocationsText.kpi_titel}
+              metadata={{
+                date: nursinghomeData.last_value.date_unix,
+                source: infectedLocationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected_locations_total"
+                absolute={nursinghomeData.last_value.infected_locations_total}
+                percentage={
+                  nursinghomeData.last_value.infected_locations_percentage
+                }
+                difference={
+                  data.difference.nursing_home__infected_locations_total
+                }
+              />
+              <Text>{infectedLocationsText.kpi_toelichting}</Text>
+            </KpiTile>
+
+            <KpiTile
+              title={infectedLocationsText.barscale_titel}
+              metadata={{
+                date: nursinghomeData.last_value.date_unix,
+                source: infectedLocationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_locations"
+                absolute={nursinghomeData.last_value.newly_infected_locations}
+              />
+              <Text>{infectedLocationsText.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChoroplethTile
+            title={infectedLocationsText.map_titel}
+            description={infectedLocationsText.map_toelichting}
             metadata={{
               date: nursinghomeData.last_value.date_unix,
-              source: locationDeaths.bronnen.rivm,
+              source: infectedLocationsText.bronnen.rivm,
+            }}
+            legend={{
+              thresholds:
+                regionThresholds.nursing_home.infected_locations_percentage,
+              title: infectedLocationsText.chloropleth_legenda.titel,
             }}
           >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={nursinghomeData.last_value.deceased_daily}
+            <SafetyRegionChoropleth
+              data={choropleth.vr}
+              metricName="nursing_home"
+              metricProperty="infected_locations_percentage"
+              tooltipContent={createInfectedLocationsRegionalTooltip(
+                siteText.choropleth_tooltip.infected_locations,
+                regionThresholds.nursing_home.infected_locations_percentage,
+                createSelectRegionHandler(router, 'verpleeghuiszorg')
+              )}
+              onSelect={createSelectRegionHandler(router, 'verpleeghuiszorg')}
             />
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <LineChartTile
-          metadata={{ source: locationDeaths.bronnen.rivm }}
-          title={locationDeaths.linechart_titel}
-          values={nursinghomeData.values}
-          ariaDescription={graphDescriptions.verpleeghuiszorg_besmette_locaties}
-          linesConfig={[
-            {
-              metricProperty: 'deceased_daily',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= nursinghomeDataUnderReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            nursinghomeDataUnderReportedValues,
-            {
-              fill: colors.data.underReported,
+          <LineChartTile
+            metadata={{ source: infectedLocationsText.bronnen.rivm }}
+            title={infectedLocationsText.linechart_titel}
+            values={nursinghomeData.values}
+            ariaDescription={
+              graphDescriptions.verpleeghuiszorg_besmette_locaties
             }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: locationDeaths.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: locationDeaths.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+            linesConfig={[
+              {
+                metricProperty: 'infected_locations_total',
+              },
+            ]}
+            padding={{
+              left: 35,
+            }}
+          />
+
+          <ContentHeader
+            id="sterfte"
+            skipLinkAnchor={true}
+            title={locationDeaths.titel}
+            icon={<CoronaVirus />}
+            subtitle={locationDeaths.pagina_toelichting}
+            metadata={{
+              datumsText: locationDeaths.datums,
+              dateOrRange: nursinghomeData.last_value.date_unix,
+              dateOfInsertionUnix:
+                nursinghomeData.last_value.date_of_insertion_unix,
+              dataSources: [locationDeaths.bronnen.rivm],
+            }}
+            reference={locationDeaths.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={locationDeaths.barscale_titel}
+              description={locationDeaths.extra_uitleg}
+              metadata={{
+                date: nursinghomeData.last_value.date_unix,
+                source: locationDeaths.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={nursinghomeData.last_value.deceased_daily}
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            metadata={{ source: locationDeaths.bronnen.rivm }}
+            title={locationDeaths.linechart_titel}
+            values={nursinghomeData.values}
+            ariaDescription={
+              graphDescriptions.verpleeghuiszorg_besmette_locaties
+            }
+            linesConfig={[
+              {
+                metricProperty: 'deceased_daily',
+              },
+            ]}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= nursinghomeDataUnderReportedValues[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              nursinghomeDataUnderReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: locationDeaths.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: locationDeaths.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-NursingHomeCare.getLayout = GetNationalLayout;
 
 export default NursingHomeCare;

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -22,8 +22,6 @@ import { createSelectMunicipalHandler } from '~/components/choropleth/select-han
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip';
 import { createRegionHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/region/create-region-hospital-admissions-tooltip';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { GetNationalLayout } from '~/domain/layout/national-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
@@ -40,6 +38,8 @@ import {
   DateRange,
   getTrailingDateRange,
 } from '~/utils/get-trailing-date-range';
+import { Layout } from '~/domain/layout/layout';
+import { NationalLayout } from '~/domain/layout/national-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -53,8 +53,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('hospitalPage'))
 );
 
-const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, content } = props;
+const IntakeHospital = (props) => {
+  const { data, choropleth, content, lastGenerated } = props;
   const router = useRouter();
   const [selectedMap, setSelectedMap] = useState<'municipal' | 'region'>(
     'region'
@@ -78,210 +78,219 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
   const graphDescriptions = siteText.accessibility.grafieken;
 
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.ziekenhuizen}
-          screenReaderCategory={
-            siteText.ziekenhuisopnames_per_dag.titel_sidebar
-          }
-          title={text.titel}
-          icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValueNice.date_unix,
-            dateOfInsertionUnix: lastValueNice.date_of_insertion_unix,
-            dataSources: [text.bronnen.nice, text.bronnen.lnaz],
-          }}
-          reference={text.reference}
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+      <NationalLayout data={data} lastGenerated={lastGenerated}>
+        <SEOHead
+          title={text.metadata.title}
+          description={text.metadata.description}
         />
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.ziekenhuizen}
+            screenReaderCategory={
+              siteText.ziekenhuisopnames_per_dag.titel_sidebar
+            }
+            title={text.titel}
+            icon={<Ziekenhuis />}
+            subtitle={text.pagina_toelichting}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: lastValueNice.date_unix,
+              dateOfInsertionUnix: lastValueNice.date_of_insertion_unix,
+              dataSources: [text.bronnen.nice, text.bronnen.lnaz],
+            }}
+            reference={text.reference}
+          />
 
-        <ArticleStrip articles={content.articles} />
+          <ArticleStrip articles={content.articles} />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              description={text.extra_uitleg}
+              metadata={{
+                date: lastValueNice.date_unix,
+                source: text.bronnen.nice,
+              }}
+            >
+              <PageBarScale
+                data={data}
+                scope="nl"
+                metricName="hospital_nice"
+                metricProperty="admissions_on_date_of_reporting"
+                localeTextKey="ziekenhuisopnames_per_dag"
+                differenceKey="hospital_nice__admissions_on_date_of_reporting"
+              />
+            </KpiTile>
+
+            <KpiTile
+              title={text.kpi_bedbezetting.title}
+              description={text.kpi_bedbezetting.description}
+              metadata={{
+                date: lastValueLcps.date_unix,
+                source: text.bronnen.lnaz,
+              }}
+            >
+              {bedsLastValue.beds_occupied_covid !== null && (
+                <KpiValue
+                  data-cy="beds_occupied_covid"
+                  absolute={bedsLastValue.beds_occupied_covid}
+                  difference={
+                    data.difference.hospital_lcps__beds_occupied_covid
+                  }
+                />
+              )}
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChoroplethTile
+            title={text.map_titel}
+            description={text.map_toelichting}
+            onChartRegionChange={setSelectedMap}
+            chartRegion={selectedMap}
+            legend={{
+              thresholds:
+                selectedMap === 'municipal'
+                  ? municipalThresholds.hospital_nice
+                      .admissions_on_date_of_reporting
+                  : regionThresholds.hospital_nice
+                      .admissions_on_date_of_reporting,
+              title: text.chloropleth_legenda.titel,
+            }}
             metadata={{
               date: lastValueNice.date_unix,
               source: text.bronnen.nice,
             }}
           >
-            <PageBarScale
-              data={data}
-              scope="nl"
-              metricName="hospital_nice"
-              metricProperty="admissions_on_date_of_reporting"
-              localeTextKey="ziekenhuisopnames_per_dag"
-              differenceKey="hospital_nice__admissions_on_date_of_reporting"
-            />
-          </KpiTile>
-
-          <KpiTile
-            title={text.kpi_bedbezetting.title}
-            description={text.kpi_bedbezetting.description}
-            metadata={{
-              date: lastValueLcps.date_unix,
-              source: text.bronnen.lnaz,
-            }}
-          >
-            {bedsLastValue.beds_occupied_covid !== null && (
-              <KpiValue
-                data-cy="beds_occupied_covid"
-                absolute={bedsLastValue.beds_occupied_covid}
-                difference={data.difference.hospital_lcps__beds_occupied_covid}
+            {selectedMap === 'municipal' && (
+              <MunicipalityChoropleth
+                data={choropleth.gm}
+                metricName="hospital_nice"
+                metricProperty="admissions_on_date_of_reporting"
+                tooltipContent={createMunicipalHospitalAdmissionsTooltip(
+                  siteText.choropleth_tooltip.hospital_admissions,
+                  municipalThresholds.hospital_nice
+                    .admissions_on_date_of_reporting,
+                  createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
+                )}
+                onSelect={createSelectMunicipalHandler(
+                  router,
+                  'ziekenhuis-opnames'
+                )}
               />
             )}
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChoroplethTile
-          title={text.map_titel}
-          description={text.map_toelichting}
-          onChartRegionChange={setSelectedMap}
-          chartRegion={selectedMap}
-          legend={{
-            thresholds:
-              selectedMap === 'municipal'
-                ? municipalThresholds.hospital_nice
-                    .admissions_on_date_of_reporting
-                : regionThresholds.hospital_nice
+            {selectedMap === 'region' && (
+              <SafetyRegionChoropleth
+                data={choropleth.vr}
+                metricName="hospital_nice"
+                metricProperty="admissions_on_date_of_reporting"
+                tooltipContent={createRegionHospitalAdmissionsTooltip(
+                  siteText.choropleth_tooltip.hospital_admissions,
+                  regionThresholds.hospital_nice
                     .admissions_on_date_of_reporting,
-            title: text.chloropleth_legenda.titel,
-          }}
-          metadata={{
-            date: lastValueNice.date_unix,
-            source: text.bronnen.nice,
-          }}
-        >
-          {selectedMap === 'municipal' && (
-            <MunicipalityChoropleth
-              data={choropleth.gm}
-              metricName="hospital_nice"
-              metricProperty="admissions_on_date_of_reporting"
-              tooltipContent={createMunicipalHospitalAdmissionsTooltip(
-                siteText.choropleth_tooltip.hospital_admissions,
-                municipalThresholds.hospital_nice
-                  .admissions_on_date_of_reporting,
-                createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
-              )}
-              onSelect={createSelectMunicipalHandler(
-                router,
-                'ziekenhuis-opnames'
-              )}
-            />
-          )}
-          {selectedMap === 'region' && (
-            <SafetyRegionChoropleth
-              data={choropleth.vr}
-              metricName="hospital_nice"
-              metricProperty="admissions_on_date_of_reporting"
-              tooltipContent={createRegionHospitalAdmissionsTooltip(
-                siteText.choropleth_tooltip.hospital_admissions,
-                regionThresholds.hospital_nice.admissions_on_date_of_reporting,
-                createSelectRegionHandler(router, 'ziekenhuis-opnames')
-              )}
-              onSelect={createSelectRegionHandler(router, 'ziekenhuis-opnames')}
-            />
-          )}
-        </ChoroplethTile>
-
-        <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_description}
-          ariaDescription={graphDescriptions.ziekenhuisopnames}
-          values={dataHospitalNice.values}
-          signaalwaarde={40}
-          formatTooltip={(values) => {
-            const value = values[0];
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={value.__date >= underReportedRange[0]}
-                underReportedText={siteText.common.incomplete}
+                  createSelectRegionHandler(router, 'ziekenhuis-opnames')
+                )}
+                onSelect={createSelectRegionHandler(
+                  router,
+                  'ziekenhuis-opnames'
+                )}
               />
-            );
-          }}
-          linesConfig={[
-            {
-              metricProperty: 'admissions_on_date_of_admission',
-            },
-          ]}
-          metadata={{
-            source: text.bronnen.nice,
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.linechart_legend_titel,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
+            )}
+          </ChoroplethTile>
 
-        <LineChartTile
-          title={text.chart_bedbezetting.title}
-          description={text.chart_bedbezetting.description}
-          values={dataHospitalLcps.values}
-          linesConfig={[
-            {
-              metricProperty: 'beds_occupied_covid',
-            },
-          ]}
-          metadata={{
-            source: text.bronnen.lnaz,
-          }}
-          componentCallback={addBackgroundRectangleCallback(lcpsOldDataRange, {
-            fill: colors.data.underReported,
-          })}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date < lcpsOldDataRange[1];
+          <LineChartTile
+            title={text.linechart_titel}
+            description={text.linechart_description}
+            ariaDescription={graphDescriptions.ziekenhuisopnames}
+            values={dataHospitalNice.values}
+            signaalwaarde={40}
+            formatTooltip={(values) => {
+              const value = values[0];
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={value.__date >= underReportedRange[0]}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            linesConfig={[
+              {
+                metricProperty: 'admissions_on_date_of_admission',
+              },
+            ]}
+            metadata={{
+              source: text.bronnen.nice,
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.linechart_legend_titel,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.linechart_legend_underreported_titel,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
 
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.chart_bedbezetting.legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.chart_bedbezetting.legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+          <LineChartTile
+            title={text.chart_bedbezetting.title}
+            description={text.chart_bedbezetting.description}
+            values={dataHospitalLcps.values}
+            linesConfig={[
+              {
+                metricProperty: 'beds_occupied_covid',
+              },
+            ]}
+            metadata={{
+              source: text.bronnen.lnaz,
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              lcpsOldDataRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date < lcpsOldDataRange[1];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.chart_bedbezetting.legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.chart_bedbezetting.legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </NationalLayout>
+    </Layout>
   );
 };
-
-IntakeHospital.getLayout = GetNationalLayout;
 
 export default IntakeHospital;

--- a/packages/app/src/pages/over-risiconiveaus.tsx
+++ b/packages/app/src/pages/over-risiconiveaus.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import { CollapsibleSection } from '~/components-styled/collapsible';
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import {
   createGetContent,
   getLastGeneratedDate,
@@ -12,6 +11,9 @@ import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
 import { RichContent } from '~/components-styled/cms/rich-content';
 import { Box } from '~/components-styled/base';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+
 interface OverRisiconiveausData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -55,11 +57,12 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<OverRisiconiveausData>(query)
 );
 
-const OverRisicoNiveaus: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const OverRisicoNiveaus = (props) => {
+  const { siteText } = useIntl();
+  const { content, lastGenerated } = props;
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"
@@ -100,12 +103,8 @@ const OverRisicoNiveaus: FCWithLayout<typeof getStaticProps> = (props) => {
           </div>
         </MaxWidth>
       </div>
-    </>
+    </Layout>
   );
 };
-
-OverRisicoNiveaus.getLayout = GetLayoutWithMetadataKey(
-  'over_risiconiveaus_metadata'
-);
 
 export default OverRisicoNiveaus;

--- a/packages/app/src/pages/over-risiconiveaus.tsx
+++ b/packages/app/src/pages/over-risiconiveaus.tsx
@@ -62,7 +62,10 @@ const OverRisicoNiveaus = (props) => {
   const { content, lastGenerated } = props;
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout
+      {...siteText.over_risiconiveaus_metadata}
+      lastGenerated={lastGenerated}
+    >
       <Head>
         <link
           key="dc-type"

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -44,7 +44,7 @@ const Over = (props) => {
   const { content, lastGenerated } = props;
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...siteText.over_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -1,7 +1,8 @@
 import Head from 'next/head';
 import { RichContent } from '~/components-styled/cms/rich-content';
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetContent,
@@ -38,11 +39,12 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<OverData>(query)
 );
 
-const Over: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const Over = (props) => {
+  const { siteText } = useIntl();
+  const { content, lastGenerated } = props;
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"
@@ -67,10 +69,8 @@ const Over: FCWithLayout<typeof getStaticProps> = (props) => {
           </div>
         </MaxWidth>
       </div>
-    </>
+    </Layout>
   );
 };
-
-Over.getLayout = GetLayoutWithMetadataKey('over_metadata');
 
 export default Over;

--- a/packages/app/src/pages/toegankelijkheid.tsx
+++ b/packages/app/src/pages/toegankelijkheid.tsx
@@ -48,7 +48,10 @@ const AccessibilityPage = (props) => {
   const { content, lastGenerated } = props;
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout
+      {...siteText.toegankelijkheid_metadata}
+      lastGenerated={lastGenerated}
+    >
       <Head>
         <link
           key="dc-type"

--- a/packages/app/src/pages/toegankelijkheid.tsx
+++ b/packages/app/src/pages/toegankelijkheid.tsx
@@ -2,8 +2,10 @@ import Head from 'next/head';
 import { Box } from '~/components-styled/base';
 import { ContentBlock } from '~/components-styled/cms/content-block';
 import { RichContent } from '~/components-styled/cms/rich-content';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+
 import {
   createGetContent,
   getLastGeneratedDate,
@@ -41,11 +43,12 @@ export const getStaticProps = createGetStaticProps(
   `)
 );
 
-const AccessibilityPage: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const AccessibilityPage = (props) => {
+  const { siteText } = useIntl();
+  const { content, lastGenerated } = props;
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"
@@ -66,12 +69,8 @@ const AccessibilityPage: FCWithLayout<typeof getStaticProps> = (props) => {
           {content.description && <RichContent blocks={content.description} />}
         </ContentBlock>
       </Box>
-    </>
+    </Layout>
   );
 };
-
-AccessibilityPage.getLayout = GetLayoutWithMetadataKey(
-  'toegankelijkheid_metadata'
-);
 
 export default AccessibilityPage;

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -2,7 +2,6 @@ import Head from 'next/head';
 import { RichContent } from '~/components-styled/cms/rich-content';
 import { CollapsibleSection } from '~/components-styled/collapsible';
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetContent,
@@ -12,6 +11,9 @@ import { CollapsibleList, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
 import { Box } from '~/components-styled/base';
+import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
+
 interface VeelgesteldeVragenData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -56,11 +58,12 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<VeelgesteldeVragenData>(query)
 );
 
-const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const Verantwoording = (props) => {
+  const { content, lastGenerated } = props;
+  const { siteText } = useIntl();
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"
@@ -101,12 +104,8 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
           </div>
         </MaxWidth>
       </div>
-    </>
+    </Layout>
   );
 };
-
-Verantwoording.getLayout = GetLayoutWithMetadataKey(
-  'veelgestelde_vragen_metadata'
-);
 
 export default Verantwoording;

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -63,7 +63,10 @@ const Verantwoording = (props) => {
   const { siteText } = useIntl();
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout
+      {...siteText.veelgestelde_vragen_metadata}
+      lastGenerated={lastGenerated}
+    >
       <Head>
         <link
           key="dc-type"

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -4,7 +4,6 @@ import { ArticleSummary } from '~/components-styled/article-teaser';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
-import { SEOHead } from '~/components-styled/seo-head';
 import { Tile } from '~/components-styled/tile';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
@@ -12,8 +11,8 @@ import { Heading, Text } from '~/components-styled/typography';
 import { BehaviorLineChartTile } from '~/domain/behavior/behavior-line-chart-tile';
 import { BehaviorTableTile } from '~/domain/behavior/behavior-table-tile';
 import { MoreInformation } from '~/domain/behavior/components/more-information';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -33,81 +32,83 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('behaviorPage'))
 );
 
-const BehaviorPage: FCWithLayout<typeof getStaticProps> = (props) => {
-  const content = props.content;
-  const behaviorData = props.data.behavior;
+const BehaviorPage = (props) => {
+  const { lastGenerated, content, data } = props;
+  const behaviorData = data.behavior;
 
   const { siteText } = useIntl();
   const text = siteText.regionaal_gedrag;
+
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+  };
+
   return (
-    <>
-      <SEOHead
-        title={text.metadata.title}
-        description={text.metadata.description}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.nationaal_layout.headings.gedrag}
-          title={text.pagina.titel}
-          icon={<Gedrag />}
-          subtitle={text.pagina.toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: {
-              start: behaviorData.last_value.date_start_unix,
-              end: behaviorData.last_value.date_end_unix,
-            },
-            dateOfInsertionUnix: behaviorData.last_value.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <Tile height="100%">
-            <Heading level={3}>{text.onderzoek_uitleg.titel}</Heading>
-            <Text>{text.onderzoek_uitleg.toelichting}</Text>
-          </Tile>
-
-          <KpiTile
-            title={text.kpi.aantal_respondenten.titel}
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.nationaal_layout.headings.gedrag}
+            title={text.pagina.titel}
+            icon={<Gedrag />}
+            subtitle={text.pagina.toelichting}
             metadata={{
-              source: text.kpi.aantal_respondenten.bron,
-              date: [
-                behaviorData.last_value.date_start_unix,
-                behaviorData.last_value.date_end_unix,
-              ],
+              datumsText: text.datums,
+              dateOrRange: {
+                start: behaviorData.last_value.date_start_unix,
+                end: behaviorData.last_value.date_end_unix,
+              },
+              dateOfInsertionUnix:
+                behaviorData.last_value.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              absolute={behaviorData.last_value.number_of_participants}
-            />
-            <Text>{text.kpi.aantal_respondenten.toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
+            reference={text.reference}
+          />
 
-        <BehaviorTableTile
-          behavior={behaviorData.last_value}
-          title={text.basisregels.title}
-          introduction={text.basisregels.intro}
-          footer={text.basisregels.voetnoot}
-          footerAsterisk={text.basisregels.voetnoot_asterisk}
-        />
+          <ArticleStrip articles={content.articles} />
 
-        <BehaviorLineChartTile
-          title={text.basisregels_over_tijd.title}
-          introduction={text.basisregels_over_tijd.intro}
-          values={behaviorData.values}
-        />
+          <TwoKpiSection>
+            <Tile height="100%">
+              <Heading level={3}>{text.onderzoek_uitleg.titel}</Heading>
+              <Text>{text.onderzoek_uitleg.toelichting}</Text>
+            </Tile>
 
-        <MoreInformation />
-      </TileList>
-    </>
+            <KpiTile
+              title={text.kpi.aantal_respondenten.titel}
+              metadata={{
+                source: text.kpi.aantal_respondenten.bron,
+                date: [
+                  behaviorData.last_value.date_start_unix,
+                  behaviorData.last_value.date_end_unix,
+                ],
+              }}
+            >
+              <KpiValue
+                absolute={behaviorData.last_value.number_of_participants}
+              />
+              <Text>{text.kpi.aantal_respondenten.toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <BehaviorTableTile
+            behavior={behaviorData.last_value}
+            title={text.basisregels.title}
+            introduction={text.basisregels.intro}
+            footer={text.basisregels.voetnoot}
+            footerAsterisk={text.basisregels.voetnoot_asterisk}
+          />
+
+          <BehaviorLineChartTile
+            title={text.basisregels_over_tijd.title}
+            introduction={text.basisregels_over_tijd.intro}
+            values={behaviorData.values}
+          />
+
+          <MoreInformation />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-BehaviorPage.getLayout = getSafetyRegionLayout();
 
 export default BehaviorPage;

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -41,6 +41,8 @@ const BehaviorPage = (props) => {
 
   const metadata = {
     ...siteText.veiligheidsregio_index.metadata,
+    title: text.metadata.title,
+    description: text.metadata.description,
   };
 
   return (

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -6,12 +6,9 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -19,6 +16,8 @@ import { getLastGeneratedDate, getVrData } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { getTrailingDateRange } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 
 export { getStaticPaths } from '~/static-paths/vr';
 
@@ -27,8 +26,8 @@ export const getStaticProps = createGetStaticProps(
   getVrData
 );
 
-const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, safetyRegionName } = props;
+const DisabilityCare = (props) => {
+  const { data, safetyRegionName, lastGenerated } = props;
 
   const { siteText } = useIntl();
 
@@ -43,254 +42,258 @@ const DisabilityCare: FCWithLayout<typeof getStaticProps> = (props) => {
   const values = data.disability_care.values;
   const underReportedValues = getTrailingDateRange(values, 7);
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(locationsText.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(locationsText.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(locationsText.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(
-          locationsText.metadata.description,
-          {
-            safetyRegionName,
-          }
-        )}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={
-            siteText.verpleeghuis_besmette_locaties.titel_sidebar
-          }
-          title={replaceVariablesInText(positiveTestPeopleText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Gehandicaptenzorg />}
-          subtitle={replaceVariablesInText(
-            positiveTestPeopleText.pagina_toelichting,
-            {
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={
+              siteText.veiligheidsregio_layout.headings.kwetsbare_groepen
+            }
+            screenReaderCategory={
+              siteText.verpleeghuis_besmette_locaties.titel_sidebar
+            }
+            title={replaceVariablesInText(positiveTestPeopleText.titel, {
               safetyRegion: safetyRegionName,
-            }
-          )}
-          metadata={{
-            datumsText: positiveTestPeopleText.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [positiveTestPeopleText.bronnen.rivm],
-          }}
-          reference={positiveTestPeopleText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={positiveTestPeopleText.barscale_titel}
-            description={positiveTestPeopleText.extra_uitleg}
-            metadata={{
-              date: lastValue.date_unix,
-              source: positiveTestPeopleText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_people"
-              absolute={lastValue.newly_infected_people}
-              difference={
-                data.difference.disability_care__newly_infected_people
+            })}
+            icon={<Gehandicaptenzorg />}
+            subtitle={replaceVariablesInText(
+              positiveTestPeopleText.pagina_toelichting,
+              {
+                safetyRegion: safetyRegionName,
               }
-            />
-          </KpiTile>
-        </TwoKpiSection>
+            )}
+            metadata={{
+              datumsText: positiveTestPeopleText.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [positiveTestPeopleText.bronnen.rivm],
+            }}
+            reference={positiveTestPeopleText.reference}
+          />
 
-        <LineChartTile
-          metadata={{ source: positiveTestPeopleText.bronnen.rivm }}
-          title={positiveTestPeopleText.linechart_titel}
-          ariaDescription={graphDescriptions.gehandicaptenzorg_positief_getest}
-          values={values}
-          linesConfig={[
-            {
-              metricProperty: 'newly_infected_people',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date >= underReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
+          <TwoKpiSection>
+            <KpiTile
+              title={positiveTestPeopleText.barscale_titel}
+              description={positiveTestPeopleText.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: positiveTestPeopleText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_people"
+                absolute={lastValue.newly_infected_people}
+                difference={
+                  data.difference.disability_care__newly_infected_people
+                }
               />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedValues,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: positiveTestPeopleText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: positiveTestPeopleText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <ContentHeader
-          id="besmette-locaties"
-          skipLinkAnchor={true}
-          title={replaceVariablesInText(locationsText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Locatie />}
-          subtitle={locationsText.pagina_toelichting}
-          metadata={{
-            datumsText: locationsText.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [locationsText.bronnen.rivm],
-          }}
-          reference={locationsText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={locationsText.kpi_titel}
-            metadata={{
-              date: lastValue.date_unix,
-              source: locationsText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="infected_locations_total"
-              absolute={lastValue.infected_locations_total}
-              percentage={lastValue.infected_locations_percentage}
-              difference={
-                data.difference.disability_care__infected_locations_total
-              }
-            />
-            <Text>{locationsText.kpi_toelichting}</Text>
-          </KpiTile>
-          <KpiTile
-            title={locationsText.barscale_titel}
-            metadata={{
-              date: lastValue.date_unix,
-              source: locationsText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_locations"
-              absolute={lastValue.newly_infected_locations}
-            />
-            <Text>{locationsText.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        {lastValue.infected_locations_total !== undefined && (
           <LineChartTile
-            title={locationsText.linechart_titel}
-            values={values}
+            metadata={{ source: positiveTestPeopleText.bronnen.rivm }}
+            title={positiveTestPeopleText.linechart_titel}
             ariaDescription={
-              graphDescriptions.gehandicaptenzorg_besmette_locaties
+              graphDescriptions.gehandicaptenzorg_positief_getest
             }
+            values={values}
             linesConfig={[
               {
-                metricProperty: 'infected_locations_total',
+                metricProperty: 'newly_infected_people',
               },
             ]}
-            metadata={{
-              source: locationsText.bronnen.rivm,
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date >= underReportedValues[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
             }}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: positiveTestPeopleText.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  positiveTestPeopleText.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
           />
-        )}
 
-        <ContentHeader
-          id="sterfte"
-          skipLinkAnchor={true}
-          title={replaceVariablesInText(mortalityText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<CoronaVirus />}
-          subtitle={mortalityText.pagina_toelichting}
-          metadata={{
-            datumsText: mortalityText.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [mortalityText.bronnen.rivm],
-          }}
-          reference={mortalityText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={mortalityText.barscale_titel}
-            description={mortalityText.extra_uitleg}
+          <ContentHeader
+            id="besmette-locaties"
+            skipLinkAnchor={true}
+            title={replaceVariablesInText(locationsText.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<Locatie />}
+            subtitle={locationsText.pagina_toelichting}
             metadata={{
-              date: lastValue.date_unix,
-              source: mortalityText.bronnen.rivm,
+              datumsText: locationsText.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [locationsText.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={lastValue.deceased_daily}
-            />
-          </KpiTile>
-        </TwoKpiSection>
+            reference={locationsText.reference}
+          />
 
-        <LineChartTile
-          metadata={{ source: mortalityText.bronnen.rivm }}
-          title={mortalityText.linechart_titel}
-          values={values}
-          ariaDescription={graphDescriptions.gehandicaptenzorg_overleden}
-          linesConfig={[
-            {
-              metricProperty: 'deceased_daily',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue = value.__date >= underReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
+          <TwoKpiSection>
+            <KpiTile
+              title={locationsText.kpi_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: locationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected_locations_total"
+                absolute={lastValue.infected_locations_total}
+                percentage={lastValue.infected_locations_percentage}
+                difference={
+                  data.difference.disability_care__infected_locations_total
+                }
               />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedValues,
-            {
-              fill: colors.data.underReported,
-            }
+              <Text>{locationsText.kpi_toelichting}</Text>
+            </KpiTile>
+            <KpiTile
+              title={locationsText.barscale_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: locationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_locations"
+                absolute={lastValue.newly_infected_locations}
+              />
+              <Text>{locationsText.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          {lastValue.infected_locations_total !== undefined && (
+            <LineChartTile
+              title={locationsText.linechart_titel}
+              values={values}
+              ariaDescription={
+                graphDescriptions.gehandicaptenzorg_besmette_locaties
+              }
+              linesConfig={[
+                {
+                  metricProperty: 'infected_locations_total',
+                },
+              ]}
+              metadata={{
+                source: locationsText.bronnen.rivm,
+              }}
+            />
           )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: mortalityText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: mortalityText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+
+          <ContentHeader
+            id="sterfte"
+            skipLinkAnchor={true}
+            title={replaceVariablesInText(mortalityText.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<CoronaVirus />}
+            subtitle={mortalityText.pagina_toelichting}
+            metadata={{
+              datumsText: mortalityText.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [mortalityText.bronnen.rivm],
+            }}
+            reference={mortalityText.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={mortalityText.barscale_titel}
+              description={mortalityText.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: mortalityText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={lastValue.deceased_daily}
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            metadata={{ source: mortalityText.bronnen.rivm }}
+            title={mortalityText.linechart_titel}
+            values={values}
+            ariaDescription={graphDescriptions.gehandicaptenzorg_overleden}
+            linesConfig={[
+              {
+                metricProperty: 'deceased_daily',
+              },
+            ]}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue = value.__date >= underReportedValues[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedValues,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: mortalityText.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: mortalityText.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-DisabilityCare.getLayout = getSafetyRegionLayout();
 
 export default DisabilityCare;

--- a/packages/app/src/pages/veiligheidsregio/[code]/index.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/index.tsx
@@ -1,7 +1,8 @@
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { getVrData, getLastGeneratedDate } from '~/static-props/get-data';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { useIntl } from '~/intl';
 
 export { getStaticPaths } from '~/static-paths/vr';
 
@@ -10,7 +11,18 @@ export const getStaticProps = createGetStaticProps(
   getVrData
 );
 
-const SafetyRegion: FCWithLayout<typeof getStaticProps> = () => null;
-SafetyRegion.getLayout = getSafetyRegionLayout();
+const SafetyRegion = (props) => {
+  const { lastGenerated } = props;
+  const { siteText } = useIntl();
+
+  return (
+    <Layout
+      {...siteText.veiligheidsregio_index.metadata}
+      lastGenerated={lastGenerated}
+    >
+      <SafetyRegionLayout lastGenerated={lastGenerated} />
+    </Layout>
+  );
+};
 
 export default SafetyRegion;

--- a/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
@@ -6,10 +6,9 @@ import { KpiSection } from '~/components-styled/kpi-section';
 import { LockdownTable } from '~/domain/restrictions/lockdown-table';
 import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
-import { SEOHead } from '~/components-styled/seo-head';
 import { Box } from '~/components-styled/base/box';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import { LockdownData, RoadmapData } from '~/types/cms';
@@ -59,8 +58,8 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<MaatregelenData>(query)
 );
 
-const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content, safetyRegionName } = props;
+const RegionalRestrictions = (props) => {
+  const { content, safetyRegionName, lastGenerated } = props;
 
   const { siteText } = useIntl();
   const text = siteText.veiligheidsregio_maatregelen;
@@ -84,66 +83,68 @@ const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
   // const effectiveEscalationLevel: EscalationLevel =
   //   escalationLevel > 4 ? 4 : (escalationLevel as EscalationLevel);
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          title={replaceVariablesInText(
-            siteText.veiligheidsregio_maatregelen.titel,
-            {
-              safetyRegionName,
-            }
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            title={replaceVariablesInText(
+              siteText.veiligheidsregio_maatregelen.titel,
+              {
+                safetyRegionName,
+              }
+            )}
+          />
+
+          {showLockdown && (
+            <KpiSection flexDirection="column">
+              <Box
+                css={css({
+                  'p:last-child': {
+                    margin: '0',
+                  },
+                })}
+              >
+                <Heading level={3}>{lockdown.message.title}</Heading>
+                {lockdown.message.description ? (
+                  <RichContent blocks={lockdown.message.description} />
+                ) : null}
+              </Box>
+            </KpiSection>
           )}
-        />
 
-        {showLockdown && (
-          <KpiSection flexDirection="column">
-            <Box
-              css={css({
-                'p:last-child': {
-                  margin: '0',
-                },
-              })}
-            >
-              <Heading level={3}>{lockdown.message.title}</Heading>
-              {lockdown.message.description ? (
-                <RichContent blocks={lockdown.message.description} />
-              ) : null}
-            </Box>
-          </KpiSection>
-        )}
+          {showLockdown && (
+            <KpiSection display="flex" flexDirection="column">
+              <Heading level={3}>{lockdown.title}</Heading>
+              <LockdownTable data={lockdown} />
+            </KpiSection>
+          )}
 
-        {showLockdown && (
-          <KpiSection display="flex" flexDirection="column">
-            <Heading level={3}>{lockdown.title}</Heading>
-            <LockdownTable data={lockdown} />
-          </KpiSection>
-        )}
-
-        <AnchorTile
-          external
-          shadow
-          title={text.titel_aanvullendemaatregelen}
-          href={regioUrl}
-          label={replaceVariablesInText(text.linktext_regionpage, {
-            safetyRegionName,
-          })}
-        >
-          {text.toelichting_aanvullendemaatregelen}
-        </AnchorTile>
-      </TileList>
-    </>
+          <AnchorTile
+            external
+            shadow
+            title={text.titel_aanvullendemaatregelen}
+            href={regioUrl}
+            label={replaceVariablesInText(text.linktext_regionpage, {
+              safetyRegionName,
+            })}
+          >
+            {text.toelichting_aanvullendemaatregelen}
+          </AnchorTile>
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-RegionalRestrictions.getLayout = getSafetyRegionLayout();
 
 export default RegionalRestrictions;

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -12,7 +12,6 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { PageBarScale } from '~/components-styled/page-barscale';
-import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Heading, Text } from '~/components-styled/typography';
@@ -21,8 +20,6 @@ import { regionThresholds } from '~/components/choropleth/region-thresholds';
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { createPositiveTestedPeopleMunicipalTooltip } from '~/components/choropleth/tooltips/municipal/create-positive-tested-people-municipal-tooltip';
 import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -36,6 +33,8 @@ import { replaceKpisInText } from '~/utils/replaceKpisInText';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 export { getStaticPaths } from '~/static-paths/vr';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -48,8 +47,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('positiveTestsPage'))
 );
 
-const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, choropleth, safetyRegionName, content } = props;
+const PositivelyTestedPeople = (props) => {
+  const { data, choropleth, safetyRegionName, content, lastGenerated } = props;
 
   const {
     siteText,
@@ -71,334 +70,340 @@ const PositivelyTestedPeople: FCWithLayout<typeof getStaticProps> = (props) => {
   const municipalCodes = regionCodeToMunicipalCodeLookup[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.besmettingen}
-          screenReaderCategory={
-            siteText.positief_geteste_personen.titel_sidebar
-          }
-          title={replaceVariablesInText(text.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Getest />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.veiligheidsregio_layout.headings.besmettingen}
+            screenReaderCategory={
+              siteText.positief_geteste_personen.titel_sidebar
+            }
+            title={replaceVariablesInText(text.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<Getest />}
+            subtitle={text.pagina_toelichting}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
+            }}
+            reference={text.reference}
+          />
 
-        <ArticleStrip articles={content.articles} />
+          <ArticleStrip articles={content.articles} />
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.kpi_titel}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.kpi_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected"
+                absolute={Math.round(lastValue.infected)}
+                difference={data.difference.tested_overall__infected}
+              />
+
+              <Text
+                as="div"
+                dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
+              />
+
+              <Box>
+                <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
+                  <span
+                    css={css({ '& > span': { color: 'data.primary' } })}
+                    dangerouslySetInnerHTML={{
+                      __html: replaceKpisInText(ggdText.summary_title, [
+                        {
+                          name: 'percentage',
+                          value: `${formatPercentage(
+                            ggdAverageLastValue.infected_percentage
+                          )}%`,
+                        },
+                      ]),
+                    }}
+                  />
+                </Heading>
+                <Text mt={0} lineHeight={1}>
+                  <Anchor name="ggd" text={ggdText.summary_link_cta} />
+                </Text>
+              </Box>
+            </KpiTile>
+
+            <KpiTile
+              title={text.barscale_titel}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <PageBarScale
+                data={data}
+                scope="vr"
+                metricName="tested_overall"
+                metricProperty="infected_per_100k"
+                localeTextKey="veiligheidsregio_positief_geteste_personen"
+                differenceKey="tested_overall__infected_per_100k"
+              />
+              <Text>{text.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            title={text.linechart_titel}
+            description={text.linechart_toelichting}
+            signaalwaarde={7}
+            values={data.tested_overall.values}
+            linesConfig={[
+              {
+                metricProperty: 'infected_per_100k',
+              },
+            ]}
+            metadata={{ source: text.bronnen.rivm }}
+            formatTooltip={(values) => {
+              const value = values[0];
+
+              return (
+                <Text textAlign="center" m={0}>
+                  <span style={{ fontWeight: 'bold' }}>
+                    {formatDateFromMilliseconds(
+                      value.__date.getTime(),
+                      'medium'
+                    )}
+                  </span>
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      marginBottom: '0.5px',
+                      backgroundColor: colors.data.primary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_value,
+                    {
+                      totalPositiveValue: formatNumber(value.__value),
+                    }
+                  )}
+                  <br />
+                  {replaceVariablesInText(
+                    siteText.common.tooltip.positive_tested_people,
+                    {
+                      totalPositiveTestedPeople: formatNumber(value.infected),
+                    }
+                  )}
+                </Text>
+              );
+            }}
+          />
+
+          <ChoroplethTile
+            title={replaceVariablesInText(text.map_titel, {
+              safetyRegion: safetyRegionName,
+            })}
             metadata={{
               date: lastValue.date_unix,
               source: text.bronnen.rivm,
             }}
-          >
-            <KpiValue
-              data-cy="infected"
-              absolute={Math.round(lastValue.infected)}
-              difference={data.difference.tested_overall__infected}
-            />
-
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{ __html: text.kpi_toelichting }}
-            />
-
-            <Box>
-              <Heading level={4} fontSize={'1.2em'} mt={'1.5em'} mb={0}>
-                <span
-                  css={css({ '& > span': { color: 'data.primary' } })}
-                  dangerouslySetInnerHTML={{
-                    __html: replaceKpisInText(ggdText.summary_title, [
-                      {
-                        name: 'percentage',
-                        value: `${formatPercentage(
-                          ggdAverageLastValue.infected_percentage
-                        )}%`,
-                      },
-                    ]),
-                  }}
-                />
-              </Heading>
-              <Text mt={0} lineHeight={1}>
-                <Anchor name="ggd" text={ggdText.summary_link_cta} />
-              </Text>
-            </Box>
-          </KpiTile>
-
-          <KpiTile
-            title={text.barscale_titel}
-            metadata={{
-              date: lastValue.date_unix,
-              source: text.bronnen.rivm,
+            description={text.map_toelichting}
+            legend={{
+              title:
+                siteText.positief_geteste_personen.chloropleth_legenda.titel,
+              thresholds: regionThresholds.tested_overall.infected_per_100k,
             }}
           >
-            <PageBarScale
-              data={data}
-              scope="vr"
+            <MunicipalityChoropleth
+              selectedCode={selectedMunicipalCode}
+              highlightSelection={false}
+              data={choropleth.gm}
               metricName="tested_overall"
               metricProperty="infected_per_100k"
-              localeTextKey="veiligheidsregio_positief_geteste_personen"
-              differenceKey="tested_overall__infected_per_100k"
+              tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
+                siteText.choropleth_tooltip.positive_tested_people,
+                regionThresholds.tested_overall.infected_per_100k,
+                createSelectMunicipalHandler(router, 'positief-geteste-mensen')
+              )}
+              onSelect={createSelectMunicipalHandler(
+                router,
+                'positief-geteste-mensen'
+              )}
             />
-            <Text>{text.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <LineChartTile
-          title={text.linechart_titel}
-          description={text.linechart_toelichting}
-          signaalwaarde={7}
-          values={data.tested_overall.values}
-          linesConfig={[
-            {
-              metricProperty: 'infected_per_100k',
-            },
-          ]}
-          metadata={{ source: text.bronnen.rivm }}
-          formatTooltip={(values) => {
-            const value = values[0];
-
-            return (
-              <Text textAlign="center" m={0}>
-                <span style={{ fontWeight: 'bold' }}>
-                  {formatDateFromMilliseconds(value.__date.getTime(), 'medium')}
-                </span>
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    marginBottom: '0.5px',
-                    backgroundColor: colors.data.primary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_value,
-                  {
-                    totalPositiveValue: formatNumber(value.__value),
-                  }
-                )}
-                <br />
-                {replaceVariablesInText(
-                  siteText.common.tooltip.positive_tested_people,
-                  {
-                    totalPositiveTestedPeople: formatNumber(value.infected),
-                  }
-                )}
-              </Text>
-            );
-          }}
-        />
-
-        <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          metadata={{
-            date: lastValue.date_unix,
-            source: text.bronnen.rivm,
-          }}
-          description={text.map_toelichting}
-          legend={{
-            title: siteText.positief_geteste_personen.chloropleth_legenda.titel,
-            thresholds: regionThresholds.tested_overall.infected_per_100k,
-          }}
-        >
-          <MunicipalityChoropleth
-            selectedCode={selectedMunicipalCode}
-            highlightSelection={false}
-            data={choropleth.gm}
-            metricName="tested_overall"
-            metricProperty="infected_per_100k"
-            tooltipContent={createPositiveTestedPeopleMunicipalTooltip(
-              siteText.choropleth_tooltip.positive_tested_people,
-              regionThresholds.tested_overall.infected_per_100k,
-              createSelectMunicipalHandler(router, 'positief-geteste-mensen')
-            )}
-            onSelect={createSelectMunicipalHandler(
-              router,
-              'positief-geteste-mensen'
-            )}
+          <ContentHeader
+            id="ggd"
+            title={replaceVariablesInText(ggdText.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            skipLinkAnchor={true}
+            icon={<Afname />}
+            subtitle={ggdText.toelichting}
+            metadata={{
+              datumsText: ggdText.datums,
+              dateOfInsertionUnix: ggdAverageLastValue.date_of_insertion_unix,
+              dateOrRange: {
+                start: ggdAverageLastValue.date_start_unix,
+                end: ggdAverageLastValue.date_end_unix,
+              },
+              dataSources: [ggdText.bronnen.rivm],
+            }}
+            reference={text.reference}
           />
-        </ChoroplethTile>
 
-        <ContentHeader
-          id="ggd"
-          title={replaceVariablesInText(ggdText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          skipLinkAnchor={true}
-          icon={<Afname />}
-          subtitle={ggdText.toelichting}
-          metadata={{
-            datumsText: ggdText.datums,
-            dateOfInsertionUnix: ggdAverageLastValue.date_of_insertion_unix,
-            dateOrRange: {
-              start: ggdAverageLastValue.date_start_unix,
-              end: ggdAverageLastValue.date_end_unix,
-            },
-            dataSources: [ggdText.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={ggdText.totaal_getest_week_titel}
-            metadata={{
-              date: [
-                ggdAverageLastValue.date_start_unix,
-                ggdAverageLastValue.date_end_unix,
-              ],
-              source: ggdText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              absolute={ggdAverageLastValue.tested_total}
-              difference={data.difference.tested_ggd_average__tested_total}
-            />
-            <Text>{ggdText.totaal_getest_week_uitleg}</Text>
-          </KpiTile>
-          <KpiTile
-            title={ggdText.positief_getest_week_titel}
-            metadata={{
-              date: ggdAverageLastValue.date_end_unix,
-              source: ggdText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              percentage={ggdAverageLastValue.infected_percentage}
-              difference={
-                data.difference.tested_ggd_average__infected_percentage
-              }
-            />
-            <Text>{ggdText.positief_getest_week_uitleg}</Text>
-            <Text>
-              <strong
-                css={css({ '& > span': { color: 'data.primary' } })}
-                dangerouslySetInnerHTML={{
-                  __html: replaceKpisInText(
-                    ggdText.positief_getest_getest_week_uitleg,
-                    [
-                      {
-                        name: 'numerator',
-                        value: formatNumber(ggdAverageLastValue.infected),
-                      },
-                      {
-                        name: 'denominator',
-                        value: formatNumber(ggdAverageLastValue.tested_total),
-                      },
-                    ]
-                  ),
-                }}
+          <TwoKpiSection>
+            <KpiTile
+              title={ggdText.totaal_getest_week_titel}
+              metadata={{
+                date: [
+                  ggdAverageLastValue.date_start_unix,
+                  ggdAverageLastValue.date_end_unix,
+                ],
+                source: ggdText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                absolute={ggdAverageLastValue.tested_total}
+                difference={data.difference.tested_ggd_average__tested_total}
               />
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_percentage_titel}
-          description={ggdText.linechart_percentage_toelichting}
-          values={ggdDailyValues}
-          linesConfig={[
-            {
-              metricProperty: 'infected_percentage',
-            },
-          ]}
-          isPercentage
-          metadata={{
-            source: ggdText.bronnen.rivm,
-          }}
-        />
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={ggdText.linechart_totaltests_titel}
-          description={ggdText.linechart_totaltests_toelichting}
-          hideFill={true}
-          showLegend
-          padding={{
-            left: 45,
-          }}
-          values={ggdDailyValues}
-          linesConfig={[
-            {
-              metricProperty: 'tested_total',
-              color: colors.data.secondary,
-              legendLabel: ggdText.linechart_totaltests_legend_label,
-            },
-            {
-              metricProperty: 'infected',
-              color: colors.data.primary,
-              legendLabel: ggdText.linechart_positivetests_legend_label,
-            },
-          ]}
-          metadata={{
-            source: ggdText.bronnen.rivm,
-          }}
-          formatTooltip={(x) => {
-            const numerator = x[0].__value;
-            const denominator = x[1].__value;
-
-            const percentage =
-              numerator === 0 ? 0 : (denominator * 100) / numerator;
-
-            return (
-              <>
-                {formatDateFromSeconds(x[0].date_unix, 'medium')}
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    backgroundColor: colors.data.secondary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
+              <Text>{ggdText.totaal_getest_week_uitleg}</Text>
+            </KpiTile>
+            <KpiTile
+              title={ggdText.positief_getest_week_titel}
+              metadata={{
+                date: ggdAverageLastValue.date_end_unix,
+                source: ggdText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                percentage={ggdAverageLastValue.infected_percentage}
+                difference={
+                  data.difference.tested_ggd_average__infected_percentage
+                }
+              />
+              <Text>{ggdText.positief_getest_week_uitleg}</Text>
+              <Text>
+                <strong
+                  css={css({ '& > span': { color: 'data.primary' } })}
+                  dangerouslySetInnerHTML={{
+                    __html: replaceKpisInText(
+                      ggdText.positief_getest_getest_week_uitleg,
+                      [
+                        {
+                          name: 'numerator',
+                          value: formatNumber(ggdAverageLastValue.infected),
+                        },
+                        {
+                          name: 'denominator',
+                          value: formatNumber(ggdAverageLastValue.tested_total),
+                        },
+                      ]
+                    ),
                   }}
-                />{' '}
-                {formatNumber(numerator)}
-                <br />
-                <span
-                  style={{
-                    height: '0.5em',
-                    width: '0.5em',
-                    backgroundColor: colors.data.primary,
-                    borderRadius: '50%',
-                    display: 'inline-block',
-                  }}
-                />{' '}
-                {formatNumber(denominator)} ({formatPercentage(percentage)}%)
-              </>
-            );
-          }}
-        />
-      </TileList>
-    </>
+                />
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={ggdText.linechart_percentage_titel}
+            description={ggdText.linechart_percentage_toelichting}
+            values={ggdDailyValues}
+            linesConfig={[
+              {
+                metricProperty: 'infected_percentage',
+              },
+            ]}
+            isPercentage
+            metadata={{
+              source: ggdText.bronnen.rivm,
+            }}
+          />
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={ggdText.linechart_totaltests_titel}
+            description={ggdText.linechart_totaltests_toelichting}
+            hideFill={true}
+            showLegend
+            padding={{
+              left: 45,
+            }}
+            values={ggdDailyValues}
+            linesConfig={[
+              {
+                metricProperty: 'tested_total',
+                color: colors.data.secondary,
+                legendLabel: ggdText.linechart_totaltests_legend_label,
+              },
+              {
+                metricProperty: 'infected',
+                color: colors.data.primary,
+                legendLabel: ggdText.linechart_positivetests_legend_label,
+              },
+            ]}
+            metadata={{
+              source: ggdText.bronnen.rivm,
+            }}
+            formatTooltip={(x) => {
+              const numerator = x[0].__value;
+              const denominator = x[1].__value;
+
+              const percentage =
+                numerator === 0 ? 0 : (denominator * 100) / numerator;
+
+              return (
+                <>
+                  {formatDateFromSeconds(x[0].date_unix, 'medium')}
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      backgroundColor: colors.data.secondary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {formatNumber(numerator)}
+                  <br />
+                  <span
+                    style={{
+                      height: '0.5em',
+                      width: '0.5em',
+                      backgroundColor: colors.data.primary,
+                      borderRadius: '50%',
+                      display: 'inline-block',
+                    }}
+                  />{' '}
+                  {formatNumber(denominator)} ({formatPercentage(percentage)}%)
+                </>
+              );
+            }}
+          />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-PositivelyTestedPeople.getLayout = getSafetyRegionLayout();
 
 export default PositivelyTestedPeople;

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -10,14 +10,13 @@ import {
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
-import { SEOHead } from '~/components-styled/seo-head';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { SewerChart } from '~/components-styled/sewer-chart';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { WarningTile } from '~/components-styled/warning-tile';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -40,8 +39,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('sewerPage'))
 );
 
-const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, safetyRegionName, content } = props;
+const SewerWater = (props) => {
+  const { data, safetyRegionName, content, lastGenerated } = props;
 
   const { siteText } = useIntl();
 
@@ -52,146 +51,148 @@ const SewerWater: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const sewerAverages = data.sewer;
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.vroege_signalen}
-          title={replaceVariablesInText(text.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<RioolwaterMonitoring />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: {
-              start: sewerAverages.last_value.date_start_unix,
-              end: sewerAverages.last_value.date_end_unix,
-            },
-            dateOfInsertionUnix:
-              sewerAverages.last_value.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
-
-        <WarningTile message={text.warning_method} icon={ExperimenteelIcon} />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
-            metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="riool_normalized"
-              absolute={data.sewer.last_value.average}
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
-              difference={data.difference.sewer__average}
-            />
-          </KpiTile>
-
-          <KpiTile
-            title={text.total_measurements_title}
-            description={text.total_measurements_description}
-            metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="total_number_of_samples"
-              absolute={sewerAverages.last_value.total_number_of_samples}
-            />
-            <Text>
-              {replaceComponentsInText(text.total_measurements_locations, {
-                sampled_installation_count: (
-                  <strong>
-                    {sewerAverages.last_value.sampled_installation_count}
-                  </strong>
-                ),
-                total_installation_count: (
-                  <strong>
-                    {sewerAverages.last_value.total_installation_count}
-                  </strong>
-                ),
-              })}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <ChartTileWithTimeframe
-          title={text.linechart_titel}
-          ariaDescription={graphDescriptions.rioolwater_meetwaarde}
-          metadata={{ source: text.bronnen.rivm }}
-          timeframeOptions={['all', '5weeks']}
-        >
-          {(timeframe) => (
-            <SewerChart
-              data={data}
-              timeframe={timeframe}
-              valueAnnotation={siteText.waarde_annotaties.riool_normalized}
-              text={{
-                select_station_placeholder:
-                  text.graph_selected_rwzi_placeholder,
-                average_label_text: text.graph_average_label_text,
-                secondary_label_text: text.graph_secondary_label_text,
-                daily_label_text: text.graph_daily_label_text_rwzi,
-                range_description: text.graph_range_description,
-                display_outliers: text.display_outliers,
-                hide_outliers: text.hide_outliers,
-              }}
-            />
-          )}
-        </ChartTileWithTimeframe>
-
-        {barChartData && (
-          <ChartTile
-            title={replaceVariablesInText(text.bar_chart_title, {
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.veiligheidsregio_layout.headings.vroege_signalen}
+            title={replaceVariablesInText(text.titel, {
               safetyRegion: safetyRegionName,
             })}
-            ariaDescription={graphDescriptions.rioolwater_meetwaarde}
+            icon={<RioolwaterMonitoring />}
+            subtitle={text.pagina_toelichting}
             metadata={{
-              date: [
-                sewerAverages.last_value.date_start_unix,
-                sewerAverages.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm,
+              datumsText: text.datums,
+              dateOrRange: {
+                start: sewerAverages.last_value.date_start_unix,
+                end: sewerAverages.last_value.date_end_unix,
+              },
+              dateOfInsertionUnix:
+                sewerAverages.last_value.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
             }}
+            reference={text.reference}
+          />
+
+          <WarningTile message={text.warning_method} icon={ExperimenteelIcon} />
+
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              description={text.extra_uitleg}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="riool_normalized"
+                absolute={data.sewer.last_value.average}
+                valueAnnotation={siteText.waarde_annotaties.riool_normalized}
+                difference={data.difference.sewer__average}
+              />
+            </KpiTile>
+
+            <KpiTile
+              title={text.total_measurements_title}
+              description={text.total_measurements_description}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="total_number_of_samples"
+                absolute={sewerAverages.last_value.total_number_of_samples}
+              />
+              <Text>
+                {replaceComponentsInText(text.total_measurements_locations, {
+                  sampled_installation_count: (
+                    <strong>
+                      {sewerAverages.last_value.sampled_installation_count}
+                    </strong>
+                  ),
+                  total_installation_count: (
+                    <strong>
+                      {sewerAverages.last_value.total_installation_count}
+                    </strong>
+                  ),
+                })}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <ChartTileWithTimeframe
+            title={text.linechart_titel}
+            ariaDescription={graphDescriptions.rioolwater_meetwaarde}
+            metadata={{ source: text.bronnen.rivm }}
+            timeframeOptions={['all', '5weeks']}
           >
-            <BarChart
-              values={barChartData.values}
-              xAxisTitle={text.bar_chart_axis_title}
-              accessibilityDescription={
-                text.bar_chart_accessibility_description
-              }
-            />
-          </ChartTile>
-        )}
-      </TileList>
-    </>
+            {(timeframe) => (
+              <SewerChart
+                data={data}
+                timeframe={timeframe}
+                valueAnnotation={siteText.waarde_annotaties.riool_normalized}
+                text={{
+                  select_station_placeholder:
+                    text.graph_selected_rwzi_placeholder,
+                  average_label_text: text.graph_average_label_text,
+                  secondary_label_text: text.graph_secondary_label_text,
+                  daily_label_text: text.graph_daily_label_text_rwzi,
+                  range_description: text.graph_range_description,
+                  display_outliers: text.display_outliers,
+                  hide_outliers: text.hide_outliers,
+                }}
+              />
+            )}
+          </ChartTileWithTimeframe>
+
+          {barChartData && (
+            <ChartTile
+              title={replaceVariablesInText(text.bar_chart_title, {
+                safetyRegion: safetyRegionName,
+              })}
+              ariaDescription={graphDescriptions.rioolwater_meetwaarde}
+              metadata={{
+                date: [
+                  sewerAverages.last_value.date_start_unix,
+                  sewerAverages.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm,
+              }}
+            >
+              <BarChart
+                values={barChartData.values}
+                xAxisTitle={text.bar_chart_axis_title}
+                accessibilityDescription={
+                  text.bar_chart_accessibility_description
+                }
+              />
+            </ChartTile>
+          )}
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-SewerWater.getLayout = getSafetyRegionLayout();
 
 export default SewerWater;

--- a/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
@@ -9,14 +9,13 @@ import { ContentHeader } from '~/components-styled/content-header';
 import { EscalationLevelInfoLabel } from '~/components-styled/escalation-level';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
-import { SEOHead } from '~/components-styled/seo-head';
 import { Tile } from '~/components-styled/tile';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Heading, InlineText, Text } from '~/components-styled/typography';
 import { useEscalationThresholds } from '~/domain/escalation-level/thresholds';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { EscalationLevel } from '~/domain/restrictions/type';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -39,8 +38,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('escalationLevelPage'))
 );
 
-const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { safetyRegionName, content, data } = props;
+const RegionalRestrictions = (props) => {
+  const { safetyRegionName, content, data, lastGenerated } = props;
 
   const { siteText, formatDateFromSeconds } = useIntl();
   const text = siteText.vr_risiconiveau;
@@ -67,148 +66,157 @@ const RegionalRestrictions: FCWithLayout<typeof getStaticProps> = (props) => {
     )
   );
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.inschaling}
-          title={replaceVariablesInText(text.titel, {
-            safetyRegionName,
-          })}
-          subtitle={text.pagina_toelichting}
-          reference={text.reference}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: hospital_nice_sum.last_value.date_end_unix,
-            dateOfInsertionUnix:
-              hospital_nice_sum.last_value.date_of_insertion_unix,
-            dataSources: [
-              text.bronnen.rivm_positieve_testen,
-              text.bronnen.rivm_ziekenhuisopnames,
-            ],
-          }}
-        />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.veiligheidsregio_layout.headings.inschaling}
+            title={replaceVariablesInText(text.titel, {
+              safetyRegionName,
+            })}
+            subtitle={text.pagina_toelichting}
+            reference={text.reference}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: hospital_nice_sum.last_value.date_end_unix,
+              dateOfInsertionUnix:
+                hospital_nice_sum.last_value.date_of_insertion_unix,
+              dataSources: [
+                text.bronnen.rivm_positieve_testen,
+                text.bronnen.rivm_ziekenhuisopnames,
+              ],
+            }}
+          />
 
-        <Tile>
-          <Heading level={3} as="h2">
-            {text.current_escalation_level}
-          </Heading>
+          <Tile>
+            <Heading level={3} as="h2">
+              {text.current_escalation_level}
+            </Heading>
 
-          <Box
-            display={{ _: 'block', sm: 'flex' }}
-            spacing={3}
-            spacingHorizontal
-          >
-            <Box flex="0 0 10rem">
-              <EscalationLevelInfoLabel
-                level={currentLevel}
-                fontSize={3}
-                useLevelColor
-              />
+            <Box
+              display={{ _: 'block', sm: 'flex' }}
+              spacing={3}
+              spacingHorizontal
+            >
+              <Box flex="0 0 10rem">
+                <EscalationLevelInfoLabel
+                  level={currentLevel}
+                  fontSize={3}
+                  useLevelColor
+                />
+              </Box>
+              {/* alignment with baseline of EscalationLevelInfoLabel */}
+              <Box mt={{ sm: '-.55rem' }}>
+                <Text
+                  as="div"
+                  dangerouslySetInnerHTML={{
+                    __html: text.types[currentLevel].toelichting,
+                  }}
+                />
+                <Text fontWeight="bold">
+                  {replaceVariablesInText(
+                    text.escalation_level_last_determined,
+                    {
+                      last_determined: formatDateFromSeconds(
+                        data.escalation_level.last_determined_unix
+                      ),
+                    }
+                  )}
+                </Text>
+              </Box>
             </Box>
-            {/* alignment with baseline of EscalationLevelInfoLabel */}
-            <Box mt={{ sm: '-.55rem' }}>
+          </Tile>
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.positieve_testen.title}
+              metadata={{
+                date: [
+                  tested_overall_sum.last_value.date_start_unix,
+                  tested_overall_sum.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm_positieve_testen_kpi,
+              }}
+            >
+              <Box spacing={2} spacingHorizontal>
+                <Box display="inline-block">
+                  <KpiValue
+                    data-cy="infected"
+                    absolute={tested_overall_sum.last_value.infected_per_100k}
+                    color={positiveTestedColor}
+                  />
+                </Box>
+                <InlineText>
+                  {text.positieve_testen.value_annotation}
+                </InlineText>
+              </Box>
+
+              <CategoricalBarScale
+                categories={positiveTestedEscalationThresholds}
+                value={tested_overall_sum.last_value.infected_per_100k}
+              />
+
               <Text
                 as="div"
                 dangerouslySetInnerHTML={{
-                  __html: text.types[currentLevel].toelichting,
+                  __html: text.positieve_testen.description,
                 }}
               />
-              <Text fontWeight="bold">
-                {replaceVariablesInText(text.escalation_level_last_determined, {
-                  last_determined: formatDateFromSeconds(
-                    data.escalation_level.last_determined_unix
-                  ),
-                })}
-              </Text>
-            </Box>
-          </Box>
-        </Tile>
+            </KpiTile>
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.positieve_testen.title}
-            metadata={{
-              date: [
-                tested_overall_sum.last_value.date_start_unix,
-                tested_overall_sum.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm_positieve_testen_kpi,
-            }}
-          >
-            <Box spacing={2} spacingHorizontal>
-              <Box display="inline-block">
-                <KpiValue
-                  data-cy="infected"
-                  absolute={tested_overall_sum.last_value.infected_per_100k}
-                  color={positiveTestedColor}
-                />
-              </Box>
-              <InlineText>{text.positieve_testen.value_annotation}</InlineText>
-            </Box>
-
-            <CategoricalBarScale
-              categories={positiveTestedEscalationThresholds}
-              value={tested_overall_sum.last_value.infected_per_100k}
-            />
-
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{
-                __html: text.positieve_testen.description,
+            <KpiTile
+              title={text.ziekenhuisopnames.title}
+              metadata={{
+                date: [
+                  hospital_nice_sum.last_value.date_start_unix,
+                  hospital_nice_sum.last_value.date_end_unix,
+                ],
+                source: text.bronnen.rivm_ziekenhuisopnames_kpi,
               }}
-            />
-          </KpiTile>
-
-          <KpiTile
-            title={text.ziekenhuisopnames.title}
-            metadata={{
-              date: [
-                hospital_nice_sum.last_value.date_start_unix,
-                hospital_nice_sum.last_value.date_end_unix,
-              ],
-              source: text.bronnen.rivm_ziekenhuisopnames_kpi,
-            }}
-          >
-            <Box spacing={2} spacingHorizontal>
-              <Box display="inline-block">
-                <KpiValue
-                  data-cy="infected"
-                  absolute={hospital_nice_sum.last_value.admissions_per_1m}
-                  color={hospitalAdmissionsColor}
-                />
+            >
+              <Box spacing={2} spacingHorizontal>
+                <Box display="inline-block">
+                  <KpiValue
+                    data-cy="infected"
+                    absolute={hospital_nice_sum.last_value.admissions_per_1m}
+                    color={hospitalAdmissionsColor}
+                  />
+                </Box>
+                <InlineText>
+                  {text.ziekenhuisopnames.value_annotation}
+                </InlineText>
               </Box>
-              <InlineText>{text.ziekenhuisopnames.value_annotation}</InlineText>
-            </Box>
 
-            <CategoricalBarScale
-              categories={hospitalAdmissionsEscalationThresholds}
-              value={hospital_nice_sum.last_value.admissions_per_1m}
-            />
+              <CategoricalBarScale
+                categories={hospitalAdmissionsEscalationThresholds}
+                value={hospital_nice_sum.last_value.admissions_per_1m}
+              />
 
-            <Text
-              as="div"
-              dangerouslySetInnerHTML={{
-                __html: text.ziekenhuisopnames.description,
-              }}
-            />
-          </KpiTile>
-        </TwoKpiSection>
+              <Text
+                as="div"
+                dangerouslySetInnerHTML={{
+                  __html: text.ziekenhuisopnames.description,
+                }}
+              />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <ArticleStrip articles={content.articles} />
-      </TileList>
-    </>
+          <ArticleStrip articles={content.articles} />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-RegionalRestrictions.getLayout = getSafetyRegionLayout();
 
 export default RegionalRestrictions;

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -6,13 +6,12 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { DeceasedMonitorSection } from '~/domain/deceased/deceased-monitor-section';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -35,11 +34,12 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('deceasedPage'))
 );
 
-const DeceasedRegionalPage: FCWithLayout<typeof getStaticProps> = (props) => {
+const DeceasedRegionalPage = (props) => {
   const {
     safetyRegionName: safetyRegion,
     data: { deceased_cbs: dataCbs, deceased_rivm: dataRivm, difference },
     content,
+    lastGenerated,
   } = props;
 
   const { siteText } = useIntl();
@@ -47,128 +47,129 @@ const DeceasedRegionalPage: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const dataRivmUnderReportedRange = getTrailingDateRange(dataRivm.values, 4);
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, { safetyRegion }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegion,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, { safetyRegion })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegion,
-        })}
-      />
-
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.besmettingen}
-          title={replaceVariablesInText(text.section_deceased_rivm.title, {
-            safetyRegion,
-          })}
-          icon={<CoronaVirusIcon />}
-          subtitle={text.section_deceased_rivm.description}
-          reference={text.section_deceased_rivm.reference}
-          metadata={{
-            datumsText: text.section_deceased_rivm.datums,
-            dateOrRange: dataRivm.last_value.date_unix,
-            dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
-            dataSources: [text.section_deceased_rivm.bronnen.rivm],
-          }}
-        />
-
-        <ArticleStrip articles={content.articles} />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_daily_title}
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.veiligheidsregio_layout.headings.besmettingen}
+            title={replaceVariablesInText(text.section_deceased_rivm.title, {
+              safetyRegion,
+            })}
+            icon={<CoronaVirusIcon />}
+            subtitle={text.section_deceased_rivm.description}
+            reference={text.section_deceased_rivm.reference}
             metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
+              datumsText: text.section_deceased_rivm.datums,
+              dateOrRange: dataRivm.last_value.date_unix,
+              dateOfInsertionUnix: dataRivm.last_value.date_of_insertion_unix,
+              dataSources: [text.section_deceased_rivm.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="covid_daily"
-              absolute={dataRivm.last_value.covid_daily}
-              difference={difference.deceased_rivm__covid_daily}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_daily_description}
-            </Text>
-          </KpiTile>
-          <KpiTile
-            title={text.section_deceased_rivm.kpi_covid_total_title}
-            metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: text.section_deceased_rivm.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="covid_total"
-              absolute={dataRivm.last_value.covid_total}
-            />
-            <Text>
-              {text.section_deceased_rivm.kpi_covid_total_description}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
+          />
 
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_deceased_rivm.line_chart_covid_daily_title}
-          description={
-            text.section_deceased_rivm.line_chart_covid_daily_description
-          }
-          values={dataRivm.values}
-          linesConfig={[
-            {
-              metricProperty: 'covid_daily',
-            },
-          ]}
-          metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
-          componentCallback={addBackgroundRectangleCallback(
-            dataRivmUnderReportedRange,
-            {
-              fill: colors.data.underReported,
+          <ArticleStrip articles={content.articles} />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_daily_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_daily"
+                absolute={dataRivm.last_value.covid_daily}
+                difference={difference.deceased_rivm__covid_daily}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_daily_description}
+              </Text>
+            </KpiTile>
+            <KpiTile
+              title={text.section_deceased_rivm.kpi_covid_total_title}
+              metadata={{
+                date: dataRivm.last_value.date_unix,
+                source: text.section_deceased_rivm.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="covid_total"
+                absolute={dataRivm.last_value.covid_total}
+              />
+              <Text>
+                {text.section_deceased_rivm.kpi_covid_total_description}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_deceased_rivm.line_chart_covid_daily_title}
+            description={
+              text.section_deceased_rivm.line_chart_covid_daily_description
             }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label:
-                text.section_deceased_rivm
-                  .line_chart_covid_daily_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                text.section_deceased_rivm
-                  .line_chart_covid_daily_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
+            values={dataRivm.values}
+            linesConfig={[
+              {
+                metricProperty: 'covid_daily',
+              },
+            ]}
+            metadata={{ source: text.section_deceased_rivm.bronnen.rivm }}
+            componentCallback={addBackgroundRectangleCallback(
+              dataRivmUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label:
+                  text.section_deceased_rivm
+                    .line_chart_covid_daily_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  text.section_deceased_rivm
+                    .line_chart_covid_daily_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
 
-        <ContentHeader
-          title={siteText.section_sterftemonitor_vr.title}
-          icon={<CoronaVirusIcon />}
-          subtitle={siteText.section_sterftemonitor_vr.description}
-          reference={siteText.section_sterftemonitor_vr.reference}
-          metadata={{
-            datumsText: siteText.section_sterftemonitor_vr.datums,
-            dateOrRange: {
-              start: dataCbs.last_value.date_start_unix,
-              end: dataCbs.last_value.date_end_unix,
-            },
-            dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
-            dataSources: [siteText.section_sterftemonitor_vr.bronnen.cbs],
-          }}
-        />
+          <ContentHeader
+            title={siteText.section_sterftemonitor_vr.title}
+            icon={<CoronaVirusIcon />}
+            subtitle={siteText.section_sterftemonitor_vr.description}
+            reference={siteText.section_sterftemonitor_vr.reference}
+            metadata={{
+              datumsText: siteText.section_sterftemonitor_vr.datums,
+              dateOrRange: {
+                start: dataCbs.last_value.date_start_unix,
+                end: dataCbs.last_value.date_end_unix,
+              },
+              dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
+              dataSources: [siteText.section_sterftemonitor_vr.bronnen.cbs],
+            }}
+          />
 
-        <DeceasedMonitorSection data={dataCbs} />
-      </TileList>
-    </>
+          <DeceasedMonitorSection data={dataCbs} />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-DeceasedRegionalPage.getLayout = getSafetyRegionLayout();
 
 export default DeceasedRegionalPage;

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -4,12 +4,11 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -25,10 +24,8 @@ export const getStaticProps = createGetStaticProps(
   getVrData
 );
 
-const ElderlyAtHomeRegionalPage: FCWithLayout<typeof getStaticProps> = (
-  props
-) => {
-  const { safetyRegionName, data } = props;
+const ElderlyAtHomeRegionalPage = (props) => {
+  const { safetyRegionName, data, lastGenerated } = props;
   const { elderly_at_home, difference } = data;
 
   const { siteText } = useIntl();
@@ -46,203 +43,214 @@ const ElderlyAtHomeRegionalPage: FCWithLayout<typeof getStaticProps> = (
     7
   );
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegion: safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegion: safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegion: safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegion: safetyRegionName,
-        })}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={siteText.thuiswonende_ouderen.titel_sidebar}
-          title={replaceVariablesInText(text.section_positive_tested.title, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<ElderlyIcon />}
-          subtitle={replaceVariablesInText(
-            text.section_positive_tested.description,
-            {
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={
+              siteText.veiligheidsregio_layout.headings.kwetsbare_groepen
+            }
+            screenReaderCategory={siteText.thuiswonende_ouderen.titel_sidebar}
+            title={replaceVariablesInText(text.section_positive_tested.title, {
               safetyRegion: safetyRegionName,
-            }
-          )}
-          metadata={{
-            datumsText: text.section_positive_tested.datums,
-            dateOrRange: elderly_at_home.last_value.date_unix,
-            dateOfInsertionUnix:
-              elderly_at_home.last_value.date_of_insertion_unix,
-            dataSources: [text.section_positive_tested.bronnen.rivm],
-          }}
-          reference={text.section_positive_tested.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_positive_tested.kpi_daily_title}
-            metadata={{
-              date: elderly_at_home.last_value.date_unix,
-              source: text.section_positive_tested.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="positive_tested_daily"
-              absolute={elderly_at_home.last_value.positive_tested_daily}
-              difference={difference.elderly_at_home__positive_tested_daily}
-            />
-            <Text>{text.section_positive_tested.kpi_daily_description}</Text>
-          </KpiTile>
-          <KpiTile
-            title={text.section_positive_tested.kpi_daily_per_100k_title}
-            metadata={{
-              date: elderly_at_home.last_value.date_unix,
-              source: text.section_positive_tested.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="positive_tested_daily_per_100k"
-              absolute={
-                elderly_at_home.last_value.positive_tested_daily_per_100k
+            })}
+            icon={<ElderlyIcon />}
+            subtitle={replaceVariablesInText(
+              text.section_positive_tested.description,
+              {
+                safetyRegion: safetyRegionName,
               }
-            />
-            <Text>
-              {text.section_positive_tested.kpi_daily_per_100k_description}
-            </Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_positive_tested.line_chart_daily_title}
-          values={elderly_at_home.values}
-          ariaDescription={graphDescriptions.thuiswonende_ouderen_besmettingen}
-          linesConfig={[
-            {
-              metricProperty: 'positive_tested_daily',
-            },
-          ]}
-          metadata={{ source: text.section_positive_tested.bronnen.rivm }}
-          componentCallback={addBackgroundRectangleCallback(
-            elderlyAtHomeUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= elderlyAtHomeUnderReportedRange[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.section_positive_tested.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label:
-                text.section_positive_tested.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ContentHeader
-          title={replaceVariablesInText(text.section_deceased.title, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<ElderlyIcon />}
-          subtitle={replaceVariablesInText(text.section_deceased.description, {
-            safetyRegion: safetyRegionName,
-          })}
-          metadata={{
-            datumsText: text.section_deceased.datums,
-            dateOrRange: elderly_at_home.last_value.date_unix,
-            dateOfInsertionUnix:
-              elderly_at_home.last_value.date_of_insertion_unix,
-            dataSources: [text.section_deceased.bronnen.rivm],
-          }}
-          reference={text.section_deceased.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={text.section_deceased.kpi_daily_title}
-            description={text.section_deceased.kpi_daily_description}
+            )}
             metadata={{
-              date: elderly_at_home.last_value.date_unix,
-              source: text.section_deceased.bronnen.rivm,
+              datumsText: text.section_positive_tested.datums,
+              dateOrRange: elderly_at_home.last_value.date_unix,
+              dateOfInsertionUnix:
+                elderly_at_home.last_value.date_of_insertion_unix,
+              dataSources: [text.section_positive_tested.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={elderly_at_home.last_value.deceased_daily}
-            />
-          </KpiTile>
-        </TwoKpiSection>
+            reference={text.section_positive_tested.reference}
+          />
 
-        <LineChartTile
-          timeframeOptions={['all', '5weeks']}
-          title={text.section_deceased.line_chart_daily_title}
-          ariaDescription={graphDescriptions.thuiswonende_ouderen_overleden}
-          values={elderly_at_home.values}
-          linesConfig={[
-            {
-              metricProperty: 'deceased_daily',
-            },
-          ]}
-          metadata={{ source: text.section_positive_tested.bronnen.rivm }}
-          componentCallback={addBackgroundRectangleCallback(
-            elderlyAtHomeDeceasedUnderReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_positive_tested.kpi_daily_title}
+              metadata={{
+                date: elderly_at_home.last_value.date_unix,
+                source: text.section_positive_tested.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="positive_tested_daily"
+                absolute={elderly_at_home.last_value.positive_tested_daily}
+                difference={difference.elderly_at_home__positive_tested_daily}
               />
-            );
-          }}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.section_deceased.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.section_deceased.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+              <Text>{text.section_positive_tested.kpi_daily_description}</Text>
+            </KpiTile>
+            <KpiTile
+              title={text.section_positive_tested.kpi_daily_per_100k_title}
+              metadata={{
+                date: elderly_at_home.last_value.date_unix,
+                source: text.section_positive_tested.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="positive_tested_daily_per_100k"
+                absolute={
+                  elderly_at_home.last_value.positive_tested_daily_per_100k
+                }
+              />
+              <Text>
+                {text.section_positive_tested.kpi_daily_per_100k_description}
+              </Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_positive_tested.line_chart_daily_title}
+            values={elderly_at_home.values}
+            ariaDescription={
+              graphDescriptions.thuiswonende_ouderen_besmettingen
+            }
+            linesConfig={[
+              {
+                metricProperty: 'positive_tested_daily',
+              },
+            ]}
+            metadata={{ source: text.section_positive_tested.bronnen.rivm }}
+            componentCallback={addBackgroundRectangleCallback(
+              elderlyAtHomeUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= elderlyAtHomeUnderReportedRange[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label:
+                  text.section_positive_tested.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label:
+                  text.section_positive_tested
+                    .line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+
+          <ContentHeader
+            title={replaceVariablesInText(text.section_deceased.title, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<ElderlyIcon />}
+            subtitle={replaceVariablesInText(
+              text.section_deceased.description,
+              {
+                safetyRegion: safetyRegionName,
+              }
+            )}
+            metadata={{
+              datumsText: text.section_deceased.datums,
+              dateOrRange: elderly_at_home.last_value.date_unix,
+              dateOfInsertionUnix:
+                elderly_at_home.last_value.date_of_insertion_unix,
+              dataSources: [text.section_deceased.bronnen.rivm],
+            }}
+            reference={text.section_deceased.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={text.section_deceased.kpi_daily_title}
+              description={text.section_deceased.kpi_daily_description}
+              metadata={{
+                date: elderly_at_home.last_value.date_unix,
+                source: text.section_deceased.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={elderly_at_home.last_value.deceased_daily}
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          <LineChartTile
+            timeframeOptions={['all', '5weeks']}
+            title={text.section_deceased.line_chart_daily_title}
+            ariaDescription={graphDescriptions.thuiswonende_ouderen_overleden}
+            values={elderly_at_home.values}
+            linesConfig={[
+              {
+                metricProperty: 'deceased_daily',
+              },
+            ]}
+            metadata={{ source: text.section_positive_tested.bronnen.rivm }}
+            componentCallback={addBackgroundRectangleCallback(
+              elderlyAtHomeDeceasedUnderReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
+            )}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInaccurateValue =
+                value.__date >= elderlyAtHomeDeceasedUnderReportedRange[0];
+
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInaccurateValue}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.section_deceased.line_chart_legend_trend_label,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.section_deceased.line_chart_legend_inaccurate_label,
+                shape: 'square',
+              },
+            ]}
+            showLegend
+          />
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-ElderlyAtHomeRegionalPage.getLayout = getSafetyRegionLayout();
 
 export default ElderlyAtHomeRegionalPage;

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -6,12 +6,11 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic';
-import { SEOHead } from '~/components-styled/seo-head';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -27,8 +26,8 @@ export const getStaticProps = createGetStaticProps(
   getVrData
 );
 
-const NursingHomeCare: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, safetyRegionName } = props;
+const NursingHomeCare = (props) => {
+  const { data, safetyRegionName, lastGenerated } = props;
 
   const { siteText } = useIntl();
 
@@ -45,218 +44,71 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = (props) => {
     7
   );
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(locationsText.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(locationsText.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(locationsText.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(
-          locationsText.metadata.description,
-          {
-            safetyRegionName,
-          }
-        )}
-      />
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.kwetsbare_groepen}
-          screenReaderCategory={
-            siteText.verpleeghuis_besmette_locaties.titel_sidebar
-          }
-          title={replaceVariablesInText(positiveTestPeopleText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Verpleeghuiszorg />}
-          subtitle={replaceVariablesInText(
-            positiveTestPeopleText.pagina_toelichting,
-            {
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={
+              siteText.veiligheidsregio_layout.headings.kwetsbare_groepen
+            }
+            screenReaderCategory={
+              siteText.verpleeghuis_besmette_locaties.titel_sidebar
+            }
+            title={replaceVariablesInText(positiveTestPeopleText.titel, {
               safetyRegion: safetyRegionName,
-            }
-          )}
-          metadata={{
-            datumsText: positiveTestPeopleText.datums,
-            dateOrRange: nursinghomeLastValue.date_unix,
-            dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
-            dataSources: [positiveTestPeopleText.bronnen.rivm],
-          }}
-          reference={positiveTestPeopleText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={positiveTestPeopleText.barscale_titel}
-            description={positiveTestPeopleText.extra_uitleg}
-            metadata={{
-              date: nursinghomeLastValue.date_unix,
-              source: positiveTestPeopleText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="newly_infected_people"
-              absolute={nursinghomeLastValue.newly_infected_people}
-              difference={data.difference.nursing_home__newly_infected_people}
-            />
-          </KpiTile>
-        </TwoKpiSection>
-
-        <LineChartTile
-          metadata={{ source: positiveTestPeopleText.bronnen.rivm }}
-          title={positiveTestPeopleText.linechart_titel}
-          ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
-          values={data.nursing_home.values}
-          linesConfig={[
-            {
-              metricProperty: 'newly_infected_people',
-            },
-          ]}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInaccurateValue =
-              value.__date >= nursinghomeDataUnderReportedValues[0];
-
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInaccurateValue}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          componentCallback={addBackgroundRectangleCallback(
-            nursinghomeDataUnderReportedValues,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: positiveTestPeopleText.line_chart_legend_trend_label,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: positiveTestPeopleText.line_chart_legend_inaccurate_label,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-
-        <ContentHeader
-          id="besmette-locaties"
-          skipLinkAnchor={true}
-          title={replaceVariablesInText(locationsText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Locatie />}
-          subtitle={locationsText.pagina_toelichting}
-          metadata={{
-            datumsText: locationsText.datums,
-            dateOrRange: nursinghomeLastValue.date_unix,
-            dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
-            dataSources: [locationsText.bronnen.rivm],
-          }}
-          reference={locationsText.reference}
-        />
-
-        <TwoKpiSection>
-          <KpiTile
-            title={locationsText.kpi_titel}
-            metadata={{
-              date: nursinghomeLastValue.date_unix,
-              source: locationsText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="infected_locations_total"
-              absolute={nursinghomeLastValue.infected_locations_total}
-              percentage={nursinghomeLastValue.infected_locations_percentage}
-              difference={
-                data.difference.nursing_home__infected_locations_total
+            })}
+            icon={<Verpleeghuiszorg />}
+            subtitle={replaceVariablesInText(
+              positiveTestPeopleText.pagina_toelichting,
+              {
+                safetyRegion: safetyRegionName,
               }
-            />
-            <Text>{locationsText.kpi_toelichting}</Text>
-          </KpiTile>
-          <KpiTile
-            title={locationsText.barscale_titel}
+            )}
             metadata={{
-              date: nursinghomeLastValue.date_unix,
-              source: locationsText.bronnen.rivm,
+              datumsText: positiveTestPeopleText.datums,
+              dateOrRange: nursinghomeLastValue.date_unix,
+              dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
+              dataSources: [positiveTestPeopleText.bronnen.rivm],
             }}
-          >
-            <KpiValue
-              data-cy="newly_infected_locations"
-              absolute={nursinghomeLastValue.newly_infected_locations}
-            />
-            <Text>{locationsText.barscale_toelichting}</Text>
-          </KpiTile>
-        </TwoKpiSection>
-
-        {nursinghomeLastValue.infected_locations_total !== undefined && (
-          <LineChartTile
-            title={locationsText.linechart_titel}
-            ariaDescription={
-              graphDescriptions.verpleeghuiszorg_besmette_locaties
-            }
-            values={data.nursing_home.values}
-            linesConfig={[
-              {
-                metricProperty: 'infected_locations_total',
-              },
-            ]}
-            metadata={{
-              source: locationsText.bronnen.rivm,
-            }}
+            reference={positiveTestPeopleText.reference}
           />
-        )}
 
-        <ContentHeader
-          id="sterfte"
-          skipLinkAnchor={true}
-          title={replaceVariablesInText(mortalityText.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<CoronaVirus />}
-          subtitle={mortalityText.pagina_toelichting}
-          metadata={{
-            datumsText: mortalityText.datums,
-            dateOrRange: nursinghomeLastValue.date_unix,
-            dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
-            dataSources: [mortalityText.bronnen.rivm],
-          }}
-          reference={mortalityText.reference}
-        />
+          <TwoKpiSection>
+            <KpiTile
+              title={positiveTestPeopleText.barscale_titel}
+              description={positiveTestPeopleText.extra_uitleg}
+              metadata={{
+                date: nursinghomeLastValue.date_unix,
+                source: positiveTestPeopleText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_people"
+                absolute={nursinghomeLastValue.newly_infected_people}
+                difference={data.difference.nursing_home__newly_infected_people}
+              />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <TwoKpiSection>
-          <KpiTile
-            title={mortalityText.barscale_titel}
-            description={mortalityText.extra_uitleg}
-            metadata={{
-              date: nursinghomeLastValue.date_unix,
-              source: mortalityText.bronnen.rivm,
-            }}
-          >
-            <KpiValue
-              data-cy="deceased_daily"
-              absolute={nursinghomeLastValue.deceased_daily}
-              difference={data.difference.nursing_home__deceased_daily}
-            />
-          </KpiTile>
-        </TwoKpiSection>
-
-        {data && (
           <LineChartTile
-            metadata={{ source: mortalityText.bronnen.rivm }}
-            title={mortalityText.linechart_titel}
+            metadata={{ source: positiveTestPeopleText.bronnen.rivm }}
+            title={positiveTestPeopleText.linechart_titel}
+            ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
             values={data.nursing_home.values}
-            ariaDescription={
-              graphDescriptions.verpleeghuiszorg_overleden_getest
-            }
             linesConfig={[
               {
-                metricProperty: 'deceased_daily',
+                metricProperty: 'newly_infected_people',
               },
             ]}
             formatTooltip={(values) => {
@@ -281,23 +133,172 @@ const NursingHomeCare: FCWithLayout<typeof getStaticProps> = (props) => {
             legendItems={[
               {
                 color: colors.data.primary,
-                label: mortalityText.line_chart_legend_trend_label,
+                label: positiveTestPeopleText.line_chart_legend_trend_label,
                 shape: 'line',
               },
               {
                 color: colors.data.underReported,
-                label: mortalityText.line_chart_legend_inaccurate_label,
+                label:
+                  positiveTestPeopleText.line_chart_legend_inaccurate_label,
                 shape: 'square',
               },
             ]}
             showLegend
           />
-        )}
-      </TileList>
-    </>
+
+          <ContentHeader
+            id="besmette-locaties"
+            skipLinkAnchor={true}
+            title={replaceVariablesInText(locationsText.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<Locatie />}
+            subtitle={locationsText.pagina_toelichting}
+            metadata={{
+              datumsText: locationsText.datums,
+              dateOrRange: nursinghomeLastValue.date_unix,
+              dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
+              dataSources: [locationsText.bronnen.rivm],
+            }}
+            reference={locationsText.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={locationsText.kpi_titel}
+              metadata={{
+                date: nursinghomeLastValue.date_unix,
+                source: locationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="infected_locations_total"
+                absolute={nursinghomeLastValue.infected_locations_total}
+                percentage={nursinghomeLastValue.infected_locations_percentage}
+                difference={
+                  data.difference.nursing_home__infected_locations_total
+                }
+              />
+              <Text>{locationsText.kpi_toelichting}</Text>
+            </KpiTile>
+            <KpiTile
+              title={locationsText.barscale_titel}
+              metadata={{
+                date: nursinghomeLastValue.date_unix,
+                source: locationsText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="newly_infected_locations"
+                absolute={nursinghomeLastValue.newly_infected_locations}
+              />
+              <Text>{locationsText.barscale_toelichting}</Text>
+            </KpiTile>
+          </TwoKpiSection>
+
+          {nursinghomeLastValue.infected_locations_total !== undefined && (
+            <LineChartTile
+              title={locationsText.linechart_titel}
+              ariaDescription={
+                graphDescriptions.verpleeghuiszorg_besmette_locaties
+              }
+              values={data.nursing_home.values}
+              linesConfig={[
+                {
+                  metricProperty: 'infected_locations_total',
+                },
+              ]}
+              metadata={{
+                source: locationsText.bronnen.rivm,
+              }}
+            />
+          )}
+
+          <ContentHeader
+            id="sterfte"
+            skipLinkAnchor={true}
+            title={replaceVariablesInText(mortalityText.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<CoronaVirus />}
+            subtitle={mortalityText.pagina_toelichting}
+            metadata={{
+              datumsText: mortalityText.datums,
+              dateOrRange: nursinghomeLastValue.date_unix,
+              dateOfInsertionUnix: nursinghomeLastValue.date_of_insertion_unix,
+              dataSources: [mortalityText.bronnen.rivm],
+            }}
+            reference={mortalityText.reference}
+          />
+
+          <TwoKpiSection>
+            <KpiTile
+              title={mortalityText.barscale_titel}
+              description={mortalityText.extra_uitleg}
+              metadata={{
+                date: nursinghomeLastValue.date_unix,
+                source: mortalityText.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="deceased_daily"
+                absolute={nursinghomeLastValue.deceased_daily}
+                difference={data.difference.nursing_home__deceased_daily}
+              />
+            </KpiTile>
+          </TwoKpiSection>
+
+          {data && (
+            <LineChartTile
+              metadata={{ source: mortalityText.bronnen.rivm }}
+              title={mortalityText.linechart_titel}
+              values={data.nursing_home.values}
+              ariaDescription={
+                graphDescriptions.verpleeghuiszorg_overleden_getest
+              }
+              linesConfig={[
+                {
+                  metricProperty: 'deceased_daily',
+                },
+              ]}
+              formatTooltip={(values) => {
+                const value = values[0];
+                const isInaccurateValue =
+                  value.__date >= nursinghomeDataUnderReportedValues[0];
+
+                return (
+                  <UnderReportedTooltip
+                    value={value}
+                    isInUnderReportedRange={isInaccurateValue}
+                    underReportedText={siteText.common.incomplete}
+                  />
+                );
+              }}
+              componentCallback={addBackgroundRectangleCallback(
+                nursinghomeDataUnderReportedValues,
+                {
+                  fill: colors.data.underReported,
+                }
+              )}
+              legendItems={[
+                {
+                  color: colors.data.primary,
+                  label: mortalityText.line_chart_legend_trend_label,
+                  shape: 'line',
+                },
+                {
+                  color: colors.data.underReported,
+                  label: mortalityText.line_chart_legend_inaccurate_label,
+                  shape: 'square',
+                },
+              ]}
+              showLegend
+            />
+          )}
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-NursingHomeCare.getLayout = getSafetyRegionLayout();
 
 export default NursingHomeCare;

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -8,7 +8,8 @@ import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
 import { LineChartTile } from '~/components-styled/line-chart-tile';
 import { addBackgroundRectangleCallback } from '~/components-styled/line-chart/logic/background-rectangle';
-import { SEOHead } from '~/components-styled/seo-head';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { TileList } from '~/components-styled/tile-list';
 import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { municipalThresholds } from '~/components/choropleth/municipal-thresholds';
@@ -16,8 +17,6 @@ import { MunicipalityChoropleth } from '~/components/choropleth/municipality-cho
 import { createSelectMunicipalHandler } from '~/components/choropleth/select-handlers/create-select-municipal-handler';
 import { createMunicipalHospitalAdmissionsTooltip } from '~/components/choropleth/tooltips/municipal/create-municipal-hospital-admissions-tooltip';
 import regionCodeToMunicipalCodeLookup from '~/data/regionCodeToMunicipalCodeLookup';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import { useIntl } from '~/intl';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
@@ -45,8 +44,8 @@ export const getStaticProps = createGetStaticProps(
   }>(createPageArticlesQuery('hospitalPage'))
 );
 
-const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { data, safetyRegionName, choropleth, content } = props;
+const IntakeHospital = (props) => {
+  const { data, safetyRegionName, choropleth, content, lastGenerated } = props;
   const router = useRouter();
   const { siteText } = useIntl();
 
@@ -59,137 +58,141 @@ const IntakeHospital: FCWithLayout<typeof getStaticProps> = (props) => {
 
   const underReportedRange = getTrailingDateRange(data.hospital_nice.values, 4);
 
+  const metadata = {
+    ...siteText.veiligheidsregio_index.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegionName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegionName,
+    }),
+  };
+
   return (
-    <>
-      <SEOHead
-        title={replaceVariablesInText(text.metadata.title, {
-          safetyRegionName,
-        })}
-        description={replaceVariablesInText(text.metadata.description, {
-          safetyRegionName,
-        })}
-      />
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        <TileList>
+          <ContentHeader
+            category={siteText.veiligheidsregio_layout.headings.ziekenhuizen}
+            title={replaceVariablesInText(text.titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            icon={<Ziekenhuis />}
+            subtitle={text.pagina_toelichting}
+            metadata={{
+              datumsText: text.datums,
+              dateOrRange: lastValue.date_unix,
+              dateOfInsertionUnix: lastValue.date_of_insertion_unix,
+              dataSources: [text.bronnen.rivm],
+            }}
+            reference={text.reference}
+          />
 
-      <TileList>
-        <ContentHeader
-          category={siteText.veiligheidsregio_layout.headings.ziekenhuizen}
-          title={replaceVariablesInText(text.titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          icon={<Ziekenhuis />}
-          subtitle={text.pagina_toelichting}
-          metadata={{
-            datumsText: text.datums,
-            dateOrRange: lastValue.date_unix,
-            dateOfInsertionUnix: lastValue.date_of_insertion_unix,
-            dataSources: [text.bronnen.rivm],
-          }}
-          reference={text.reference}
-        />
+          <ArticleStrip articles={content.articles} />
 
-        <ArticleStrip articles={content.articles} />
+          <TwoKpiSection>
+            <KpiTile
+              title={text.barscale_titel}
+              description={text.extra_uitleg}
+              metadata={{
+                date: lastValue.date_unix,
+                source: text.bronnen.rivm,
+              }}
+            >
+              <KpiValue
+                data-cy="hospital_moving_avg_per_region"
+                absolute={lastValue.admissions_on_date_of_reporting}
+                difference={
+                  data.difference.hospital_nice__admissions_on_date_of_reporting
+                }
+              />
+            </KpiTile>
+          </TwoKpiSection>
 
-        <TwoKpiSection>
-          <KpiTile
-            title={text.barscale_titel}
-            description={text.extra_uitleg}
+          <ChoroplethTile
+            title={replaceVariablesInText(text.map_titel, {
+              safetyRegion: safetyRegionName,
+            })}
+            description={text.map_toelichting}
+            legend={{
+              thresholds:
+                municipalThresholds.hospital_nice
+                  .admissions_on_date_of_reporting,
+              title:
+                siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
+            }}
             metadata={{
               date: lastValue.date_unix,
               source: text.bronnen.rivm,
             }}
           >
-            <KpiValue
-              data-cy="hospital_moving_avg_per_region"
-              absolute={lastValue.admissions_on_date_of_reporting}
-              difference={
-                data.difference.hospital_nice__admissions_on_date_of_reporting
-              }
+            <MunicipalityChoropleth
+              selectedCode={selectedMunicipalCode}
+              highlightSelection={false}
+              data={choropleth.gm}
+              metricName="hospital_nice"
+              metricProperty="admissions_on_date_of_reporting"
+              tooltipContent={createMunicipalHospitalAdmissionsTooltip(
+                siteText.choropleth_tooltip.hospital_admissions,
+                municipalThresholds.hospital_nice
+                  .admissions_on_date_of_reporting,
+                createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
+              )}
+              onSelect={createSelectMunicipalHandler(
+                router,
+                'ziekenhuis-opnames'
+              )}
             />
-          </KpiTile>
-        </TwoKpiSection>
+          </ChoroplethTile>
 
-        <ChoroplethTile
-          title={replaceVariablesInText(text.map_titel, {
-            safetyRegion: safetyRegionName,
-          })}
-          description={text.map_toelichting}
-          legend={{
-            thresholds:
-              municipalThresholds.hospital_nice.admissions_on_date_of_reporting,
-            title: siteText.ziekenhuisopnames_per_dag.chloropleth_legenda.titel,
-          }}
-          metadata={{
-            date: lastValue.date_unix,
-            source: text.bronnen.rivm,
-          }}
-        >
-          <MunicipalityChoropleth
-            selectedCode={selectedMunicipalCode}
-            highlightSelection={false}
-            data={choropleth.gm}
-            metricName="hospital_nice"
-            metricProperty="admissions_on_date_of_reporting"
-            tooltipContent={createMunicipalHospitalAdmissionsTooltip(
-              siteText.choropleth_tooltip.hospital_admissions,
-              municipalThresholds.hospital_nice.admissions_on_date_of_reporting,
-              createSelectMunicipalHandler(router, 'ziekenhuis-opnames')
+          <LineChartTile
+            metadata={{ source: text.bronnen.rivm }}
+            title={text.linechart_titel}
+            description={text.linechart_description}
+            ariaDescription={graphDescriptions.ziekenhuis_opnames}
+            values={data.hospital_nice.values}
+            formatTooltip={(values) => {
+              const value = values[0];
+              const isInrange =
+                value.__date >= underReportedRange[0] &&
+                value.__date <= underReportedRange[1];
+              return (
+                <UnderReportedTooltip
+                  value={value}
+                  isInUnderReportedRange={isInrange}
+                  underReportedText={siteText.common.incomplete}
+                />
+              );
+            }}
+            linesConfig={[
+              {
+                metricProperty: 'admissions_on_date_of_admission',
+              },
+            ]}
+            componentCallback={addBackgroundRectangleCallback(
+              underReportedRange,
+              {
+                fill: colors.data.underReported,
+              }
             )}
-            onSelect={createSelectMunicipalHandler(
-              router,
-              'ziekenhuis-opnames'
-            )}
+            legendItems={[
+              {
+                color: colors.data.primary,
+                label: text.linechart_legend_titel,
+                shape: 'line',
+              },
+              {
+                color: colors.data.underReported,
+                label: text.linechart_legend_underreported_titel,
+                shape: 'square',
+              },
+            ]}
+            showLegend
           />
-        </ChoroplethTile>
-
-        <LineChartTile
-          metadata={{ source: text.bronnen.rivm }}
-          title={text.linechart_titel}
-          description={text.linechart_description}
-          ariaDescription={graphDescriptions.ziekenhuis_opnames}
-          values={data.hospital_nice.values}
-          formatTooltip={(values) => {
-            const value = values[0];
-            const isInrange =
-              value.__date >= underReportedRange[0] &&
-              value.__date <= underReportedRange[1];
-            return (
-              <UnderReportedTooltip
-                value={value}
-                isInUnderReportedRange={isInrange}
-                underReportedText={siteText.common.incomplete}
-              />
-            );
-          }}
-          linesConfig={[
-            {
-              metricProperty: 'admissions_on_date_of_admission',
-            },
-          ]}
-          componentCallback={addBackgroundRectangleCallback(
-            underReportedRange,
-            {
-              fill: colors.data.underReported,
-            }
-          )}
-          legendItems={[
-            {
-              color: colors.data.primary,
-              label: text.linechart_legend_titel,
-              shape: 'line',
-            },
-            {
-              color: colors.data.underReported,
-              label: text.linechart_legend_underreported_titel,
-              shape: 'square',
-            },
-          ]}
-          showLegend
-        />
-      </TileList>
-    </>
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-IntakeHospital.getLayout = getSafetyRegionLayout();
 
 export default IntakeHospital;

--- a/packages/app/src/pages/veiligheidsregio/index.tsx
+++ b/packages/app/src/pages/veiligheidsregio/index.tsx
@@ -2,15 +2,14 @@ import { useRouter } from 'next/router';
 import { Box } from '~/components-styled/base';
 import { ChoroplethTile } from '~/components-styled/choropleth-tile';
 import { EscalationMapLegenda } from '~/components-styled/escalation-map-legenda';
-import { SEOHead } from '~/components-styled/seo-head';
+
 import { TileList } from '~/components-styled/tile-list';
 import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';
 import { SafetyRegionComboBox } from '~/domain/layout/components/safety-region-combo-box';
-import { FCWithLayout } from '~/domain/layout/layout';
-import { getSafetyRegionLayout } from '~/domain/layout/safety-region-layout';
+
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
@@ -19,6 +18,8 @@ import {
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { useIntl } from '~/intl';
+import { Layout } from '~/domain/layout/layout';
+import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -27,13 +28,13 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
-const SafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
+const SafetyRegion = (props) => {
   const router = useRouter();
   const breakpoints = useBreakpoints();
 
   const { siteText, formatDate } = useIntl();
 
-  const { choropleth } = props;
+  const { choropleth, lastGenerated } = props;
 
   const goToSafetyRegion = createSelectRegionHandler(
     router,
@@ -42,64 +43,63 @@ const SafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
   );
 
   return (
-    <>
-      <SEOHead
-        title={siteText.veiligheidsregio_index.metadata.title}
-        description={siteText.veiligheidsregio_index.metadata.description}
-      />
-
-      {!breakpoints.md && (
-        <Box bg="white">
-          <SafetyRegionComboBox onSelect={goToSafetyRegion} />
-        </Box>
-      )}
-
-      <TileList>
-        {siteText.regionaal_index.belangrijk_bericht && (
-          <WarningTile
-            message={siteText.regionaal_index.belangrijk_bericht}
-            variant="emphasis"
-          />
+    <Layout
+      {...siteText.veiligheidsregio_index.metadata}
+      lastGenerated={lastGenerated}
+    >
+      <SafetyRegionLayout lastGenerated={lastGenerated}>
+        {!breakpoints.md && (
+          <Box bg="white">
+            <SafetyRegionComboBox onSelect={goToSafetyRegion} />
+          </Box>
         )}
 
-        <ChoroplethTile
-          title={siteText.veiligheidsregio_index.selecteer_titel}
-          description={
-            <>
-              <div
-                dangerouslySetInnerHTML={{
-                  __html: replaceVariablesInText(
-                    siteText.veiligheidsregio_index.selecteer_toelichting,
-                    {
-                      last_update: formatDate(
-                        choropleth.vr.escalation_levels[0].last_determined_unix,
-                        'day-month'
-                      ),
-                    }
-                  ),
-                }}
-              />
-              <EscalationMapLegenda
-                data={choropleth.vr}
-                metricName="escalation_levels"
-                metricProperty="level"
-              />
-            </>
-          }
-        >
-          <SafetyRegionChoropleth
-            data={choropleth.vr}
-            metricName="escalation_levels"
-            metricProperty="level"
-            onSelect={goToSafetyRegion}
-            tooltipContent={escalationTooltip(goToSafetyRegion)}
-          />
-        </ChoroplethTile>
-      </TileList>
-    </>
+        <TileList>
+          {siteText.regionaal_index.belangrijk_bericht && (
+            <WarningTile
+              message={siteText.regionaal_index.belangrijk_bericht}
+              variant="emphasis"
+            />
+          )}
+
+          <ChoroplethTile
+            title={siteText.veiligheidsregio_index.selecteer_titel}
+            description={
+              <>
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: replaceVariablesInText(
+                      siteText.veiligheidsregio_index.selecteer_toelichting,
+                      {
+                        last_update: formatDate(
+                          choropleth.vr.escalation_levels[0]
+                            .last_determined_unix,
+                          'day-month'
+                        ),
+                      }
+                    ),
+                  }}
+                />
+                <EscalationMapLegenda
+                  data={choropleth.vr}
+                  metricName="escalation_levels"
+                  metricProperty="level"
+                />
+              </>
+            }
+          >
+            <SafetyRegionChoropleth
+              data={choropleth.vr}
+              metricName="escalation_levels"
+              metricProperty="level"
+              onSelect={goToSafetyRegion}
+              tooltipContent={escalationTooltip(goToSafetyRegion)}
+            />
+          </ChoroplethTile>
+        </TileList>
+      </SafetyRegionLayout>
+    </Layout>
   );
 };
-
-SafetyRegion.getLayout = getSafetyRegionLayout();
 
 export default SafetyRegion;

--- a/packages/app/src/pages/verantwoording.tsx
+++ b/packages/app/src/pages/verantwoording.tsx
@@ -2,7 +2,6 @@ import Head from 'next/head';
 import { RichContent } from '~/components-styled/cms/rich-content';
 import { CollapsibleSection } from '~/components-styled/collapsible';
 import { MaxWidth } from '~/components-styled/max-width';
-import { FCWithLayout, GetLayoutWithMetadataKey } from '~/domain/layout/layout';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
   createGetContent,
@@ -12,6 +11,9 @@ import { CollapsibleList, RichContentBlock } from '~/types/cms';
 import { getSkipLinkId } from '~/utils/skipLinks';
 import styles from './over.module.scss';
 import { Box } from '~/components-styled/base';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+
 interface VerantwoordingData {
   title: string | null;
   description: RichContentBlock[] | null;
@@ -56,11 +58,12 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<VerantwoordingData>(query)
 );
 
-const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
+const Verantwoording = (props) => {
+  const { siteText } = useIntl();
+  const { content, lastGenerated } = props;
 
   return (
-    <>
+    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"
@@ -101,10 +104,8 @@ const Verantwoording: FCWithLayout<typeof getStaticProps> = (props) => {
           </div>
         </MaxWidth>
       </div>
-    </>
+    </Layout>
   );
 };
-
-Verantwoording.getLayout = GetLayoutWithMetadataKey('verantwoording_metadata');
 
 export default Verantwoording;

--- a/packages/app/src/pages/verantwoording.tsx
+++ b/packages/app/src/pages/verantwoording.tsx
@@ -63,7 +63,7 @@ const Verantwoording = (props) => {
   const { content, lastGenerated } = props;
 
   return (
-    <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>
+    <Layout {...siteText.verantwoording_metadata} lastGenerated={lastGenerated}>
       <Head>
         <link
           key="dc-type"

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -1,6 +1,5 @@
 import { Box } from '~/components-styled/base';
 import { EditorialDetail } from '~/components-styled/editorial-detail';
-import { FCWithLayout, GetLayoutWithMetadata } from '~/domain/layout/layout';
 import { client, getImageSrc, localize } from '~/lib/sanity';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
 import {
@@ -9,6 +8,7 @@ import {
 } from '~/static-props/get-data';
 import { Block, Editorial, RichContentBlock } from '~/types/cms';
 import { assert } from '~/utils/assert';
+import { Layout } from '~/domain/layout/layout';
 
 const editorialsQuery = `*[_type == 'editorial'] {"slug":slug.current}`;
 
@@ -69,32 +69,27 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
-const EditorialDetailPage: FCWithLayout<typeof getStaticProps> = (props) => {
-  const { content } = props;
-
-  return (
-    <Box backgroundColor="white">
-      <EditorialDetail editorial={content} />
-    </Box>
-  );
-};
-
-/**
- *  @TODO this implementation below is not very sexy yet, its hacked together
- * to simply have _something_
- */
-EditorialDetailPage.getLayout = (page, props) => {
+const EditorialDetailPage = (props) => {
+  const { content, lastGenerated } = props;
   const { cover } = props.content;
   const { asset } = cover;
 
   const imgPath = getImageSrc(asset, 1200);
 
-  return GetLayoutWithMetadata({
+  const metadata = {
     title: getTitle(props.content.title),
     description: toPlainText(props.content.intro),
     openGraphImage: imgPath,
     twitterImage: imgPath,
-  })(page, props);
+  };
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <Box backgroundColor="white">
+        <EditorialDetail editorial={content} />
+      </Box>
+    </Layout>
+  );
 };
 
 export default EditorialDetailPage;


### PR DESCRIPTION
## Summary

While working on https://github.com/minvws/nl-covid19-data-dashboard/pull/2295 I noticed the getLayout helpers [based on this blogpost](https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/) are designed with the idea that siteText is globally available. Instead of overcomplicating things and figuring out a way to pass context to these helpers, I took a step back and decided we're probably better off removing all of the layout abstractions.

Those abstractions make the code less readable, and they hide some of the SEO stuff that's happening. I'd rather hove some duplication in our pages and make it super obvious what SEO settings you're using to rendering the page.

As a pleasant side effect, by putting layout components in your pages you can now use `useIntl()` to retrieve the right settings per page.

## Motivation

- Easier readable code
- Easier to adapt the code
- Not doing this blocks progress on https://github.com/minvws/nl-covid19-data-dashboard/pull/2295

## Detailed design

Basically, this example but with 2 components instead of 1.
https://github.com/vercel/next.js/tree/canary/examples/layout-component

## Drawbacks

- This increases the size of code that needs to pass code review before we can finish an already big refactor. However, I think it's worth it. The code will be easier to maintain and this change is not very complex.

## Todo / Open

- [x] Need to check if all metadata information is provided correctly. I'll do that once I've converted all pages to the new layout components. It should be easy to do with the diff in front of me on GitHub.
