### PR TITLE
Fix react rehydration errors

### DIFF
--- a/packages/app/src/components-styled/area-chart/hooks/use-area-configs.ts
+++ b/packages/app/src/components-styled/area-chart/hooks/use-area-configs.ts
@@ -6,6 +6,7 @@ import {
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { timestampToDate } from '~/components-styled/stacked-chart/logic';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { TimeframeOption } from '~/utils/timeframe';
 import { createUniqueId } from '~/utils/use-unique-id';
 import { AreaDescriptor } from '../area-chart';
@@ -16,20 +17,22 @@ export function useAreaConfigs<T extends TimestampedValue>(
   areaDescriptors: AreaDescriptor<T>[],
   timeframe: TimeframeOption
 ): AreaConfig<T & TimestampedTrendValue>[] {
+  const today = useCurrentDate();
   const areaConfigs = useMemo(() => {
     return areaDescriptors.map<AreaConfig<T & TimestampedTrendValue>>(
       (descriptor) => ({
         values: getAreaData(
           descriptor.values,
           descriptor.displays.map((x) => x.metricProperty),
-          timeframe
+          timeframe,
+          today
         ),
         displays: [
           ...descriptor.displays.map((x) => ({ id: createUniqueId(), ...x })),
         ],
       })
     );
-  }, [areaDescriptors, timeframe]);
+  }, [areaDescriptors, timeframe, today]);
 
   return areaConfigs;
 }
