### PR TITLE
Fix console error collapsible bug

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -137,23 +137,24 @@ export const CollapsibleSection = ({
         </Summary>
 
         <Panel
-          ref={wrapperRef}
           style={{
             /* panel max height is only controlled when collapsed, or during animations */
             height: open ? contentHeight : 0,
           }}
         >
-          <div
-            ref={ref}
-            css={css({
-              /**
-               * Outside margins of children are breaking height calculations ヽ(ಠ_ಠ)ノ..
-               * We'll add `overflow: hidden` in order to fix this.
-               */
-              overflow: 'hidden',
-            })}
-          >
-            {children}
+          <div ref={wrapperRef}>
+            <div
+              ref={ref}
+              css={css({
+                /**
+                 * Outside margins of children are breaking height calculations ヽ(ಠ_ಠ)ノ..
+                 * We'll add `overflow: hidden` in order to fix this.
+                 */
+                overflow: 'hidden',
+              })}
+            >
+              {children}
+            </div>
           </div>
         </Panel>
       </Disclosure>


### PR DESCRIPTION
Move the `wrapperRef` to his own element, I couldn't spot any difference in terms of working. We also use the same technique on the `collapsible-button` to not directly put it directly on the `DisclosurePanel`.