### PR TITLE
Remove IE11 transpilation

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -2,11 +2,6 @@ const withPlugins = require('next-compose-plugins');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const sitemap = require('./generate-sitemap.js');
 
-const withTM = require('next-transpile-modules')([
-  'internmap', // `internmap` is a dependency of `d3-array`
-  'geometric',
-]);
-
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -81,7 +76,7 @@ const nextConfig = {
     ],
   },*/
 
-  webpack(config, { isServer, webpack, defaultLoaders }) {
+  webpack(config, { isServer, webpack }) {
     if (
       isServer &&
       process.env.DISABLE_SITEMAP !== '1' &&
@@ -130,16 +125,6 @@ const nextConfig = {
       },
     });
 
-    /**
-     * All d3-* packages needs to be transpiled to make them ie11 compatible.
-     * For some reason `next-transpile-modules` doesn't pick them up properly.
-     */
-    config.module.rules.push({
-      test: /\.js$/,
-      loader: defaultLoaders.babel,
-      include: /[\\/]node_modules[\\/](d3-.*|react-use-measure)[\\/]/,
-    });
-
     config.resolve.alias = {
       ...config.resolve.alias,
 
@@ -166,6 +151,6 @@ const nextConfig = {
   },
 };
 
-const plugins = [withTM, withBundleAnalyzer];
+const plugins = [withBundleAnalyzer];
 
 module.exports = withPlugins(plugins, nextConfig);

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -106,7 +106,6 @@
     "lint-staged": "^10.5.4",
     "lodash-webpack-plugin": "^0.11.5",
     "next-compose-plugins": "^2.2.0",
-    "next-transpile-modules": "^6.3.0",
     "node-sass": "^5.0.0",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6542,14 +6542,6 @@ enhanced-resolve@^3.4.0:
     object-assign "^4.0.1"
     tapable "^0.2.7"
 
-enhanced-resolve@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
-  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
-  dependencies:
-    graceful-fs "^4.2.4"
-    tapable "^2.2.0"
-
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -11029,14 +11021,6 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next-transpile-modules@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-6.3.0.tgz#291ccb792cda73322a434590893e9965ed65a533"
-  integrity sha512-ehR2RkJdNrJTvJ/cRCT4/qpcmU/FB/61RcKV4amAgTMSMQD1tmkle0ji38zCUhtffs7H2UfCioDjJxd3zthitg==
-  dependencies:
-    enhanced-resolve "^5.7.0"
-    escalade "^3.1.1"
-
 next@10.0.8:
   version "10.0.8"
   resolved "https://registry.yarnpkg.com/next/-/next-10.0.8.tgz#a2232c11ffad974d67f3d572b8db2acaa5ddedd7"
@@ -15366,11 +15350,6 @@ tapable@^0.2.7:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.9.tgz#af2d8bbc9b04f74ee17af2b4d9048f807acd18a8"
   integrity sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==
-
-tapable@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
-  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
 tar-fs@^1.16.0:
   version "1.16.3"


### PR DESCRIPTION
## Summary

We don't officially support IE11 anymore. That means we don't need to use transpilation either?