### PR TITLE
Add partially_or_fully_vaccinated_percentage to vaccine_coverage_per_age_group schema

### DIFF
--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -23,6 +23,7 @@
         "age_group_total",
         "fully_vaccinated_percentage",
         "partially_vaccinated_percentage",
+        "partially_or_fully_vaccinated_percentage",
         "date_of_insertion_unix",
         "date_unix",
         "date_of_report_unix",
@@ -49,6 +50,9 @@
           "type": "number"
         },
         "partially_vaccinated_percentage": {
+          "type": "number"
+        },
+        "partially_or_fully_vaccinated_percentage": {
           "type": "number"
         },
         "date_unix": {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -715,6 +715,7 @@ export interface NlVaccineCoveragePerAgeGroupValue {
   partially_vaccinated: number;
   fully_vaccinated_percentage: number;
   partially_vaccinated_percentage: number;
+  partially_or_fully_vaccinated_percentage: number;
   date_unix: number;
   date_of_insertion_unix: number;
   date_of_report_unix: number;


### PR DESCRIPTION
## Summary

As the title states

## Motivation

Feature request

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
