### PR TITLE
Set the tick values of the reproduction chart

### DIFF
--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -49,7 +49,7 @@ export function ReproductionChartTile({
 
   const tickSteps = Array(highestTick / tickStep + 1)
     .fill(tickStep)
-    .map((v, i) => i * v);
+    .map((step, index) => index * step);
 
   return (
     <ChartTile
@@ -80,7 +80,7 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
-          xtickValues={tickSteps}
+          tickValues={tickSteps}
         />
       )}
     </ChartTile>

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -34,24 +34,21 @@ export function ReproductionChartTile({
     0,
     data.values.findIndex((x) => !isPresent(x.index_average))
   );
-  const last_value = last(values) as NationalReproductionValue;
 
-  const findMaxAverage = values.reduce((prev, current) =>
-    isPresent(prev.index_average) > isPresent(current.index_average)
-      ? prev
-      : current
-  );
-
+  /**
+   * Calculate the highest tick and round it up on the closet number on the 0.5 scales.
+   * Then create an array with every tickStep till the highestTick
+   * to use for the tickValues in the chart.
+   */
   const tickStep = 0.5;
 
-  assert(
-    findMaxAverage.index_average,
-    "It coudn't find the highest average for the reproduction number"
+  const last_value = last(values) as NationalReproductionValue;
+  const maxIndexAverage = Math.max(
+    ...values.map((x) => x.index_average).filter(isPresent)
   );
+  const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
 
-  const highestTick = Math.ceil(findMaxAverage.index_average * 2) / 2;
-
-  const tickSteps = Array(highestTick / 0.5 + 1)
+  const tickSteps = Array(highestTick / tickStep + 1)
     .fill(tickStep)
     .map((v, i) => i * v);
 
@@ -84,7 +81,7 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
-          tickValues={tickSteps}
+          xtickValues={tickSteps}
         />
       )}
     </ChartTile>

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -9,7 +9,6 @@ import {
 import { ChartTile } from '~/components/chart-tile';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TimeframeOption } from '~/utils/timeframe';
-import { assert } from '~/utils/assert';
 
 interface ReproductionChartTileProps {
   data: NationalReproduction;

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -33,23 +33,9 @@ export function ReproductionChartTile({
     0,
     data.values.findIndex((x) => !isPresent(x.index_average))
   );
-
-  /**
-   * Calculate the highest tick and round it up on the closet number on the 0.5 scales.
-   * Then create an array with every tickStep till the highestTick
-   * to use for the tickValues in the chart.
-   */
-  const tickStep = 0.5;
-
   const last_value = last(values) as NationalReproductionValue;
-  const maxIndexAverage = Math.max(
-    ...values.map((x) => x.index_average).filter(isPresent)
-  );
-  const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
 
-  const tickSteps = Array(highestTick / tickStep + 1)
-    .fill(tickStep)
-    .map((step, index) => index * step);
+  const tickSteps = calculateTickValues(values, 0.5);
 
   return (
     <ChartTile
@@ -85,4 +71,23 @@ export function ReproductionChartTile({
       )}
     </ChartTile>
   );
+}
+
+/**
+ * Calculate the highest tick and round it up on the closet number on the 0.5 scales.
+ * Then create an array with every tickStep till the highestTick
+ * to use for the tickValues in the chart.
+ */
+function calculateTickValues(
+  values: NationalReproductionValue[],
+  tickStep: number
+) {
+  const maxIndexAverage = Math.max(
+    ...values.map((x) => x.index_average).filter(isPresent)
+  );
+  const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
+
+  return Array(highestTick / tickStep + 1)
+    .fill(tickStep)
+    .map((step, index) => index * step);
 }

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -9,6 +9,7 @@ import {
 import { ChartTile } from '~/components/chart-tile';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TimeframeOption } from '~/utils/timeframe';
+import { assert } from '~/utils/assert';
 
 interface ReproductionChartTileProps {
   data: NationalReproduction;
@@ -34,6 +35,25 @@ export function ReproductionChartTile({
     data.values.findIndex((x) => !isPresent(x.index_average))
   );
   const last_value = last(values) as NationalReproductionValue;
+
+  const findMaxAverage = values.reduce((prev, current) =>
+    isPresent(prev.index_average) > isPresent(current.index_average)
+      ? prev
+      : current
+  );
+
+  const tickStep = 0.5;
+
+  assert(
+    findMaxAverage.index_average,
+    "It coudn't find the highest average for the reproduction number"
+  );
+
+  const highestTick = Math.ceil(findMaxAverage.index_average * 2) / 2;
+
+  const tickSteps = Array(highestTick / 0.5 + 1)
+    .fill(tickStep)
+    .map((v, i) => i * v);
 
   return (
     <ChartTile
@@ -64,7 +84,7 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
-          tickValues={[0, 0.5, 1.0, 1.5, 2, 2.5]}
+          tickValues={tickSteps}
         />
       )}
     </ChartTile>

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -64,6 +64,7 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
+          tickValues={[0, 0.5, 1.0, 1.5, 2, 2.5]}
         />
       )}
     </ChartTile>


### PR DESCRIPTION
A more dynamic approach I've added.
But I could also use the manual approach `tickValues={[0, 0.5, 1.0, 1.5, 2, 2.5]}` but in the end, it is visually the same.
