### PR TITLE
Add separate datum key for vaccination willingness content header

### DIFF
--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2084,6 +2084,7 @@
     "title": "COVID-19 vaccinations",
     "description": "Vaccination is the most important step towards getting life back to normal. The Netherlands began vaccinating people against COVID-19 on 6 January 2021. Eventually, the vaccine will be offered to everyone aged 18 and over. This page shows how many doses of vaccine have been administered and how many doses are on their way.",
     "datums": "Last values obtained on {{dateOfInsertion}}. Is updated on a daily basis.",
+    "bereidheid_datums": "Last values obtained on {{dateOfInsertion}}. Is updated every 3 weeks.",
     "date_unix": "1613650547",
     "date_of_insertion_unix": "1613650547",
     "reference": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -2084,6 +2084,7 @@
     "title": "COVID-19-vaccinaties",
     "description": "Vaccineren is de belangrijkste stap naar een samenleving zonder coronaregels. Op 6 januari 2021 is Nederland begonnen met vaccineren. Uiteindelijk komt iedereen van 18 jaar of ouder aan de beurt. De cijfers op deze pagina laten zien hoeveel prikken zijn gezet en hoeveel vaccins er beschikbaar komen.",
     "datums": "Laatste waardes verkregen op {{dateOfInsertion}}. Wordt dagelijks bijgewerkt.",
+    "bereidheid_datums": "Laatste waardes verkregen op {{dateOfInsertion}}. Wordt 3-wekelijks bijgewerkt.",
     "date_unix": "1613650547",
     "date_of_insertion_unix": "1613650547",
     "reference": {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -373,7 +373,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             reference={text.bereidheid_section.reference}
             icon={scaledVaccineIcon}
             metadata={{
-              datumsText: text.datums,
+              datumsText: text.bereidheid_datums,
               dateOrRange:
                 data.vaccine_support.last_value.date_of_insertion_unix,
               dateOfInsertionUnix:


### PR DESCRIPTION
## Summary

As per the title

## Motivation

Design request.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
