### PR TITLE
Add option to validate a single metric in a data file

### DIFF
--- a/packages/cli/src/schema/create-validate-function.ts
+++ b/packages/cli/src/schema/create-validate-function.ts
@@ -3,13 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import { equalsRootProperty } from './keywords';
 
-export function createValidateFunctionFromSchemaObject(
-  schema: any,
-  basePath: string
-) {
-  return compileValidator(schema, loadSchema.bind(null, basePath));
-}
-
 export function loadRootSchema(schemaPath: string) {
   try {
     return JSON.parse(
@@ -27,12 +20,16 @@ export function loadRootSchema(schemaPath: string) {
  *
  * @returns A Promise object that will resolve to a ValidateFunction.
  */
-export function createValidateFunctionFromSchemaPath(schemaPath: string) {
-  const basePath = path.dirname(schemaPath);
+export function createValidateFunction(
+  schemaOrPath: string | any,
+  schemaBasePath: string
+) {
+  const schema =
+    typeof schemaOrPath === 'string'
+      ? loadRootSchema(schemaOrPath)
+      : schemaOrPath;
 
-  const schema = loadRootSchema(schemaPath);
-
-  return compileValidator(schema, loadSchema.bind(null, basePath));
+  return compileValidator(schema, loadSchema.bind(null, schemaBasePath));
 }
 
 function compileValidator(

--- a/packages/cli/src/schema/create-validate-function.ts
+++ b/packages/cli/src/schema/create-validate-function.ts
@@ -16,24 +16,24 @@ export function loadRootSchema(schemaPath: string) {
 }
 
 /**
- * Creates an Ajv ValidateFunction for the given schema
+ * Creates an Ajv ValidateFunction for the given schema or schema filename
  *
  * @returns A Promise object that will resolve to a ValidateFunction.
  */
 export function createValidateFunction(
-  schemaOrPath: string | any,
+  schemaOrFilename: string | object,
   schemaBasePath: string
 ) {
   const schema =
-    typeof schemaOrPath === 'string'
-      ? loadRootSchema(schemaOrPath)
-      : schemaOrPath;
+    typeof schemaOrFilename === 'string'
+      ? loadRootSchema(path.join(schemaBasePath, schemaOrFilename))
+      : schemaOrFilename;
 
   return compileValidator(schema, loadSchema.bind(null, schemaBasePath));
 }
 
 function compileValidator(
-  rootSchema: any,
+  rootSchema: object,
   loadSchema: (
     uri: string,
     cb?: (err: Error, schema: object) => void

--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -2,7 +2,7 @@ import { UnknownObject } from '@corona-dashboard/common';
 import fs from 'fs';
 import path from 'path';
 import { isDefined } from 'ts-is-present';
-import { CustomValidationFunction } from './types';
+import { CustomValidationFunction, JSONType, JSONValue } from './types';
 
 export function createChoroplethValidation(
   choroplethCollectionPath: string,
@@ -44,9 +44,9 @@ export function createChoroplethValidation(
  */
 export const validateChoroplethValues = (
   collectionJsonFilename: string,
-  collectionJson: Record<string, any>, // The GM_COLLECTION.sjon or VR_COLLECTION.json
+  collectionJson: JSONType, // The GM_COLLECTION.sjon or VR_COLLECTION.json
   codeProperty: string, //the gmcode or vrcode property name
-  input: Record<string, any> //GM***.json or VR***.json
+  input: JSONType //GM***.json or VR***.json
 ): string[] | undefined => {
   const commonDataProperties = getCommonDataProperties(input, collectionJson);
 
@@ -54,13 +54,18 @@ export const validateChoroplethValues = (
 
   const results = commonDataProperties
     .map((propertyName) => {
-      const collectionValue = collectionJson[propertyName].find(
+      const collectionValue = (collectionJson[
+        propertyName
+      ] as JSONValue[])?.find(
         (x: any) => x[codeProperty] === code
-      );
+      ) as UnknownObject;
+
       if (!collectionValue) {
         return `No item with property ${codeProperty} == ${code} was found in the ${propertyName} collection (${collectionJsonFilename})`;
       }
-      const lastValue = input[propertyName].last_value;
+
+      const lastValue = (input[propertyName] as { last_value: UnknownObject })
+        .last_value;
       return validateCommonPropertyEquality(
         lastValue,
         collectionValue,

--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -2,7 +2,7 @@ import { UnknownObject } from '@corona-dashboard/common';
 import fs from 'fs';
 import path from 'path';
 import { isDefined } from 'ts-is-present';
-import { CustomValidationFunction, JSONType, JSONValue } from './types';
+import { CustomValidationFunction, JSONObject, JSONValue } from './types';
 
 export function createChoroplethValidation(
   choroplethCollectionPath: string,
@@ -44,9 +44,9 @@ export function createChoroplethValidation(
  */
 export const validateChoroplethValues = (
   collectionJsonFilename: string,
-  collectionJson: JSONType, // The GM_COLLECTION.sjon or VR_COLLECTION.json
+  collectionJson: JSONObject, // The GM_COLLECTION.sjon or VR_COLLECTION.json
   codeProperty: string, //the gmcode or vrcode property name
-  input: JSONType //GM***.json or VR***.json
+  input: JSONObject //GM***.json or VR***.json
 ): string[] | undefined => {
   const commonDataProperties = getCommonDataProperties(input, collectionJson);
 

--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -1,8 +1,9 @@
 import { UnknownObject } from '@corona-dashboard/common';
 import fs from 'fs';
+import isObject from 'lodash/isObject';
 import path from 'path';
 import { isDefined } from 'ts-is-present';
-import { CustomValidationFunction } from './types';
+import { CustomValidationFunction, JSONType, JSONValue } from './types';
 
 export function createChoroplethValidation(
   choroplethCollectionPath: string,
@@ -29,6 +30,10 @@ export function createChoroplethValidation(
   ) as CustomValidationFunction;
 }
 
+function isJsonObject(value: JSONValue): value is { [key: string]: JSONValue } {
+  return typeof value === 'object';
+}
+
 /**
  * This validation function receives a data file (either VR of GM) and a choropleth data file (GM_COLLECTION or VR_COLLECTION).
  * It extracts all of the data points that both files have in common, then it
@@ -44,9 +49,9 @@ export function createChoroplethValidation(
  */
 export const validateChoroplethValues = (
   collectionJsonFilename: string,
-  collectionJson: Record<string, any>, // The GM_COLLECTION.sjon or VR_COLLECTION.json
+  collectionJson: JSONType, // The GM_COLLECTION.sjon or VR_COLLECTION.json
   codeProperty: string, //the gmcode or vrcode property name
-  input: Record<string, any> //GM***.json or VR***.json
+  input: JSONType //GM***.json or VR***.json
 ): string[] | undefined => {
   const commonDataProperties = getCommonDataProperties(input, collectionJson);
 
@@ -54,16 +59,17 @@ export const validateChoroplethValues = (
 
   const results = commonDataProperties
     .map((propertyName) => {
-      const collectionValue = collectionJson[propertyName].find(
-        (x: any) => x[codeProperty] === code
-      );
+      const collectionValue = (collectionJson[propertyName] as JSONValue[])
+        ?.filter(isJsonObject)
+        .find((x) => x[codeProperty] === code);
       if (!collectionValue) {
         return `No item with property ${codeProperty} == ${code} was found in the ${propertyName} collection (${collectionJsonFilename})`;
       }
-      const lastValue = input[propertyName].last_value;
+      const lastValue = (input[propertyName] as { last_value: UnknownObject })
+        ?.last_value;
       return validateCommonPropertyEquality(
         lastValue,
-        collectionValue,
+        collectionValue as UnknownObject,
         propertyName
       );
     })
@@ -85,7 +91,9 @@ function validateCommonPropertyEquality(
   const commonProperties = getCommonProperties(collectionValue, lastValue);
   const result = commonProperties
     .map((key) => {
-      return lastValue[key] !== collectionValue[key]
+      return isObject(lastValue) && isObject(collectionValue)
+        ? lastValue[key] !== collectionValue[key]
+        : false
         ? `property ${propertyName}.${key} is not equal: (last_value) ${lastValue[key]} !== (choropleth data) ${collectionValue[key]}`
         : undefined;
     })
@@ -94,12 +102,16 @@ function validateCommonPropertyEquality(
 }
 
 function getCommonProperties(left: UnknownObject, right: UnknownObject) {
-  return Object.keys(left).filter((key) => right.hasOwnProperty(key));
+  return isObject(left) && isObject(right)
+    ? Object.keys(left).filter((key) => right.hasOwnProperty(key))
+    : [];
 }
 
 function getCommonDataProperties(left: UnknownObject, right: UnknownObject) {
-  return Object.entries(left)
-    .filter(([, values]) => typeof values === 'object')
-    .map(([key]) => key)
-    .filter((key) => right.hasOwnProperty(key));
+  return isObject(left) && isObject(right)
+    ? Object.entries(left)
+        .filter(([, values]) => typeof values === 'object')
+        .map(([key]) => key)
+        .filter((key) => right.hasOwnProperty(key))
+    : [];
 }

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,7 +1,7 @@
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import { isDefined } from 'ts-is-present';
-import { JSONValue } from './types';
+import { JSONType, JSONValue } from './types';
 
 function hasValuesProperty(
   input: [string, JSONValue]
@@ -10,7 +10,7 @@ function hasValuesProperty(
   return isObject(value) && 'values' in value;
 }
 
-export function validateMovingAverages(input: Record<string, JSONValue>) {
+export function validateMovingAverages(input: JSONType) {
   const result = Object.entries(input)
     // first filter out all the non-metric properties (we only want the ones with a values collection)
     .filter(hasValuesProperty)

--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -1,7 +1,7 @@
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import { isDefined } from 'ts-is-present';
-import { JSONType, JSONValue } from './types';
+import { JSONObject, JSONValue } from './types';
 
 function hasValuesProperty(
   input: [string, JSONValue]
@@ -10,7 +10,7 @@ function hasValuesProperty(
   return isObject(value) && 'values' in value;
 }
 
-export function validateMovingAverages(input: JSONType) {
+export function validateMovingAverages(input: JSONObject) {
   const result = Object.entries(input)
     // first filter out all the non-metric properties (we only want the ones with a values collection)
     .filter(hasValuesProperty)

--- a/packages/cli/src/schema/custom-validations/types.ts
+++ b/packages/cli/src/schema/custom-validations/types.ts
@@ -6,6 +6,8 @@ export type JSONValue =
   | JSONValue[]
   | { [key: string]: JSONValue };
 
+export type JSONType = Record<string, JSONValue>;
+
 export type CustomValidationFunction = (
-  input: Record<string, JSONValue>
+  input: JSONType
 ) => string[] | undefined;

--- a/packages/cli/src/schema/custom-validations/types.ts
+++ b/packages/cli/src/schema/custom-validations/types.ts
@@ -6,8 +6,8 @@ export type JSONValue =
   | JSONValue[]
   | { [key: string]: JSONValue };
 
-export type JSONType = Record<string, JSONValue>;
+export type JSONObject = Record<string, JSONValue>;
 
 export type CustomValidationFunction = (
-  input: JSONType
+  input: JSONObject
 ) => string[] | undefined;

--- a/packages/cli/src/scripts/generate-data-types.ts
+++ b/packages/cli/src/scripts/generate-data-types.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import path from 'path';
 import { compile, JSONSchema } from 'json-schema-to-typescript';
-import { createValidateFunction } from '../schema';
+import path from 'path';
 import { schemaDirectory } from '../config';
+import { createValidateFunctionFromSchemaPath } from '../schema';
 
 // The directory where the resulting data.d.ts file will be saved
 const outputDirectory = path.join(
@@ -47,7 +47,7 @@ async function generateTypeScriptFromSchema(schemaName: string) {
     bannerComment: '',
   };
 
-  const validate = await createValidateFunction(
+  const validate = await createValidateFunctionFromSchemaPath(
     path.join(schemaDirectory, schemaName, `__index.json`)
   );
 

--- a/packages/cli/src/scripts/generate-data-types.ts
+++ b/packages/cli/src/scripts/generate-data-types.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { compile, JSONSchema } from 'json-schema-to-typescript';
 import path from 'path';
 import { schemaDirectory } from '../config';
-import { createValidateFunctionFromSchemaPath } from '../schema';
+import { createValidateFunction } from '../schema';
 
 // The directory where the resulting data.d.ts file will be saved
 const outputDirectory = path.join(
@@ -47,8 +47,9 @@ async function generateTypeScriptFromSchema(schemaName: string) {
     bannerComment: '',
   };
 
-  const validate = await createValidateFunctionFromSchemaPath(
-    path.join(schemaDirectory, schemaName, `__index.json`)
+  const validate = await createValidateFunction(
+    '__index.json',
+    path.join(schemaDirectory, schemaName)
   );
 
   const typeDefinition = await compile(

--- a/packages/cli/src/scripts/validate-json-all.ts
+++ b/packages/cli/src/scripts/validate-json-all.ts
@@ -4,7 +4,7 @@ import meow from 'meow';
 import path from 'path';
 import { schemaDirectory } from '../config';
 import {
-  createValidateFunctionFromSchemaPath,
+  createValidateFunction,
   executeValidations,
   getSchemaInfo,
   SchemaInfo,
@@ -86,8 +86,9 @@ Promise.all(promisedValidations)
  * @returns An array of promises that will resolve either to true or false dependent on the validation result
  */
 async function validate(schemaName: string, schemaInfo: SchemaInfoItem) {
-  const validateFunction = await createValidateFunctionFromSchemaPath(
-    path.join(schemaDirectory, schemaName, `__index.json`)
+  const validateFunction = await createValidateFunction(
+    '__index.json',
+    path.join(schemaDirectory, schemaName)
   );
 
   return schemaInfo.files.map((fileName) => {

--- a/packages/cli/src/scripts/validate-json-all.ts
+++ b/packages/cli/src/scripts/validate-json-all.ts
@@ -4,7 +4,7 @@ import meow from 'meow';
 import path from 'path';
 import { schemaDirectory } from '../config';
 import {
-  createValidateFunction,
+  createValidateFunctionFromSchemaPath,
   executeValidations,
   getSchemaInfo,
   SchemaInfo,
@@ -86,7 +86,7 @@ Promise.all(promisedValidations)
  * @returns An array of promises that will resolve either to true or false dependent on the validation result
  */
 async function validate(schemaName: string, schemaInfo: SchemaInfoItem) {
-  const validateFunction = await createValidateFunction(
+  const validateFunction = await createValidateFunctionFromSchemaPath(
     path.join(schemaDirectory, schemaName, `__index.json`)
   );
 

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import fs from 'fs';
 import meow from 'meow';
 import path from 'path';
@@ -11,6 +10,8 @@ import {
   loadRootSchema,
   SchemaInfo,
 } from '../schema';
+import { JSONType } from '../schema/custom-validations';
+import { logError, logSuccess } from '../utils';
 
 /**
  * When a single metric name is specified to be validated, we first load the associated schema.
@@ -24,10 +25,8 @@ function loadStrippedSchema(metricName: string, basePath: string) {
   const strippedSchema = loadRootSchema(path.join(basePath, `__index.json`));
 
   if (!isDefined(strippedSchema.properties[metricName])) {
-    console.error(
-      chalk.bgRed.bold(
-        `  ${metricName} is not a metric in the specified schema '${schemaName}'  \n`
-      )
+    logError(
+      `  ${metricName} is not a metric in the specified schema '${schemaName}'  \n`
     );
     process.exit(1);
   }
@@ -114,12 +113,12 @@ createValidateFunction(rootSchema, schemaBasePath).then((validateFunction) => {
     encoding: 'utf8',
   });
 
-  let jsonData: any = null;
+  let jsonData: JSONType | null = null;
   try {
     jsonData = JSON.parse(contentAsString);
   } catch (e) {
     console.group();
-    console.error(chalk.bgRed.bold(`  ${fileName} cannot be parsed  \n`));
+    logError(`  ${fileName} cannot be parsed  \n`);
     console.groupEnd();
     process.exit(1);
   }
@@ -132,9 +131,9 @@ createValidateFunction(rootSchema, schemaBasePath).then((validateFunction) => {
 
   if (!isValid) {
     console.error(schemaErrors);
-    console.error(chalk.bgRed.bold(`  ${jsonFileName} is invalid  \n`));
+    logError(`  ${jsonFileName} is invalid  \n`);
     process.exit(1);
   }
 
-  console.log(chalk.green.bold(`  ${jsonFileName} is valid  \n`));
+  logSuccess(`  ${jsonFileName} is valid  \n`);
 });

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -66,6 +66,7 @@ Where schema-name must be one of these values: ${validSchemaNames.join(', ')},
 json-filename must be a file associated with that schema and metric-name must be a valid
 metric in the specified schema.
 
+${cli.help}
 `
   );
   process.exit(1);

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -10,7 +10,7 @@ import {
   loadRootSchema,
   SchemaInfo,
 } from '../schema';
-import { JSONType } from '../schema/custom-validations';
+import { JSONObject } from '../schema/custom-validations';
 import { logError, logSuccess } from '../utils';
 
 /**
@@ -113,7 +113,7 @@ createValidateFunction(rootSchema, schemaBasePath).then((validateFunction) => {
     encoding: 'utf8',
   });
 
-  let jsonData: JSONType | null = null;
+  let jsonData: JSONObject | null = null;
   try {
     jsonData = JSON.parse(contentAsString);
   } catch (e) {

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -17,22 +17,23 @@ const validSchemaNames = Object.keys(schemaInformation);
 const cli = meow(
   `
     Usage
-      $ validate-json-single <schema-name> <json-path>
+      $ validate-json-single <schema-name> <json-path> <optional-metric-name>
 
     Examples
-      $ validate-json-single national nl.json
+      $ validate-json-single national nl.json vaccine_coverage
 `
 );
 
 const cliArgs = cli.input;
 
-if (cliArgs.length !== 2) {
+if (cliArgs.length < 2 || cliArgs.length > 3) {
   console.error(
     `
-Expected two command line arguments: schema-name and json-filename.
+Expected at least two command line arguments: schema-name and json-filename, and optionally a third one: metric-name
 
-Where schema-name must be one of these values: ${validSchemaNames.join(', ')}
-and json-filename must be a file associated with that schema.
+Where schema-name must be one of these values: ${validSchemaNames.join(', ')},
+json-filename must be a file associated with that schema and metric-name must be a valid
+metric in the specified schema.
 
 `
   );
@@ -41,6 +42,7 @@ and json-filename must be a file associated with that schema.
 
 const schemaName = cliArgs[0] as keyof SchemaInfo;
 const jsonFileName = cliArgs[1];
+const metricName = cliArgs[2];
 
 if (!validSchemaNames.includes(schemaName)) {
   console.error(

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -51,7 +51,7 @@ const cli = meow(
       $ validate-json-single <schema-name> <json-path> <optional-metric-name>
 
     Examples
-      $ validate-json-single national nl.json vaccine_coverage
+      $ validate-json-single national NL.json vaccine_coverage
 `
 );
 

--- a/packages/cli/src/scripts/validate-json-single.ts
+++ b/packages/cli/src/scripts/validate-json-single.ts
@@ -51,7 +51,7 @@ const cli = meow(
       $ validate-json-single <schema-name> <json-path> <optional-metric-name>
 
     Examples
-      $ validate-json-single national NL.json vaccine_coverage
+      $ validate-json-single nl NL.json vaccine_coverage
 `
 );
 


### PR DESCRIPTION
## Summary

Previously `validate-single-json <schema-name> <json-filename>` could be used to validate one single data file instead of the entire list.
An extra optional command line option has been added that allows to have only ONE metric within the specified datafile to be validated: `validate-single-json <schema-name> <json-filename> <metric-name>`.

## Motivation

Feature request.

## Detailed design

If a metric name is specified the script now first loads the specified schema file, removes all of the required properties and leaves only the specified metric name in that list. It then sets `additionalProperties` to `true` and removes all the property definitions except for the one describing the metric name.

This way all of the other properties are ignored and only the specified metric will be validated.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
