### PR TITLE
Add collapse to milestones view

### DIFF
--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -39,7 +39,9 @@ export function MilestonesView(props: MilestoneViewProps) {
 
   useEffect(() => setIsExpanded(false), []);
 
-  const handleExpand = () => setIsExpanded(!isExpanded);
+  const visibleMilestones = isExpanded
+    ? milestones
+    : milestones.slice(-MAX_ITEMS_VISIBLE);
 
   return (
     <Tile>
@@ -70,7 +72,7 @@ export function MilestonesView(props: MilestoneViewProps) {
             <Box pl={`calc(1rem + ${CIRCLE_SIZE}px)`}>
               <ExpandButton
                 color="link"
-                onClick={handleExpand}
+                onClick={() => setIsExpanded((x) => !x)}
                 hasDashedLine={!isExpanded}
               >
                 {isExpanded
@@ -81,64 +83,59 @@ export function MilestonesView(props: MilestoneViewProps) {
           </ListItem>
         )}
 
-        {milestones
-          .filter(
-            (_x, index) =>
-              isExpanded || index > milestones.length - 1 - MAX_ITEMS_VISIBLE
-          )
-          .map((milestone, index, list) => (
-            <Fragment key={index}>
-              {index !== list.length - 1 ? (
-                <ListItem>
-                  <CircleIcon>
-                    <VaccineIcon />
-                  </CircleIcon>
-                  <Box pl="3" maxWidth="maxWidthText" width="100%">
-                    <InlineText
-                      color="gray"
-                      css={css({ position: 'absolute', top: '-1.3rem' })}
-                    >
-                      {formatDate(new Date(milestone.date))}
-                    </InlineText>
-                    <Text m={0}>{milestone.title}</Text>
-                    {isExpanded &&
-                      index === milestones.length - 1 - MAX_ITEMS_VISIBLE && (
-                        <Box
-                          pt={3}
-                          mb={2}
-                          borderBottomWidth="1px"
-                          borderBottomStyle="solid"
-                          borderBottomColor="gray"
-                        ></Box>
-                      )}
-                  </Box>
-                </ListItem>
-              ) : (
-                <ListItemLast>
-                  <CircleIcon isLast={true}>
-                    <VaccineIcon />
-                  </CircleIcon>
-                  <Box
-                    pl="3"
-                    maxWidth="maxWidthText"
-                    position="relative"
-                    zIndex={2}
+        {visibleMilestones.map((milestone, index, list) => (
+          <Fragment key={index}>
+            {list[index + 1] ? (
+              <ListItem>
+                <CircleIcon>
+                  <VaccineIcon />
+                </CircleIcon>
+                <Box pl="3" maxWidth="maxWidthText" width="100%">
+                  <InlineText
+                    color="gray"
+                    css={css({ position: 'absolute', top: '-1.3rem' })}
                   >
-                    <InlineText
-                      color="white"
-                      fontWeight="bold"
-                      css={css({ position: 'absolute', top: '-1.3rem' })}
-                    >
-                      {formatDate(new Date(milestone.date))}
-                    </InlineText>
-                    <Text m={0} color="white" fontSize={3} fontWeight="bold">
-                      {milestone.title}
-                    </Text>
-                  </Box>
-                </ListItemLast>
-              )}
-            </Fragment>
-          ))}
+                    {formatDate(new Date(milestone.date))}
+                  </InlineText>
+                  <Text m={0}>{milestone.title}</Text>
+                  {isExpanded &&
+                    index === milestones.length - 1 - MAX_ITEMS_VISIBLE && (
+                      <Box
+                        pt={3}
+                        mb={2}
+                        borderBottomWidth="1px"
+                        borderBottomStyle="solid"
+                        borderBottomColor="gray"
+                      />
+                    )}
+                </Box>
+              </ListItem>
+            ) : (
+              <ListItemLast>
+                <CircleIcon isLast={true}>
+                  <VaccineIcon />
+                </CircleIcon>
+                <Box
+                  pl="3"
+                  maxWidth="maxWidthText"
+                  position="relative"
+                  zIndex={2}
+                >
+                  <InlineText
+                    color="white"
+                    fontWeight="bold"
+                    css={css({ position: 'absolute', top: '-1.3rem' })}
+                  >
+                    {formatDate(new Date(milestone.date))}
+                  </InlineText>
+                  <Text m={0} color="white" fontSize={3} fontWeight="bold">
+                    {milestone.title}
+                  </Text>
+                </Box>
+              </ListItemLast>
+            )}
+          </Fragment>
+        ))}
       </Box>
 
       {expectedMilestones && (

--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -72,7 +72,7 @@ export function MilestonesView(props: MilestoneViewProps) {
             <Box pl={`calc(1rem + ${CIRCLE_SIZE}px)`}>
               <ExpandButton
                 color="link"
-                onClick={() => setIsExpanded(x => !x}
+                onClick={() => setIsExpanded((x) => !x)}
                 hasDashedLine={!isExpanded}
               >
                 {isExpanded

--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -281,7 +281,7 @@ const ExpandButton = styled.button<{ hasDashedLine: boolean }>((x) =>
       width: '2px',
       backgroundColor: 'white',
       backgroundImage: `linear-gradient(${colors.header} ${
-        x.hasDashedLine ? '50' : 100
+        x.hasDashedLine ? '50' : '100'
       }%, rgba(255,255,255,0) 0%)`,
       backgroundSize: '100% 7px',
       backgroundPosition: '0 3px',

--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -72,7 +72,7 @@ export function MilestonesView(props: MilestoneViewProps) {
             <Box pl={`calc(1rem + ${CIRCLE_SIZE}px)`}>
               <ExpandButton
                 color="link"
-                onClick={() => setIsExpanded(!isExpanded)}
+                onClick={() => setIsExpanded(x => !x}
                 hasDashedLine={!isExpanded}
               >
                 {isExpanded

--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -6,10 +6,10 @@ import { Box } from '~/components/base';
 import { RichContent } from '~/components/cms/rich-content';
 import { Tile } from '~/components/tile';
 import { Heading, InlineText, Text } from '~/components/typography';
-import { colors } from '~/style/theme';
-import { RichContentBlock } from '~/types/cms';
 import { useIntl } from '~/intl';
+import { colors } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
+import { RichContentBlock } from '~/types/cms';
 
 const MAX_ITEMS_VISIBLE = 5;
 const CIRCLE_SIZE = 26;
@@ -39,7 +39,7 @@ export function MilestonesView(props: MilestoneViewProps) {
 
   useEffect(() => setIsExpanded(false), []);
 
-  const handleExpand = () => setIsExpanded(true);
+  const handleExpand = () => setIsExpanded(!isExpanded);
 
   return (
     <Tile>
@@ -58,71 +58,87 @@ export function MilestonesView(props: MilestoneViewProps) {
         position="relative"
         css={css({ listStyleType: 'none' })}
       >
-        <ListItemFirst isExpanded={isExpanded}>
+        <ListItemFirst>
           <CircleSmall />
           <Text fontWeight="bold" m={0} pl={`calc(1rem)`}>
             2021
           </Text>
         </ListItemFirst>
 
-        {milestones.length > MAX_ITEMS_VISIBLE && !isExpanded && (
+        {milestones.length > MAX_ITEMS_VISIBLE && (
           <ListItem>
             <Box pl={`calc(1rem + ${CIRCLE_SIZE}px)`}>
-              <ExpandButton color="link" onClick={handleExpand}>
-                {siteText.milestones.toon_meer}
+              <ExpandButton
+                color="link"
+                onClick={handleExpand}
+                hasDashedLine={!isExpanded}
+              >
+                {isExpanded
+                  ? siteText.milestones.toon_minder
+                  : siteText.milestones.toon_meer}
               </ExpandButton>
             </Box>
           </ListItem>
         )}
 
-        {milestones.map((milestone, index) => (
-          <Fragment key={index}>
-            {(isExpanded ||
-              index > milestones.length - 1 - MAX_ITEMS_VISIBLE) && (
-              <>
-                {index !== milestones.length - 1 ? (
-                  <ListItem>
-                    <CircleIcon>
-                      <VaccineIcon />
-                    </CircleIcon>
-                    <Box pl="3" maxWidth="maxWidthText">
-                      <InlineText
-                        color="gray"
-                        css={css({ position: 'absolute', top: '-1.3rem' })}
-                      >
-                        {formatDate(new Date(milestone.date))}
-                      </InlineText>
-                      <Text m={0}>{milestone.title}</Text>
-                    </Box>
-                  </ListItem>
-                ) : (
-                  <ListItemLast>
-                    <CircleIcon isLast={true}>
-                      <VaccineIcon />
-                    </CircleIcon>
-                    <Box
-                      pl="3"
-                      maxWidth="maxWidthText"
-                      position="relative"
-                      zIndex={2}
+        {milestones
+          .filter(
+            (_x, index) =>
+              isExpanded || index > milestones.length - 1 - MAX_ITEMS_VISIBLE
+          )
+          .map((milestone, index, list) => (
+            <Fragment key={index}>
+              {index !== list.length - 1 ? (
+                <ListItem>
+                  <CircleIcon>
+                    <VaccineIcon />
+                  </CircleIcon>
+                  <Box pl="3" maxWidth="maxWidthText" width="100%">
+                    <InlineText
+                      color="gray"
+                      css={css({ position: 'absolute', top: '-1.3rem' })}
                     >
-                      <InlineText
-                        color="white"
-                        fontWeight="bold"
-                        css={css({ position: 'absolute', top: '-1.3rem' })}
-                      >
-                        {formatDate(new Date(milestone.date))}
-                      </InlineText>
-                      <Text m={0} color="white" fontSize={3} fontWeight="bold">
-                        {milestone.title}
-                      </Text>
-                    </Box>
-                  </ListItemLast>
-                )}
-              </>
-            )}
-          </Fragment>
-        ))}
+                      {formatDate(new Date(milestone.date))}
+                    </InlineText>
+                    <Text m={0}>{milestone.title}</Text>
+                    {isExpanded &&
+                      index === milestones.length - 1 - MAX_ITEMS_VISIBLE && (
+                        <Box
+                          pt={3}
+                          mb={2}
+                          borderBottomWidth="1px"
+                          borderBottomStyle="solid"
+                          borderBottomColor="gray"
+                        ></Box>
+                      )}
+                  </Box>
+                </ListItem>
+              ) : (
+                <ListItemLast>
+                  <CircleIcon isLast={true}>
+                    <VaccineIcon />
+                  </CircleIcon>
+                  <Box
+                    pl="3"
+                    maxWidth="maxWidthText"
+                    position="relative"
+                    zIndex={2}
+                  >
+                    <InlineText
+                      color="white"
+                      fontWeight="bold"
+                      css={css({ position: 'absolute', top: '-1.3rem' })}
+                    >
+                      {formatDate(new Date(milestone.date))}
+                    </InlineText>
+                    <Text m={0} color="white" fontSize={3} fontWeight="bold">
+                      {milestone.title}
+                    </Text>
+                  </Box>
+                </ListItemLast>
+              )}
+            </Fragment>
+          ))}
       </Box>
 
       {expectedMilestones && (
@@ -161,10 +177,10 @@ const commonListItemStyles = {
 
 const ListItem = styled.li(css(commonListItemStyles));
 
-const ListItemFirst = styled.li<{ isExpanded: boolean }>((x) =>
+const ListItemFirst = styled.li(
   css({
     ...commonListItemStyles,
-    paddingBottom: x.isExpanded ? 4 : 3,
+    paddingBottom: 3,
   })
 );
 
@@ -240,7 +256,7 @@ const CircleSmall = styled.div(
   })
 );
 
-const ExpandButton = styled.button(
+const ExpandButton = styled.button<{ hasDashedLine: boolean }>((x) =>
   css({
     position: 'relative',
     padding: 0,
@@ -264,7 +280,9 @@ const ExpandButton = styled.button(
       height: '100%',
       width: '2px',
       backgroundColor: 'white',
-      backgroundImage: `linear-gradient(${colors.header} 50%, rgba(255,255,255,0) 0%)`,
+      backgroundImage: `linear-gradient(${colors.header} ${
+        x.hasDashedLine ? '50' : 100
+      }%, rgba(255,255,255,0) 0%)`,
       backgroundSize: '100% 7px',
       backgroundPosition: '0 3px',
       backgroundRepeat: 'repeat-y',

--- a/packages/app/src/domain/vaccine/milestones-view.tsx
+++ b/packages/app/src/domain/vaccine/milestones-view.tsx
@@ -72,7 +72,7 @@ export function MilestonesView(props: MilestoneViewProps) {
             <Box pl={`calc(1rem + ${CIRCLE_SIZE}px)`}>
               <ExpandButton
                 color="link"
-                onClick={() => setIsExpanded((x) => !x)}
+                onClick={() => setIsExpanded(!isExpanded)}
                 hasDashedLine={!isExpanded}
               >
                 {isExpanded

--- a/packages/app/src/locale/en.json
+++ b/packages/app/src/locale/en.json
@@ -801,13 +801,7 @@
     "barchart_titel": "New cases by age group",
     "barchart_toelichting": "This figure shows the distribution of confirmed cases by age group. This is based on only the new cases that have been reported in comparison to the day before.",
     "barchart_axis_titel": "Total number of confirmed cases",
-    "barscale_keys": [
-      "0 to 20",
-      "20 to 40",
-      "40 to 60",
-      "60 to 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 to 20", "20 to 40", "40 to 60", "60 to 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2178,11 +2172,7 @@
     "expected_page_additions": {
       "title": "Expected data on vaccinations",
       "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "Do not remove this key. It is required as a temporary workaround",
@@ -2307,11 +2297,7 @@
       "kpi_expected_page_additions": {
         "title": "Expected data on vaccinations",
         "description": "More data on vaccinations will be added in the near future, including the vaccination coverage.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2908,6 +2894,7 @@
   },
   "milestones": {
     "toon_meer": "Show earlier events",
+    "toon_minder": "Hide earlier events",
     "verwacht": "Expected"
   },
   "section_sterftemonitor_vr": {

--- a/packages/app/src/locale/nl.json
+++ b/packages/app/src/locale/nl.json
@@ -801,13 +801,7 @@
     "barchart_titel": "Verdeling naar leeftijd (totaal aantal mensen)",
     "barchart_toelichting": "Deze grafiek toont de verdeling van het aantal positieve tests over leeftijdsgroepen.",
     "barchart_axis_titel": "Totaal aantal positief geteste mensen",
-    "barscale_keys": [
-      "0 tot 20",
-      "20 tot 40",
-      "40 tot 60",
-      "60 tot 80",
-      "80+"
-    ],
+    "barscale_keys": ["0 tot 20", "20 tot 40", "40 tot 60", "60 tot 80", "80+"],
     "bron": {
       "href": "https://data.rivm.nl/geonetwork/srv/dut/catalog.search#/metadata/5f6bc429-1596-490e-8618-1ed8fd768427",
       "text": "RIVM"
@@ -2178,11 +2172,7 @@
     "expected_page_additions": {
       "title": "Verwachte toevoegingen aan deze pagina",
       "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-      "additions": [
-        "",
-        "",
-        ""
-      ]
+      "additions": ["", "", ""]
     },
     "data": {
       "difference": "Do not remove this key. It is required as a temporary workaround",
@@ -2307,11 +2297,7 @@
       "kpi_expected_page_additions": {
         "title": "Verwachte toevoegingen aan deze pagina",
         "description": "De komende tijd plaatsen we meer data over vaccinaties op het dashboard. Verwachte toevoegingen zijn onder meer de vaccinatiegraad.",
-        "additions": [
-          "",
-          "",
-          ""
-        ]
+        "additions": ["", "", ""]
       },
       "vaccination_chart": {
         "product_names": {
@@ -2908,6 +2894,7 @@
   },
   "milestones": {
     "toon_meer": "Toon eerdere gebeurtenissen",
+    "toon_minder": "Verberg eerdere gebeurtenissen",
     "verwacht": "Verwacht"
   },
   "section_sterftemonitor_vr": {


### PR DESCRIPTION
## Summary

Previously the milestones view could only be expanded, now it can be collapsed again. After expanding a divider is shown between the collapsable content en the rest.

## Motivation

Feature request

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
