### PR TITLE
Add total count to vaccine area chart tooltip

### DIFF
--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -1,6 +1,5 @@
 import {
   formatNumber,
-  isDateSpanValue,
   NlVaccineAdministeredEstimateValue,
   NlVaccineAdministeredValue,
   NlVaccineDeliveryEstimateValue,
@@ -10,6 +9,7 @@ import { Fragment } from 'react';
 import styled from 'styled-components';
 import { HoverPoint } from '~/components-styled/area-chart/components/marker';
 import { TimestampedTrendValue } from '~/components-styled/area-chart/logic';
+import { Spacer } from '~/components-styled/base';
 import { InlineText, Text } from '~/components-styled/typography';
 import { AllLanguages } from '~/locale/APP_LOCALE';
 import { formatDateFromSeconds } from '~/utils/formatDate';
@@ -22,13 +22,7 @@ export type TooltipValue = (
 ) &
   TimestampedTrendValue;
 
-export function createDeliveryTooltipFormatter(text: AllLanguages) {
-  return (values: HoverPoint<TooltipValue>[]) => {
-    return formatVaccinationsTooltip(values, text);
-  };
-}
-
-function formatVaccinationsTooltip(
+export function formatVaccinationsTooltip(
   values: HoverPoint<TooltipValue>[],
   text: AllLanguages
 ) {
@@ -36,15 +30,11 @@ function formatVaccinationsTooltip(
     return null;
   }
 
-  const data = values[0].data;
-
-  if (!isDateSpanValue(data)) {
-    throw new Error(
-      `Invalid value passed to format tooltip function: ${JSON.stringify(
-        values
-      )}`
-    );
-  }
+  /**
+   * The values with administered data are index >= 1. These kind of things will
+   * be solved later when converting to TimeSeriesChart.
+   */
+  const data = values[1].data;
 
   const dateEndString = formatDateFromSeconds(data.date_end_unix, 'day-month');
 
@@ -90,6 +80,13 @@ function formatVaccinationsTooltip(
             )}
           </Fragment>
         ))}
+        <Spacer mb={1} />
+        <TooltipListItem color="transparent">
+          <TooltipValueContainer>
+            {text.vaccinaties.data.vaccination_chart.doses_administered_total}:{' '}
+            <strong>{formatNumber(data.total)}</strong>
+          </TooltipValueContainer>
+        </TooltipListItem>
       </TooltipList>
     </>
   );

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -770,13 +770,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2114,11 +2108,7 @@
     "expected_page_additions": {
       "title": "Expected data on vaccinations",
       "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "",
@@ -2243,11 +2233,7 @@
       "kpi_expected_page_additions": {
         "title": "Expected data on vaccinations",
         "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2268,7 +2254,8 @@
         },
         "legend_label": "Number of {{name}} doses administered",
         "doses_administered": "Number of doses administered",
-        "doses_administered_estimated": "Expected number of doses administered"
+        "doses_administered_estimated": "Expected number of doses administered",
+        "doses_administered_total": "Total"
       }
     },
     "current_amount_of_administrations_text": "So far approximately {{amount}} vaccine doses have been administered.",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -770,13 +770,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2114,11 +2108,7 @@
     "expected_page_additions": {
       "title": "Verwachte toevoegingen aan deze pagina",
       "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "Do not remove this key. It is required as a temporary workaround",
@@ -2243,11 +2233,7 @@
       "kpi_expected_page_additions": {
         "title": "Verwachte toevoegingen aan deze pagina",
         "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2268,7 +2254,8 @@
         },
         "legend_label": "Aantal gezette prikken {{name}}",
         "doses_administered": "Aantal gezette prikken",
-        "doses_administered_estimated": "Verwacht aantal gezette prikken"
+        "doses_administered_estimated": "Verwacht aantal gezette prikken",
+        "doses_administered_total": "Totaal"
       }
     },
     "current_amount_of_administrations_text": "Tot nu toe zijn er ongeveer {{amount}} prikken gezet.",

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -24,7 +24,7 @@ import { InlineText, Text } from '~/components-styled/typography';
 import { FCWithLayout } from '~/domain/layout/layout';
 import { getNationalLayout } from '~/domain/layout/national-layout';
 import { VaccineSupportTooltip } from '~/domain/vaccine/components/vaccine-support-tooltip';
-import { createDeliveryTooltipFormatter } from '~/domain/vaccine/create-delivery-tooltip-formatter';
+import { formatVaccinationsTooltip } from '~/domain/vaccine/create-delivery-tooltip-formatter';
 import {
   MilestonesView,
   MilestoneViewProps,
@@ -249,7 +249,9 @@ const VaccinationPage: FCWithLayout<typeof getStaticProps> = ({
                     valueAnnotation={siteText.waarde_annotaties.x_miljoen}
                     width={width}
                     timeframe="all"
-                    formatTooltip={createDeliveryTooltipFormatter(siteText)}
+                    formatTooltip={(values) =>
+                      formatVaccinationsTooltip(values, siteText)
+                    }
                     divider={{
                       color: colors.annotation,
                       leftLabel: text.data.vaccination_chart.left_divider_label,


### PR DESCRIPTION
## Summary

Display the sum of all administered values in the vaccine area chart tooltip. This PR was inspired by #2234 , but rather than computing the sum we need to have the number as part of the actual supplied data.

