### PR TITLE
Adjustments tested per age group

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -28,6 +28,7 @@
     "tested_ggd_daily",
     "tested_ggd_average",
     "tested_overall",
+    "tested_per_age_group",
     "vaccine_support",
     "vaccine_delivery",
     "vaccine_delivery_estimate",

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -7,13 +7,14 @@ import css from '@styled-system/css';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components-styled/base';
-import { InlineText } from '~/components-styled/typography';
+import { InlineText, Text } from '~/components-styled/typography';
 import { VisuallyHidden } from '~/components-styled/visually-hidden';
 import { SeriesConfig } from '../../logic';
 import { SeriesIcon } from '../series-icon';
 import { TooltipData } from './types';
 import { useIntl } from '~/intl';
 import { isPresent } from 'ts-is-present';
+import { colors } from '~/style/theme';
 
 export function TooltipSeriesList<T extends TimestampedValue>({
   data: tooltipData,
@@ -76,9 +77,9 @@ export function TooltipSeriesList<T extends TimestampedValue>({
       <VisuallyHidden>{dateString}</VisuallyHidden>
 
       {timespanAnnotation && (
-        <InlineText>
+        <Text fontSize={0} color={colors.annotation} textAlign={'center'}>
           {timespanAnnotation.shortLabel || timespanAnnotation.label}
-        </InlineText>
+        </Text>
       )}
       <TooltipList>
         {seriesConfig.map((x, index) => {
@@ -159,7 +160,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   );
 }
 
-const TooltipList = styled.ol`
+export const TooltipList = styled.ol`
   margin: 0;
   padding: 0;
   list-style: none;

--- a/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { Text } from '~/components-styled/typography';
 import { useIntl } from '~/intl';
+import { colors } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 
 interface AgeGroupLegendProps {
@@ -28,7 +29,9 @@ export function AgeGroupLegend({
 
   return (
     <>
-      <Text fontSize={1}>{text.legend_help_text}</Text>
+      <Text fontSize={1} fontWeight="bold" mb={0} mt={2}>
+        {text.legend_help_text}
+      </Text>
       <Legend>
         <List>
           {seriesConfig.map((item) => {
@@ -39,7 +42,6 @@ export function AgeGroupLegend({
                   onClick={() => onToggleAgeGroup(item.metricProperty)}
                   isActive={hasSelection && isSelected}
                   color={item.color}
-                  data-metric-property={item.metricProperty}
                   data-text={item.label}
                 >
                   {item.label}
@@ -60,17 +62,19 @@ export function AgeGroupLegend({
           {alwaysEnabledConfig.map((item) => {
             return (
               <Item key={item.label}>
-                <ItemText
-                  color={item.color}
-                  data-metric-property={item.metricProperty}
-                  data-text={item.label}
-                >
+                <ItemText color={item.color} data-text={item.label}>
                   {item.label}
                   <Line color={item.color} lineStyle={item.style ?? 'solid'} />
                 </ItemText>
               </Item>
             );
           })}
+          <Item>
+            <ItemText data-text={text.line_chart_legend_inaccurate_label}>
+              {text.line_chart_legend_inaccurate_label}
+              <Square color={colors.data.underReported} />
+            </ItemText>
+          </Item>
         </List>
       </Legend>
     </>
@@ -159,11 +163,10 @@ const ItemButton = styled.button<{
 const ItemText = styled.span(
   css({
     pr: asResponsiveArray({ _: '5px', md: 10 }),
-    pl: asResponsiveArray({ _: 25, md: 30 }),
-    py: '3px',
+    pl: asResponsiveArray({ _: 20, md: 25 }),
+    py: '6px',
     fontSize: 1,
-    border: '3px solid',
-    borderColor: 'transparent',
+    border: 'none',
     fontWeight: 'normal',
     fontFamily: 'inherit',
     position: 'relative',
@@ -194,9 +197,26 @@ const Line = styled.div<{ color: string; lineStyle: 'dashed' | 'solid' }>(
       borderTopColor: color as SystemStyleObject,
       borderTopStyle: lineStyle,
       borderTopWidth: '3px',
-      top: '9px',
+      top: '10px',
       width: '15px',
       height: 0,
       borderRadius: '2px',
+      [`${ItemText} &`]: {
+        left: asResponsiveArray({ _: 0, md: '5px' }),
+        top: 13,
+      },
     })
+);
+
+const Square = styled.div<{ color: string }>(({ color }) =>
+  css({
+    content: '',
+    display: 'block',
+    position: 'absolute',
+    left: asResponsiveArray({ _: 0, md: '5px' }),
+    backgroundColor: color,
+    top: '5px',
+    width: '15px',
+    height: '15px',
+  })
 );

--- a/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
@@ -8,6 +8,7 @@ import { asResponsiveArray } from '~/style/utils';
 
 interface AgeGroupLegendProps {
   seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[];
+  alwaysEnabledConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[];
   ageGroupSelection: string[];
   onToggleAgeGroup: (ageGroupRange: string) => void;
   onReset: () => void;
@@ -15,6 +16,7 @@ interface AgeGroupLegendProps {
 
 export function AgeGroupLegend({
   seriesConfig,
+  alwaysEnabledConfig,
   ageGroupSelection,
   onToggleAgeGroup,
   onReset,
@@ -26,6 +28,7 @@ export function AgeGroupLegend({
 
   return (
     <>
+      <Text fontSize={1}>{text.legend_help_text}</Text>
       <Legend>
         <List>
           {seriesConfig.map((item) => {
@@ -52,7 +55,24 @@ export function AgeGroupLegend({
           </Item>
         </List>
       </Legend>
-      <Text fontSize={1}>{text.legend_help_text}</Text>
+      <Legend>
+        <List>
+          {alwaysEnabledConfig.map((item) => {
+            return (
+              <Item key={item.label}>
+                <ItemText
+                  color={item.color}
+                  data-metric-property={item.metricProperty}
+                  data-text={item.label}
+                >
+                  {item.label}
+                  <Line color={item.color} lineStyle={item.style ?? 'solid'} />
+                </ItemText>
+              </Item>
+            );
+          })}
+        </List>
+      </Legend>
     </>
   );
 }
@@ -108,6 +128,7 @@ const ItemButton = styled.button<{
     display: 'inline-flex',
     flexDirection: 'column',
     alignItems: 'center',
+    fontSize: 1,
     justifyContent: 'space-between',
     '&:hover,&:focus': {
       '&:before': {
@@ -133,6 +154,19 @@ const ItemButton = styled.button<{
       fontWeight: 'bold',
       pr: '1px',
     },
+  })
+);
+const ItemText = styled.span(
+  css({
+    pr: asResponsiveArray({ _: '5px', md: 10 }),
+    pl: asResponsiveArray({ _: 25, md: 30 }),
+    py: '3px',
+    fontSize: 1,
+    border: '3px solid',
+    borderColor: 'transparent',
+    fontWeight: 'normal',
+    fontFamily: 'inherit',
+    position: 'relative',
   })
 );
 

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -2,7 +2,10 @@ import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { useMemo } from 'react';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
-import { TooltipSeriesList } from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
+import {
+  TooltipList,
+  TooltipSeriesList,
+} from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
 import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { useIntl } from '~/intl';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
@@ -68,7 +71,7 @@ export function InfectedPerAgeGroup({
     return ageGroupBaseConfig.filter((item) =>
       alwayEnabled.includes(item.metricProperty)
     );
-  }, []);
+  }, [ageGroupBaseConfig, alwayEnabled]);
 
   /* Conditionally wrap tooltip over two columns due to amount of items */
   const tooltipColumns = list.length === 0 || list.length > 4 ? 2 : 1;
@@ -82,7 +85,7 @@ export function InfectedPerAgeGroup({
         height={breakpoints.md ? 300 : 250}
         disableLegend
         formatTooltip={(data) => (
-          <div css={css({ columns: tooltipColumns })}>
+          <div css={css({ [`${TooltipList}`]: { columns: tooltipColumns } })}>
             <TooltipSeriesList data={data} />
           </div>
         )}
@@ -91,9 +94,8 @@ export function InfectedPerAgeGroup({
             {
               start: underReportedDateStart,
               end: Infinity,
-              label:
-                positiveTestedPeopleText.line_chart_legend_inaccurate_label,
-              shortLabel: positiveTestedPeopleText.tooltip_labels.inaccurate,
+              label: text.line_chart_legend_inaccurate_label,
+              shortLabel: text.tooltip_labels.inaccurate,
             },
           ],
         }}

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2907,7 +2907,11 @@
       "infected_overall_per_100k": "All ages"
     },
     "reset_button_label": "Reset",
-    "legend_help_text": "Select one or more age groups that you want to see separately."
+    "legend_help_text": "Select one or more age groups that you want to see separately.",
+    "line_chart_legend_inaccurate_label": "Laatste dagen zijn niet compleet omdat meldingen vertraagd binnenkomen",
+    "tooltip_labels" : {
+      "inaccurate": "Incompleet"
+    }
   },
   "g_number": {
     "bar_chart": {

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2910,7 +2910,7 @@
     "legend_help_text": "Select one or more age groups that you want to see separately.",
     "line_chart_legend_inaccurate_label": "Laatste dagen zijn niet compleet omdat meldingen vertraagd binnenkomen",
     "tooltip_labels" : {
-      "inaccurate": "Incompleet"
+      "inaccurate": "Incomplete"
     }
   },
   "g_number": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -2910,7 +2910,7 @@
     "legend_help_text": "Selecteer één of meerdere leeftijdsgroepen om deze apart te bekijken.",
     "line_chart_legend_inaccurate_label": "Laatste dagen zijn niet compleet omdat meldingen vertraagd binnenkomen",
     "tooltip_labels" : {
-      "inaccurate": "Incompleet"
+      "inaccurate": "Niet compleet"
     }
   },
   "g_number": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -2907,7 +2907,11 @@
       "infected_overall_per_100k": "Alle leeftijden"
     },
     "reset_button_label": "Reset",
-    "legend_help_text": "Selecteer één of meerdere leeftijdsgroepen om deze apart te bekijken."
+    "legend_help_text": "Selecteer één of meerdere leeftijdsgroepen om deze apart te bekijken.",
+    "line_chart_legend_inaccurate_label": "Laatste dagen zijn niet compleet omdat meldingen vertraagd binnenkomen",
+    "tooltip_labels" : {
+      "inaccurate": "Incompleet"
+    }
   },
   "g_number": {
     "bar_chart": {

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -47,6 +47,7 @@ import {
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+import { InfectedPerAgeGroup } from '~/domain/tested/infected-per-age-group';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -262,11 +263,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
             )}
           </ChartTileWithTimeframe>
 
-          {/* 
-          @TODO re-enable after UX changes
           <ChartTileWithTimeframe
             title={siteText.infected_per_age_group.title}
             description={siteText.infected_per_age_group.description}
+            timeframeOptions={['all', '5weeks']}
             metadata={{
               source: text.bronnen.rivm,
             }}
@@ -277,7 +277,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 timeframe={timeframe}
               />
             )}
-          </ChartTileWithTimeframe> */}
+          </ChartTileWithTimeframe>
 
           <GNumberBarChartTile data={data.g_number} />
 

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -150,7 +150,7 @@ export interface National {
   infectious_people: NationalInfectiousPeople;
   intensive_care_nice: NationalIntensiveCareNice;
   tested_overall: NationalTestedOverall;
-  tested_per_age_group?: NlTestedPerAgeGroup;
+  tested_per_age_group: NlTestedPerAgeGroup;
   reproduction: NationalReproduction;
   sewer: NationalSewer;
   hospital_nice: NationalHospitalNice;


### PR DESCRIPTION
## Summary

Adjustments tested per age group

* Re-enable tile
* Re-order legend labels
* Split legend into dynamic and static
* Add incomplete range to graph + legend
* remove "week" from time toggles
* "All age groups" is always visible