### PR TITLE
Adjust default timeseries grid lines to 4

### DIFF
--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -129,7 +129,7 @@ export function TimeSeriesChart<
   timeframe = 'all',
   formatTooltip,
   dataOptions,
-  numGridLines = 3,
+  numGridLines = 4,
   tickValues: yTickValues,
   formatTickValue: formatYTickValue,
   paddingLeft,


### PR DESCRIPTION
## Summary

Adjust default timeseries grid lines to 4