### PR TITLE
Add 0 y tick value to mobile view for graphs

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -124,6 +124,8 @@ export const Axes = memo(function Axes({
   const isLongStartLabel = formatXAxis(startUnix).length > 6;
   const isLongEndLabel = formatXAxis(endUnix).length > 6;
 
+  console.dir(yScale.domain());
+
   return (
     <g css={css({ pointerEvents: 'none' })}>
       <GridRows
@@ -223,7 +225,7 @@ export const Axes = memo(function Axes({
         {isYAxisCollapsed && numGridLines !== 0 && (
           <AxisLeft
             scale={yScale}
-            tickValues={[yScale.domain()[1]]}
+            tickValues={yScale.domain()}
             numTicks={numGridLines}
             hideTicks
             hideAxisLine

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -124,8 +124,6 @@ export const Axes = memo(function Axes({
   const isLongStartLabel = formatXAxis(startUnix).length > 6;
   const isLongEndLabel = formatXAxis(endUnix).length > 6;
 
-  console.dir(yScale.domain());
-
   return (
     <g css={css({ pointerEvents: 'none' })}>
       <GridRows


### PR DESCRIPTION
## Summary

Currently, only the last domain value was shown on the y-axis on mobile view. This was changed to use the entire domain so that 0 zero values are shown as well:

![image](https://user-images.githubusercontent.com/69849293/115223194-d11d4280-a10b-11eb-9f04-71a4703ad803.png)

## Motivation

Design request.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
