### PR TITLE
Code improvements confirmed cases per age group chart

### DIFF
--- a/packages/app/src/components-styled/interactive-legend.tsx
+++ b/packages/app/src/components-styled/interactive-legend.tsx
@@ -14,7 +14,7 @@ interface InteractiveLegendProps {
   helpText: string;
   seriesConfig: SimplifiedSeriesConfig[];
   selection: string[];
-  onToggleAgeGroup: (ageGroupRange: string) => void;
+  onToggleItem: (item: string) => void;
   onReset: () => void;
 }
 
@@ -22,7 +22,7 @@ export function InteractiveLegend({
   helpText,
   seriesConfig,
   selection,
-  onToggleAgeGroup,
+  onToggleItem,
   onReset,
 }: InteractiveLegendProps) {
   const { siteText } = useIntl();
@@ -41,7 +41,7 @@ export function InteractiveLegend({
             return (
               <Item key={item.label}>
                 <ItemButton
-                  onClick={() => onToggleAgeGroup(item.metricProperty)}
+                  onClick={() => onToggleItem(item.metricProperty)}
                   isActive={hasSelection && isSelected}
                   color={item.color}
                   data-text={item.label}

--- a/packages/app/src/components-styled/interactive-legend.tsx
+++ b/packages/app/src/components-styled/interactive-legend.tsx
@@ -1,38 +1,43 @@
-import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { Text } from '~/components-styled/typography';
 import { useIntl } from '~/intl';
 import { asResponsiveArray } from '~/style/utils';
 
-interface AgeGroupLegendProps {
-  seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[];
-  ageGroupSelection: string[];
+interface SimplifiedSeriesConfig {
+  metricProperty: string;
+  label: string;
+  color: string;
+}
+
+interface InteractiveLegendProps {
+  helpText: string;
+  seriesConfig: SimplifiedSeriesConfig[];
+  selection: string[];
   onToggleAgeGroup: (ageGroupRange: string) => void;
   onReset: () => void;
 }
 
-export function AgeGroupLegend({
+export function InteractiveLegend({
+  helpText,
   seriesConfig,
-  ageGroupSelection,
+  selection,
   onToggleAgeGroup,
   onReset,
-}: AgeGroupLegendProps) {
+}: InteractiveLegendProps) {
   const { siteText } = useIntl();
-  const text = siteText.infected_per_age_group;
 
-  const hasSelection = ageGroupSelection.length !== 0;
+  const hasSelection = selection.length !== 0;
 
   return (
     <>
       <Text fontSize={1} fontWeight="bold" mb={0} mt={2}>
-        {text.legend_help_text}
+        {helpText}
       </Text>
       <Legend>
         <List>
           {seriesConfig.map((item) => {
-            const isSelected = ageGroupSelection.includes(item.metricProperty);
+            const isSelected = selection.includes(item.metricProperty);
             return (
               <Item key={item.label}>
                 <ItemButton
@@ -49,7 +54,7 @@ export function AgeGroupLegend({
           })}
           <Item>
             <ResetButton onClick={onReset} isVisible={hasSelection}>
-              {text.reset_button_label}
+              {siteText.common.interactive_legend.reset_button_label}
             </ResetButton>
           </Item>
         </List>

--- a/packages/app/src/components-styled/interactive-legend.tsx
+++ b/packages/app/src/components-styled/interactive-legend.tsx
@@ -146,6 +146,7 @@ const ItemButton = styled.button<{
 const ResetButton = styled.button<{ isVisible: boolean }>(({ isVisible }) =>
   css({
     backgroundColor: 'transparent',
+    cursor: 'pointer',
     color: 'blue',
     py: '6px',
     border: 'none',

--- a/packages/app/src/components-styled/legend.tsx
+++ b/packages/app/src/components-styled/legend.tsx
@@ -1,13 +1,14 @@
-import css from '@styled-system/css';
+import css, { SystemStyleObject } from '@styled-system/css';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 export type LegendShape = 'line' | 'square' | 'circle';
+type LegendLineStyle = 'solid' | 'dashed';
 
 export type LegendItem = {
   label: string;
 } & (
-  | { shape: LegendShape; color: string }
+  | { shape: LegendShape; color: string; style?: LegendLineStyle }
   | { shape: 'custom'; shapeComponent: ReactNode }
 );
 
@@ -32,7 +33,9 @@ export function Legend({ items }: LegendProps) {
           <Item key={i}>
             {item.label}
             {item.shape === 'square' && <Square color={item.color} />}
-            {item.shape === 'line' && <Line color={item.color} />}
+            {item.shape === 'line' && (
+              <Line color={item.color} lineStyle={item.style ?? 'solid'} />
+            )}
             {item.shape === 'circle' && <Circle color={item.color} />}
           </Item>
         );
@@ -71,20 +74,10 @@ const CustomShape = styled.div(
 
 const Shape = styled.div<{ color: string }>((x) =>
   css({
-    content: '',
     display: 'block',
     position: 'absolute',
     left: 0,
     backgroundColor: x.color,
-  })
-);
-
-const Line = styled(Shape)(
-  css({
-    top: '10px',
-    width: '15px',
-    height: '3px',
-    borderRadius: '2px',
   })
 );
 
@@ -103,4 +96,20 @@ const Circle = styled(Shape)(
     height: '10px',
     borderRadius: '50%',
   })
+);
+
+const Line = styled.div<{ color: string; lineStyle: LegendLineStyle }>(
+  ({ color, lineStyle }) =>
+    css({
+      display: 'block',
+      position: 'absolute',
+      borderTopColor: color as SystemStyleObject,
+      borderTopStyle: lineStyle,
+      borderTopWidth: '3px',
+      top: '10px',
+      width: '15px',
+      height: 0,
+      borderRadius: '2px',
+      left: 0,
+    })
 );

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -18,10 +18,10 @@ import { colors } from '~/style/theme';
 
 export function TooltipSeriesList<T extends TimestampedValue>({
   data: tooltipData,
-  columns,
+  hasMultipleColumns,
 }: {
   data: TooltipData<T>;
-  columns: 1 | 2;
+  hasMultipleColumns?: boolean;
 }) {
   const {
     value,
@@ -83,7 +83,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
           {timespanAnnotation.shortLabel || timespanAnnotation.label}
         </Text>
       )}
-      <TooltipList columns={columns ?? 1}>
+      <TooltipList hasMultipleColumns={hasMultipleColumns}>
         {seriesConfig.map((x, index) => {
           switch (x.type) {
             case 'stacked-area':
@@ -162,13 +162,14 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   );
 }
 
-export const TooltipList = styled.ol<{ columns: 1 | 2 }>(({ columns }) =>
-  css({
-    columns,
-    m: 0,
-    p: 0,
-    listStyle: 'none',
-  })
+export const TooltipList = styled.ol<{ hasMultipleColumns: boolean }>(
+  ({ hasMultipleColumns }) =>
+    css({
+      columns: hasMultipleColumns ? 2 : 1,
+      m: 0,
+      p: 0,
+      listStyle: 'none',
+    })
 );
 
 interface TooltipListItemProps {

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -18,8 +18,10 @@ import { colors } from '~/style/theme';
 
 export function TooltipSeriesList<T extends TimestampedValue>({
   data: tooltipData,
+  columns,
 }: {
   data: TooltipData<T>;
+  columns: 1 | 2;
 }) {
   const {
     value,
@@ -81,7 +83,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
           {timespanAnnotation.shortLabel || timespanAnnotation.label}
         </Text>
       )}
-      <TooltipList>
+      <TooltipList columns={columns ?? 1}>
         {seriesConfig.map((x, index) => {
           switch (x.type) {
             case 'stacked-area':
@@ -160,11 +162,14 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   );
 }
 
-export const TooltipList = styled.ol`
-  margin: 0;
-  padding: 0;
-  list-style: none;
-`;
+export const TooltipList = styled.ol<{ columns: 1 | 2 }>(({ columns }) =>
+  css({
+    columns,
+    m: 0,
+    p: 0,
+    listStyle: 'none',
+  })
+);
 
 interface TooltipListItemProps {
   children: ReactNode;

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -18,10 +18,10 @@ import { colors } from '~/style/theme';
 
 export function TooltipSeriesList<T extends TimestampedValue>({
   data: tooltipData,
-  hasMultipleColumns,
+  hasTwoColumns,
 }: {
   data: TooltipData<T>;
-  hasMultipleColumns?: boolean;
+  hasTwoColumns?: boolean;
 }) {
   const {
     value,
@@ -83,7 +83,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
           {timespanAnnotation.shortLabel || timespanAnnotation.label}
         </Text>
       )}
-      <TooltipList hasMultipleColumns={hasMultipleColumns}>
+      <TooltipList hasTwoColumns={hasTwoColumns}>
         {seriesConfig.map((x, index) => {
           switch (x.type) {
             case 'stacked-area':
@@ -162,10 +162,10 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   );
 }
 
-export const TooltipList = styled.ol<{ hasMultipleColumns: boolean }>(
-  ({ hasMultipleColumns }) =>
+export const TooltipList = styled.ol<{ hasTwoColumns: boolean }>(
+  ({ hasTwoColumns }) =>
     css({
-      columns: hasMultipleColumns ? 2 : 1,
+      columns: hasTwoColumns ? 2 : 1,
       m: 0,
       p: 0,
       listStyle: 'none',

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -162,7 +162,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   );
 }
 
-export const TooltipList = styled.ol<{ hasTwoColumns: boolean }>(
+export const TooltipList = styled.ol<{ hasTwoColumns?: boolean }>(
   ({ hasTwoColumns }) =>
     css({
       columns: hasTwoColumns ? 2 : 1,

--- a/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/components/age-group-legend.tsx
@@ -1,15 +1,13 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
-import css, { SystemStyleObject } from '@styled-system/css';
+import css from '@styled-system/css';
 import styled from 'styled-components';
 import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { Text } from '~/components-styled/typography';
 import { useIntl } from '~/intl';
-import { colors } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 
 interface AgeGroupLegendProps {
   seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[];
-  alwaysEnabledConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[];
   ageGroupSelection: string[];
   onToggleAgeGroup: (ageGroupRange: string) => void;
   onReset: () => void;
@@ -17,7 +15,6 @@ interface AgeGroupLegendProps {
 
 export function AgeGroupLegend({
   seriesConfig,
-  alwaysEnabledConfig,
   ageGroupSelection,
   onToggleAgeGroup,
   onReset,
@@ -45,7 +42,7 @@ export function AgeGroupLegend({
                   data-text={item.label}
                 >
                   {item.label}
-                  <Line color={item.color} lineStyle={item.style ?? 'solid'} />
+                  <Line color={item.color} />
                 </ItemButton>
               </Item>
             );
@@ -54,26 +51,6 @@ export function AgeGroupLegend({
             <ResetButton onClick={onReset} isVisible={hasSelection}>
               {text.reset_button_label}
             </ResetButton>
-          </Item>
-        </List>
-      </Legend>
-      <Legend>
-        <List>
-          {alwaysEnabledConfig.map((item) => {
-            return (
-              <Item key={item.label}>
-                <ItemText color={item.color} data-text={item.label}>
-                  {item.label}
-                  <Line color={item.color} lineStyle={item.style ?? 'solid'} />
-                </ItemText>
-              </Item>
-            );
-          })}
-          <Item>
-            <ItemText data-text={text.line_chart_legend_inaccurate_label}>
-              {text.line_chart_legend_inaccurate_label}
-              <Square color={colors.data.underReported} />
-            </ItemText>
           </Item>
         </List>
       </Legend>
@@ -160,18 +137,6 @@ const ItemButton = styled.button<{
     },
   })
 );
-const ItemText = styled.span(
-  css({
-    pr: asResponsiveArray({ _: '5px', md: 10 }),
-    pl: asResponsiveArray({ _: 20, md: 25 }),
-    py: '6px',
-    fontSize: 1,
-    border: 'none',
-    fontWeight: 'normal',
-    fontFamily: 'inherit',
-    position: 'relative',
-  })
-);
 
 const ResetButton = styled.button<{ isVisible: boolean }>(({ isVisible }) =>
   css({
@@ -188,35 +153,15 @@ const ResetButton = styled.button<{ isVisible: boolean }>(({ isVisible }) =>
   })
 );
 
-const Line = styled.div<{ color: string; lineStyle: 'dashed' | 'solid' }>(
-  ({ color, lineStyle }) =>
-    css({
-      display: 'block',
-      position: 'absolute',
-      left: asResponsiveArray({ _: '5px', md: 10 }),
-      borderTopColor: color as SystemStyleObject,
-      borderTopStyle: lineStyle,
-      borderTopWidth: '3px',
-      top: '10px',
-      width: '15px',
-      height: 0,
-      borderRadius: '2px',
-      [`${ItemText} &`]: {
-        left: asResponsiveArray({ _: 0, md: '5px' }),
-        top: 13,
-      },
-    })
-);
-
-const Square = styled.div<{ color: string }>(({ color }) =>
+const Line = styled.div<{ color: string }>(({ color }) =>
   css({
-    content: '',
+    top: '10px',
+    width: '15px',
+    height: '3px',
+    borderRadius: '2px',
     display: 'block',
     position: 'absolute',
-    left: asResponsiveArray({ _: 0, md: '5px' }),
+    left: asResponsiveArray({ _: '5px', md: 10 }),
     backgroundColor: color,
-    top: '5px',
-    width: '15px',
-    height: '15px',
   })
 );

--- a/packages/app/src/domain/tested/infected-per-age-group/index.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/index.ts
@@ -1,2 +1,1 @@
-export * from './components/age-group-legend';
 export * from './infected-per-age-group';

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -1,18 +1,15 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
-import css from '@styled-system/css';
 import { useMemo } from 'react';
+import { Legend, LegendItem } from '~/components-styled/legend';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
-import {
-  TooltipList,
-  TooltipSeriesList,
-} from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
+import { TooltipSeriesList } from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
 import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { useIntl } from '~/intl';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { useList } from '~/utils/use-list';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { AgeGroupLegend } from './components/age-group-legend';
-import { SERIES_CONFIG } from './series-config';
+import { BASE_SERIES_CONFIG, UNDER_REPORTED_CONFIG } from './series-config';
 
 interface InfectedPerAgeGroup {
   values: NlTestedPerAgeGroupValue[];
@@ -38,8 +35,8 @@ export function InfectedPerAgeGroup({
   }, []);
 
   /* Enrich config with dynamic data / locale */
-  const ageGroupBaseConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[] = useMemo(() => {
-    return SERIES_CONFIG.map((baseAgeGroup) => {
+  const seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[] = useMemo(() => {
+    return BASE_SERIES_CONFIG.map((baseAgeGroup) => {
       return {
         ...baseAgeGroup,
         type: 'line',
@@ -51,43 +48,67 @@ export function InfectedPerAgeGroup({
     });
   }, [text.legend]);
 
+  const underReported = useMemo(
+    () => ({
+      ...UNDER_REPORTED_CONFIG,
+      label: text.line_chart_legend_inaccurate_label,
+    }),
+    [text.line_chart_legend_inaccurate_label]
+  );
+
   /* Filter for each config group */
-  const ageGroupChartConfig = useMemo(() => {
+
+  /**
+   * Chart:
+   * - when nothing selected: all items
+   * - otherwise: selected items + always enabled items
+   */
+  const chartConfig = useMemo(() => {
     const compareList = list.concat(...alwayEnabled);
-    return ageGroupBaseConfig.filter(
+    return seriesConfig.filter(
       (item) =>
         compareList.includes(item.metricProperty) ||
         compareList.length === alwayEnabled.length
     );
-  }, [ageGroupBaseConfig, list, alwayEnabled]);
+  }, [seriesConfig, list, alwayEnabled]);
 
-  const ageGroupLegendConfig = useMemo(() => {
-    return ageGroupBaseConfig.filter(
+  const dynamicLegendConfig = useMemo(() => {
+    return seriesConfig.filter(
       (item) => !alwayEnabled.includes(item.metricProperty)
     );
-  }, [ageGroupBaseConfig, alwayEnabled]);
+  }, [seriesConfig, alwayEnabled]);
 
-  const alwaysEnabledConfig = useMemo(() => {
-    return ageGroupBaseConfig.filter((item) =>
-      alwayEnabled.includes(item.metricProperty)
-    );
-  }, [ageGroupBaseConfig, alwayEnabled]);
+  /* Static legend contains always enabled items and the under reported item */
+  const staticLegendItems: LegendItem[] = useMemo(() => {
+    return seriesConfig
+      .filter((item) => alwayEnabled.includes(item.metricProperty))
+      .map(
+        (item): LegendItem => ({
+          label: item.label,
+          shape: item.type,
+          color: item.color,
+          style: item.style,
+        })
+      )
+      .concat([underReported]);
+  }, [seriesConfig, alwayEnabled, underReported]);
 
   /* Conditionally wrap tooltip over two columns due to amount of items */
-  const tooltipColumns = list.length === 0 || list.length > 4 ? 2 : 1;
+  const tooltipColumns: 1 | 2 = useMemo(
+    () => (list.length === 0 || list.length > 4 ? 2 : 1),
+    [list.length]
+  );
 
   return (
     <>
       <TimeSeriesChart
         values={values}
         timeframe={timeframe}
-        seriesConfig={ageGroupChartConfig}
+        seriesConfig={chartConfig}
         height={breakpoints.md ? 300 : 250}
         disableLegend
         formatTooltip={(data) => (
-          <div css={css({ [`${TooltipList}`]: { columns: tooltipColumns } })}>
-            <TooltipSeriesList data={data} />
-          </div>
+          <TooltipSeriesList data={data} columns={tooltipColumns} />
         )}
         dataOptions={{
           timespanAnnotations: [
@@ -101,12 +122,12 @@ export function InfectedPerAgeGroup({
         }}
       />
       <AgeGroupLegend
-        seriesConfig={ageGroupLegendConfig}
-        alwaysEnabledConfig={alwaysEnabledConfig}
+        seriesConfig={dynamicLegendConfig}
         ageGroupSelection={list}
         onToggleAgeGroup={toggle}
         onReset={clear}
       />
+      <Legend items={staticLegendItems} />
     </>
   );
 }

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -112,7 +112,7 @@ export function InfectedPerAgeGroup({
         helpText={text.legend_help_text}
         seriesConfig={dynamicLegendConfig}
         selection={list}
-        onToggleAgeGroup={toggle}
+        onToggleItem={toggle}
         onReset={clear}
       />
       <Legend items={staticLegendItems} />

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -1,15 +1,15 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
-import { useMemo } from 'react';
 import { Legend, LegendItem } from '~/components-styled/legend';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
 import { TooltipSeriesList } from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
 import { LineSeriesDefinition } from '~/components-styled/time-series-chart/logic';
 import { useIntl } from '~/intl';
+import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { useList } from '~/utils/use-list';
 import { useBreakpoints } from '~/utils/useBreakpoints';
 import { AgeGroupLegend } from './components/age-group-legend';
-import { BASE_SERIES_CONFIG, UNDER_REPORTED_CONFIG } from './series-config';
+import { BASE_SERIES_CONFIG } from './series-config';
 
 interface InfectedPerAgeGroup {
   values: NlTestedPerAgeGroupValue[];
@@ -20,23 +20,18 @@ export function InfectedPerAgeGroup({
   values,
   timeframe,
 }: InfectedPerAgeGroup) {
+  const { siteText } = useIntl();
   const { list, toggle, clear } = useList<string>();
-
   const breakpoints = useBreakpoints(true);
 
-  const { siteText } = useIntl();
   const text = siteText.infected_per_age_group;
 
   const underReportedDateStart = getBoundaryDateStartUnix(values, 7);
-
-  /* @TODO Always enabled is temporary logic pending on new UX */
-  const alwayEnabled = useMemo(() => {
-    return ['infected_overall_per_100k'];
-  }, []);
+  const alwayEnabled = ['infected_overall_per_100k'];
 
   /* Enrich config with dynamic data / locale */
-  const seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[] = useMemo(() => {
-    return BASE_SERIES_CONFIG.map((baseAgeGroup) => {
+  const seriesConfig: LineSeriesDefinition<NlTestedPerAgeGroupValue>[] = BASE_SERIES_CONFIG.map(
+    (baseAgeGroup) => {
       return {
         ...baseAgeGroup,
         type: 'line',
@@ -45,16 +40,14 @@ export function InfectedPerAgeGroup({
             ? text.legend[baseAgeGroup.metricProperty]
             : baseAgeGroup.metricProperty,
       };
-    });
-  }, [text.legend]);
-
-  const underReported = useMemo(
-    () => ({
-      ...UNDER_REPORTED_CONFIG,
-      label: text.line_chart_legend_inaccurate_label,
-    }),
-    [text.line_chart_legend_inaccurate_label]
+    }
   );
+
+  const underReportedLegendItem: LegendItem = {
+    shape: 'square',
+    color: colors.data.underReported,
+    label: text.line_chart_legend_inaccurate_label,
+  };
 
   /* Filter for each config group */
 
@@ -63,41 +56,32 @@ export function InfectedPerAgeGroup({
    * - when nothing selected: all items
    * - otherwise: selected items + always enabled items
    */
-  const chartConfig = useMemo(() => {
-    const compareList = list.concat(...alwayEnabled);
-    return seriesConfig.filter(
-      (item) =>
-        compareList.includes(item.metricProperty) ||
-        compareList.length === alwayEnabled.length
-    );
-  }, [seriesConfig, list, alwayEnabled]);
+  const compareList = list.concat(...alwayEnabled);
+  const chartConfig = seriesConfig.filter(
+    (item) =>
+      compareList.includes(item.metricProperty) ||
+      compareList.length === alwayEnabled.length
+  );
 
-  const dynamicLegendConfig = useMemo(() => {
-    return seriesConfig.filter(
-      (item) => !alwayEnabled.includes(item.metricProperty)
-    );
-  }, [seriesConfig, alwayEnabled]);
+  const dynamicLegendConfig = seriesConfig.filter(
+    (item) => !alwayEnabled.includes(item.metricProperty)
+  );
 
   /* Static legend contains always enabled items and the under reported item */
-  const staticLegendItems: LegendItem[] = useMemo(() => {
-    return seriesConfig
-      .filter((item) => alwayEnabled.includes(item.metricProperty))
-      .map(
-        (item): LegendItem => ({
-          label: item.label,
-          shape: item.type,
-          color: item.color,
-          style: item.style,
-        })
-      )
-      .concat([underReported]);
-  }, [seriesConfig, alwayEnabled, underReported]);
+  const staticLegendItems: LegendItem[] = seriesConfig
+    .filter((item) => alwayEnabled.includes(item.metricProperty))
+    .map(
+      (item): LegendItem => ({
+        label: item.label,
+        shape: item.type,
+        color: item.color,
+        style: item.style,
+      })
+    )
+    .concat([underReportedLegendItem]);
 
-  /* Conditionally wrap tooltip over two columns due to amount of items */
-  const tooltipColumns: 1 | 2 = useMemo(
-    () => (list.length === 0 || list.length > 4 ? 2 : 1),
-    [list.length]
-  );
+  /* Conditionally let tooltip span over multiple columns */
+  const hasMultipleColumns = list.length === 0 || list.length > 4;
 
   return (
     <>
@@ -108,7 +92,10 @@ export function InfectedPerAgeGroup({
         height={breakpoints.md ? 300 : 250}
         disableLegend
         formatTooltip={(data) => (
-          <TooltipSeriesList data={data} columns={tooltipColumns} />
+          <TooltipSeriesList
+            data={data}
+            hasMultipleColumns={hasMultipleColumns}
+          />
         )}
         dataOptions={{
           timespanAnnotations: [

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -81,7 +81,7 @@ export function InfectedPerAgeGroup({
     .concat([underReportedLegendItem]);
 
   /* Conditionally let tooltip span over multiple columns */
-  const hasMultipleColumns = list.length === 0 || list.length > 4;
+  const hasTwoColumns = list.length === 0 || list.length > 4;
 
   return (
     <>
@@ -92,10 +92,7 @@ export function InfectedPerAgeGroup({
         height={breakpoints.md ? 300 : 250}
         disableLegend
         formatTooltip={(data) => (
-          <TooltipSeriesList
-            data={data}
-            hasMultipleColumns={hasMultipleColumns}
-          />
+          <TooltipSeriesList data={data} hasTwoColumns={hasTwoColumns} />
         )}
         dataOptions={{
           timespanAnnotations: [

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -1,4 +1,5 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
+import { InteractiveLegend } from '~/components-styled/interactive-legend';
 import { Legend, LegendItem } from '~/components-styled/legend';
 import { TimeSeriesChart } from '~/components-styled/time-series-chart';
 import { TooltipSeriesList } from '~/components-styled/time-series-chart/components/tooltip/tooltip-series-list';
@@ -8,7 +9,6 @@ import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { useList } from '~/utils/use-list';
 import { useBreakpoints } from '~/utils/useBreakpoints';
-import { AgeGroupLegend } from './components/age-group-legend';
 import { BASE_SERIES_CONFIG } from './series-config';
 
 interface InfectedPerAgeGroup {
@@ -108,9 +108,10 @@ export function InfectedPerAgeGroup({
           ],
         }}
       />
-      <AgeGroupLegend
+      <InteractiveLegend
+        helpText={text.legend_help_text}
         seriesConfig={dynamicLegendConfig}
-        ageGroupSelection={list}
+        selection={list}
         onToggleAgeGroup={toggle}
         onReset={clear}
       />

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -1,5 +1,4 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
-import { LegendShape } from '~/components-styled/legend';
 import { colors } from '~/style/theme';
 
 export const BASE_SERIES_CONFIG: {
@@ -56,8 +55,3 @@ export const BASE_SERIES_CONFIG: {
     style: 'dashed',
   },
 ];
-
-export const UNDER_REPORTED_CONFIG: { shape: LegendShape; color: string } = {
-  shape: 'square',
-  color: colors.data.underReported,
-};

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -1,7 +1,8 @@
 import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
+import { LegendShape } from '~/components-styled/legend';
 import { colors } from '~/style/theme';
 
-export const SERIES_CONFIG: {
+export const BASE_SERIES_CONFIG: {
   metricProperty: keyof Omit<
     NlTestedPerAgeGroupValue,
     'date_unix' | 'date_of_insertion_unix'
@@ -55,3 +56,8 @@ export const SERIES_CONFIG: {
     style: 'dashed',
   },
 ];
+
+export const UNDER_REPORTED_CONFIG: { shape: LegendShape; color: string } = {
+  shape: 'square',
+  color: colors.data.underReported,
+};

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -1,14 +1,6 @@
-import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
 import { colors } from '~/style/theme';
 
-export const BASE_SERIES_CONFIG: {
-  metricProperty: keyof Omit<
-    NlTestedPerAgeGroupValue,
-    'date_unix' | 'date_of_insertion_unix'
-  >;
-  color: string;
-  style?: 'dashed' | 'solid';
-}[] = [
+export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'infected_age_0_9_per_100k',
     color: colors.data.multiseries.cyan,
@@ -54,4 +46,4 @@ export const BASE_SERIES_CONFIG: {
     color: colors.gray,
     style: 'dashed',
   },
-];
+] as const;

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -686,7 +686,10 @@
     "miljoen": "million",
     "signaalwaarde": "Alert value",
     "totaal": "Total",
-    "rond": "rond"
+    "rond": "rond",
+    "interactive_legend": {
+      "reset_button_label": "Reset"
+    }
   },
   "seoHead": {
     "default_description": "Information on the development of the coronavirus in the Netherlands.",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -686,7 +686,10 @@
     "miljoen": "miljoen",
     "signaalwaarde": "Signaalwaarde",
     "totaal": "Totaal",
-    "rond": "rond"
+    "rond": "rond",
+    "interactive_legend": {
+      "reset_button_label": "Reset"
+    }
   },
   "seoHead": {
     "default_description": "Informatie over de ontwikkeling van het coronavirus in Nederland.",


### PR DESCRIPTION
## Summary

Code improvements confirmed cases per age group chart

* Moved the static legend items to a regular `legend` component
* Extended the regular `legend` component to accept `dashed` lines
* Above changes allowed for some cleanup in the legend
* Adjusted `tooltip-series-list` to accept an optional `hasMultipleColumns` prop
* Cleaned up the odd code to pass columns from `infected-per-age-group` to the tooltip by using above prop
* Cleanup of `useMemo`, adjusted some names and added comments
* `age-group-legend` is made re-usable as `interactive-legend` component