### PR TITLE
Add `displayTooltipValueOnly` option to TimeSeriesChart

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -29,6 +29,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
     config,
     options,
     markNearestPointOnly,
+    displayTooltipValueOnly,
     timespanAnnotation,
   } = tooltipData;
 
@@ -88,37 +89,41 @@ export function TooltipSeriesList<T extends TimestampedValue>({
           switch (x.type) {
             case 'stacked-area':
               return (
-                <TooltipListItem key={index} icon={<SeriesIcon config={x} />}>
-                  <TooltipValueContainer>
-                    <InlineText mr={2}>{x.shortLabel || x.label}:</InlineText>
-                    <b>
-                      {getValueStringForKey(
-                        value,
-                        x.metricProperty,
-                        options.isPercentage
-                      )}
-                    </b>
-                  </TooltipValueContainer>
+                <TooltipListItem
+                  key={index}
+                  icon={<SeriesIcon config={x} />}
+                  label={x.shortLabel ?? x.label}
+                  displayTooltipValueOnly={displayTooltipValueOnly}
+                >
+                  <b>
+                    {getValueStringForKey(
+                      value,
+                      x.metricProperty,
+                      options.isPercentage
+                    )}
+                  </b>
                 </TooltipListItem>
               );
 
             case 'range':
               return (
-                <TooltipListItem key={index} icon={<SeriesIcon config={x} />}>
-                  <TooltipValueContainer>
-                    <InlineText mr={2}>{x.shortLabel || x.label}:</InlineText>
-                    <b css={css({ whiteSpace: 'nowrap' })}>
-                      {`${getValueStringForKey(
-                        value,
-                        x.metricPropertyLow,
-                        options.isPercentage
-                      )} - ${getValueStringForKey(
-                        value,
-                        x.metricPropertyHigh,
-                        options.isPercentage
-                      )}`}
-                    </b>
-                  </TooltipValueContainer>
+                <TooltipListItem
+                  key={index}
+                  icon={<SeriesIcon config={x} />}
+                  label={x.shortLabel ?? x.label}
+                  displayTooltipValueOnly={displayTooltipValueOnly}
+                >
+                  <b css={css({ whiteSpace: 'nowrap' })}>
+                    {`${getValueStringForKey(
+                      value,
+                      x.metricPropertyLow,
+                      options.isPercentage
+                    )} - ${getValueStringForKey(
+                      value,
+                      x.metricPropertyHigh,
+                      options.isPercentage
+                    )}`}
+                  </b>
                 </TooltipListItem>
               );
 
@@ -126,33 +131,36 @@ export function TooltipSeriesList<T extends TimestampedValue>({
             case 'area':
             case 'bar':
               return (
-                <TooltipListItem key={index} icon={<SeriesIcon config={x} />}>
-                  <TooltipValueContainer>
-                    <InlineText mr={2}>{x.shortLabel || x.label}:</InlineText>
-                    <b>
-                      {getValueStringForKey(
-                        value,
-                        x.metricProperty,
-                        options.isPercentage
-                      )}
-                    </b>
-                  </TooltipValueContainer>
+                <TooltipListItem
+                  key={index}
+                  icon={<SeriesIcon config={x} />}
+                  label={x.shortLabel ?? x.label}
+                  displayTooltipValueOnly={displayTooltipValueOnly}
+                >
+                  <b>
+                    {getValueStringForKey(
+                      value,
+                      x.metricProperty,
+                      options.isPercentage
+                    )}
+                  </b>
                 </TooltipListItem>
               );
 
             case 'invisible':
               return (
-                <TooltipListItem key={index}>
-                  <TooltipValueContainer>
-                    <InlineText mr={2}>{x.label}:</InlineText>
-                    <b>
-                      {getValueStringForKey(
-                        value,
-                        x.metricProperty,
-                        x.isPercentage
-                      )}
-                    </b>
-                  </TooltipValueContainer>
+                <TooltipListItem
+                  key={index}
+                  label={x.label}
+                  displayTooltipValueOnly={displayTooltipValueOnly}
+                >
+                  <b>
+                    {getValueStringForKey(
+                      value,
+                      x.metricProperty,
+                      x.isPercentage
+                    )}
+                  </b>
                 </TooltipListItem>
               );
           }
@@ -174,10 +182,26 @@ export const TooltipList = styled.ol<{ hasTwoColumns?: boolean }>(
 
 interface TooltipListItemProps {
   children: ReactNode;
+  label?: string;
   icon?: ReactNode;
+  displayTooltipValueOnly?: boolean;
 }
 
-function TooltipListItem({ children, icon }: TooltipListItemProps) {
+function TooltipListItem({
+  children,
+  icon,
+  label,
+  displayTooltipValueOnly,
+}: TooltipListItemProps) {
+  const labelComponent = <InlineText mr={2}>{label}:</InlineText>;
+  const iconComponent = icon ? (
+    <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
+      {icon}
+    </Box>
+  ) : (
+    <Box width="1em" mt={1} />
+  );
+
   return (
     <Box
       as="li"
@@ -186,15 +210,17 @@ function TooltipListItem({ children, icon }: TooltipListItemProps) {
       display="flex"
       alignItems="stretch"
     >
-      {icon ? (
-        <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
-          {icon}
-        </Box>
-      ) : (
-        <Box width="1em" mt={1} />
-      )}
-
-      <Box flexGrow={1}>{children}</Box>
+      {!displayTooltipValueOnly && iconComponent}
+      <Box flexGrow={1}>
+        <TooltipValueContainer>
+          {displayTooltipValueOnly ? (
+            <VisuallyHidden>{labelComponent}</VisuallyHidden>
+          ) : (
+            labelComponent
+          )}
+          {children}
+        </TooltipValueContainer>
+      </Box>
     </Box>
   );
 }

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -193,15 +193,6 @@ function TooltipListItem({
   label,
   displayTooltipValueOnly,
 }: TooltipListItemProps) {
-  const labelComponent = <InlineText mr={2}>{label}:</InlineText>;
-  const iconComponent = icon ? (
-    <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
-      {icon}
-    </Box>
-  ) : (
-    <Box width="1em" mt={1} />
-  );
-
   return (
     <Box
       as="li"
@@ -213,15 +204,23 @@ function TooltipListItem({
       {displayTooltipValueOnly ? (
         <Box flexGrow={1}>
           <TooltipValueContainer>
-            <VisuallyHidden>{labelComponent}</VisuallyHidden>
+            <VisuallyHidden>
+              <InlineText mr={2}>{label}:</InlineText>
+            </VisuallyHidden>
             {children}
           </TooltipValueContainer>
         </Box>
       ) : (
         <>
-          {iconComponent}
+          {icon ? (
+            <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
+              {icon}
+            </Box>
+          ) : (
+            <Box width="1em" mt={1} />
+          )}
           <TooltipValueContainer>
-            {labelComponent}
+            <InlineText mr={2}>{label}:</InlineText>
             {children}
           </TooltipValueContainer>
         </>

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -210,17 +210,22 @@ function TooltipListItem({
       display="flex"
       alignItems="stretch"
     >
-      {!displayTooltipValueOnly && iconComponent}
-      <Box flexGrow={1}>
-        <TooltipValueContainer>
-          {displayTooltipValueOnly ? (
+      {displayTooltipValueOnly ? (
+        <Box flexGrow={1}>
+          <TooltipValueContainer>
             <VisuallyHidden>{labelComponent}</VisuallyHidden>
-          ) : (
-            labelComponent
-          )}
-          {children}
-        </TooltipValueContainer>
-      </Box>
+            {children}
+          </TooltipValueContainer>
+        </Box>
+      ) : (
+        <>
+          {iconComponent}
+          <TooltipValueContainer>
+            {labelComponent}
+            {children}
+          </TooltipValueContainer>
+        </>
+      )}
     </Box>
   );
 }

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -219,10 +219,12 @@ function TooltipListItem({
           ) : (
             <Box width="1em" mt={1} />
           )}
-          <TooltipValueContainer>
-            <InlineText mr={2}>{label}:</InlineText>
-            {children}
-          </TooltipValueContainer>
+          <Box flexGrow={1}>
+            <TooltipValueContainer>
+              <InlineText mr={2}>{label}:</InlineText>
+              {children}
+            </TooltipValueContainer>
+          </Box>
         </>
       )}
     </Box>

--- a/packages/app/src/components-styled/time-series-chart/components/tooltip/types.ts
+++ b/packages/app/src/components-styled/time-series-chart/components/tooltip/types.ts
@@ -37,6 +37,11 @@ export type TooltipData<T extends TimestampedValue> = {
    * Configuration to display the nearest point only in the tooltip
    */
   markNearestPointOnly?: boolean;
+
+  /**
+   * Configuration to display only a value in the tooltip
+   */
+  displayTooltipValueOnly?: boolean;
 };
 
 export type TooltipFormatter<T extends TimestampedValue> = (

--- a/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components-styled/time-series-chart/time-series-chart.tsx
@@ -110,6 +110,12 @@ export type TimeSeriesChartProps<
    * will result in a user interacting with the single nearest point only.
    */
   markNearestPointOnly?: boolean;
+
+  /**
+   * Display only values inside the tooltip.
+   * This option only makes sense when we display a single trend.
+   */
+  displayTooltipValueOnly?: boolean;
 };
 
 export function TimeSeriesChart<
@@ -132,6 +138,7 @@ export function TimeSeriesChart<
   disableLegend,
   onSeriesClick,
   markNearestPointOnly,
+  displayTooltipValueOnly,
 }: TimeSeriesChartProps<T, C>) {
   const {
     tooltipData,
@@ -224,6 +231,7 @@ export function TimeSeriesChart<
           config: seriesConfig,
           configIndex: nearestPoint.seriesConfigIndex,
           markNearestPointOnly,
+          displayTooltipValueOnly,
           options: dataOptions || {},
           /**
            * Pass the full annotation data. We could just pass the index because
@@ -250,6 +258,7 @@ export function TimeSeriesChart<
     dataOptions,
     timespanAnnotations,
     markNearestPointOnly,
+    displayTooltipValueOnly,
   ]);
 
   useOnClickOutside([sizeRef], () => tooltipData && hideTooltip());


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/73584448/114007295-7fe69680-9861-11eb-8c31-c63f378f0979.png)
