### PR TITLE
Update query to also get english label

### DIFF
--- a/packages/app/src/queries/topical-page-query.ts
+++ b/packages/app/src/queries/topical-page-query.ts
@@ -30,7 +30,7 @@ export function getTopicalPageQuery(_context: GetStaticPropsContext) {
       highlights[]{
         "title":title.${locale},
         "category": category.${locale},
-        "label":label.nl,
+        "label":label.${locale},
         href,
         "cover": {
           ...cover,


### PR DESCRIPTION
Forgot to use the translation key for labels in the highlighted articles query.