### PR TITLE
Change numgridLines on timeframe reproduction chart

### DIFF
--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -64,6 +64,7 @@ export function ReproductionChartTile({
               label: siteText.common.signaalwaarde,
             },
           }}
+          numGridLines={timeframe === 'all' ? 4 : 3}
         />
       )}
     </ChartTile>


### PR DESCRIPTION
Small fix for setting different gridlines based on the timeframe, this should fix the issue of the weird alignment of the 5 weeks trend.