### PR TITLE
Add stepped curve support for line and area trends

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
@@ -1,3 +1,4 @@
+import { curveLinear, curveStep } from '@visx/curve';
 import { AreaClosed, LinePath } from '@visx/shape';
 import { PositionScale } from '@visx/shape/lib/types';
 import { useMemo } from 'react';
@@ -16,6 +17,7 @@ type AreaTrendProps = {
   getX: (v: SeriesItem) => number;
   getY: (v: SeriesSingleValue) => number;
   yScale: PositionScale;
+  curve?: 'linear' | 'step';
 };
 
 export function AreaTrend({
@@ -26,6 +28,7 @@ export function AreaTrend({
   getX,
   getY,
   yScale,
+  curve = 'linear',
 }: AreaTrendProps) {
   const nonNullSeries = useMemo(
     () => series.filter((x) => isPresent(x.__value)),
@@ -42,6 +45,7 @@ export function AreaTrend({
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
+        curve={curve === 'linear' ? curveLinear : curveStep}
       />
       <AreaClosed
         data={nonNullSeries}
@@ -49,6 +53,7 @@ export function AreaTrend({
         y={getY}
         fill={color}
         fillOpacity={fillOpacity}
+        curve={curve === 'linear' ? curveLinear : curveStep}
         yScale={yScale}
       />
     </>

--- a/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/area-trend.tsx
@@ -1,10 +1,9 @@
-import { curveLinear, curveStep } from '@visx/curve';
 import { AreaClosed, LinePath } from '@visx/shape';
 import { PositionScale } from '@visx/shape/lib/types';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { useUniqueId } from '~/utils/use-unique-id';
-import { SeriesItem, SeriesSingleValue } from '../logic';
+import { SeriesItem, SeriesSingleValue, curves } from '../logic';
 
 const DEFAULT_FILL_OPACITY = 0.2;
 const DEFAULT_STROKE_WIDTH = 2;
@@ -45,7 +44,7 @@ export function AreaTrend({
         strokeWidth={strokeWidth}
         strokeLinecap="round"
         strokeLinejoin="round"
-        curve={curve === 'linear' ? curveLinear : curveStep}
+        curve={curves[curve]}
       />
       <AreaClosed
         data={nonNullSeries}
@@ -53,7 +52,7 @@ export function AreaTrend({
         y={getY}
         fill={color}
         fillOpacity={fillOpacity}
-        curve={curve === 'linear' ? curveLinear : curveStep}
+        curve={curves[curve]}
         yScale={yScale}
       />
     </>

--- a/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
@@ -1,3 +1,4 @@
+import { curveLinear, curveStep } from '@visx/curve';
 import { LinePath } from '@visx/shape';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
@@ -15,6 +16,7 @@ type LineTrendProps = {
   strokeWidth?: number;
   getX: (v: SeriesItem) => number;
   getY: (v: SeriesSingleValue) => number;
+  curve?: 'linear' | 'step';
 };
 
 export function LineTrend({
@@ -24,6 +26,7 @@ export function LineTrend({
   color,
   getX,
   getY,
+  curve = 'linear',
 }: LineTrendProps) {
   const nonNullSeries = useMemo(
     () => series.filter((x) => isPresent(x.__value)),
@@ -37,6 +40,7 @@ export function LineTrend({
       y={getY}
       stroke={color}
       strokeWidth={strokeWidth}
+      curve={curve === 'linear' ? curveLinear : curveStep}
       strokeDasharray={style === 'dashed' ? 4 : undefined}
       strokeLinecap="butt"
       strokeLinejoin="round"

--- a/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/line-trend.tsx
@@ -1,8 +1,7 @@
-import { curveLinear, curveStep } from '@visx/curve';
 import { LinePath } from '@visx/shape';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
-import { SeriesItem, SeriesSingleValue } from '../logic';
+import { SeriesItem, SeriesSingleValue, curves } from '../logic';
 
 export type LineStyle = 'solid' | 'dashed';
 
@@ -40,7 +39,7 @@ export function LineTrend({
       y={getY}
       stroke={color}
       strokeWidth={strokeWidth}
-      curve={curve === 'linear' ? curveLinear : curveStep}
+      curve={curves[curve]}
       strokeDasharray={style === 'dashed' ? 4 : undefined}
       strokeLinecap="butt"
       strokeLinejoin="round"

--- a/packages/app/src/components-styled/time-series-chart/components/series.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/series.tsx
@@ -60,6 +60,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                   color={config.color}
                   style={config.style}
                   strokeWidth={config.strokeWidth}
+                  curve={config.curve}
                   getX={getX}
                   getY={getY}
                 />
@@ -72,6 +73,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                   color={config.color}
                   fillOpacity={config.fillOpacity}
                   strokeWidth={config.strokeWidth}
+                  curve={config.curve}
                   getX={getX}
                   getY={getY}
                   yScale={yScale}

--- a/packages/app/src/components-styled/time-series-chart/logic/curves.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/curves.ts
@@ -1,0 +1,6 @@
+import { curveLinear, curveStep } from '@visx/curve';
+
+export const curves = {
+  linear: curveLinear,
+  step: curveStep,
+} as const;

--- a/packages/app/src/components-styled/time-series-chart/logic/index.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/index.ts
@@ -4,3 +4,4 @@ export * from './hover-state';
 export * from './common';
 export * from './legend';
 export * from './dimensions';
+export * from './curves';

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -24,6 +24,7 @@ export type LineSeriesDefinition<T extends TimestampedValue> = {
   color: string;
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
+  curve?: 'linear' | 'step';
 };
 
 export type AreaSeriesDefinition<T extends TimestampedValue> = {
@@ -34,6 +35,7 @@ export type AreaSeriesDefinition<T extends TimestampedValue> = {
   color: string;
   fillOpacity?: number;
   strokeWidth?: number;
+  curve?: 'linear' | 'step';
 };
 
 export type BarSeriesDefinition<T extends TimestampedValue> = {

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -246,6 +246,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.positief_geteste_personen.tooltip_labels
                         .infected_per_100k,
                     color: colors.data.primary,
+                    /**
+                     * @TODO remove this before merging the PR
+                     */
+                    curve: 'step',
                   },
                   {
                     type: 'invisible',

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -246,10 +246,6 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.positief_geteste_personen.tooltip_labels
                         .infected_per_100k,
                     color: colors.data.primary,
-                    /**
-                     * @TODO remove this before merging the PR
-                     */
-                    curve: 'step',
                   },
                   {
                     type: 'invisible',


### PR DESCRIPTION
## Summary

We need a stepped curve from some future charts. This adds support for stepped line and area trends.

![image](https://user-images.githubusercontent.com/71320230/113878731-2aa37a00-97ba-11eb-9223-5b3f827c33b0.png)
