### PR TITLE
Remove timeframe toggle from g-number chart

### DIFF
--- a/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
+++ b/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
@@ -1,5 +1,5 @@
 import { NlGNumber, VrGNumber } from '@corona-dashboard/common';
-import { ChartTileWithTimeframe } from '~/components-styled/chart-tile';
+import { ChartTile } from '~/components-styled/chart-tile';
 import { InlineText } from '~/components-styled/typography';
 import { VerticalBarChart } from '~/components-styled/vertical-bar-chart';
 import { useIntl } from '~/intl';
@@ -14,8 +14,6 @@ interface GNumberBarChartTileProps {
 
 export function GNumberBarChartTile({
   data: __data,
-  timeframeOptions = ['5weeks'],
-  timeframeInitialValue = '5weeks',
 }: GNumberBarChartTileProps) {
   const { formatPercentage, siteText } = useIntl();
 
@@ -25,47 +23,43 @@ export function GNumberBarChartTile({
   const last_value = __data.last_value;
 
   return (
-    <ChartTileWithTimeframe
+    <ChartTile
       title={text.title}
       description={text.description}
-      timeframeOptions={timeframeOptions}
-      timeframeInitialValue={timeframeInitialValue}
       metadata={{
         date: last_value.date_of_insertion_unix,
         source: text.bronnen,
       }}
     >
-      {(timeframe) => (
-        <VerticalBarChart
-          timeframe={timeframe}
-          ariaLabelledBy="chart_g_number"
-          values={values}
-          numGridLines={3}
-          dataOptions={{
-            isPercentage: true,
-          }}
-          seriesConfig={[
-            {
-              type: 'bar',
-              metricProperty: 'g_number',
-              color: colors.data.primary,
-              secondaryColor: colors.red,
-            },
-          ]}
-          formatTooltip={({ value }) => {
-            return (
-              <>
-                <InlineText fontWeight="bold">
-                  {`${formatPercentage(value.g_number)}% `}
-                </InlineText>
-                {value.g_number > 0
-                  ? text.positive_descriptor
-                  : text.negative_descriptor}
-              </>
-            );
-          }}
-        />
-      )}
-    </ChartTileWithTimeframe>
+      <VerticalBarChart
+        timeframe={'5weeks'}
+        ariaLabelledBy="chart_g_number"
+        values={values}
+        numGridLines={3}
+        dataOptions={{
+          isPercentage: true,
+        }}
+        seriesConfig={[
+          {
+            type: 'bar',
+            metricProperty: 'g_number',
+            color: colors.data.primary,
+            secondaryColor: colors.red,
+          },
+        ]}
+        formatTooltip={({ value }) => {
+          return (
+            <>
+              <InlineText fontWeight="bold">
+                {`${formatPercentage(value.g_number)}% `}
+              </InlineText>
+              {value.g_number > 0
+                ? text.positive_descriptor
+                : text.negative_descriptor}
+            </>
+          );
+        }}
+      />
+    </ChartTile>
   );
 }


### PR DESCRIPTION
## Summary

Removed timeframe toggle from g-number chart and gave it a default timeframe of 5weeks
