### PR TITLE
Fix missing key warning choropleths

### DIFF
--- a/packages/app/src/components/choropleth/safety-region-choropleth.tsx
+++ b/packages/app/src/components/choropleth/safety-region-choropleth.tsx
@@ -156,6 +156,7 @@ export function SafetyRegionChoropleth<T, K extends RegionsMetricName>(
           stroke={isEscalationLevelTheme || isSelected ? '#fff' : undefined}
           strokeWidth={isEscalationLevelTheme || isSelected ? 3 : undefined}
           isSelected={isSelected}
+          key={vrcode}
           {...anchorEventHandlers}
         />
       );


### PR DESCRIPTION
There was a key missing in a hover path, this should fix the warning.