### PR TITLE
Add schema for ic admissions nice per age group

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -79,6 +79,9 @@
     "intensive_care_nice": {
       "$ref": "intensive_care_nice.json"
     },
+    "intensive_care_nice_per_age_group": {
+      "$ref": "intensive_care_nice_per_age_group.json"
+    },
     "tested_overall": {
       "$ref": "tested_overall.json"
     },

--- a/packages/app/schema/nl/intensive_care_nice_per_age_group.json
+++ b/packages/app/schema/nl/intensive_care_nice_per_age_group.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_intensive_care_nice_per_age_group",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "required": ["values", "last_value"],
+  "definitions": {
+    "value": {
+      "title": "nl_intensive_care_nice_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        
+        "admissions_age_0_19_per_million",
+        "admissions_age_20_29_per_million",
+        "admissions_age_30_39_per_million",
+        "admissions_age_40_49_per_million",
+        "admissions_age_50_59_per_million",
+        "admissions_age_60_69_per_million",
+        "admissions_age_70_79_per_million",
+        "admissions_age_80_89_per_million",
+        "admissions_age_90_plus_per_million",
+        "admissions_overall_per_million",
+        "date_unix",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "admissions_age_0_19_per_million": {
+          "type": "number"
+        },
+        "admissions_age_20_29_per_million": {
+          "type": "number"
+        },
+        "admissions_age_30_39_per_million": {
+          "type": "number"
+        },
+        "admissions_age_40_49_per_million": {
+          "type": "number"
+        },
+        "admissions_age_50_59_per_million": {
+          "type": "number"
+        },
+        "admissions_age_60_69_per_million": {
+          "type": "number"
+        },
+        "admissions_age_70_79_per_million": {
+          "type": "number"
+        },
+        "admissions_age_80_89_per_million": {
+          "type": "number"
+        },
+        "admissions_age_90_plus_per_million": {
+          "type": "number"
+        },
+        "admissions_overall_per_million": {
+          "type": "number"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -150,6 +150,7 @@ export interface National {
   g_number: NlGNumber;
   infectious_people: NationalInfectiousPeople;
   intensive_care_nice: NationalIntensiveCareNice;
+  intensive_care_nice_per_age_group?: NlIntensiveCareNicePerAgeGroup;
   tested_overall: NationalTestedOverall;
   tested_per_age_group: NlTestedPerAgeGroup;
   reproduction: NationalReproduction;
@@ -274,6 +275,24 @@ export interface NationalIntensiveCareNice {
 export interface NationalIntensiveCareNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_reporting: number;
+  date_unix: number;
+  date_of_insertion_unix: number;
+}
+export interface NlIntensiveCareNicePerAgeGroup {
+  values: NlIntensiveCareNicePerAgeGroupValue[];
+  last_value: NlIntensiveCareNicePerAgeGroupValue;
+}
+export interface NlIntensiveCareNicePerAgeGroupValue {
+  admissions_age_0_19_per_million: number;
+  admissions_age_20_29_per_million: number;
+  admissions_age_30_39_per_million: number;
+  admissions_age_40_49_per_million: number;
+  admissions_age_50_59_per_million: number;
+  admissions_age_60_69_per_million: number;
+  admissions_age_70_79_per_million: number;
+  admissions_age_80_89_per_million: number;
+  admissions_age_90_plus_per_million: number;
+  admissions_overall_per_million: number;
   date_unix: number;
   date_of_insertion_unix: number;
 }


### PR DESCRIPTION
- Took the `tested_per_age_group.json` as a reference to transform it to the `intensive_care_nice_per_age_group` schema
- Combined the 0-9 and the 10-19 into one category
- Made it not required in the `__index.json` file