### PR TITLE
Don't fail fast during validation init when VR_ or GM_COLLECTION.json doesn't exist

### DIFF
--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -11,6 +11,16 @@ export function createChoroplethValidation(
   choroplethCollectionPath: string,
   codeProperty: string
 ) {
+  if (!fs.existsSync(choroplethCollectionPath)) {
+    console.warn(
+      `${choroplethCollectionPath} does not exist, unable to create Choropleth validation`
+    );
+    return () => {
+      throw new Error(
+        `${choroplethCollectionPath} does not exist, unable to to validate!`
+      );
+    };
+  }
   const collectionJson = JSON.parse(
     fs.readFileSync(choroplethCollectionPath, { encoding: 'utf8' })
   );


### PR DESCRIPTION
## Summary

Title says it all

## Motivation

bug fix

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
