### PR TITLE
Test branch for branch-specific vercel ENV variables

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -44,7 +44,9 @@
     "vaccine_administered_rate_moving_average",
     "vaccine_administered_planned",
     "vaccine_stock",
-    "vaccine_delivery_per_supplier"
+    "vaccine_delivery_per_supplier",
+    "vaccine_coverage_per_age_group",
+    "vaccine_coverage"
   ],
   "additionalProperties": false,
   "properties": {

--- a/packages/app/src/config/features.ts
+++ b/packages/app/src/config/features.ts
@@ -15,7 +15,7 @@ export const features: Feature[] = [
   },
   {
     name: 'vaccinationPerAgegroup',
-    isEnabled: false,
+    isEnabled: true,
     metricScopes: ['nl'],
     metricName: 'vaccine_coverage_per_age_group',
   },
@@ -29,7 +29,7 @@ export const features: Feature[] = [
   },
   {
     name: 'vaccineCimsData',
-    isEnabled: false,
+    isEnabled: true,
     metricScopes: ['nl'],
     metricName: 'vaccine_coverage',
   },

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -84,7 +84,8 @@ export const getStaticProps = createGetStaticProps(
     'tested_overall',
     'hospital_nice',
     'difference',
-    'vaccine_administered_total'
+    'vaccine_administered_total',
+    'vaccine_coverage'
   )
 );
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -6,8 +6,8 @@ import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { ContentHeader } from '~/components/content-header';
 import { KpiValue } from '~/components/kpi-value';
-import { Tile } from '~/components/tile';
 import { Markdown } from '~/components/markdown';
+import { Tile } from '~/components/tile';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { Heading, Text } from '~/components/typography';
@@ -62,7 +62,8 @@ export const getStaticProps = createGetStaticProps(
     'vaccine_administered_hospitals_and_care_institutions',
     'vaccine_administered_doctors',
     'vaccine_administered_ggd_ghor',
-    'vaccine_coverage'
+    'vaccine_coverage',
+    'vaccine_coverage_per_age_group'
   ),
   createGetContent<{
     page: VaccinationPageQuery;
@@ -93,8 +94,8 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   const { page } = content;
 
   // TODO: put this back this when data is available
-  //const {vaccine_coverage_per_age_group} = data;
-  const vaccine_coverage_per_age_group = mockCoverageData();
+  const { vaccine_coverage_per_age_group } = data;
+  //const vaccine_coverage_per_age_group = mockCoverageData();
 
   const metadata = {
     ...siteText.nationaal_metadata,

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -173,7 +173,7 @@ export interface National {
   elderly_at_home: NationalElderlyAtHome;
   vaccine_support: NlVaccineSupport;
   corona_melder_app: NlCoronaMelderApp;
-  vaccine_coverage?: NlVaccineCoverage;
+  vaccine_coverage: NlVaccineCoverage;
   vaccine_delivery: NlVaccineDelivery;
   vaccine_delivery_estimate: NlVaccineDeliveryEstimate;
   vaccine_delivery_per_supplier: NlVaccineDeliveryPerSupplier;
@@ -186,7 +186,7 @@ export interface National {
   vaccine_administered_total: NlVaccineAdministeredTotal;
   vaccine_administered_rate_moving_average: NlVaccineAdministeredRateMovingAverage;
   vaccine_administered_planned: NlVaccineAdministeredPlanned;
-  vaccine_coverage_per_age_group?: NlVaccineCoveragePerAgeGroup;
+  vaccine_coverage_per_age_group: NlVaccineCoveragePerAgeGroup;
   vaccine_stock: NlVaccineStock;
 }
 export interface NationalDifference {


### PR DESCRIPTION
## Summary

This branch has both of the feature flags on the vaccination page turned on, so that the backend team can have a branch to test their data with.
Vercel allows specific ENV vars per branch, so they can test deployments themselves. (This PR is also meant to test that specific Vercel functionality)

## Motivation

DX

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
