### PR TITLE
Add schema for hospital admissions by age group

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -94,6 +94,9 @@
     "hospital_nice": {
       "$ref": "hospital_nice.json"
     },
+    "hospital_nice_per_age_group": {
+      "$ref": "hospital_nice_per_age_group.json"
+    },
     "hospital_lcps": {
       "$ref": "hospital_lcps.json"
     },

--- a/packages/app/schema/nl/hospital_nice_per_age_group.json
+++ b/packages/app/schema/nl/hospital_nice_per_age_group.json
@@ -21,48 +21,48 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "admissions_age_0_19_per_100k",
-        "admissions_age_20_29_per_100k",
-        "admissions_age_30_39_per_100k",
-        "admissions_age_40_49_per_100k",
-        "admissions_age_50_59_per_100k",
-        "admissions_age_60_69_per_100k",
-        "admissions_age_70_79_per_100k",
-        "admissions_age_80_89_per_100k",
-        "admissions_age_90_plus_per_100k",
-        "admissions_overall_per_100k",
+        "admissions_age_0_19_per_million",
+        "admissions_age_20_29_per_million",
+        "admissions_age_30_39_per_million",
+        "admissions_age_40_49_per_million",
+        "admissions_age_50_59_per_million",
+        "admissions_age_60_69_per_million",
+        "admissions_age_70_79_per_million",
+        "admissions_age_80_89_per_million",
+        "admissions_age_90_plus_per_million",
+        "admissions_overall_per_million",
         "date_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
-        "admissions_age_0_19_per_100k": {
+        "admissions_age_0_19_per_million": {
           "type": "number"
         },
-        "admissions_age_20_29_per_100k": {
+        "admissions_age_20_29_per_million": {
           "type": "number"
         },
-        "admissions_age_30_39_per_100k": {
+        "admissions_age_30_39_per_million": {
           "type": "number"
         },
-        "admissions_age_40_49_per_100k": {
+        "admissions_age_40_49_per_million": {
           "type": "number"
         },
-        "admissions_age_50_59_per_100k": {
+        "admissions_age_50_59_per_million": {
           "type": "number"
         },
-        "admissions_age_60_69_per_100k": {
+        "admissions_age_60_69_per_million": {
           "type": "number"
         },
-        "admissions_age_70_79_per_100k": {
+        "admissions_age_70_79_per_million": {
           "type": "number"
         },
-        "admissions_age_80_89_per_100k": {
+        "admissions_age_80_89_per_million": {
           "type": "number"
         },
-        "admissions_age_90_plus_per_100k": {
+        "admissions_age_90_plus_per_million": {
           "type": "number"
         },
-        "admissions_overall_per_100k": {
+        "admissions_overall_per_million": {
           "type": "number"
         },
         "date_unix": {

--- a/packages/app/schema/nl/hospital_nice_per_age_group.json
+++ b/packages/app/schema/nl/hospital_nice_per_age_group.json
@@ -21,7 +21,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        
         "admissions_age_0_19_per_100k",
         "admissions_age_20_29_per_100k",
         "admissions_age_30_39_per_100k",

--- a/packages/app/schema/nl/hospital_nice_per_age_group.json
+++ b/packages/app/schema/nl/hospital_nice_per_age_group.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_hospital_nice_per_age_group",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "required": ["values", "last_value"],
+  "definitions": {
+    "value": {
+      "title": "nl_hospital_nice_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        
+        "admissions_age_0_19_per_100k",
+        "admissions_age_20_29_per_100k",
+        "admissions_age_30_39_per_100k",
+        "admissions_age_40_49_per_100k",
+        "admissions_age_50_59_per_100k",
+        "admissions_age_60_69_per_100k",
+        "admissions_age_70_79_per_100k",
+        "admissions_age_80_89_per_100k",
+        "admissions_age_90_plus_per_100k",
+        "admissions_overall_per_100k",
+        "date_unix",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "admissions_age_0_19_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_20_29_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_30_39_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_40_49_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_50_59_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_60_69_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_70_79_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_80_89_per_100k": {
+          "type": "number"
+        },
+        "admissions_age_90_plus_per_100k": {
+          "type": "number"
+        },
+        "admissions_overall_per_100k": {
+          "type": "number"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -155,6 +155,7 @@ export interface National {
   reproduction: NationalReproduction;
   sewer: NationalSewer;
   hospital_nice: NationalHospitalNice;
+  hospital_nice_per_age_group?: NlHospitalNicePerAgeGroup;
   hospital_lcps: NationalHospitalLcps;
   intensive_care_lcps: NationalIntensiveCareLcps;
   tested_ggd_daily: NationalTestedGgdDaily;
@@ -337,6 +338,24 @@ export interface NationalHospitalNice {
 export interface NationalHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_reporting: number;
+  date_unix: number;
+  date_of_insertion_unix: number;
+}
+export interface NlHospitalNicePerAgeGroup {
+  values: NlHospitalNicePerAgeGroupValue[];
+  last_value: NlHospitalNicePerAgeGroupValue;
+}
+export interface NlHospitalNicePerAgeGroupValue {
+  admissions_age_0_19_per_100k: number;
+  admissions_age_20_29_per_100k: number;
+  admissions_age_30_39_per_100k: number;
+  admissions_age_40_49_per_100k: number;
+  admissions_age_50_59_per_100k: number;
+  admissions_age_60_69_per_100k: number;
+  admissions_age_70_79_per_100k: number;
+  admissions_age_80_89_per_100k: number;
+  admissions_age_90_plus_per_100k: number;
+  admissions_overall_per_100k: number;
   date_unix: number;
   date_of_insertion_unix: number;
 }

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -346,16 +346,16 @@ export interface NlHospitalNicePerAgeGroup {
   last_value: NlHospitalNicePerAgeGroupValue;
 }
 export interface NlHospitalNicePerAgeGroupValue {
-  admissions_age_0_19_per_100k: number;
-  admissions_age_20_29_per_100k: number;
-  admissions_age_30_39_per_100k: number;
-  admissions_age_40_49_per_100k: number;
-  admissions_age_50_59_per_100k: number;
-  admissions_age_60_69_per_100k: number;
-  admissions_age_70_79_per_100k: number;
-  admissions_age_80_89_per_100k: number;
-  admissions_age_90_plus_per_100k: number;
-  admissions_overall_per_100k: number;
+  admissions_age_0_19_per_million: number;
+  admissions_age_20_29_per_million: number;
+  admissions_age_30_39_per_million: number;
+  admissions_age_40_49_per_million: number;
+  admissions_age_50_59_per_million: number;
+  admissions_age_60_69_per_million: number;
+  admissions_age_70_79_per_million: number;
+  admissions_age_80_89_per_million: number;
+  admissions_age_90_plus_per_million: number;
+  admissions_overall_per_million: number;
   date_unix: number;
   date_of_insertion_unix: number;
 }


### PR DESCRIPTION
- Took the `tested_per_age_group.json` as a reference to transform it to the `hospital_nice_per_age_group` schema.
- Combined the 0-9 and the 10-19 into one category
- Made it not required in the `__index.json` file