### PR TITLE
Round the scale outputs to render on round pixels

### DIFF
--- a/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
+++ b/packages/app/src/components-styled/time-series-chart/components/date-line-marker.tsx
@@ -1,13 +1,9 @@
-import {
-  DateSpanValue,
-  isDateSpanValue,
-  TimestampedValue,
-} from '@corona-dashboard/common';
+import { isDateSpanValue, TimestampedValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import styled from 'styled-components';
+import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { HoveredPoint } from '../logic';
-import { useIntl } from '~/intl';
 
 type LineProps = {
   color: string;
@@ -28,23 +24,21 @@ export function DateLineMarker<T extends TimestampedValue>({
   point,
   value,
 }: DateLineMarkerProps<T>) {
-  const isDateSpan = isDateSpanValue(value);
   const { formatDateFromSeconds } = useIntl();
-
   return (
     <Container style={{ transform: `translateX(${point.x}px)` }}>
       <Line color={lineColor} />
       <LabelContainer>
         <Label>
-          {isDateSpan
-            ? `${formatDateFromSeconds(
-                (value as DateSpanValue).date_start_unix,
-                'axis'
-              )} - ${formatDateFromSeconds(
-                (value as DateSpanValue).date_end_unix,
-                'axis'
-              )}`
-            : formatDateFromSeconds(point.seriesValue.__date_unix, 'axis')}
+          {isDateSpanValue(value) ? (
+            <>
+              {formatDateFromSeconds(value.date_start_unix, 'axis')}
+              <> &ndash; </>
+              {formatDateFromSeconds(value.date_end_unix, 'axis')}
+            </>
+          ) : (
+            formatDateFromSeconds(point.seriesValue.__date_unix, 'axis')
+          )}
         </Label>
       </LabelContainer>
     </Container>

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -61,12 +61,14 @@ export function useScales<T extends TimestampedValue>(args: {
     const xScale = scaleLinear({
       domain: [start, end],
       range: [0, bounds.width],
+      round: true, // round the output values so we render on round pixels
     });
 
     const yScale = scaleLinear({
       domain: [0, maximumValue],
       range: [bounds.height, 0],
       nice: numTicks,
+      round: true, // round the output values so we render on round pixels
     });
 
     const result: UseScalesResult = {

--- a/packages/app/src/domain/topical/mini-trend-tile-layout.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile-layout.tsx
@@ -16,12 +16,7 @@ export function MiniTrendTileLayout({
   const gutterSize = 4;
 
   return (
-    <Box
-      display={{ _: 'block', md: 'flex' }}
-      overflow="hidden"
-      mx={-gutterSize}
-      id={id}
-    >
+    <Box display={{ _: 'block', md: 'flex' }} mx={-gutterSize} id={id}>
       {tiles.map((tile: ReactNode, index: number) => (
         <Box flex={`1 1 ${columnWidth}`} key={index} mx={gutterSize}>
           {tile}


### PR DESCRIPTION
## Summary

This will prevent "blurry" lines in our charts.