@@ -37,9 +40,10 @@ export function useAreaConfigs<T extends TimestampedValue>(
 export function getAreaData<T extends TimestampedValue>(
   values: T[],
   metricProperties: (keyof T)[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ): (T & TimestampedTrendValue)[] {
-  const valuesInFrame = getTimeframeValues(values, timeframe);
+  const valuesInFrame = getTimeframeValues(values, timeframe, today);
 
   if (valuesInFrame.length === 0) {
     /**

--- a/packages/app/src/components-styled/area-chart/hooks/use-trend-configs.ts
+++ b/packages/app/src/components-styled/area-chart/hooks/use-trend-configs.ts
@@ -1,5 +1,6 @@
 import { TimestampedValue } from '@corona-dashboard/common';
 import { useMemo } from 'react';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { getValuesInTimeframe, TimeframeOption } from '~/utils/timeframe';
 import { TrendDescriptor } from '../area-chart';
 import { TrendConfig } from '../components/area-chart-graph';
@@ -9,11 +10,16 @@ export function useTrendConfigs<T extends TimestampedValue>(
   trendDescriptors: TrendDescriptor<T>[],
   timeframe: TimeframeOption
 ): TrendConfig<T & TimestampedTrendValue>[] {
+  const today = useCurrentDate();
   const trendConfigs = useMemo(
     () =>
       trendDescriptors
         .map((descriptor) => {
-          const series = getValuesInTimeframe(descriptor.values, timeframe);
+          const series = getValuesInTimeframe(
+            descriptor.values,
+            timeframe,
+            today
+          );
           return descriptor.displays.map<
             TrendConfig<T & TimestampedTrendValue>
           >((displayConfig) => {
@@ -29,7 +35,7 @@ export function useTrendConfigs<T extends TimestampedValue>(
           });
         })
         .flat(),
-    [trendDescriptors, timeframe]
+    [trendDescriptors, timeframe, today]
   );
 
   return trendConfigs;

--- a/packages/app/src/components-styled/area-chart/logic/index.ts
+++ b/packages/app/src/components-styled/area-chart/logic/index.ts
@@ -55,9 +55,10 @@ export function calculateYMax(values: TrendValue[], signaalwaarde = -Infinity) {
  */
 export function getTimeframeValues(
   values: TimestampedValue[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ) {
-  const boundary = getTimeframeBoundaryUnix(timeframe);
+  const boundary = getTimeframeBoundaryUnix(timeframe, today);
 
   if (isDateSeries(values)) {
     return values.filter((x) => x.date_unix >= boundary);
@@ -72,12 +73,12 @@ export function getTimeframeValues(
 
 const oneDayInSeconds = 24 * 60 * 60;
 
-function getTimeframeBoundaryUnix(timeframe: TimeframeOption) {
+function getTimeframeBoundaryUnix(timeframe: TimeframeOption, today: Date) {
   if (timeframe === 'all') {
     return 0;
   }
   const days = getDaysForTimeframe(timeframe);
-  return Date.now() / 1000 - days * oneDayInSeconds;
+  return today.getTime() / 1000 - days * oneDayInSeconds;
 }
 
 export type TrendValue = {
@@ -90,9 +91,10 @@ export type TimestampedTrendValue = TrendValue & TimestampedValue;
 export function getTrendData<T extends TimestampedValue>(
   values: T[],
   metricProperties: (keyof T)[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ): (T & TimestampedTrendValue)[][] {
-  const series = getValuesInTimeframe(values, timeframe);
+  const series = getValuesInTimeframe(values, timeframe, today);
 
   const trendData = metricProperties.map(
     (metricProperty) =>

--- a/packages/app/src/components-styled/layout/app-footer.tsx
+++ b/packages/app/src/components-styled/layout/app-footer.tsx
@@ -9,7 +9,7 @@ import { Link } from '~/utils/link';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { Markdown } from '~/components-styled/markdown';
 
-export function AppFooter({ lastGenerated }: { lastGenerated: string }) {
+export function AppFooter({ lastGenerated }: { lastGenerated: number }) {
   const { siteText: text } = useIntl();
 
   return (
@@ -66,10 +66,10 @@ export function AppFooter({ lastGenerated }: { lastGenerated: string }) {
   );
 }
 
-function LastGeneratedMessage({ date }: { date: string }) {
+function LastGeneratedMessage({ date }: { date: number }) {
   const { siteText: text, formatDateFromSeconds } = useIntl();
-  const dateIso = formatDateFromSeconds(Number(date), 'iso');
-  const dateLong = formatDateFromSeconds(Number(date), 'long');
+  const dateIso = formatDateFromSeconds(date, 'iso');
+  const dateLong = formatDateFromSeconds(date, 'long');
 
   return (
     <Box maxWidth={450}>

--- a/packages/app/src/components-styled/line-chart/line-chart.tsx
+++ b/packages/app/src/components-styled/line-chart/line-chart.tsx
@@ -28,6 +28,7 @@ import { TimeframeOption } from '~/utils/timeframe';
 import { useElementSize } from '~/utils/use-element-size';
 import { HoverPoint, Marker, Tooltip, Trend } from './components';
 import { calculateYMax, getTrendData, TrendValue } from './logic';
+import { useCurrentDate } from '~/utils/current-date-context';
 
 export type LineConfig<T extends TimestampedValue> = {
   metricProperty: keyof T;
@@ -133,9 +134,10 @@ export function LineChart<T extends TimestampedValue>({
     [signaalwaarde, text.common.signaalwaarde]
   );
 
+  const today = useCurrentDate();
   const trendsList = useMemo(
-    () => getTrendData(values, metricProperties as string[], timeframe),
-    [values, metricProperties, timeframe]
+    () => getTrendData(values, metricProperties as string[], timeframe, today),
+    [values, metricProperties, timeframe, today]
   );
 
   const calculatedSeriesMax = useMemo(

--- a/packages/app/src/components-styled/line-chart/logic/index.ts
+++ b/packages/app/src/components-styled/line-chart/logic/index.ts
@@ -60,9 +60,10 @@ export type TrendData = (TrendValue & TimestampedValue)[][];
 export function getTrendData<T extends TimestampedValue>(
   values: T[],
   metricProperties: string[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ): TrendData {
-  const series = getValuesInTimeframe(values, timeframe);
+  const series = getValuesInTimeframe(values, timeframe, today);
 
   const trendData = metricProperties.map(
     (metricProperty) =>

--- a/packages/app/src/components-styled/sewer-chart/logic.ts
+++ b/packages/app/src/components-styled/sewer-chart/logic.ts
@@ -6,6 +6,7 @@ import { bisector } from 'd3-array';
 import { lineLength } from 'geometric';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { SelectProps } from '~/components-styled/select';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
 
 export interface Dimensions {
@@ -27,6 +28,7 @@ export function useSewerChartValues(
   data: Regionaal | Municipal,
   timeframe: TimeframeOption
 ) {
+  const today = useCurrentDate();
   /**
    * Create average sewer data, used for the line chart
    */
@@ -36,6 +38,7 @@ export function useSewerChartValues(
         ? getFilteredValues(
             data.sewer.values,
             timeframe,
+            today,
             (x) => x.date_start_unix * 1000
           )
             .map((x) => ({
@@ -53,7 +56,7 @@ export function useSewerChartValues(
               id: [x.name, x.value, x.dateMs].join('-'),
             }))
         : [],
-    [data.sewer, timeframe]
+    [data.sewer, timeframe, today]
   );
 
   /**
@@ -67,6 +70,7 @@ export function useSewerChartValues(
               getFilteredValues(
                 value.values,
                 timeframe,
+                today,
                 (x) => x.date_unix * 1000
               )
                 .map((x) => ({
@@ -85,7 +89,7 @@ export function useSewerChartValues(
             .filter(dedupe('id'))
         : [],
 
-    [data.sewer_per_installation, timeframe]
+    [data.sewer_per_installation, timeframe, today]
   );
 
   return [averageValues, stationValues] as const;

--- a/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components-styled/stacked-chart/stacked-chart.tsx
@@ -27,6 +27,7 @@ import { InlineText } from '~/components-styled/typography';
 import { ValueAnnotation } from '~/components-styled/value-annotation';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { getValuesInTimeframe, TimeframeOption } from '~/utils/timeframe';
 import { useElementSize } from '~/utils/use-element-size';
 import { useIsMountedRef } from '~/utils/use-is-mounted-ref';
@@ -181,9 +182,11 @@ export function StackedChart<T extends TimestampedValue>(
     config,
   ]);
 
+  const today = useCurrentDate();
+
   const valuesInTimeframe = useMemo(
-    () => getValuesInTimeframe(values, timeframe),
-    [values, timeframe]
+    () => getValuesInTimeframe(values, timeframe, today),
+    [values, timeframe, today]
   );
 
   const series = useMemo(

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -35,12 +35,11 @@ export function useScales<T extends TimestampedValue>(args: {
   bounds: Bounds;
   numTicks: number;
 }) {
-  const todayDate = useCurrentDate();
+  const today = useCurrentDate().getTime() / 1000;
   const { maximumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
     if (isEmpty(values)) {
-      const today = todayDate.getTime() / 1000;
       return {
         xScale: scaleLinear({
           domain: [today, today + ONE_DAY_IN_SECONDS],
@@ -84,7 +83,7 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [values, maximumValue, bounds, numTicks, todayDate]);
+  }, [values, maximumValue, bounds, numTicks, today]);
 }
 
 /**

--- a/packages/app/src/components-styled/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/scales.ts
@@ -10,6 +10,7 @@ import { ScaleLinear } from 'd3-scale';
 import { first, isEmpty, last } from 'lodash';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { Bounds } from './common';
 import { SeriesDoubleValue, SeriesItem, SeriesSingleValue } from './series';
 
@@ -34,11 +35,12 @@ export function useScales<T extends TimestampedValue>(args: {
   bounds: Bounds;
   numTicks: number;
 }) {
+  const todayDate = useCurrentDate();
   const { maximumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
     if (isEmpty(values)) {
-      const today = Date.now() / 1000;
+      const today = todayDate.getTime() / 1000;
       return {
         xScale: scaleLinear({
           domain: [today, today + ONE_DAY_IN_SECONDS],
@@ -82,7 +84,7 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [values, maximumValue, bounds, numTicks]);
+  }, [values, maximumValue, bounds, numTicks, todayDate]);
 }
 
 /**

--- a/packages/app/src/components-styled/time-series-chart/logic/series.ts
+++ b/packages/app/src/components-styled/time-series-chart/logic/series.ts
@@ -5,6 +5,7 @@ import {
 } from '@corona-dashboard/common';
 import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { getValuesInTimeframe, TimeframeOption } from '~/utils/timeframe';
 
 export type SeriesConfig<T extends TimestampedValue> = (
@@ -117,9 +118,11 @@ export function useValuesInTimeframe<T extends TimestampedValue>(
   values: T[],
   timeframe: TimeframeOption
 ) {
-  return useMemo(() => getValuesInTimeframe(values, timeframe), [
+  const today = useCurrentDate();
+  return useMemo(() => getValuesInTimeframe(values, timeframe, today), [
     values,
     timeframe,
+    today,
   ]);
 }
 

--- a/packages/app/src/components-styled/vertical-bar-chart/logic/scales.tsx
+++ b/packages/app/src/components-styled/vertical-bar-chart/logic/scales.tsx
@@ -29,7 +29,8 @@ export function useScales<T extends TimestampedValue>(args: {
   bounds: Bounds;
   numTicks: number;
 }) {
-  const todayDate = useCurrentDate();
+  const today = useCurrentDate().getTime() / 1000;
+
   const {
     maximumValue,
     minimumValue,
@@ -41,7 +42,6 @@ export function useScales<T extends TimestampedValue>(args: {
 
   return useMemo(() => {
     if (isEmpty(values)) {
-      const today = todayDate.getTime() / 1000;
       return {
         xScale: scaleBand({
           domain: [today, today + ONE_DAY_IN_SECONDS],
@@ -84,14 +84,5 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [
-    values,
-    bounds.width,
-    bounds.height,
-    tickValues,
-    maximumValue,
-    minimumValue,
-    numTicks,
-    todayDate,
-  ]);
+  }, [values, bounds, tickValues, maximumValue, minimumValue, numTicks, today]);
 }

--- a/packages/app/src/components-styled/vertical-bar-chart/logic/scales.tsx
+++ b/packages/app/src/components-styled/vertical-bar-chart/logic/scales.tsx
@@ -10,6 +10,7 @@ import {
   GetX,
   GetY,
 } from '~/components-styled/time-series-chart/logic';
+import { useCurrentDate } from '~/utils/current-date-context';
 
 export const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 
@@ -28,6 +29,7 @@ export function useScales<T extends TimestampedValue>(args: {
   bounds: Bounds;
   numTicks: number;
 }) {
+  const todayDate = useCurrentDate();
   const {
     maximumValue,
     minimumValue,
@@ -39,7 +41,7 @@ export function useScales<T extends TimestampedValue>(args: {
 
   return useMemo(() => {
     if (isEmpty(values)) {
-      const today = Date.now() / 1000;
+      const today = todayDate.getTime() / 1000;
       return {
         xScale: scaleBand({
           domain: [today, today + ONE_DAY_IN_SECONDS],
@@ -82,5 +84,14 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [values, maximumValue, minimumValue, bounds, numTicks, tickValues]);
+  }, [
+    values,
+    bounds.width,
+    bounds.height,
+    tickValues,
+    maximumValue,
+    minimumValue,
+    numTicks,
+    todayDate,
+  ]);
 }

--- a/packages/app/src/domain/layout/layout.tsx
+++ b/packages/app/src/domain/layout/layout.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from 'next/router';
 import React from 'react';
-import { SEOHead } from '~/components-styled/seo-head';
 import { AppFooter } from '~/components-styled/layout/app-footer';
 import { AppHeader } from '~/components-styled/layout/app-header';
+import { SEOHead } from '~/components-styled/seo-head';
 import { SkipLinkMenu } from '~/components-styled/skip-link-menu';
 import { useIntl } from '~/intl';
+import { CurrentDateProvider } from '~/utils/current-date-context';
 
 interface LayoutProps {
   title: string;
@@ -52,9 +53,11 @@ export function Layout(
 
       <AppHeader />
 
-      <div>{children}</div>
+      <CurrentDateProvider dateInSeconds={Number(lastGenerated)}>
+        <div>{children}</div>
+      </CurrentDateProvider>
 
-      <AppFooter lastGenerated={lastGenerated} />
+      <AppFooter lastGenerated={Number(lastGenerated)} />
     </div>
   );
 }

--- a/packages/app/src/domain/vaccine/vaccine-stock-per-supplier-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-stock-per-supplier-chart.tsx
@@ -13,6 +13,7 @@ import {
 } from '~/components-styled/time-series-chart';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
+import { useCurrentDate } from '~/utils/current-date-context';
 import { replaceVariablesInText } from '~/utils/replaceVariablesInText';
 import { getValuesInTimeframe, TimeframeOption } from '~/utils/timeframe';
 
@@ -29,13 +30,14 @@ export function VaccineStockPerSupplierChart({
   const productNames =
     siteText.vaccinaties.data.vaccination_chart.product_names;
 
+  const today = useCurrentDate();
   const maximumValuesPerTimeframeOption = useMemo(
     () =>
       ({
-        all: getMaximumPropertyValueInTimeframe(values, 'all'),
-        '5weeks': getMaximumPropertyValueInTimeframe(values, '5weeks'),
+        all: getMaximumPropertyValueInTimeframe(values, 'all', today),
+        '5weeks': getMaximumPropertyValueInTimeframe(values, '5weeks', today),
       } as Record<TimeframeOption, number>),
-    [values]
+    [values, today]
   );
 
   const optionsConfig: SelectOption[] = [
@@ -124,9 +126,10 @@ export function VaccineStockPerSupplierChart({
 
 function getMaximumPropertyValueInTimeframe(
   values: NlVaccineStockValue[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ) {
-  const valuesInTimeframe = getValuesInTimeframe(values, timeframe);
+  const valuesInTimeframe = getValuesInTimeframe(values, timeframe, today);
 
   return valuesInTimeframe.reduce(
     (acc, value) =>

--- a/packages/app/src/intl/hooks/use-intl.ts
+++ b/packages/app/src/intl/hooks/use-intl.ts
@@ -43,8 +43,8 @@ if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {
 
 // Helper functions
 
-function isDayBeforeYesterday(date: Date) {
-  return isSameDay(date, subDays(Date.now(), 2));
+function isDayBeforeYesterday(date: Date, compareDate: Date) {
+  return isSameDay(date, subDays(compareDate, 2));
 }
 
 type DateDefinition = Date | { seconds: number } | { milliseconds: number };
@@ -196,7 +196,7 @@ export function useIntlHelperContext(locale: string, siteText: AllLanguages) {
         ? siteText.utils.date_today
         : isYesterday(date)
         ? siteText.utils.date_yesterday
-        : isDayBeforeYesterday(date)
+        : isDayBeforeYesterday(date, new Date())
         ? siteText.utils.date_day_before_yesterday
         : undefined;
     }

--- a/packages/app/src/utils/current-date-context.tsx
+++ b/packages/app/src/utils/current-date-context.tsx
@@ -8,7 +8,19 @@ import {
 } from 'react';
 
 /**
+ * Dates shouldn't be created during render because the server-side date can be
+ * different compared to the date created client-side (especially with a static
+ * site: build today, visit tomorrow). The difference between dates (or any
+ * variable actually) between server and client can result in different html
+ * output between server and client. These differences can in turn result in
+ * react rehydration errors such as missing DOM-elements or DOM-
+ * elements with wrong attributes.
  *
+ * The CurrentDateContext will now hold the "today" date. On the server this is
+ * populated with the "last generated" date and on the client the state will be
+ * mutated after mount. The explicit state mutation will ensure components are
+ * correctly re-rendered where necessary, which means rehydration issues won't
+ * pop up anymore.
  */
 
 const CurrentDateContext = createContext<Date | undefined>(undefined);

--- a/packages/app/src/utils/current-date-context.tsx
+++ b/packages/app/src/utils/current-date-context.tsx
@@ -1,0 +1,38 @@
+import { assert } from '@corona-dashboard/common';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+/**
+ *
+ */
+
+const CurrentDateContext = createContext<Date | undefined>(undefined);
+
+export function CurrentDateProvider({
+  dateInSeconds,
+  children,
+}: {
+  dateInSeconds: number;
+  children: ReactNode;
+}) {
+  const [date, setDate] = useState(new Date(dateInSeconds * 1000));
+  useEffect(() => setDate(new Date()), []);
+
+  return (
+    <CurrentDateContext.Provider value={date}>
+      {children}
+    </CurrentDateContext.Provider>
+  );
+}
+
+export function useCurrentDate() {
+  const currentDate = useContext(CurrentDateContext);
+  assert(currentDate, 'Missing CurrentDateProvider in component tree');
+
+  return currentDate;
+}

--- a/packages/app/src/utils/timeframe/__tests__/getFilteredValues.spec.ts
+++ b/packages/app/src/utils/timeframe/__tests__/getFilteredValues.spec.ts
@@ -42,19 +42,34 @@ describe('Utils: getFilteredValues', () => {
   });
 
   it('should filter the list by week', () => {
-    const result = getFilteredValues(_testList, 'week', testCallback);
+    const result = getFilteredValues(
+      _testList,
+      'week',
+      new Date(),
+      testCallback
+    );
 
     expect(result.length).toEqual(2);
   });
 
   it('should filter the list by 5weeks', () => {
-    const result = getFilteredValues(_testList, '5weeks', testCallback);
+    const result = getFilteredValues(
+      _testList,
+      '5weeks',
+      new Date(),
+      testCallback
+    );
 
     expect(result.length).toEqual(4);
   });
 
   it('should filter the list by all', () => {
-    const result = getFilteredValues(_testList, 'all', testCallback);
+    const result = getFilteredValues(
+      _testList,
+      'all',
+      new Date(),
+      testCallback
+    );
 
     expect(result.length).toEqual(5);
   });

--- a/packages/app/src/utils/timeframe/__tests__/getMinimumUnixForTimeframe.spec.ts
+++ b/packages/app/src/utils/timeframe/__tests__/getMinimumUnixForTimeframe.spec.ts
@@ -2,29 +2,29 @@ import { getMinimumUnixForTimeframe } from '..';
 
 describe('Utils: getMinimumUnixForTimeframe', () => {
   it('should return zero for all', () => {
-    const result = getMinimumUnixForTimeframe('all');
+    const result = getMinimumUnixForTimeframe('all', new Date());
 
     expect(result).toEqual(0);
   });
 
   it('should return greater than zero for week', () => {
-    const result = getMinimumUnixForTimeframe('week');
+    const result = getMinimumUnixForTimeframe('week', new Date());
 
     const today = new Date().getTime();
 
-    var secondsDelta = Math.abs(today - result) / 1000;
-    var daysDelta = Math.floor(secondsDelta / 86400);
+    const secondsDelta = Math.abs(today - result) / 1000;
+    const daysDelta = Math.floor(secondsDelta / 86400);
 
     expect(daysDelta).toEqual(8);
   });
 
   it('should return greater than zero for 5weeks', () => {
-    const result = getMinimumUnixForTimeframe('5weeks');
+    const result = getMinimumUnixForTimeframe('5weeks', new Date());
 
     const today = new Date().getTime();
 
-    var secondsDelta = Math.abs(today - result) / 1000;
-    var daysDelta = Math.floor(secondsDelta / 86400);
+    const secondsDelta = Math.abs(today - result) / 1000;
+    const daysDelta = Math.floor(secondsDelta / 86400);
 
     expect(daysDelta).toEqual(36);
   });

--- a/packages/app/src/utils/timeframe/index.ts
+++ b/packages/app/src/utils/timeframe/index.ts
@@ -22,13 +22,14 @@ export const getDaysForTimeframe = (timeframe: TimeframeOption): number => {
 const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
 
 export const getMinimumUnixForTimeframe = (
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ): number => {
   if (timeframe === 'all') {
     return 0;
   }
   const days = getDaysForTimeframe(timeframe);
-  return new Date().getTime() - days * oneDayInMilliseconds;
+  return today.getTime() - days * oneDayInMilliseconds;
 };
 
 type CompareCallbackFunction<T> = (value: T) => number;
@@ -43,9 +44,10 @@ type CompareCallbackFunction<T> = (value: T) => number;
 export const getFilteredValues = <T>(
   values: T[],
   timeframe: TimeframeOption,
+  today: Date,
   compareCallback: CompareCallbackFunction<T>
 ): T[] => {
-  const minimumUnix = getMinimumUnixForTimeframe(timeframe);
+  const minimumUnix = getMinimumUnixForTimeframe(timeframe, today);
   return values.filter((value: T): boolean => {
     return compareCallback(value) >= minimumUnix;
   });
@@ -60,9 +62,10 @@ export const getFilteredValues = <T>(
  */
 export function getValuesInTimeframe<T extends TimestampedValue>(
   values: T[],
-  timeframe: TimeframeOption
+  timeframe: TimeframeOption,
+  today: Date
 ): T[] {
-  const boundary = getTimeframeBoundaryUnix(timeframe);
+  const boundary = getTimeframeBoundaryUnix(timeframe, today);
 
   if (isDateSeries(values)) {
     return values.filter((x: DateValue) => x.date_unix >= boundary) as T[];
@@ -79,10 +82,10 @@ export function getValuesInTimeframe<T extends TimestampedValue>(
 
 const oneDayInSeconds = 24 * 60 * 60;
 
-function getTimeframeBoundaryUnix(timeframe: TimeframeOption) {
+function getTimeframeBoundaryUnix(timeframe: TimeframeOption, today: Date) {
   if (timeframe === 'all') {
     return 0;
   }
   const days = getDaysForTimeframe(timeframe);
-  return Date.now() / 1000 - days * oneDayInSeconds;
+  return today.getTime() / 1000 - days * oneDayInSeconds;
 }


### PR DESCRIPTION
Dates shouldn't be created during render because the server-side date can be different compared to the date created client-side (especially with a static site: build today, visit tomorrow).
The difference between dates (or any variable actually) between server and client can result in different html output between server and client. These differences can in turn result in react rehydration errors such as missing DOM-elements or DOM-elements with wrong attributes.

The CurrentDateContext will now hold the "today" date. On the server this is populated with the "last generated" date and on the client the state will be mutated after mount. The explicit state mutation will ensure components are correctly re-rendered where necessary, which means rehydration issues won't pop up anymore.