### PR TITLE
Remove plugin since we switched to bundling both languages

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -66,7 +66,7 @@ const nextConfig = {
     ],
   },*/
 
-  webpack(config, { isServer, webpack, defaultLoaders }) {
+  webpack(config, { isServer }) {
     if (
       isServer &&
       process.env.DISABLE_SITEMAP !== '1' &&

--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -81,7 +81,7 @@ const nextConfig = {
     ],
   },*/
 
-  webpack(config, { isServer, webpack, defaultLoaders }) {
+  webpack(config, { isServer, defaultLoaders }) {
     if (
       isServer &&
       process.env.DISABLE_SITEMAP !== '1' &&
@@ -93,25 +93,6 @@ const nextConfig = {
         process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
       );
     }
-
-    /** To prevent importing two languages, we use the NormalModuleReplacementPlugin plugin
-     *  We match any import that uses APP_LOCALE and replace it with the value of
-     *  process.env.NEXT_PUBLIC_LOCALE
-     *  e.g. ~/src/locale/APP_LOCALE.json becomes ~/src/locale/nl.json
-     */
-    var appLocale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
-
-    config.plugins.push(
-      new webpack.NormalModuleReplacementPlugin(
-        /(.*)APP_LOCALE(\.*)/,
-        function (resource) {
-          resource.request = resource.request.replace(
-            /APP_LOCALE/,
-            `${appLocale}`
-          );
-        }
-      )
-    );
 
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
## Summary

We used NormalModuleReplacementPlugin plugin to prevent bundling 2 languages in the bundle. This PR removes the plugin in preparation to i18n routing.

## Motivation

- Easier to maintain
- NormalModuleReplacement was unused in the new useIntl() method
- In the future we will serve multiple languages from 1 app, meaning we'll bundle both locales either way

