### PR TITLE
Remove chart hover interaction

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
@@ -1,6 +1,6 @@
 import { AreaClosed, LinePath } from '@visx/shape';
 import { PositionScale } from '@visx/shape/lib/types';
-import { MouseEvent, TouchEvent, useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { useUniqueId } from '~/utils/use-unique-id';
 import { SeriesItem, SeriesSingleValue } from '../logic';
@@ -17,7 +17,6 @@ type AreaTrendProps = {
   getX: (v: SeriesItem) => number;
   getY: (v: SeriesSingleValue) => number;
   yScale: PositionScale;
-  onHover: (event: TouchEvent<SVGElement> | MouseEvent<SVGElement>) => void;
 };
 
 export function AreaTrend({
@@ -28,22 +27,10 @@ export function AreaTrend({
   getX,
   getY,
   yScale,
-  onHover,
 }: AreaTrendProps) {
-  const [isHovered, setIsHovered] = useState(false);
-
   const nonNullSeries = useMemo(
     () => series.filter((x) => isPresent(x.__value)),
     [series]
-  );
-
-  const handleHover = useCallback(
-    (event: TouchEvent<SVGElement> | MouseEvent<SVGElement>) => {
-      const isLeave = event.type === 'mouseleave';
-      setIsHovered(!isLeave);
-      onHover(event);
-    },
-    [onHover]
   );
 
   return (
@@ -53,11 +40,7 @@ export function AreaTrend({
         x={getX}
         y={getY}
         stroke={color}
-        strokeWidth={isHovered ? strokeWidth + 1 : strokeWidth}
-        onTouchStart={handleHover}
-        onMouseLeave={handleHover}
-        onMouseOver={handleHover}
-        onMouseMove={handleHover}
+        strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -68,10 +51,6 @@ export function AreaTrend({
         fill={color}
         fillOpacity={fillOpacity}
         yScale={yScale}
-        onTouchStart={handleHover}
-        onMouseLeave={handleHover}
-        onMouseOver={handleHover}
-        onMouseMove={handleHover}
       />
     </>
   );

--- a/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
@@ -1,5 +1,5 @@
 import { LinePath } from '@visx/shape';
-import { MouseEvent, TouchEvent, useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { SeriesItem, SeriesSingleValue } from '../logic';
 
@@ -15,7 +15,6 @@ type LineTrendProps = {
   strokeWidth?: number;
   getX: (v: SeriesItem) => number;
   getY: (v: SeriesSingleValue) => number;
-  onHover: (event: TouchEvent<SVGElement> | MouseEvent<SVGElement>) => void;
 };
 
 export function LineTrend({
@@ -25,25 +24,11 @@ export function LineTrend({
   color,
   getX,
   getY,
-  onHover,
 }: LineTrendProps) {
-  const [isHovered, setIsHovered] = useState(false);
-
   const nonNullSeries = useMemo(
     () => series.filter((x) => isPresent(x.__value)),
     [series]
   );
-
-  const handleHover = useCallback(
-    (event: TouchEvent<SVGElement> | MouseEvent<SVGElement>) => {
-      const isLeave = event.type === 'mouseleave';
-      setIsHovered(!isLeave);
-      onHover(event);
-    },
-    [onHover]
-  );
-
-  const strokeDasharray = style === 'dashed' ? 4 : undefined;
 
   return (
     <LinePath
@@ -51,12 +36,8 @@ export function LineTrend({
       x={getX}
       y={getY}
       stroke={color}
-      strokeWidth={isHovered ? strokeWidth + 1 : strokeWidth}
-      strokeDasharray={strokeDasharray}
-      onTouchStart={handleHover}
-      onMouseLeave={handleHover}
-      onMouseOver={handleHover}
-      onMouseMove={handleHover}
+      strokeWidth={strokeWidth}
+      strokeDasharray={style === 'dashed' ? 4 : undefined}
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -8,7 +8,6 @@ import {
   GetY,
   GetY0,
   GetY1,
-  HoverHandler,
   SeriesConfig,
   SeriesDoubleValue,
   SeriesList,
@@ -16,7 +15,6 @@ import {
 } from '../logic';
 
 interface SeriesProps<T extends TimestampedValue> {
-  onHover?: HoverHandler;
   seriesConfig: SeriesConfig<T>;
   seriesList: SeriesList;
   getX: GetX;
@@ -37,7 +35,6 @@ interface SeriesProps<T extends TimestampedValue> {
 export const Series = memo(SeriesUnmemoized) as typeof SeriesUnmemoized;
 
 function SeriesUnmemoized<T extends TimestampedValue>({
-  onHover,
   seriesConfig,
   seriesList,
   getX,
@@ -63,7 +60,6 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                 strokeWidth={config.strokeWidth}
                 getX={getX}
                 getY={getY}
-                onHover={(evt) => onHover && onHover(evt, index)}
               />
             );
           case 'area':
@@ -78,7 +74,6 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                 getX={getX}
                 getY={getY}
                 yScale={yScale}
-                onHover={(evt) => onHover && onHover(evt, index)}
               />
             );
 


### PR DESCRIPTION
## Summary

The hover interaction of the time-series-chart doesn't add a lot of value, so let's get rid of it.