### PR TITLE
Support bar-series without markers

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
@@ -68,13 +68,13 @@ const Label = styled.span(
   })
 );
 
-const Line = styled.div<LineProps>(
+const Line = styled.div<LineProps>((x) =>
   css({
     width: '1px',
     height: '100%',
     borderLeftWidth: '1px',
     borderLeftStyle: 'dashed',
-    borderLeftColor: (props) => props.color,
+    borderLeftColor: x.color,
   })
 );
 

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -351,9 +351,18 @@ export function TimeSeriesChart<
               width={dateSpanWidth}
               point={hoverState.nearestPoint}
             />
+
             <DateLineMarker
               point={hoverState.nearestPoint}
-              lineColor="#5B5B5B"
+              lineColor={
+                /**
+                 * Only display a line when we have range- or line-points.
+                 * Bar-series have no markers, which defeats the need of a line.
+                 */
+                hoverState.rangePoints.length || hoverState.linePoints.length
+                  ? '#5B5B5B'
+                  : 'transparent'
+              }
               value={values[hoverState.valuesIndex]}
             />
             <PointMarkers points={hoverState.rangePoints} />


### PR DESCRIPTION
## Summary

The bar series weren't part of the hover state, therefore a `nearestPoint` could be undefined when a chart was configured to display bar-data only.

This PR creates a separate `barPoints` collection as key of the hoverState, this allows us to not render markers for the bar series.
