### PR TITLE
Improve performance of the time-series-chart

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
@@ -13,6 +13,44 @@ type LineProps = {
   color: string;
 };
 
+interface DateLineMarkerProps<T extends TimestampedValue> {
+  point: HoveredPoint<T>;
+  lineColor?: string;
+  /**
+   * The original data value gets passed in so that we can render the original
+   * date start/end in case of the data span value
+   */
+  value: T;
+}
+
+export function DateLineMarker<T extends TimestampedValue>({
+  lineColor = colors.data.primary,
+  point,
+  value,
+}: DateLineMarkerProps<T>) {
+  const isDateSpan = isDateSpanValue(value);
+  const { formatDateFromSeconds } = useIntl();
+
+  return (
+    <Container style={{ transform: `translateX(${point.x}px)` }}>
+      <Line color={lineColor} />
+      <LabelContainer>
+        <Label>
+          {isDateSpan
+            ? `${formatDateFromSeconds(
+                (value as DateSpanValue).date_start_unix,
+                'axis'
+              )} - ${formatDateFromSeconds(
+                (value as DateSpanValue).date_end_unix,
+                'axis'
+              )}`
+            : formatDateFromSeconds(point.seriesValue.__date_unix, 'axis')}
+        </Label>
+      </LabelContainer>
+    </Container>
+  );
+}
+
 const LabelContainer = styled.div({
   display: 'flex',
   justifyContent: 'center',
@@ -48,45 +86,3 @@ const Container = styled.div(
     bottom: 0,
   })
 );
-
-interface DateLineMarkerProps<T extends TimestampedValue> {
-  point: HoveredPoint<T>;
-  lineColor?: string;
-  /**
-   * The original data value gets passed in so that we can render the original
-   * date start/end in case of the data span value
-   */
-  value: T;
-}
-
-export function DateLineMarker<T extends TimestampedValue>({
-  lineColor = colors.data.primary,
-  point,
-  value,
-}: DateLineMarkerProps<T>) {
-  const isDateSpan = isDateSpanValue(value);
-  const { formatDateFromSeconds } = useIntl();
-
-  return (
-    <Container
-      style={{
-        left: point.x,
-      }}
-    >
-      <Line color={lineColor} />
-      <LabelContainer>
-        <Label>
-          {isDateSpan
-            ? `${formatDateFromSeconds(
-                (value as DateSpanValue).date_start_unix,
-                'axis'
-              )} - ${formatDateFromSeconds(
-                (value as DateSpanValue).date_end_unix,
-                'axis'
-              )}`
-            : formatDateFromSeconds(point.seriesValue.__date_unix, 'axis')}
-        </Label>
-      </LabelContainer>
-    </Container>
-  );
-}

--- a/packages/app/src/components-styled/time-series-chart/components/date-span-marker.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/date-span-marker.tsx
@@ -29,7 +29,7 @@ export function DateSpanMarker<T extends TimestampedValue>(
     <Container
       style={{
         width,
-        left: point.x,
+        transform: `translateX(${point.x - width / 2}px)`,
       }}
     >
       <DateSpan />

--- a/packages/app/src/components-styled/time-series-chart/components/point-markers.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/point-markers.tsx
@@ -1,69 +1,31 @@
 import { TimestampedValue } from '@corona-dashboard/common';
+import { transparentize } from 'polished';
 import styled from 'styled-components';
 import { HoveredPoint } from '../logic/hover-state';
 
-const MARKER_POINT_SIZE = 18;
+const MARKER_POINT_SIZE = 8;
 
 type MarkerProps = {
   color: string;
   size: number;
 };
 
-const Container = styled.div`
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  transform: translate(-50%, 0);
-`;
-
-const PointMarker = styled.div<MarkerProps>`
-  position: absolute;
-
-  &::after {
-    content: '';
-    position: absolute;
-    height: 8px;
-    width: 8px;
-    transform: translate(50%, -50%);
-    border-radius: 50%;
-    border: 1px solid white;
-    background: ${(props) => props.color};
-  }
-
-  &::before {
-    content: '';
-    position: absolute;
-    height: ${(props) => props.size}px;
-    width: ${(props) => props.size}px;
-    /*
-      Without the -5% the outer circle is a little off for some reason
-    */
-    transform: translate(-5%, -50%);
-    border-radius: 50%;
-    background: ${(props) => props.color};
-    opacity: 0.4;
-  }
-`;
-
 interface PointMarkerProps<T extends TimestampedValue> {
   points: HoveredPoint<T>[];
-  size?: number;
 }
 
 export function PointMarkers<T extends TimestampedValue>(
   props: PointMarkerProps<T>
 ) {
-  const { points, size = MARKER_POINT_SIZE } = props;
+  const size = MARKER_POINT_SIZE;
+  const { points } = props;
 
   if (!points.length) return null;
 
   return (
     <Container
       style={{
-        /**
-         * Not sure why we need +1 to align them with LineMarker
-         */
-        left: points[0].x + 1,
+        transform: `translateX(${points[0].x - size / 2}px)`,
         width: size,
       }}
     >
@@ -75,10 +37,33 @@ export function PointMarkers<T extends TimestampedValue>(
            * Dynamic properties like y position are set via inline style because
            * SC would dynamically generate and inject a new class for every position
            */
-          style={{ top: point.y }}
+          style={{ transform: `translateY(${point.y - size / 2}px)` }}
           key={index}
         />
       ))}
     </Container>
   );
 }
+
+const Container = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+`;
+
+const PointMarker = styled.div<MarkerProps>`
+  position: absolute;
+
+  position: absolute;
+  height: ${(x) => x.size}px;
+  width: ${(x) => x.size}px;
+  border-radius: 50%;
+  border: 1px solid white;
+  background: ${(props) => props.color};
+
+  box-shadow: 0 0 0 ${(x) => x.size / 2}px
+    ${(x) => transparentize(0.6, x.color)};
+`;


### PR DESCRIPTION
- use css transforms instead of the top/left properties
- throttle point-state mutations