### PR TITLE
Improve Time Series Chart Tooltip Layout

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -75,91 +75,6 @@ export function TooltipSeriesList<T extends TimestampedValue>({
     ? [config[configIndex]]
     : [...config];
 
-  const seriesList = (
-    <TooltipList>
-      {seriesConfig.map((x, index) => {
-        switch (x.type) {
-          case 'stacked-area':
-            return (
-              <TooltipListItem
-                key={index}
-                icon={<SeriesIcon config={x} />}
-                label={x.shortLabel ?? x.label}
-                displayTooltipValueOnly={displayTooltipValueOnly}
-              >
-                <b>
-                  {getValueStringForKey(
-                    value,
-                    x.metricProperty,
-                    options.isPercentage
-                  )}
-                </b>
-              </TooltipListItem>
-            );
-
-          case 'range':
-            return (
-              <TooltipListItem
-                key={index}
-                icon={<SeriesIcon config={x} />}
-                label={x.shortLabel ?? x.label}
-                displayTooltipValueOnly={displayTooltipValueOnly}
-              >
-                <b css={css({ whiteSpace: 'nowrap' })}>
-                  {`${getValueStringForKey(
-                    value,
-                    x.metricPropertyLow,
-                    options.isPercentage
-                  )} - ${getValueStringForKey(
-                    value,
-                    x.metricPropertyHigh,
-                    options.isPercentage
-                  )}`}
-                </b>
-              </TooltipListItem>
-            );
-
-          case 'line':
-          case 'area':
-          case 'bar':
-            return (
-              <TooltipListItem
-                key={index}
-                icon={<SeriesIcon config={x} />}
-                label={x.shortLabel ?? x.label}
-                displayTooltipValueOnly={displayTooltipValueOnly}
-              >
-                <b>
-                  {getValueStringForKey(
-                    value,
-                    x.metricProperty,
-                    options.isPercentage
-                  )}
-                </b>
-              </TooltipListItem>
-            );
-
-          case 'invisible':
-            return (
-              <TooltipListItem
-                key={index}
-                label={x.label}
-                displayTooltipValueOnly={displayTooltipValueOnly}
-              >
-                <b>
-                  {getValueStringForKey(
-                    value,
-                    x.metricProperty,
-                    x.isPercentage
-                  )}
-                </b>
-              </TooltipListItem>
-            );
-        }
-      })}
-    </TooltipList>
-  );
-
   return (
     <section>
       <VisuallyHidden>{dateString}</VisuallyHidden>
@@ -170,7 +85,90 @@ export function TooltipSeriesList<T extends TimestampedValue>({
         </Text>
       )}
 
-      <Box css={css({ columnCount: hasTwoColumns ? 2 : 1 })}>{seriesList}</Box>
+      <Box css={css({ columnCount: hasTwoColumns ? 2 : 1 })}>
+        <TooltipList>
+          {seriesConfig.map((x, index) => {
+            switch (x.type) {
+              case 'stacked-area':
+                return (
+                  <TooltipListItem
+                    key={index}
+                    icon={<SeriesIcon config={x} />}
+                    label={x.shortLabel ?? x.label}
+                    displayTooltipValueOnly={displayTooltipValueOnly}
+                  >
+                    <b>
+                      {getValueStringForKey(
+                        value,
+                        x.metricProperty,
+                        options.isPercentage
+                      )}
+                    </b>
+                  </TooltipListItem>
+                );
+
+              case 'range':
+                return (
+                  <TooltipListItem
+                    key={index}
+                    icon={<SeriesIcon config={x} />}
+                    label={x.shortLabel ?? x.label}
+                    displayTooltipValueOnly={displayTooltipValueOnly}
+                  >
+                    <b css={css({ whiteSpace: 'nowrap' })}>
+                      {`${getValueStringForKey(
+                        value,
+                        x.metricPropertyLow,
+                        options.isPercentage
+                      )} - ${getValueStringForKey(
+                        value,
+                        x.metricPropertyHigh,
+                        options.isPercentage
+                      )}`}
+                    </b>
+                  </TooltipListItem>
+                );
+
+              case 'line':
+              case 'area':
+              case 'bar':
+                return (
+                  <TooltipListItem
+                    key={index}
+                    icon={<SeriesIcon config={x} />}
+                    label={x.shortLabel ?? x.label}
+                    displayTooltipValueOnly={displayTooltipValueOnly}
+                  >
+                    <b>
+                      {getValueStringForKey(
+                        value,
+                        x.metricProperty,
+                        options.isPercentage
+                      )}
+                    </b>
+                  </TooltipListItem>
+                );
+
+              case 'invisible':
+                return (
+                  <TooltipListItem
+                    key={index}
+                    label={x.label}
+                    displayTooltipValueOnly={displayTooltipValueOnly}
+                  >
+                    <b>
+                      {getValueStringForKey(
+                        value,
+                        x.metricProperty,
+                        x.isPercentage
+                      )}
+                    </b>
+                  </TooltipListItem>
+                );
+            }
+          })}
+        </TooltipList>
+      </Box>
     </section>
   );
 }

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -75,6 +75,91 @@ export function TooltipSeriesList<T extends TimestampedValue>({
     ? [config[configIndex]]
     : [...config];
 
+  const seriesList = (
+    <TooltipList>
+      {seriesConfig.map((x, index) => {
+        switch (x.type) {
+          case 'stacked-area':
+            return (
+              <TooltipListItem
+                key={index}
+                icon={<SeriesIcon config={x} />}
+                label={x.shortLabel ?? x.label}
+                displayTooltipValueOnly={displayTooltipValueOnly}
+              >
+                <b>
+                  {getValueStringForKey(
+                    value,
+                    x.metricProperty,
+                    options.isPercentage
+                  )}
+                </b>
+              </TooltipListItem>
+            );
+
+          case 'range':
+            return (
+              <TooltipListItem
+                key={index}
+                icon={<SeriesIcon config={x} />}
+                label={x.shortLabel ?? x.label}
+                displayTooltipValueOnly={displayTooltipValueOnly}
+              >
+                <b css={css({ whiteSpace: 'nowrap' })}>
+                  {`${getValueStringForKey(
+                    value,
+                    x.metricPropertyLow,
+                    options.isPercentage
+                  )} - ${getValueStringForKey(
+                    value,
+                    x.metricPropertyHigh,
+                    options.isPercentage
+                  )}`}
+                </b>
+              </TooltipListItem>
+            );
+
+          case 'line':
+          case 'area':
+          case 'bar':
+            return (
+              <TooltipListItem
+                key={index}
+                icon={<SeriesIcon config={x} />}
+                label={x.shortLabel ?? x.label}
+                displayTooltipValueOnly={displayTooltipValueOnly}
+              >
+                <b>
+                  {getValueStringForKey(
+                    value,
+                    x.metricProperty,
+                    options.isPercentage
+                  )}
+                </b>
+              </TooltipListItem>
+            );
+
+          case 'invisible':
+            return (
+              <TooltipListItem
+                key={index}
+                label={x.label}
+                displayTooltipValueOnly={displayTooltipValueOnly}
+              >
+                <b>
+                  {getValueStringForKey(
+                    value,
+                    x.metricProperty,
+                    x.isPercentage
+                  )}
+                </b>
+              </TooltipListItem>
+            );
+        }
+      })}
+    </TooltipList>
+  );
+
   return (
     <section>
       <VisuallyHidden>{dateString}</VisuallyHidden>
@@ -84,100 +169,21 @@ export function TooltipSeriesList<T extends TimestampedValue>({
           {timespanAnnotation.shortLabel || timespanAnnotation.label}
         </Text>
       )}
-      <TooltipList hasTwoColumns={hasTwoColumns}>
-        {seriesConfig.map((x, index) => {
-          switch (x.type) {
-            case 'stacked-area':
-              return (
-                <TooltipListItem
-                  key={index}
-                  icon={<SeriesIcon config={x} />}
-                  label={x.shortLabel ?? x.label}
-                  displayTooltipValueOnly={displayTooltipValueOnly}
-                >
-                  <b>
-                    {getValueStringForKey(
-                      value,
-                      x.metricProperty,
-                      options.isPercentage
-                    )}
-                  </b>
-                </TooltipListItem>
-              );
 
-            case 'range':
-              return (
-                <TooltipListItem
-                  key={index}
-                  icon={<SeriesIcon config={x} />}
-                  label={x.shortLabel ?? x.label}
-                  displayTooltipValueOnly={displayTooltipValueOnly}
-                >
-                  <b css={css({ whiteSpace: 'nowrap' })}>
-                    {`${getValueStringForKey(
-                      value,
-                      x.metricPropertyLow,
-                      options.isPercentage
-                    )} - ${getValueStringForKey(
-                      value,
-                      x.metricPropertyHigh,
-                      options.isPercentage
-                    )}`}
-                  </b>
-                </TooltipListItem>
-              );
-
-            case 'line':
-            case 'area':
-            case 'bar':
-              return (
-                <TooltipListItem
-                  key={index}
-                  icon={<SeriesIcon config={x} />}
-                  label={x.shortLabel ?? x.label}
-                  displayTooltipValueOnly={displayTooltipValueOnly}
-                >
-                  <b>
-                    {getValueStringForKey(
-                      value,
-                      x.metricProperty,
-                      options.isPercentage
-                    )}
-                  </b>
-                </TooltipListItem>
-              );
-
-            case 'invisible':
-              return (
-                <TooltipListItem
-                  key={index}
-                  label={x.label}
-                  displayTooltipValueOnly={displayTooltipValueOnly}
-                >
-                  <b>
-                    {getValueStringForKey(
-                      value,
-                      x.metricProperty,
-                      x.isPercentage
-                    )}
-                  </b>
-                </TooltipListItem>
-              );
-          }
-        })}
-      </TooltipList>
+      <Box css={css({ columnCount: hasTwoColumns ? 2 : 1 })}>{seriesList}</Box>
     </section>
   );
 }
 
-export const TooltipList = styled.ol<{ hasTwoColumns?: boolean }>(
-  ({ hasTwoColumns }) =>
-    css({
-      columns: hasTwoColumns ? 2 : 1,
-      m: 0,
-      p: 0,
-      listStyle: 'none',
-    })
+export const TooltipList = styled.ol(
+  css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, auto)',
+    maxWidth: 500,
+    m: 0,
+    p: 0,
+    listStyle: 'none',
+  })
 );
 
 interface TooltipListItemProps {
@@ -194,46 +200,27 @@ function TooltipListItem({
   displayTooltipValueOnly,
 }: TooltipListItemProps) {
   return (
-    <Box
-      as="li"
-      spacing={2}
-      spacingHorizontal
-      display="flex"
-      alignItems="stretch"
-    >
+    <>
       {displayTooltipValueOnly ? (
-        <Box flexGrow={1}>
-          <TooltipValueContainer>
-            <VisuallyHidden>
-              <InlineText mr={2}>{label}:</InlineText>
-            </VisuallyHidden>
-            {children}
-          </TooltipValueContainer>
-        </Box>
+        <>
+          <VisuallyHidden>
+            <InlineText mr={2}>{label}:</InlineText>
+          </VisuallyHidden>
+          <Box css={css({ gridColumn: 'span 2' })}>{children}</Box>
+        </>
       ) : (
         <>
           {icon ? (
-            <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
+            <Box mt={1} mr={2}>
               {icon}
             </Box>
           ) : (
-            <Box width="1em" mt={1} />
+            <Box width="1em" mt={1} mr={2} />
           )}
-          <Box flexGrow={1}>
-            <TooltipValueContainer>
-              <InlineText mr={2}>{label}:</InlineText>
-              {children}
-            </TooltipValueContainer>
-          </Box>
+          <InlineText mr={2}>{label}:</InlineText>
+          <Box>{children}</Box>
         </>
       )}
-    </Box>
+    </>
   );
 }
-
-const TooltipValueContainer = styled.span`
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  align-items: flex-end;
-`;

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -177,7 +177,6 @@ export const TooltipList = styled.ol(
   css({
     display: 'grid',
     gridTemplateColumns: 'repeat(3, auto)',
-    maxWidth: 500,
     m: 0,
     p: 0,
     listStyle: 'none',

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -274,7 +274,8 @@ export function TimeSeriesChart<
           height={height}
           padding={padding}
           ariaLabelledBy={ariaLabelledBy || ''}
-          onHover={handleHover}
+          onHover={!tooltipData ? handleHover : undefined}
+          // onHover={handleHover}
           onClick={handleClick}
         >
           <Axes


### PR DESCRIPTION
## Summary

Brief explanation of the feature, and describe how other developers can test and see your implementation.

## Motivation

Tooltip layout behaves strangely when values are of different widths

## Detailed design

Updated the `TooltipSeriesList` component to use a css grid layout for the `ol` and wrapped it in a multi column div for when the list is configured to be positioned in 2 columns. 

Currently this results in some inconsistent "cut off" behavior across browsers 
![image](https://user-images.githubusercontent.com/75375917/115395440-2c226880-a1e4-11eb-84ce-55c4caa246ce.png)
![image](https://user-images.githubusercontent.com/75375917/115395454-30e71c80-a1e4-11eb-9f64-c3864ef9d64e.png)


I tried making the grid twice the width (so 6 columns wide), but it ordered the list items from left to right rather than top to bottom

## Drawbacks

## Alternatives

## Unresolved questions
