### PR TITLE
Add afschaling placeholder page

### DIFF
--- a/packages/app/src/pages/afschaling.tsx
+++ b/packages/app/src/pages/afschaling.tsx
@@ -1,5 +1,8 @@
+import { isEmpty } from 'lodash';
 import Head from 'next/head';
+import { Box } from '~/components-styled/base';
 import { MaxWidth } from '~/components-styled/max-width';
+import { WarningTile } from '~/components-styled/warning-tile';
 import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import {
@@ -31,7 +34,20 @@ const Afschaling = (props: StaticProps<typeof getStaticProps>) => {
       </Head>
 
       <div>
-        <MaxWidth></MaxWidth>
+        <MaxWidth>
+          {!isEmpty(
+            siteText.nationaal_actueel.risiconiveaus.belangrijk_bericht
+          ) && (
+            <Box mb={3}>
+              <WarningTile
+                message={
+                  siteText.nationaal_actueel.risiconiveaus.belangrijk_bericht
+                }
+                variant="emphasis"
+              />
+            </Box>
+          )}
+        </MaxWidth>
       </div>
     </Layout>
   );

--- a/packages/app/src/pages/afschaling.tsx
+++ b/packages/app/src/pages/afschaling.tsx
@@ -1,0 +1,40 @@
+import Head from 'next/head';
+import { MaxWidth } from '~/components-styled/max-width';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+import {
+  createGetStaticProps,
+  StaticProps,
+} from '~/static-props/create-get-static-props';
+import { getLastGeneratedDate } from '~/static-props/get-data';
+
+export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
+
+const Afschaling = (props: StaticProps<typeof getStaticProps>) => {
+  const { siteText } = useIntl();
+  const { lastGenerated } = props;
+
+  return (
+    <Layout {...siteText.over_metadata} lastGenerated={lastGenerated}>
+      <Head>
+        <link
+          key="dc-type"
+          rel="dcterms:type"
+          href="https://standaarden.overheid.nl/owms/terms/webpagina"
+        />
+        <link
+          key="dc-type-title"
+          rel="dcterms:type"
+          href="https://standaarden.overheid.nl/owms/terms/webpagina"
+          title="webpagina"
+        />
+      </Head>
+
+      <div>
+        <MaxWidth></MaxWidth>
+      </div>
+    </Layout>
+  );
+};
+
+export default Afschaling;


### PR DESCRIPTION
## Summary

Add a simple placeholder page where all the bits and pieces concerning downscaling can be placed in.

## Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
