### PR TITLE
Fix handling of empty values in timeframe

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -37,11 +37,12 @@ export function useScales<T extends TimestampedValue>(args: {
   const { maximumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
+    const [start, end] = getTimeDomain(values, { withPadding: true });
+
     if (isEmpty(values)) {
-      const today = Date.now() / 1000;
       return {
         xScale: scaleLinear({
-          domain: [today, today + ONE_DAY_IN_SECONDS],
+          domain: [start, end],
           range: [0, bounds.width],
         }),
         yScale: scaleLinear({
@@ -55,8 +56,6 @@ export function useScales<T extends TimestampedValue>(args: {
         dateSpanWidth: 0,
       };
     }
-
-    const [start, end] = getTimeDomain(values, { withPadding: true });
 
     const xScale = scaleLinear({
       domain: [start, end],
@@ -99,6 +98,14 @@ export function getTimeDomain<T extends TimestampedValue>(
   values: T[],
   { withPadding }: { withPadding: boolean }
 ): [start: number, end: number] {
+  /**
+   * Return a sensible default when no values fall within the selected timeframe
+   */
+  if (isEmpty(values)) {
+    const today = Date.now() / 1000;
+    return [today, today + ONE_DAY_IN_SECONDS];
+  }
+
   /**
    * This code is assuming the values array is already sorted in time, so we
    * only need to pick the first and last values.

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -247,6 +247,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.positief_geteste_personen.tooltip_labels
                         .infected_per_100k,
                     color: colors.data.primary,
+                    /**
+                     * @TODO remove this before merging the PR
+                     */
+                    curve: 'step',
                   },
                   {
                     type: 'invisible',

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -247,10 +247,6 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.positief_geteste_personen.tooltip_labels
                         .infected_per_100k,
                     color: colors.data.primary,
-                    /**
-                     * @TODO remove this before merging the PR
-                     */
-                    curve: 'step',
                   },
                   {
                     type: 'invisible',


### PR DESCRIPTION
## Summary

Handle situation where chart is rendered with a timeframe that contains no values.