### PR TITLE
Fix UnreportedTooltip for IC admissions line chart

### DIFF
--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -2,7 +2,6 @@ import { getLastFilledValue } from '@corona-dashboard/common';
 import Arts from '~/assets/arts.svg';
 import { ArticleStrip } from '~/components-styled/article-strip';
 import { ArticleSummary } from '~/components-styled/article-teaser';
-import { Box } from '~/components-styled/base';
 import { ContentHeader } from '~/components-styled/content-header';
 import { KpiTile } from '~/components-styled/kpi-tile';
 import { KpiValue } from '~/components-styled/kpi-value';
@@ -15,6 +14,7 @@ import { TwoKpiSection } from '~/components-styled/two-kpi-section';
 import { Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
+import { UnderReportedTooltip } from '~/domain/underreported/under-reported-tooltip';
 import siteText from '~/locale/index';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import { createGetStaticProps } from '~/static-props/create-get-static-props';
@@ -25,8 +25,6 @@ import {
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/createDate';
-import { formatDateFromSeconds } from '~/utils/formatDate';
-import { formatNumber } from '~/utils/formatNumber';
 import {
   DateRange,
   getTrailingDateRange,
@@ -133,6 +131,18 @@ const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
           ]}
           signaalwaarde={10}
           metadata={{ source: text.bronnen.nice }}
+          formatTooltip={(values) => {
+            const value = values[0];
+            return (
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={
+                  value.__date >= intakeUnderReportedRange[0]
+                }
+                underReportedText={siteText.common.incomplete}
+              />
+            );
+          }}
           componentCallback={addBackgroundRectangleCallback(
             intakeUnderReportedRange,
             {
@@ -169,24 +179,13 @@ const IntakeIntensiveCare: FCWithLayout<typeof getStaticProps> = (props) => {
           })}
           formatTooltip={(values) => {
             const value = values[0];
-            const isInaccurateValue = value.__date < lcpsOldDataRange[1];
 
             return (
-              <>
-                <Box display="flex" alignItems="center" flexDirection="column">
-                  {isInaccurateValue && (
-                    <Text as="span" fontSize={0} color={colors.annotation}>
-                      ({siteText.common.incomplete})
-                    </Text>
-                  )}
-                  <Box>
-                    <Text as="span" fontWeight="bold">
-                      {`${formatDateFromSeconds(value.date_unix, 'medium')}: `}
-                    </Text>
-                    {formatNumber(value.__value)}
-                  </Box>
-                </Box>
-              </>
+              <UnderReportedTooltip
+                value={value}
+                isInUnderReportedRange={value.__date < lcpsOldDataRange[1]}
+                underReportedText={siteText.common.incomplete}
+              />
             );
           }}
           legendItems={[


### PR DESCRIPTION
## Summary

The admissions linechart on the IC page shows an unreported area but the tooltip didn't indicate yet that this was underreported data. This pR fixes that.

## Motivation

Bug report

## Detailed design

Simply added the UnderReportedTooltip tooltip to the appropriate chart.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
