### PR TITLE
Add partially_vaccinated_percentage property to vaccine_coverage_per_age_group schema

### DIFF
--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -22,6 +22,7 @@
         "age_group_range",
         "age_group_total",
         "fully_vaccinated_percentage",
+        "partially_vaccinated_percentage",
         "date_of_insertion_unix",
         "date_unix",
         "date_of_report_unix",
@@ -46,6 +47,9 @@
         },
         "fully_vaccinated_percentage": {
           "type": "number"
+        },
+        "partially_vaccinated_percentage": {
+          "type": "integer"
         },
         "date_unix": {
           "type": "integer"

--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -49,7 +49,7 @@
           "type": "number"
         },
         "partially_vaccinated_percentage": {
-          "type": "integer"
+          "type": "number"
         },
         "date_unix": {
           "type": "integer"

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -703,6 +703,7 @@ export interface NlVaccineCoveragePerAgeGroupValue {
   fully_vaccinated: number;
   partially_vaccinated: number;
   fully_vaccinated_percentage: number;
+  partially_vaccinated_percentage: number;
   date_unix: number;
   date_of_insertion_unix: number;
   date_of_report_unix: number;


### PR DESCRIPTION
## Summary

The title says it all

## Motivation

Missing data

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
