### PR TITLE
Fix tooltip showing the 'total' value for all the products

### DIFF
--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -46,8 +46,6 @@ function formatVaccinationsTooltip(
     );
   }
 
-  console.dir(values);
-
   const dateEndString = formatDateFromSeconds(data.date_end_unix, 'day-month');
 
   return (

--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -46,6 +46,8 @@ function formatVaccinationsTooltip(
     );
   }
 
+  console.dir(values);
+
   const dateEndString = formatDateFromSeconds(data.date_end_unix, 'day-month');
 
   return (
@@ -104,10 +106,10 @@ function formatLabel(labelKey: string | undefined, text: AllLanguages) {
 
 function formatValue(value: HoverPoint<TooltipValue>) {
   const data: any = value.data;
-  if (data.total) {
-    return formatNumber(data.total);
+  if (data[value.label as string]) {
+    return formatNumber(data[value.label as string]);
   }
-  return formatNumber(data[value.label as string]);
+  return formatNumber(data.total);
 }
 
 const TooltipList = styled.ol`


### PR DESCRIPTION
## Summary

As the title says.
The tooltip was rendered like this:
![image](https://user-images.githubusercontent.com/69849293/111466328-71560500-8723-11eb-9abb-dbf636f5cc8e.png)
This PR fixes this:
![image](https://user-images.githubusercontent.com/69849293/111466424-9185c400-8723-11eb-930b-a563ac8ed9ad.png)

## Motivation

Bug report

## Detailed design

Due to some data change the total property is now always present, I had flip some logic to make it display the correct data.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
