### PR TITLE
Create y-axis tick format feature

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/axes.tsx
@@ -35,6 +35,7 @@ type AxesProps = {
   yAxisRef: Ref<SVGGElement>;
   yTickValues?: number[];
   xTickValues: [number, number];
+  formatYTickValue?: (value: number) => string;
 };
 
 type AnyTickFormatter = (value: any) => string;
@@ -47,6 +48,7 @@ export const Axes = memo(function Axes({
   yScale,
   yTickValues,
   xTickValues,
+  formatYTickValue,
   yAxisRef,
 }: AxesProps) {
   const [startUnix, endUnix] = xTickValues;
@@ -131,7 +133,9 @@ export const Axes = memo(function Axes({
           hideAxisLine
           stroke={colors.silver}
           tickFormat={
-            isPercentage
+            formatYTickValue
+              ? (formatYTickValue as AnyTickFormatter)
+              : isPercentage
               ? (formatYAxisPercentage as AnyTickFormatter)
               : (formatYAxis as AnyTickFormatter)
           }

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -116,6 +116,7 @@ export type TimeSeriesChartProps<
    */
   numGridLines?: number;
   tickValues?: number[];
+  formatTickValue?: (value: number) => string;
   paddingLeft?: number;
   /**
    * The data specific options are grouped together. This way we can pass them
@@ -147,6 +148,7 @@ export function TimeSeriesChart<
   dataOptions,
   numGridLines = 3,
   tickValues: yTickValues,
+  formatTickValue: formatYTickValue,
   paddingLeft,
   ariaLabelledBy,
   tooltipTitle,
@@ -301,6 +303,7 @@ export function TimeSeriesChart<
             numGridLines={numGridLines}
             yTickValues={yTickValues}
             xTickValues={xTickValues}
+            formatYTickValue={formatYTickValue}
             xScale={xScale}
             yScale={yScale}
             isPercentage={isPercentage}


### PR DESCRIPTION
Create y-axis tick formatter in order to format our Y-axis values (e.g. write `1.000.000` as `1M`)