### PR TITLE
Add custom validation for moving averages

### DIFF
--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { isDefined } from 'ts-is-present';
 
 export type CustomValidationFunction = (
-  input: Record<string, unknown>
+  input: Record<string, any>
 ) => string[] | undefined;
 
 export function createChoroplethValidation(

--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -2,10 +2,7 @@ import { UnknownObject } from '@corona-dashboard/common';
 import fs from 'fs';
 import path from 'path';
 import { isDefined } from 'ts-is-present';
-
-export type CustomValidationFunction = (
-  input: Record<string, any>
-) => string[] | undefined;
+import { CustomValidationFunction } from './types';
 
 export function createChoroplethValidation(
   choroplethCollectionPath: string,

--- a/packages/cli/src/schema/custom-validations/index.ts
+++ b/packages/cli/src/schema/custom-validations/index.ts
@@ -1,2 +1,3 @@
 export * from './choropleth';
+export * from './moving-averages';
 export * from './placeholders';

--- a/packages/cli/src/schema/custom-validations/index.ts
+++ b/packages/cli/src/schema/custom-validations/index.ts
@@ -1,3 +1,4 @@
 export * from './choropleth';
 export * from './moving-averages';
 export * from './placeholders';
+export * from './types';

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,15 +1,18 @@
 import set from 'lodash/set';
 import { isDefined } from 'ts-is-present';
+import { JSONValue } from './types';
 
 function hasValuesProperty(
-  input: [string, { values?: Record<string, unknown>[] }]
-): input is [string, { values: Record<string, unknown>[] }] {
-  return input[1].hasOwnProperty('values');
+  input: [string, JSONValue]
+): input is [string, { values: Record<string, JSONValue>[] }] {
+  return (
+    input[1] !== null &&
+    typeof input[1] === 'object' &&
+    input[1].hasOwnProperty('values')
+  );
 }
 
-export function validateMovingAverages(
-  input: Record<string, { values?: Record<string, unknown>[] }>
-) {
+export function validateMovingAverages(input: Record<string, JSONValue>) {
   const result = Object.entries(input)
     // first filter out all the non-metric properties (we only want the ones with a values collection)
     .filter(hasValuesProperty)

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -28,7 +28,7 @@ export function validateMovingAverages(input: Record<string, JSONValue>) {
         );
       }),
     }))
