### PR TITLE
Remove push triggers from github actions main flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: Main
 
 on:
-  push:
-    branches:
-      - master
-      - develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary

This removes the branch push triggers from github actions, as they are currently only a waste of resources. We do not deploy anything on push.