### PR TITLE
Allow null values in vaccine support chart

### DIFF
--- a/packages/app/schema/nl/vaccine_support.json
+++ b/packages/app/schema/nl/vaccine_support.json
@@ -24,19 +24,19 @@
           "type": "number"
         },
         "percentage_70_plus": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "percentage_55_69": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "percentage_40_54": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "percentage_25_39": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "percentage_16_24": {
-          "type": "number"
+          "type": ["number", "null"]
         },
         "date_start_unix": {
           "type": "integer"

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -570,11 +570,11 @@ export interface NlVaccineSupport {
 }
 export interface NlVaccineSupportValue {
   percentage_average: number;
-  percentage_70_plus: number;
-  percentage_55_69: number;
-  percentage_40_54: number;
-  percentage_25_39: number;
-  percentage_16_24: number;
+  percentage_70_plus: number | null;
+  percentage_55_69: number | null;
+  percentage_40_54: number | null;
+  percentage_25_39: number | null;
+  percentage_16_24: number | null;
   date_start_unix: number;
   date_end_unix: number;
   date_of_insertion_unix: number;


### PR DESCRIPTION
## Summary

Allow null values so we can cut out trends like 70+ at some point in time.