### PR TITLE
G number tweaks

### DIFF
--- a/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
+++ b/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
@@ -1,5 +1,5 @@
 import { NlGNumber, VrGNumber } from '@corona-dashboard/common';
-import { ChartTile } from '~/components-styled/chart-tile';
+import { ChartTileWithTimeframe } from '~/components-styled/chart-tile';
 import { InlineText } from '~/components-styled/typography';
 import { VerticalBarChart } from '~/components-styled/vertical-bar-chart';
 import { useIntl } from '~/intl';
@@ -14,6 +14,8 @@ interface GNumberBarChartTileProps {
 
 export function GNumberBarChartTile({
   data: __data,
+  timeframeOptions = ['5weeks', 'week'],
+  timeframeInitialValue = '5weeks',
 }: GNumberBarChartTileProps) {
   const { formatPercentage, siteText } = useIntl();
 
@@ -23,43 +25,47 @@ export function GNumberBarChartTile({
   const last_value = __data.last_value;
 
   return (
-    <ChartTile
+    <ChartTileWithTimeframe
       title={text.title}
       description={text.description}
+      timeframeOptions={timeframeOptions}
+      timeframeInitialValue={timeframeInitialValue}
       metadata={{
         date: last_value.date_of_insertion_unix,
         source: text.bronnen,
       }}
     >
-      <VerticalBarChart
-        timeframe={'5weeks'}
-        ariaLabelledBy="chart_g_number"
-        values={values}
-        numGridLines={3}
-        dataOptions={{
-          isPercentage: true,
-        }}
-        seriesConfig={[
-          {
-            type: 'bar',
-            metricProperty: 'g_number',
-            color: colors.data.primary,
-            secondaryColor: colors.red,
-          },
-        ]}
-        formatTooltip={({ value }) => {
-          return (
-            <>
-              <InlineText fontWeight="bold">
-                {`${formatPercentage(value.g_number)}% `}
-              </InlineText>
-              {value.g_number > 0
-                ? text.positive_descriptor
-                : text.negative_descriptor}
-            </>
-          );
-        }}
-      />
-    </ChartTile>
+      {(timeframe) => (
+        <VerticalBarChart
+          timeframe={timeframe}
+          ariaLabelledBy="chart_g_number"
+          values={values}
+          numGridLines={3}
+          dataOptions={{
+            isPercentage: true,
+          }}
+          seriesConfig={[
+            {
+              type: 'bar',
+              metricProperty: 'g_number',
+              color: colors.red,
+              secondaryColor: colors.data.primary,
+            },
+          ]}
+          formatTooltip={({ value }) => {
+            return (
+              <>
+                <InlineText fontWeight="bold">
+                  {`${formatPercentage(Math.abs(value.g_number))}% `}
+                </InlineText>
+                {value.g_number > 0
+                  ? text.positive_descriptor
+                  : text.negative_descriptor}
+              </>
+            );
+          }}
+        />
+      )}
+    </ChartTileWithTimeframe>
   );
 }

--- a/packages/app/src/utils/timeframe/index.ts
+++ b/packages/app/src/utils/timeframe/index.ts
@@ -70,7 +70,7 @@ export function getValuesInTimeframe<T extends TimestampedValue>(
 
   if (isDateSpanSeries(values)) {
     return values.filter(
-      (x: DateSpanValue) => x.date_start_unix >= boundary
+      (x: DateSpanValue) => x.date_end_unix >= boundary
     ) as T[];
   }
 


### PR DESCRIPTION
## Summary

- Remove the negative sign in the tooltip since the copy insinuates the growth/decrease
- Updated the getValuesInTimeframe function to return values from date spans based on the date_end_unix value
- Switched the colors

