### PR TITLE
Hide expected additions component if empty

### DIFF
--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -569,9 +569,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
         </TwoKpiSection>
               */}
 
-          <TwoKpiSection>
-            <KpiTile title={text.expected_page_additions.title}>
-              {additions.length > 0 && (
+          {additions.length > 0 && (
+            <TwoKpiSection>
+              <KpiTile title={text.expected_page_additions.title}>
                 <ul>
                   {text.expected_page_additions.additions
                     .filter((x) => x.length)
@@ -581,9 +581,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                       </li>
                     ))}
                 </ul>
-              )}
-            </KpiTile>
-          </TwoKpiSection>
+              </KpiTile>
+            </TwoKpiSection>
+          )}
         </TileList>
       </NationalLayout>
     </Layout>


### PR DESCRIPTION
## Summary

prevent rendering an empty tile:
![image](https://user-images.githubusercontent.com/73584448/112616385-f75d0480-8e23-11eb-849e-1d57451e46d4.png)
