### PR TITLE
Fix chart hover regression

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/hover-state.ts
@@ -221,13 +221,6 @@ export function useHoverState<T extends TimestampedValue>({
       .filter(isDefined);
 
     /**
-     * If there are no points getting hovered, hover state should be undefined
-     */
-    if (!linePoints.length) {
-      return;
-    }
-
-    /**
      * Point markers on range data are rendered differently, so we split them
      * out here, so we avoid having to create a union type and complicate
      * things.


### PR DESCRIPTION
## Summary

I've fixed the same issue with another PR, but on line 288 by checking the existence of the nearestPoint. The removed lines in this PR enable hover interaction for bar charts.

```tsx
    /**
     * Empty hoverstate when there's no nearest point detected
     */
    if (!nearestPoint) {
      return undefined;
    }