-    // Perform the validations on those moving averages
+    // Perform the validations on those moving averages (make sure the first six items have explicit NULL values and check if there are no non-consecutive values in the rest of the array)
     .map((x) =>
       Object.entries(x).map(([propertyName, values]) => {
         const propsWithValuesInFirstSixEntries = hasValuesInFirstSixEntries(

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -66,13 +66,17 @@ function hasNonConsecutiveValuesInMetric(
   collection: Record<string, unknown>[]
 ) {
   const values = collection.slice(6).map((x) => x[propertyName]);
-  let lastValue = values.pop();
+  let lastValue;
 
-  while (lastValue === null && values.length) {
-    lastValue = values.pop();
+  for (const value of values) {
+    if (lastValue === null && value !== null) {
+      return true;
+    }
+
+    lastValue = value;
   }
 
-  return values.indexOf(null) > -1;
+  return false;
 }
 
 function hasValuesInFirstSixEntries(values: Record<string, unknown>[]) {

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,10 +1,18 @@
 import set from 'lodash/set';
 import { isDefined } from 'ts-is-present';
 
-export function validateMovingAverages(input: Record<string, any>) {
+function hasValuesProperty(
+  input: [string, { values?: Record<string, unknown>[] }]
+): input is [string, { values: Record<string, unknown>[] }] {
+  return input[1].hasOwnProperty('values');
+}
+
+export function validateMovingAverages(
+  input: Record<string, { values?: Record<string, unknown>[] }>
+) {
   const result = Object.entries(input)
     // first filter out all the non-metric properties (we only want the ones with a values collection)
-    .filter(([_p, value]) => value.hasOwnProperty('values'))
+    .filter(hasValuesProperty)
     // Then filter out all the metrics that contain no properties with a '_moving_average' suffix
     .filter(([_p, value]) => hasMovingAverages(value.values[0]))
     // Map to objects that ONLY contain the moving average properties

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -5,10 +5,11 @@ import { JSONValue } from './types';
 function hasValuesProperty(
   input: [string, JSONValue]
 ): input is [string, { values: Record<string, JSONValue>[] }] {
+  const value = input[1];
   return (
-    input[1] !== null &&
-    typeof input[1] === 'object' &&
-    input[1].hasOwnProperty('values')
+    value !== null &&
+    typeof value === 'object' &&
+    value.hasOwnProperty('values')
   );
 }
 
@@ -31,7 +32,7 @@ export function validateMovingAverages(input: Record<string, JSONValue>) {
     // Perform the validations on those moving averages (make sure the first six items have explicit NULL values and check if there are no non-consecutive values in the rest of the array)
     .map((x) =>
       Object.entries(x).map(([propertyName, values]) => {
-        const propsWithValuesInFirstSixEntries = hasValuesInFirstSixEntries(
+        const propsWithValuesInFirstSixEntries = findPropertiesWithValuesInFirstSixEntries(
           values
         );
         if (propsWithValuesInFirstSixEntries.length) {
@@ -39,7 +40,9 @@ export function validateMovingAverages(input: Record<string, JSONValue>) {
             ' and '
           )}`;
         }
-        const propsWithNonConsecutiveValues = hasNonConsecutiveValues(values);
+        const propsWithNonConsecutiveValues = findPropertiesWithNonConsecutiveValues(
+          values
+        );
         if (propsWithNonConsecutiveValues.length) {
           return `${propertyName} has non consecutive values in metric ${propsWithNonConsecutiveValues.join(
             ' and '
@@ -54,7 +57,9 @@ export function validateMovingAverages(input: Record<string, JSONValue>) {
   return result.length ? result : undefined;
 }
 
-function hasNonConsecutiveValues(values: Record<string, unknown>[]) {
+function findPropertiesWithNonConsecutiveValues(
+  values: Record<string, unknown>[]
+) {
   const propertyNames = Object.keys(values[0]);
   return propertyNames.filter((propertyName) =>
     hasNonConsecutiveValuesInMetric(propertyName, values)
@@ -79,7 +84,9 @@ function hasNonConsecutiveValuesInMetric(
   return false;
 }
 
-function hasValuesInFirstSixEntries(values: Record<string, unknown>[]) {
+function findPropertiesWithValuesInFirstSixEntries(
+  values: Record<string, unknown>[]
+) {
   return values
     .slice(0, 5)
     .map((x) =>

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,3 +1,4 @@
+import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import { isDefined } from 'ts-is-present';
 import { JSONValue } from './types';
@@ -6,11 +7,7 @@ function hasValuesProperty(
   input: [string, JSONValue]
 ): input is [string, { values: Record<string, JSONValue>[] }] {
   const value = input[1];
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    value.hasOwnProperty('values')
-  );
+  return isObject(value) && 'values' in value;
 }
 
 export function validateMovingAverages(input: Record<string, JSONValue>) {
@@ -89,14 +86,12 @@ function findPropertiesWithValuesInFirstSixEntries(
 ) {
   return values
     .slice(0, 5)
-    .map((x) =>
+    .flatMap((x) =>
       Object.entries(x).map(([propertyName, value]) =>
         value !== null ? propertyName : undefined
       )
     )
-    .flat()
-    .filter((x, index, arr) => index === arr.indexOf(x))
-    .filter(isDefined);
+    .filter((x, index, arr) => isDefined(x) && index === arr.indexOf(x));
 }
 
 function hasMovingAverages(input: Record<string, unknown>) {

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -67,11 +67,7 @@ function hasNonConsecutiveNullValuesInMetric(
       while (currentValue === null) {
         currentValue = collection[++i]?.[propertyName];
       }
-      if (
-        currentValue !== null &&
-        currentValue !== undefined &&
-        i < collection.length
-      ) {
+      if (isDefined(currentValue) && i < collection.length) {
         return true;
       }
     }

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -2,8 +2,11 @@ import { isDefined } from 'ts-is-present';
 
 export function validateMovingAverages(input: Record<string, any>) {
   const result = Object.entries(input)
+    // first filter out all the non-metric properties (we only want the ones with a values collection)
     .filter(([_p, value]) => value.hasOwnProperty('values'))
+    // Then filter out all the metrics that contain no properties with a '_moving_average' suffix
     .filter(([_p, value]) => hasMovingAverages(value.values[0]))
+    // Map to objects that ONLY contain the moving average properties
     .map(([propertyName, value]) => ({
       [propertyName]: value.values.map((x: Record<string, unknown>) => {
         const movingAverageProperties = findMovingAverages(x);
@@ -13,6 +16,7 @@ export function validateMovingAverages(input: Record<string, any>) {
         }, {} as Record<string, unknown>);
       }),
     }))
+    // Perform the validations on those moving averages
     .map((x) =>
       Object.entries(x).map(([propertyName, values]) => {
         const propsWithValuesInFirstSixEntries = hasValuesInFirstSixEntries(

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,0 +1,75 @@
+import { isDefined } from 'ts-is-present';
+
+export function validateMovingAverages(input: Record<string, any>) {
+  const result = Object.entries(input)
+    .filter(([_p, value]) => value.hasOwnProperty('values'))
+    .filter(([_p, value]) => hasMovingAverages(value.values[0]))
+    .map(([propertyName, value]) => ({
+      [propertyName]: value.values.map((x: Record<string, unknown>) => {
+        const movingAverageProperties = findMovingAverages(x);
+        return movingAverageProperties.reduce((aggr, p) => {
+          aggr[p] = x[p];
+          return aggr;
+        }, {} as Record<string, unknown>);
+      }),
+    }))
+    .map((x) =>
+      Object.entries(x).map(([propertyName, values]) => {
+        const propsWithValuesInFirstSixEntries = hasValuesInFirstSixEntries(
+          values
+        );
+        if (propsWithValuesInFirstSixEntries.length) {
+          return `${propertyName} has non NULL values in the first six items of metric ${propsWithValuesInFirstSixEntries.join(
+            ' and '
+          )}`;
+        }
+        const propsWithNullValuesInOtherEntries = hasNullValuesInOtherEntries(
+          values
+        );
+        if (propsWithNullValuesInOtherEntries.length) {
+          return `${propertyName} has NULL values in items above index 5 of metric ${propsWithNullValuesInOtherEntries.join(
+            ' and '
+          )}`;
+        }
+        return undefined;
+      })
+    )
+    .flat()
+    .filter(isDefined);
+
+  return result.length ? result : undefined;
+}
+
+function hasNullValuesInOtherEntries(values: Record<string, unknown>[]) {
+  return values
+    .slice(6)
+    .map((x) =>
+      Object.entries(x).map(([propertyName, value]) =>
+        value === null ? propertyName : undefined
+      )
+    )
+    .flat()
+    .filter((x, index, arr) => index === arr.indexOf(x))
+    .filter(isDefined);
+}
+
+function hasValuesInFirstSixEntries(values: Record<string, unknown>[]) {
+  return values
+    .slice(0, 5)
+    .map((x) =>
+      Object.entries(x).map(([propertyName, value]) =>
+        value !== null ? propertyName : undefined
+      )
+    )
+    .flat()
+    .filter((x, index, arr) => index === arr.indexOf(x))
+    .filter(isDefined);
+}
+
+function hasMovingAverages(input: Record<string, unknown>) {
+  return findMovingAverages(input).length > 0;
+}
+
+function findMovingAverages(input: Record<string, unknown>) {
+  return Object.keys(input).filter((x) => x.endsWith('_moving_average'));
+}

--- a/packages/cli/src/schema/custom-validations/types.ts
+++ b/packages/cli/src/schema/custom-validations/types.ts
@@ -1,0 +1,3 @@
+export type CustomValidationFunction = (
+  input: Record<string, any>
+) => string[] | undefined;

--- a/packages/cli/src/schema/custom-validations/types.ts
+++ b/packages/cli/src/schema/custom-validations/types.ts
@@ -1,3 +1,3 @@
 export type CustomValidationFunction = (
-  input: Record<string, any>
+  input: Record<string, { values: Record<string, unknown>[] }>
 ) => string[] | undefined;

--- a/packages/cli/src/schema/custom-validations/types.ts
+++ b/packages/cli/src/schema/custom-validations/types.ts
@@ -1,3 +1,11 @@
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
 export type CustomValidationFunction = (
-  input: Record<string, { values: Record<string, unknown>[] }>
+  input: Record<string, JSONValue>
 ) => string[] | undefined;

--- a/packages/cli/src/schema/schema-info.ts
+++ b/packages/cli/src/schema/schema-info.ts
@@ -6,9 +6,9 @@ import { getFileNames } from '../utils';
 import {
   createChoroplethValidation,
   CustomValidationFunction,
+  validateMovingAverages,
   validatePlaceholders,
 } from './custom-validations';
-import { validateMovingAverages } from './custom-validations/moving-averages';
 
 export type SchemaInfo = Record<MetricScope | 'locale', SchemaInfoItem>;
 

--- a/packages/cli/src/schema/schema-info.ts
+++ b/packages/cli/src/schema/schema-info.ts
@@ -1,15 +1,14 @@
+import { assert, MetricScope } from '@corona-dashboard/common';
 import fs from 'fs';
 import path from 'path';
 import { defaultJsonDirectory, localeDirectory } from '../config';
+import { getFileNames } from '../utils';
 import {
-  validatePlaceholders,
   createChoroplethValidation,
   CustomValidationFunction,
+  validatePlaceholders,
 } from './custom-validations';
-import { assert } from '@corona-dashboard/common';
-import { getFileNames } from '../utils';
-
-import { MetricScope } from '@corona-dashboard/common';
+import { validateMovingAverages } from './custom-validations/moving-averages';
 
 export type SchemaInfo = Record<MetricScope | 'locale', SchemaInfoItem>;
 
@@ -37,6 +36,7 @@ export function getSchemaInfo(
           path.join(defaultJsonDirectory, 'VR_COLLECTION.json'),
           'vrcode'
         ),
+        validateMovingAverages,
       ],
     },
     gm: {
@@ -47,6 +47,7 @@ export function getSchemaInfo(
           path.join(defaultJsonDirectory, 'GM_COLLECTION.json'),
           'gmcode'
         ),
+        validateMovingAverages,
       ],
     },
     gm_collection: { files: ['GM_COLLECTION.json'], basePath: jsonDirectory },


### PR DESCRIPTION
## Summary

This PR adds a custom validation for the moving averages.

## Motivation

Feature request

## Detailed design

The custom validation function `validateMovingAverages` loops through all the metrics in GM and VR and looks for collections that contain objects with property names suffixed by '_moving_average'.
These collections are checked to make sure that the first six entries of these specific metrics have a value of `NULL` _and_ that there are no non-consecutive null values in the rest of the collection.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
