### PR TITLE
Hide link text when not filled in risk level page safety region

### DIFF
--- a/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
@@ -226,7 +226,7 @@ const RegionalRestrictions = (props: StaticProps<typeof getStaticProps>) => {
               </Box>
             </Box>
 
-            {!breakpoints.lg && (
+            {!breakpoints.lg && text.momenteel.link_text && (
               <Box mb={3}>
                 <Link
                   passHref


### PR DESCRIPTION
The text is not filled in but was still showing his margin. It should hide now when there is no content.