### PR TITLE
Remove last week option from timeframe nursing home charts

### DIFF
--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -106,6 +106,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
             metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
             title={positiveTestedPeopleText.linechart_titel}
             ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
+            timeframeOptions={['all', '5weeks']}
           >
             {(timeframe) => (
               <TimeSeriesChart
@@ -228,6 +229,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
           <ChartTileWithTimeframe
             metadata={{ source: infectedLocationsText.bronnen.rivm }}
             title={infectedLocationsText.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
             ariaDescription={
               graphDescriptions.verpleeghuiszorg_besmette_locaties
             }
@@ -285,6 +287,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
           <ChartTileWithTimeframe
             metadata={{ source: deceased.bronnen.rivm }}
             title={deceased.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
           >
             {(timeframe) => (
               <TimeSeriesChart

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -113,6 +113,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
           <ChartTileWithTimeframe
             metadata={{ source: positiveTestedPeopleText.bronnen.rivm }}
             title={positiveTestedPeopleText.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
             ariaDescription={graphDescriptions.verpleeghuiszorg_positief_getest}
           >
             {(timeframe) => (
@@ -210,6 +211,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
           <ChartTileWithTimeframe
             metadata={{ source: infectedLocationsText.bronnen.rivm }}
             title={infectedLocationsText.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
             ariaDescription={
               graphDescriptions.verpleeghuiszorg_besmette_locaties
             }
@@ -269,6 +271,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
           <ChartTileWithTimeframe
             metadata={{ source: deceased.bronnen.rivm }}
             title={deceased.linechart_titel}
+            timeframeOptions={['all', '5weeks']}
           >
             {(timeframe) => (
               <TimeSeriesChart


### PR DESCRIPTION
## Summary

This removes the "last week" option from all charts on the nursing home pages, because it doesn't add much value compared to the 5 week view, and the data doesn't render nicely since it's often incomplete.
