### PR TITLE
Add option for dateText for tiles

### DIFF
--- a/packages/app/src/components-styled/metadata.tsx
+++ b/packages/app/src/components-styled/metadata.tsx
@@ -13,6 +13,7 @@ export interface MetadataProps {
   };
   obtained?: number;
   isTileFooter?: boolean;
+  datumsText?: string;
 }
 
 export function Metadata({
@@ -20,6 +21,7 @@ export function Metadata({
   source,
   obtained,
   isTileFooter,
+  datumsText,
 }: MetadataProps) {
   const { siteText, formatDateFromSeconds } = useIntl();
 
@@ -49,15 +51,27 @@ export function Metadata({
       {isTileFooter && (
         <Box as="footer" mt={3} mb={{ _: 0, sm: -3 }} gridArea="metadata">
           <Text my={0} color="annotation" fontSize={1}>
-            {dateString}
-            {obtained &&
-              ` ${replaceVariablesInText(siteText.common.metadata.obtained, {
-                date: formatDateFromSeconds(obtained, 'weekday-medium'),
-              })}`}
-            {dateString && source ? ' · ' : null}
-            {source
-              ? `${siteText.common.metadata.source}: ${source.text}`
-              : null}
+            {datumsText && Array.isArray(date) ? (
+              replaceVariablesInText(datumsText, {
+                weekStart: formatDateFromSeconds(date[0], 'weekday-medium'),
+                weekEnd: formatDateFromSeconds(date[1], 'weekday-medium'),
+              })
+            ) : (
+              <>
+                {dateString}
+                {obtained &&
+                  ` ${replaceVariablesInText(
+                    siteText.common.metadata.obtained,
+                    {
+                      date: formatDateFromSeconds(obtained, 'weekday-medium'),
+                    }
+                  )}`}
+                {dateString && source ? ' · ' : null}
+                {source
+                  ? `${siteText.common.metadata.source}: ${source.text}`
+                  : null}
+              </>
+            )}
           </Text>
         </Box>
       )}

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -2144,7 +2144,8 @@
       "omschrijving": "This graph shows the percentage per age group and in total of the population that wishes to be vaccinated against COVID-19. The figures are taken from a survey where people are asked if they wish to be vaccinated. The survey is conducted every three weeks.",
       "kpi_omschrijving": "Percentage of the population that wishes to be vaccinated against COVID-19",
       "tooltip_gemiddeld": "In total",
-      "leeftijd_jaar": "{{ageGroup}} years old"
+      "leeftijd_jaar": "{{ageGroup}} years old",
+      "metadata_tekst": "This survey was carried out between {{weekStart}} and {{weekEnd}}. Is updated every 3 weeks."
     },
     "gezette_prikken": {
       "title": "Number of doses administered",

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -2144,7 +2144,8 @@
       "omschrijving": "Deze grafiek toont per leeftijdsgroep en in totaal hoeveel procent van de bevolking zelf een prik tegen corona wil hebben. De cijfers komen uit onderzoek waarin wordt gevraagd of mensen een prik willen krijgen. Het onderzoek wordt elke drie weken herhaald.",
       "kpi_omschrijving": "Percentage van de Nederlandse bevolking dat zelf een prik tegen corona wil hebben",
       "tooltip_gemiddeld": "Totaal",
-      "leeftijd_jaar": "{{ageGroup}} jaar"
+      "leeftijd_jaar": "{{ageGroup}} jaar",
+      "metadata_tekst": "Enquête is afgenomen tussen {{weekStart}} en {{weekEnd}}. Wordt 3-wekelijks bijgewerkt."
     },
     "gezette_prikken": {
       "title": "Aantal gezette prikken",

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -265,8 +265,11 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               siteText.accessibility.grafieken.vaccinatie_draagvlak
             }
             metadata={{
-              date: data.vaccine_support.last_value.date_of_insertion_unix,
-              source: text.bronnen.rivm,
+              datumsText: siteText.vaccinaties.grafiek_draagvlak.metadata_tekst,
+              date: [
+                data.vaccine_support.last_value.date_start_unix,
+                data.vaccine_support.last_value.date_end_unix,
+              ],
             }}
           >
             <section>


### PR DESCRIPTION
The willingness to be vaccinated tile needed a more descriptive text. Added the `datumsText` props to show something like: `Enquête is afgenomen tussen maandag 8 maart en zondag 14 maart. Wordt 3-wekelijks bijgewerkt.`.