### PR TITLE
Make image from article strip consistent in size on smaller screens

### DIFF
--- a/packages/app/src/components-styled/article-strip.tsx
+++ b/packages/app/src/components-styled/article-strip.tsx
@@ -66,7 +66,7 @@ function ArticleStripItem(props: ArticleStripItemProps) {
   return (
     <Link passHref href={`/artikelen/${slug}`}>
       <StyledLink>
-        <Box width={122} maxHeight={122} overflow="hidden">
+        <Box width={122} minWidth={122} maxHeight={122} overflow="hidden">
           <SanityImage
             {...getImageProps(cover, {
               defaultWidth: 122,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -80,7 +80,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        {/* <TileList>
+        <TileList>
           <VaccinePageIntroduction data={data} text={text} />
 
           <ArticleStrip articles={content.highlight.articles} />
@@ -230,7 +230,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               )}
             </KpiTile>
           )}
-        </TileList> */}
+        </TileList>
       </NationalLayout>
     </Layout>
   );

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -80,7 +80,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NationalLayout data={data} lastGenerated={lastGenerated}>
-        <TileList>
+        {/* <TileList>
           <VaccinePageIntroduction data={data} text={text} />
 
           <ArticleStrip articles={content.highlight.articles} />
@@ -230,7 +230,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               )}
             </KpiTile>
           )}
-        </TileList>
+        </TileList> */}
       </NationalLayout>
     </Layout>
   );


### PR DESCRIPTION
Added a min-width so that flex doesn't squish the images. They don't appear unequal in size on smaller screens.