### PR TITLE
Format dates in sanity list previews

### DIFF
--- a/packages/cms/src/schemas/documents/article.ts
+++ b/packages/cms/src/schemas/documents/article.ts
@@ -25,8 +25,15 @@ export default {
   preview: {
     select: {
       title: 'title.nl',
-      subtitle: 'publicationDate',
+      date: 'publicationDate',
       media: 'cover',
+    },
+    prepare(selection: { title: string; date: string }) {
+      const { title, date } = selection;
+      return {
+        title,
+        subtitle: new Date(date).toLocaleString(),
+      };
     },
   },
 };

--- a/packages/cms/src/schemas/documents/article.ts
+++ b/packages/cms/src/schemas/documents/article.ts
@@ -28,8 +28,7 @@ export default {
       date: 'publicationDate',
       media: 'cover',
     },
-    prepare(selection: { title: string; date: string }) {
-      const { title, date } = selection;
+    prepare({ title, date }: { title: string; date: string }) {
       return {
         title,
         subtitle: new Date(date).toLocaleString(),

--- a/packages/cms/src/schemas/documents/editorial.ts
+++ b/packages/cms/src/schemas/documents/editorial.ts
@@ -25,8 +25,15 @@ export default {
   preview: {
     select: {
       title: 'title.nl',
-      subtitle: 'publicationDate',
+      date: 'publicationDate',
       media: 'cover',
+    },
+    prepare(selection: { title: string; date: string }) {
+      const { title, date } = selection;
+      return {
+        title,
+        subtitle: new Date(date).toLocaleString(),
+      };
     },
   },
 };

--- a/packages/cms/src/schemas/documents/editorial.ts
+++ b/packages/cms/src/schemas/documents/editorial.ts
@@ -28,8 +28,7 @@ export default {
       date: 'publicationDate',
       media: 'cover',
     },
-    prepare(selection: { title: string; date: string }) {
-      const { title, date } = selection;
+    prepare({ title, date }: { title: string; date: string }) {
       return {
         title,
         subtitle: new Date(date).toLocaleString(),

--- a/packages/cms/src/schemas/restrictions/restriction.tsx
+++ b/packages/cms/src/schemas/restrictions/restriction.tsx
@@ -29,9 +29,7 @@ export default {
       title: 'text.nl',
       icon: 'icon',
     },
-    prepare(selection: { icon: RestrictionIcon; title: string }) {
-      const { title, icon } = selection;
-
+    prepare({ title, icon }: { icon: RestrictionIcon; title: string }) {
       return {
         title: title,
         media: (


### PR DESCRIPTION
## Summary

Display readable dates in the list previews, instead of ISO date strings.