### PR TITLE
Update admission per age group schemas

### DIFF
--- a/packages/app/schema/nl/hospital_nice_per_age_group.json
+++ b/packages/app/schema/nl/hospital_nice_per_age_group.json
@@ -31,7 +31,8 @@
         "admissions_age_80_89_per_million",
         "admissions_age_90_plus_per_million",
         "admissions_overall_per_million",
-        "date_unix",
+        "date_start_unix",
+        "dat_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
@@ -65,7 +66,10 @@
         "admissions_overall_per_million": {
           "type": "number"
         },
-        "date_unix": {
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {

--- a/packages/app/schema/nl/intensive_care_nice_per_age_group.json
+++ b/packages/app/schema/nl/intensive_care_nice_per_age_group.json
@@ -21,7 +21,6 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        
         "admissions_age_0_19_per_million",
         "admissions_age_20_29_per_million",
         "admissions_age_30_39_per_million",
@@ -32,7 +31,8 @@
         "admissions_age_80_89_per_million",
         "admissions_age_90_plus_per_million",
         "admissions_overall_per_million",
-        "date_unix",
+        "date_start_unix",
+        "dat_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
@@ -66,7 +66,10 @@
         "admissions_overall_per_million": {
           "type": "number"
         },
-        "date_unix": {
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -298,7 +298,8 @@ export interface NlIntensiveCareNicePerAgeGroupValue {
   admissions_age_80_89_per_million: number;
   admissions_age_90_plus_per_million: number;
   admissions_overall_per_million: number;
-  date_unix: number;
+  date_start_unix: number;
+  date_end_unix?: number;
   date_of_insertion_unix: number;
 }
 export interface NationalTestedOverall {
@@ -381,7 +382,8 @@ export interface NlHospitalNicePerAgeGroupValue {
   admissions_age_80_89_per_million: number;
   admissions_age_90_plus_per_million: number;
   admissions_overall_per_million: number;
-  date_unix: number;
+  date_start_unix: number;
+  date_end_unix?: number;
   date_of_insertion_unix: number;
 }
 export interface NationalHospitalLcps {


### PR DESCRIPTION
## Summary

Updating the admissions per age group schemas to have a date span

## Motivation

The data is representative of a weeks worth of admissions and needs to be visually represented that way as well. The current data structure makes it hard to do that 

## Detailed design

replaced the `date_unix` with `date_start_unix` and `date_end_unix`

