### PR TITLE
Handle null values in the tooltip for the timeSeriesChart

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -62,13 +62,11 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   ) {
     const numberValue = (value[key] as unknown) as number | null;
 
-    if (numberValue === null) return '-';
-
     return isPresent(numberValue)
       ? isPercentage
         ? `${formatPercentage(numberValue)}%`
         : formatNumber(numberValue)
-      : '';
+      : '-';
   }
 
   const dateString = getDateStringFromValue(value);

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -62,6 +62,8 @@ export function TooltipSeriesList<T extends TimestampedValue>({
   ) {
     const numberValue = (value[key] as unknown) as number | null;
 
+    if (numberValue === null) return '-';
+
     return isPresent(numberValue)
       ? isPercentage
         ? `${formatPercentage(numberValue)}%`


### PR DESCRIPTION
Render `-` when a null value is passed in the tooltip.

<img width="399" alt="Screenshot 2021-04-21 at 13 23 46" src="https://user-images.githubusercontent.com/76471292/115546623-8fc09a80-a2a5-11eb-9f7a-cd17dccb6d80.png">
