### PR TITLE
Add null option to VPH schemas moving average

### DIFF
--- a/packages/app/schema/nl/nursing_home.json
+++ b/packages/app/schema/nl/nursing_home.json
@@ -24,13 +24,13 @@
           "type": "integer"
         },
         "newly_infected_people_moving_average": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "deceased_daily": {
           "type": "integer"
         },
         "deceased_daily_moving_average": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "newly_infected_locations": {
           "type": "integer"

--- a/packages/app/schema/vr/nursing_home.json
+++ b/packages/app/schema/vr/nursing_home.json
@@ -24,7 +24,7 @@
           "type": "integer"
         },
         "newly_infected_people_moving_average": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "newly_infected_locations": {
           "type": "integer"
@@ -39,7 +39,7 @@
           "type": "integer"
         },
         "deceased_daily_moving_average": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "date_unix": {
           "type": "integer"

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -436,9 +436,9 @@ export interface NationalNursingHome {
 }
 export interface NationalNursingHomeValue {
   newly_infected_people: number;
-  newly_infected_people_moving_average: number;
+  newly_infected_people_moving_average: number | null;
   deceased_daily: number;
-  deceased_daily_moving_average: number;
+  deceased_daily_moving_average: number | null;
   newly_infected_locations: number;
   infected_locations_total: number;
   infected_locations_percentage: number;
@@ -925,12 +925,12 @@ export interface RegionalNursingHome {
 }
 export interface RegionalNursingHomeValue {
   newly_infected_people: number;
-  newly_infected_people_moving_average: number;
+  newly_infected_people_moving_average: number | null;
   newly_infected_locations: number;
   infected_locations_total: number;
   infected_locations_percentage: number;
   deceased_daily: number;
-  deceased_daily_moving_average: number;
+  deceased_daily_moving_average: number | null;
   date_unix: number;
   date_of_insertion_unix: number;
   vrcode: string;


### PR DESCRIPTION
Add the option for null in the moving average schemas that already existed to make it more consistent with the newly added schemas for the moving average