### PR TITLE
Update sidebar with a button for Measures and Risk level items

### DIFF
--- a/packages/app/src/components-styled/aside/menu.tsx
+++ b/packages/app/src/components-styled/aside/menu.tsx
@@ -11,6 +11,7 @@ import { Link } from '~/utils/link';
 import { Box } from '../base';
 import { Category } from './category';
 import { Title } from './title';
+import { asResponsiveArray } from '~/style/utils';
 
 type Url = UrlObject | string;
 
@@ -37,23 +38,15 @@ export function CategoryMenu({
   );
 }
 
-const MetricMenuItem = styled.li(
-  css({
-    borderBottom: '1px solid',
-    borderBottomColor: 'border',
-    '&:first-child': {
-      borderTop: '1px solid',
-      borderTopColor: 'border',
-    },
-  })
-);
-
+type buttonVariantType = 'top' | 'bottom' | 'default';
 interface MetricMenuItemLinkProps {
   title: string;
   icon?: ReactNode;
   href?: Url;
   subtitle?: string;
   children?: ReactNode;
+  isButton?: boolean;
+  buttonVariant?: buttonVariantType;
 }
 
 export function MetricMenuItemLink({
@@ -62,6 +55,8 @@ export function MetricMenuItemLink({
   title,
   subtitle,
   children: children,
+  isButton,
+  buttonVariant = 'default',
 }: MetricMenuItemLinkProps) {
   const router = useRouter();
 
@@ -87,11 +82,23 @@ export function MetricMenuItemLink({
   const isActive = isActivePath(router, href);
 
   return (
-    <MetricMenuItem>
-      <Link href={href} passHref>
-        <StyledLink isActive={isActive}>{content}</StyledLink>
-      </Link>
-    </MetricMenuItem>
+    <>
+      {isButton ? (
+        <MetricMenuButton isActive={isActive} buttonVariant={buttonVariant}>
+          <Link href={href} passHref>
+            <StyledLink isButton isActive={isActive}>
+              {content}
+            </StyledLink>
+          </Link>
+        </MetricMenuButton>
+      ) : (
+        <MetricMenuItem>
+          <Link href={href} passHref>
+            <StyledLink isActive={isActive}>{content}</StyledLink>
+          </Link>
+        </MetricMenuItem>
+      )}
+    </>
   );
 }
 
@@ -105,6 +112,41 @@ function isActivePath(router: NextRouter, href: Url) {
 /**
  * The following css is copied from the layout.scss file, it can be cleaned up
  */
+const MetricMenuItem = styled.li(
+  css({
+    borderBottom: '1px solid',
+    borderBottomColor: 'border',
+
+    '&:first-child': {
+      borderTop: '1px solid',
+      borderTopColor: 'border',
+    },
+  })
+);
+
+const MetricMenuButton = styled.li<{
+  buttonVariant: buttonVariantType;
+  isActive?: boolean;
+}>((x) =>
+  css({
+    borderRadius: x.buttonVariant === 'default' ? 5 : undefined,
+    border: '1px solid',
+    borderColor: 'border',
+
+    borderTopLeftRadius: x.buttonVariant === 'top' ? 5 : undefined,
+    borderTopRightRadius: x.buttonVariant === 'top' ? 5 : undefined,
+    borderBottomLeftRadius: x.buttonVariant === 'bottom' ? 5 : undefined,
+    borderBottomRightRadius: x.buttonVariant === 'bottom' ? 5 : undefined,
+
+    borderTop: x.buttonVariant === 'bottom' ? '0px' : undefined,
+
+    mx: 3,
+    overflow: 'hidden',
+    bg: x.isActive
+      ? asResponsiveArray({ _: null, lg: '#ebebeb' })
+      : 'transparent',
+  })
+);
 
 const ChildrenWrapper = styled.div(
   css({
@@ -118,7 +160,7 @@ const ChildrenWrapper = styled.div(
 const Unavailable = styled.span(
   css({
     display: 'block',
-    padding: '1rem',
+    padding: 3,
     color: 'gray',
 
     svg: {
@@ -128,18 +170,21 @@ const Unavailable = styled.span(
   })
 );
 
-const StyledLink = styled.a<{ isActive: boolean }>((x) =>
+const StyledLink = styled.a<{ isActive: boolean; isButton?: boolean }>((x) =>
   css({
-    padding: '1rem',
+    padding: 3,
     display: 'block',
     borderRight: '5px solid transparent',
     color: 'black',
     textDecoration: 'none',
     position: 'relative',
 
-    bg: x.isActive ? [null, null, null, '#ebebeb'] : 'transparent',
+    bg:
+      x.isActive && !x.isButton
+        ? asResponsiveArray({ _: null, lg: '#ebebeb' })
+        : 'transparent',
     borderRightColor: x.isActive
-      ? [null, null, null, 'sidebarLinkBorder']
+      ? asResponsiveArray({ _: null, lg: 'sidebarLinkBorder' })
       : 'transparent',
 
     '&:hover': {
@@ -151,7 +196,9 @@ const StyledLink = styled.a<{ isActive: boolean }>((x) =>
     },
 
     '&::after': {
-      content: x.isActive ? 'none' : ['none', null, null, "''"],
+      content: x.isActive
+        ? 'none'
+        : asResponsiveArray({ _: 'none', xs: undefined }),
       backgroundImage: `url('/images/chevron.svg')`,
       // match aspect ratio of chevron.svg
       backgroundSize: '0.6em 1.2em',
@@ -159,7 +206,7 @@ const StyledLink = styled.a<{ isActive: boolean }>((x) =>
       width: '0.6em',
       display: 'block',
       position: 'absolute',
-      right: '1em',
+      right: 3,
       top: '1.35em',
     },
   })

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -85,6 +85,20 @@ export function NationalLayout(props: NationalLayoutProps) {
           >
             <Menu>
               <MetricMenuItemLink
+                title={siteText.nationaal_maatregelen.titel_sidebar}
+                subtitle={siteText.nationaal_maatregelen.subtitel_sidebar}
+                isButton
+                href={{
+                  pathname: '/landelijk/maatregelen',
+                  query: breakpoints.md
+                    ? {} // only add menu flags on narrow devices
+                    : isMenuOpen
+                    ? { menu: '0' }
+                    : { menu: '1' },
+                }}
+              />
+
+              {/* <MetricMenuItemLink
                 href={{
                   pathname: '/landelijk/maatregelen',
                   query: breakpoints.md
@@ -95,7 +109,7 @@ export function NationalLayout(props: NationalLayoutProps) {
                 }}
                 title={siteText.nationaal_maatregelen.titel_sidebar}
                 subtitle={siteText.nationaal_maatregelen.subtitel_sidebar}
-              />
+              /> */}
 
               <CategoryMenu
                 title={siteText.nationaal_layout.headings.vaccinaties}

--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -114,6 +114,8 @@ export function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
                   <MetricMenuItemLink
                     href={`/veiligheidsregio/${code}/maatregelen`}
                     title={siteText.veiligheidsregio_maatregelen.titel_sidebar}
+                    isButton
+                    buttonVariant="top"
                     subtitle={
                       siteText.veiligheidsregio_maatregelen.subtitel_sidebar
                     }
@@ -121,6 +123,8 @@ export function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
                   <MetricMenuItemLink
                     href={`/veiligheidsregio/${code}/risiconiveau`}
                     title={siteText.veiligheidsregio_layout.headings.inschaling}
+                    isButton
+                    buttonVariant="bottom"
                   >
                     <Box mt={2}>
                       <EscalationLevelInfoLabel


### PR DESCRIPTION
The sidebar can now render a button styling for an item.
It introduces the `isButton` and `buttonVariant` properties to display them nicely on the screen. 

Default
<img width="392" alt="Screenshot 2021-03-29 at 14 39 21" src="https://user-images.githubusercontent.com/76471292/112837815-a277f300-909c-11eb-81ad-90ea6590cb97.png">

Top and bottom stacked on top of each other
<img width="387" alt="Screenshot 2021-03-29 at 14 39 31" src="https://user-images.githubusercontent.com/76471292/112837825-a572e380-909c-11eb-8eab-52bd736882f1.png">

