### PR TITLE
Improve main workflow speed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: compile
+    needs: init
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The `test` task was waiting for the `compile` but the `compile` and `test` tasks can also run in parallel.