### PR TITLE
Remove logic for calculating ticks reproduction chart

### DIFF
--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -35,7 +35,7 @@ export function ReproductionChartTile({
   );
   const last_value = last(values) as NationalReproductionValue;
 
-  const tickSteps = calculateTickValues(values, 0.5);
+  // const tickSteps = calculateTickValues(values, 0.5)
 
   return (
     <ChartTile
@@ -66,7 +66,6 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
-          tickValues={tickSteps}
         />
       )}
     </ChartTile>
@@ -78,16 +77,16 @@ export function ReproductionChartTile({
  * Then create an array with every tickStep till the highestTick
  * to use for the tickValues in the chart.
  */
-function calculateTickValues(
-  values: NationalReproductionValue[],
-  tickStep: number
-) {
-  const maxIndexAverage = Math.max(
-    ...values.map((x) => x.index_average).filter(isPresent)
-  );
-  const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
+// function calculateTickValues(
+//   values: NationalReproductionValue[],
+//   tickStep: number
+// ) {
+//   const maxIndexAverage = Math.max(
+//     ...values.map((x) => x.index_average).filter(isPresent)
+//   );
+//   const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
 
-  return Array(highestTick / tickStep + 1)
-    .fill(tickStep)
-    .map((step, index) => index * step);
-}
+//   return Array(highestTick / tickStep + 1)
+//     .fill(tickStep)
+//     .map((step, index) => index * step);
+// }

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -35,8 +35,6 @@ export function ReproductionChartTile({
   );
   const last_value = last(values) as NationalReproductionValue;
 
-  // const tickSteps = calculateTickValues(values, 0.5)
-
   return (
     <ChartTile
       title={text.linechart_titel}
@@ -71,22 +69,3 @@ export function ReproductionChartTile({
     </ChartTile>
   );
 }
-
-/**
- * Calculate the highest tick and round it up on the closet number on the 0.5 scales.
- * Then create an array with every tickStep till the highestTick
- * to use for the tickValues in the chart.
- */
-// function calculateTickValues(
-//   values: NationalReproductionValue[],
-//   tickStep: number
-// ) {
-//   const maxIndexAverage = Math.max(
-//     ...values.map((x) => x.index_average).filter(isPresent)
-//   );
-//   const highestTick = Math.ceil(maxIndexAverage * 2) / 2;
-
-//   return Array(highestTick / tickStep + 1)
-//     .fill(tickStep)
-//     .map((step, index) => index * step);
-// }


### PR DESCRIPTION
This gave some unintended side effects when switching to 5 weeks. But with setting the default ticks to 4 for the `TimeSeries` the default steps are now 0.5 without using the logic. So since it created a bug there was not a reason to keep the code for calculating.  I'm not sure why but I've reverted it.

Update: Seems like the `tickValues` cannot handle it when switching to to a different timeframe.

<img width="1011" alt="Screenshot 2021-04-29 at 14 21 00" src="https://user-images.githubusercontent.com/76471292/116549720-20c2f180-a8f6-11eb-97c5-8c39fd3d9974.png">
