### PR TITLE
Remove percentage data option from infected over time graphs on VR an…

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -155,7 +155,6 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   },
                 ]}
                 dataOptions={{
-                  isPercentage: true,
                   benchmark: {
                     value: 7,
                     label: siteText.common.signaalwaarde,

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -190,7 +190,6 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   },
                 ]}
                 dataOptions={{
-                  isPercentage: true,
                   benchmark: {
                     value: 7,
                     label: siteText.common.signaalwaarde,


### PR DESCRIPTION
## Summary

Remove percentage data option from infected over time graphs on municipal and region pages

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
