### PR TITLE
Remove trailing slash config

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -19,16 +19,6 @@ const nextConfig = {
   },
 
   /**
-   * Our static preview environment cannot handle requests like `/{pagename}`
-   * which should resolve to `{pagename}.html`.
-   * The `trailingSlash: true` will export the pages as `/{pagename}/index.html`.
-   *
-   * read more:
-   * https://nextjs.org/docs/api-reference/next.config.js/exportPathMap#adding-a-trailing-slash
-   */
-  trailingSlash: process.env.BUILD_TARGET === 'preview',
-
-  /**
    * Enables react strict mode https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode
    */
   reactStrictMode: true,


### PR DESCRIPTION
## Summary

Since we are now using Vercel for deploy previews, we don't need this configuration anymore.