### PR TITLE
No empty message warning

### DIFF
--- a/packages/app/src/domain/topical/topical-choropleth-container.tsx
+++ b/packages/app/src/domain/topical/topical-choropleth-container.tsx
@@ -1,5 +1,6 @@
 import { ChoroplethThresholdsValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
+import { isEmpty } from 'lodash';
 import { ReactNode } from 'react';
 import { Box } from '~/components-styled/base';
 import { ChoroplethLegenda } from '~/components-styled/choropleth-legenda';
@@ -49,7 +50,7 @@ export function TopicalChoroplethContainer({
       pr={{ md: '50%' }}
       minHeight={{ md: '620px' }}
     >
-      {message && (
+      {message && !isEmpty(message) && (
         <Box mb={3}>
           <WarningTile message={message} variant="emphasis" />
         </Box>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -117,10 +117,6 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
                   : undefined
               }
             />
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
 
             <MiniTrendTileLayout>
               <MiniTrendTile
@@ -249,6 +245,9 @@ const TopicalMunicipality: FCWithLayout<typeof getStaticProps> = (props) => {
                       metricName="escalation_levels"
                       metricProperty="level"
                     />
+                  }
+                  message={
+                    siteText.nationaal_actueel.risiconiveaus.belangrijk_bericht
                   }
                 >
                   <SafetyRegionChoropleth

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -11,7 +11,6 @@ import { QuickLinks } from '~/components-styled/quick-links';
 import { RiskLevelIndicator } from '~/components-styled/risk-level-indicator';
 import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
-import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -117,11 +117,6 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
               }}
             />
 
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
-
             <MiniTrendTileLayout>
               <MiniTrendTile
                 title={text.mini_trend_tiles.positief_getest.title}
@@ -228,6 +223,9 @@ const TopicalSafetyRegion: FCWithLayout<typeof getStaticProps> = (props) => {
                       metricName="escalation_levels"
                       metricProperty="level"
                     />
+                  }
+                  message={
+                    siteText.nationaal_actueel.risiconiveaus.belangrijk_bericht
                   }
                 >
                   <SafetyRegionChoropleth

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -13,7 +13,6 @@ import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
-import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -12,7 +12,6 @@ import { SEOHead } from '~/components-styled/seo-head';
 import { TileList } from '~/components-styled/tile-list';
 import { Heading } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
-import { WarningTile } from '~/components-styled/warning-tile';
 import { SafetyRegionChoropleth } from '~/components/choropleth/safety-region-choropleth';
 import { createSelectRegionHandler } from '~/components/choropleth/select-handlers/create-select-region-handler';
 import { escalationTooltip } from '~/components/choropleth/tooltips/region/escalation-tooltip';

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -115,11 +115,6 @@ const Home: FCWithLayout<typeof getStaticProps> = (props) => {
               <Search />
             </Box>
 
-            <WarningTile
-              message={siteText.regionaal_index.belangrijk_bericht}
-              variant="emphasis"
-            />
-
             <MiniTrendTileLayout>
               <MiniTrendTile
                 title={text.mini_trend_tiles.positief_getest.title}


### PR DESCRIPTION
## Summary

This hotfix prevents empty message strings from rendering a warning tile. Empty messages are the only way for communications to disable these things.