### PR TITLE
Hide additions block on vaccinations page when no additions are defined

### DIFF
--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -569,9 +569,10 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
         </TwoKpiSection>
               */}
 
-          {additions.length > 0 && (
-            <TwoKpiSection>
-              <KpiTile title={text.expected_page_additions.title}>
+          <TwoKpiSection>
+            <KpiTile title={text.expected_page_additions.title}>
+              <Text>{text.expected_page_additions.description}</Text>
+              {additions.length > 0 && (
                 <ul>
                   {additions.map((addition) => (
                     <li key={addition}>
@@ -579,9 +580,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                     </li>
                   ))}
                 </ul>
-              </KpiTile>
-            </TwoKpiSection>
-          )}
+              )}
+            </KpiTile>
+          </TwoKpiSection>
         </TileList>
       </NationalLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -569,21 +569,19 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
         </TwoKpiSection>
               */}
 
-          <TwoKpiSection>
-            <KpiTile title={text.expected_page_additions.title}>
-              {additions.length > 0 && (
+          {additions.length > 0 && (
+            <TwoKpiSection>
+              <KpiTile title={text.expected_page_additions.title}>
                 <ul>
-                  {text.expected_page_additions.additions
-                    .filter((x) => x.length)
-                    .map((addition) => (
-                      <li key={addition}>
-                        <InlineText>{addition}</InlineText>
-                      </li>
-                    ))}
+                  {additions.map((addition) => (
+                    <li key={addition}>
+                      <InlineText>{addition}</InlineText>
+                    </li>
+                  ))}
                 </ul>
-              )}
-            </KpiTile>
-          </TwoKpiSection>
+              </KpiTile>
+            </TwoKpiSection>
+          )}
         </TileList>
       </NationalLayout>
     </Layout>


### PR DESCRIPTION
## Summary

As the title states. Nuff said.

## Motivation

Bug report

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
