### PR TITLE
Fix area chart tooltip logic

### DIFF
--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -5,12 +5,11 @@ import {
   NlVaccineDeliveryEstimateValue,
   NlVaccineDeliveryValue,
 } from '@corona-dashboard/common';
-import { Fragment } from 'react';
 import styled from 'styled-components';
 import { HoverPoint } from '~/components-styled/area-chart/components/marker';
 import { TimestampedTrendValue } from '~/components-styled/area-chart/logic';
 import { Spacer } from '~/components-styled/base';
-import { InlineText, Text } from '~/components-styled/typography';
+import { Text } from '~/components-styled/typography';
 import { AllLanguages } from '~/locale/APP_LOCALE';
 import { formatDateFromSeconds } from '~/utils/formatDate';
 
@@ -30,13 +29,18 @@ export function formatVaccinationsTooltip(
     return null;
   }
 
-  /**
-   * The values with administered data are index >= 1. These kind of things will
-   * be solved later when converting to TimeSeriesChart.
-   */
-  const data = values[1].data;
+  const [firstValue, ...otherValues] = values;
 
-  const dateEndString = formatDateFromSeconds(data.date_end_unix, 'day-month');
+  /**
+   * The values with administered data are all of the "other" value. These kind
+   * of things will be solved later when converting to TimeSeriesChart.
+   */
+  const administeredData = otherValues[0].data;
+
+  const dateEndString = formatDateFromSeconds(
+    administeredData.date_end_unix,
+    'day-month'
+  );
 
   return (
     <>
@@ -44,47 +48,35 @@ export function formatVaccinationsTooltip(
         {dateEndString}
       </Text>
       <TooltipList>
-        {values.map((value) => (
-          <Fragment key={value.label}>
-            <TooltipListItem color={value.color ?? 'black'}>
-              <TooltipValueContainer>
-                {formatLabel(value.label, text)}:{' '}
-                <strong>{formatValue(value)}</strong>
-              </TooltipValueContainer>
-            </TooltipListItem>
+        <TooltipListItem>
+          <span>
+            <ColorIndicator color={firstValue.color} />
+            {formatLabel(firstValue.label, text)}:
+          </span>
+          <TooltipValueContainer>
+            {formatNumber(firstValue.data.total)}
+          </TooltipValueContainer>
+        </TooltipListItem>
 
-            {/**
-             * This is a bit hacky, but when the current value's label equals
-             * the 'delivered' or 'estimated' label, we'll render an extra
-             * list-item as header for the vaccines which are the next values
-             * in the array.
-             */}
-            {value.label ===
-              text.vaccinaties.data.vaccination_chart.delivered && (
-              <TooltipListItem>
-                <InlineText mt={2} fontWeight="bold">
-                  {text.vaccinaties.data.vaccination_chart.doses_administered}
-                </InlineText>
-              </TooltipListItem>
-            )}
-            {value.label ===
-              text.vaccinaties.data.vaccination_chart.estimated && (
-              <TooltipListItem>
-                <InlineText mt={2} fontWeight="bold">
-                  {
-                    text.vaccinaties.data.vaccination_chart
-                      .doses_administered_estimated
-                  }
-                </InlineText>
-              </TooltipListItem>
-            )}
-          </Fragment>
+        {otherValues.map((value) => (
+          <TooltipListItem key={value.label}>
+            <span>
+              <ColorIndicator color={value.color} />
+              {formatLabel(value.label, text)}:
+            </span>
+            <TooltipValueContainer>
+              <strong>
+                {formatNumber((value.data as any)[value.label as string] || 0)}
+              </strong>
+            </TooltipValueContainer>
+          </TooltipListItem>
         ))}
+
         <Spacer mb={1} />
         <TooltipListItem color="transparent">
           <TooltipValueContainer>
             {text.vaccinaties.data.vaccination_chart.doses_administered_total}:{' '}
-            <strong>{formatNumber(data.total)}</strong>
+            <strong>{formatNumber(administeredData.total)}</strong>
           </TooltipValueContainer>
         </TooltipListItem>
       </TooltipList>
@@ -99,43 +91,34 @@ function formatLabel(labelKey: string | undefined, text: AllLanguages) {
   return labelText ?? labelKey;
 }
 
-function formatValue(value: HoverPoint<TooltipValue>) {
-  const data: any = value.data;
-  if (data[value.label as string]) {
-    return formatNumber(data[value.label as string]);
-  }
-  return formatNumber(data.total);
-}
-
 const TooltipList = styled.ol`
   margin: 0;
   padding: 0;
   list-style: none;
 `;
 
-interface TooltipListItemProps {
+const ColorIndicator = styled.span<{
   color?: string;
-}
-
-const TooltipListItem = styled.li<TooltipListItemProps>`
-  display: flex;
-  align-items: center;
-
+}>`
   &::before {
     content: '';
     display: ${(x) => (x.color ? 'inline-block' : 'none')};
     height: 8px;
     width: 8px;
     border-radius: 50%;
-    background: ${(x) => x.color};
+    background: ${(x) => x.color || 'black'};
     margin-right: 0.5em;
     flex-shrink: 0;
   }
 `;
 
-const TooltipValueContainer = styled.span`
+const TooltipListItem = styled.li`
   display: flex;
-  width: 100%;
-  min-width: 150px;
+  align-items: center;
   justify-content: space-between;
+`;
+
+const TooltipValueContainer = styled.span`
+  font-weight: bold;
+  margin-left: 1em;
 `;

--- a/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
+++ b/packages/app/src/domain/vaccine/create-delivery-tooltip-formatter.tsx
@@ -73,9 +73,12 @@ export function formatVaccinationsTooltip(
         ))}
 
         <Spacer mb={1} />
-        <TooltipListItem color="transparent">
+        <TooltipListItem>
+          <span>
+            <ColorIndicator color="transparent" />
+            {text.vaccinaties.data.vaccination_chart.doses_administered_total}:
+          </span>
           <TooltipValueContainer>
-            {text.vaccinaties.data.vaccination_chart.doses_administered_total}:{' '}
             <strong>{formatNumber(administeredData.total)}</strong>
           </TooltipValueContainer>
         </TooltipListItem>


### PR DESCRIPTION
## Summary
 
The area chart tooltip logic was pretty tangled up. I think this fixes it but I'm honestly not sure what was going on exactly and why I could remove the amount of code I did.

By accident I seem to have included a few styling changes that were part of the bar chart branch....I think they can't hurt and they should be an improvement anyway.

![image](https://user-images.githubusercontent.com/71320230/111498529-50e97300-8742-11eb-92b9-eda678c9ac67.png)

