### PR TITLE
Fix x-axis date range

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/axes.tsx
@@ -35,6 +35,7 @@ type AxesProps = {
    */
   yAxisRef: Ref<SVGGElement>;
   yTickValues?: number[];
+  xTickValues: [number, number];
 };
 
 const formatYAxis = (y: number) => formatNumber(y);
@@ -46,12 +47,13 @@ export const Axes = memo(function Axes({
   numGridLines,
   bounds,
   isPercentage,
-  yTickValues,
   xScale,
   yScale,
+  yTickValues,
+  xTickValues,
   yAxisRef,
 }: AxesProps) {
-  const [startUnix, endUnix] = xScale.domain();
+  const [startUnix, endUnix] = xTickValues;
 
   const formatXAxis = useCallback(
     (date_unix: number) => {
@@ -92,7 +94,7 @@ export const Axes = memo(function Axes({
       />
       <AxisBottom
         scale={xScale}
-        tickValues={xScale.domain()}
+        tickValues={xTickValues}
         tickFormat={formatXAxis as AnyTickFormatter}
         top={bounds.height}
         stroke={colors.silver}

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -56,7 +56,7 @@ export function useScales<T extends TimestampedValue>(args: {
       };
     }
 
-    const [start, end] = getTimeDomain(values);
+    const [start, end] = getTimeDomain(values, { withPadding: true });
 
     const xScale = scaleLinear({
       domain: [start, end],
@@ -93,7 +93,10 @@ export function useScales<T extends TimestampedValue>(args: {
  * series starts and where the last series ends, and that would remove all
  * "empty" space on both ends of the chart.
  */
-function getTimeDomain<T extends TimestampedValue>(values: T[]) {
+export function getTimeDomain<T extends TimestampedValue>(
+  values: T[],
+  { withPadding }: { withPadding: boolean }
+): [start: number, end: number] {
   /**
    * This code is assuming the values array is already sorted in time, so we
    * only need to pick the first and last values.
@@ -111,7 +114,9 @@ function getTimeDomain<T extends TimestampedValue>(values: T[]) {
      * time scale "padding" so that the markers and their date span fall nicely
      * within the "stretched" domain on both ends of the graph.
      */
-    return [start - ONE_DAY_IN_SECONDS, end + ONE_DAY_IN_SECONDS];
+    return withPadding
+      ? [start - ONE_DAY_IN_SECONDS / 2, end + ONE_DAY_IN_SECONDS / 2]
+      : [start, end];
   }
 
   if (isDateSpanSeries(values)) {
@@ -144,7 +149,7 @@ function getDateSpanWidth<T extends TimestampedValue>(
   xScale: ScaleLinear<number, number>
 ) {
   if (isDateSeries(values)) {
-    return xScale(ONE_DAY_IN_SECONDS);
+    return xScale(ONE_DAY_IN_SECONDS) - xScale(0);
   }
 
   if (isDateSpanSeries(values)) {

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -33,6 +33,7 @@ import {
   useScales,
   useSeriesList,
   useValuesInTimeframe,
+  getTimeDomain,
 } from './logic';
 import { useDimensions } from './logic/dimensions';
 export type { SeriesConfig } from './logic';
@@ -291,6 +292,7 @@ export function TimeSeriesChart<
             bounds={bounds}
             numGridLines={numGridLines}
             yTickValues={tickValues}
+            xTickValues={getTimeDomain(values, { withPadding: false })}
             xScale={xScale}
             yScale={yScale}
             isPercentage={isPercentage}

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -143,7 +143,7 @@ export function TimeSeriesChart<
   formatTooltip,
   dataOptions,
   numGridLines = 3,
-  tickValues,
+  tickValues: yTickValues,
   paddingLeft,
   ariaLabelledBy,
   title,
@@ -206,8 +206,13 @@ export function TimeSeriesChart<
       values,
       maximumValue: seriesMax,
       bounds,
-      numTicks: tickValues?.length || numGridLines,
+      numTicks: yTickValues?.length || numGridLines,
     }
+  );
+
+  const xTickValues = useMemo(
+    () => getTimeDomain(values, { withPadding: false }),
+    [values]
   );
 
   const [handleHover, hoverState] = useHoverState({
@@ -291,8 +296,8 @@ export function TimeSeriesChart<
           <Axes
             bounds={bounds}
             numGridLines={numGridLines}
-            yTickValues={tickValues}
-            xTickValues={getTimeDomain(values, { withPadding: false })}
+            yTickValues={yTickValues}
+            xTickValues={xTickValues}
             xScale={xScale}
             yScale={yScale}
             isPercentage={isPercentage}


### PR DESCRIPTION
## Summary

Make sure the x-axis of the time series charts renders the start and end date of the value-range, instead of the padded value-range.