### PR TITLE
Simplify downscaling schema using single object

### DIFF
--- a/packages/app/schema/nl/downscaling.json
+++ b/packages/app/schema/nl/downscaling.json
@@ -18,7 +18,7 @@
     "reproduction_threshold_day_span": {
       "type": "integer"
     },
-    "intensive_care_is_below_threshold": {
+    "intensive_care_nice_is_below_threshold": {
       "type": "boolean"
     },
     "intensive_care_nice_threshold_value": {
@@ -46,7 +46,7 @@
     "reproduction_is_below_threshold",
     "reproduction_threshold_value",
     "reproduction_threshold_day_span",
-    "intensive_care_is_below_threshold",
+    "intensive_care_nice_is_below_threshold",
     "intensive_care_nice_threshold_value",
     "intensive_care_nice_threshold_day_span",
     "hospital_nice_is_below_threshold",

--- a/packages/app/schema/nl/downscaling.json
+++ b/packages/app/schema/nl/downscaling.json
@@ -7,7 +7,7 @@
       "type": "boolean"
     },
     "current_level_of_measures": {
-      "type": "number"
+      "type": "integer"
     },
     "reproduction_is_below_threshold": {
       "type": "boolean"

--- a/packages/app/schema/nl/downscaling.json
+++ b/packages/app/schema/nl/downscaling.json
@@ -3,79 +3,56 @@
   "title": "nl_downscaling",
   "type": "object",
   "properties": {
-    "values": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/value"
-      }
+    "is_downscaling_possible": {
+      "type": "boolean"
     },
-    "last_value": {
-      "$ref": "#/definitions/value"
+    "current_level_of_measures": {
+      "type": "number"
+    },
+    "reproduction_is_below_threshold": {
+      "type": "boolean"
+    },
+    "reproduction_threshold_value": {
+      "type": "number"
+    },
+    "reproduction_threshold_day_span": {
+      "type": "integer"
+    },
+    "intensive_care_is_below_threshold": {
+      "type": "boolean"
+    },
+    "intensive_care_nice_threshold_value": {
+      "type": "number"
+    },
+    "intensive_care_nice_threshold_day_span": {
+      "type": "integer"
+    },
+    "hospital_nice_is_below_threshold": {
+      "type": "boolean"
+    },
+    "hospital_nice_threshold_value": {
+      "type": "number"
+    },
+    "hospital_nice_threshold_day_span": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
     }
   },
-  "required": ["values", "last_value"],
-  "additionalProperties": false,
-  "definitions": {
-    "value": {
-      "title": "nl_downscaling_value",
-      "type": "object",
-      "properties": {
-        "is_downscaling_possible": {
-          "type": "boolean"
-        },
-        "current_level_of_measures": {
-          "type": "number"
-        },
-        "reproduction_is_below_threshold": {
-          "type": "boolean"
-        },
-        "reproduction_threshold_value": {
-          "type": "number"
-        },
-        "reproduction_threshold_day_span": {
-          "type": "integer"
-        },
-        "intensive_care_is_below_threshold": {
-          "type": "boolean"
-        },
-        "intensive_care_nice_threshold_value": {
-          "type": "number"
-        },
-        "intensive_care_nice_threshold_day_span": {
-          "type": "integer"
-        },
-        "hospital_nice_is_below_threshold": {
-          "type": "boolean"
-        },
-        "hospital_nice_threshold_value": {
-          "type": "number"
-        },
-        "hospital_nice_threshold_day_span": {
-          "type": "integer"
-        },
-        "date_unix": {
-          "type": "integer"
-        },
-        "date_of_insertion_unix": {
-          "type": "integer"
-        }
-      },
-      "required": [
-        "is_downscaling_possible",
-        "current_level_of_measures",
-        "reproduction_is_below_threshold",
-        "reproduction_threshold_value",
-        "reproduction_threshold_day_span",
-        "intensive_care_is_below_threshold",
-        "intensive_care_nice_threshold_value",
-        "intensive_care_nice_threshold_day_span",
-        "hospital_nice_is_below_threshold",
-        "hospital_nice_threshold_value",
-        "hospital_nice_threshold_day_span",
-        "date_end_unix",
-        "date_of_insertion_unix"
-      ],
-      "additionalProperties": false
-    }
-  }
+  "required": [
+    "is_downscaling_possible",
+    "current_level_of_measures",
+    "reproduction_is_below_threshold",
+    "reproduction_threshold_value",
+    "reproduction_threshold_day_span",
+    "intensive_care_is_below_threshold",
+    "intensive_care_nice_threshold_value",
+    "intensive_care_nice_threshold_day_span",
+    "hospital_nice_is_below_threshold",
+    "hospital_nice_threshold_value",
+    "hospital_nice_threshold_day_span",
+    "date_of_insertion_unix"
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

This simplifies the downscaling schema by removing value/last_value and only keeping data for one calculation. This also removes the need for date_unix as a standard property for all time-series, since it no longer is considered a series.