### PR TITLE
Move order infected people graph 

### DIFF
--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -92,19 +92,19 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
                 ariaLabelledBy=""
                 seriesConfig={[
                   {
+                    type: 'line',
+                    metricProperty: 'estimate',
+                    label: text.legenda_line,
+                    shortLabel: text.lineLegendLabel,
+                    color: colors.data.primary,
+                  },
+                  {
                     type: 'range',
                     metricPropertyLow: 'margin_low',
                     metricPropertyHigh: 'margin_high',
                     label: text.legenda_marge,
                     shortLabel: text.rangeLegendLabel,
                     color: colors.data.margin,
-                  },
-                  {
-                    type: 'line',
-                    metricProperty: 'estimate',
-                    label: text.legenda_line,
-                    shortLabel: text.lineLegendLabel,
-                    color: colors.data.primary,
                   },
                 ]}
               />


### PR DESCRIPTION
The uncertainty margin was rendered above the line, reversed the order