### PR TITLE
Cut trend values based on timespan annotation

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -16,6 +16,7 @@ export interface TimespanAnnotationConfig {
   end: number;
   label: string;
   shortLabel?: string;
+  cutValuesForMetricProperties?: string[];
 }
 
 /**

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -3,7 +3,7 @@ import {
   isDateSpanSeries,
   TimestampedValue,
 } from '@corona-dashboard/common';
-import { findIndex } from 'lodash';
+import { findIndex, omit, pick } from 'lodash';
 import { useMemo } from 'react';
 import { hasValueAtKey, isDefined } from 'ts-is-present';
 import { useCurrentDate } from '~/utils/current-date-context';
@@ -333,7 +333,7 @@ function getSeriesData<T extends TimestampedValue>(
 }
 
 /**
- * Technically cutting values means filling __value with null. We still want
+ * Cutting values means setting series item.__value to undefined. We still want
  * them to be fully qualified series items.
  */
 function cutValues(
@@ -395,10 +395,9 @@ function getCutIndexStartEnd(
 }
 
 /**
- * Convert timespanAnnotations to a simplified the type used to process the
- * series. We could just pass down the full annotations type but that would
- * create a bit of an odd dependency between the two mostly independent
- * concepts.
+ * Convert timespanAnnotations to a simplified type used to cut the series data.
+ * We could just pass down the full annotations type but that would create a bit
+ * of an odd dependency between two mostly independent concepts.
  */
 export function extractCutValuesConfig(
   timespanAnnotations?: TimespanAnnotationConfig[]
@@ -423,5 +422,16 @@ function clearValues(
 ) {
   for (let index = startIndex; index <= endIndex; ++index) {
     if (values[index]) values[index].__value = undefined;
+  }
+}
+
+export function omitValuePropertiesForAnnotation<T extends TimestampedValue>(
+  value: T,
+  timespan: TimespanAnnotationConfig
+) {
+  if (timespan.cutValuesForMetricProperties) {
+    return omit(value, timespan.cutValuesForMetricProperties) as T;
+  } else {
+    return value;
   }
 }

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -3,7 +3,7 @@ import {
   isDateSpanSeries,
   TimestampedValue,
 } from '@corona-dashboard/common';
-import { findIndex, omit, pick } from 'lodash';
+import { omit } from 'lodash';
 import { useMemo } from 'react';
 import { hasValueAtKey, isDefined } from 'ts-is-present';
 import { useCurrentDate } from '~/utils/current-date-context';
@@ -367,8 +367,7 @@ function getCutIndexStartEnd(
   start: number,
   end: number
 ) {
-  const startIndex = findIndex(
-    values,
+  const startIndex = values.findIndex(
     (x) => x.__date_unix > start && x.__date_unix < end
   );
 
@@ -380,7 +379,7 @@ function getCutIndexStartEnd(
     return [];
   }
 
-  const endIndex = findIndex(values, (x) => x.__date_unix >= end);
+  const endIndex = values.findIndex((x) => x.__date_unix >= end);
 
   if (endIndex === -1) {
     /**

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -420,7 +420,12 @@ function clearValues(
   endIndex: number
 ) {
   for (let index = startIndex; index <= endIndex; ++index) {
-    if (values[index]) values[index].__value = undefined;
+    const originalValue = values[index];
+
+    values[index] = {
+      ...originalValue,
+      __value: undefined,
+    };
   }
 }
 

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -368,7 +368,7 @@ function getCutIndexStartEnd(
   end: number
 ) {
   const startIndex = values.findIndex(
-    (x) => x.__date_unix > start && x.__date_unix < end
+    (x) => x.__date_unix >= start && x.__date_unix < end
   );
 
   if (startIndex === -1) {

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -26,6 +26,7 @@ import { Benchmark } from './components/benchmark';
 import { Series } from './components/series';
 import {
   calculateSeriesMaximum,
+  omitValuePropertiesForAnnotation,
   DataOptions,
   extractCutValuesConfig,
   getTimeDomain,
@@ -226,8 +227,17 @@ export function TimeSeriesChart<
            * nearest/active hover property and the full series configuration.
            * With these three arguments we should be able to render any sort of
            * tooltip.
+           *
+           * If we are hovering a timespanAnnotation, we use that data to cut
+           * out any property values that should be blocked from the tooltip.
            */
-          value: values[valuesIndex],
+          value:
+            timespanAnnotations && isDefined(timespanAnnotationIndex)
+              ? omitValuePropertiesForAnnotation(
+                  values[valuesIndex],
+                  timespanAnnotations[timespanAnnotationIndex]
+                )
+              : values[valuesIndex],
           config: seriesConfig,
           configIndex: nearestPoint.seriesConfigIndex,
           markNearestPointOnly,

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -264,6 +264,14 @@ export function TimeSeriesChart<
     }
   }, [onSeriesClick, seriesConfig, tooltipData]);
 
+  const cutValuesConfig = timespanAnnotations
+    ?.filter((x) => isDefined(x.cutValuesFromMetricProperties))
+    .map((x) => ({
+      start: x.start,
+      end: x.end,
+      metricProperties: x.cutValuesFromMetricProperties as string[],
+    }));
+
   return (
     <Box ref={sizeRef}>
       {valueAnnotation && (
@@ -312,6 +320,7 @@ export function TimeSeriesChart<
             bounds={bounds}
             yScale={yScale}
             benchmark={benchmark}
+            cutValuesConfig={cutValuesConfig}
           />
 
           {benchmark && (

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -27,6 +27,7 @@ import { Series } from './components/series';
 import {
   calculateSeriesMaximum,
   DataOptions,
+  extractCutValuesConfig,
   getTimeDomain,
   SeriesConfig,
   useHoverState,
@@ -169,7 +170,11 @@ export function TimeSeriesChart<
 
   const values = useValuesInTimeframe(allValues, timeframe);
 
-  const seriesList = useSeriesList(values, seriesConfig);
+  const seriesList = useSeriesList(
+    values,
+    seriesConfig,
+    extractCutValuesConfig(timespanAnnotations)
+  );
 
   /**
    * The maximum is calculated over all values, because you don't want the
@@ -264,14 +269,6 @@ export function TimeSeriesChart<
     }
   }, [onSeriesClick, seriesConfig, tooltipData]);
 
-  const cutValuesConfig = timespanAnnotations
-    ?.filter((x) => isDefined(x.cutValuesFromMetricProperties))
-    .map((x) => ({
-      start: x.start,
-      end: x.end,
-      metricProperties: x.cutValuesFromMetricProperties as string[],
-    }));
-
   return (
     <Box ref={sizeRef}>
       {valueAnnotation && (
@@ -320,7 +317,6 @@ export function TimeSeriesChart<
             bounds={bounds}
             yScale={yScale}
             benchmark={benchmark}
-            cutValuesConfig={cutValuesConfig}
           />
 
           {benchmark && (

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -171,11 +171,12 @@ export function TimeSeriesChart<
 
   const values = useValuesInTimeframe(allValues, timeframe);
 
-  const seriesList = useSeriesList(
-    values,
-    seriesConfig,
-    extractCutValuesConfig(timespanAnnotations)
+  const cutValuesConfig = useMemo(
+    () => extractCutValuesConfig(timespanAnnotations),
+    [timespanAnnotations]
   );
+
+  const seriesList = useSeriesList(values, seriesConfig, cutValuesConfig);
 
   /**
    * The maximum is calculated over all values, because you don't want the

--- a/packages/app/src/config/features.ts
+++ b/packages/app/src/config/features.ts
@@ -21,10 +21,10 @@ export const features: Feature[] = [
   },
   {
     name: 'hospitalMovingAverage',
-    isEnabled: false,
+    isEnabled: true,
   },
   {
     name: 'intensiveCareMovingAverage',
-    isEnabled: false,
+    isEnabled: true,
   },
 ];

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -170,6 +170,9 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
                         text.section_deceased_rivm
                           .line_chart_covid_daily_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'covid_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -190,6 +190,9 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                         end: Infinity,
                         label: text.linechart_legend_underreported_titel,
                         shortLabel: siteText.common.incomplete,
+                        cutValuesForMetricProperties: [
+                          'admissions_on_date_of_admission_moving_average',
+                        ],
                       },
                     ],
                   }}

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -135,6 +135,9 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                       label:
                         positiveTestedPeopleText.line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'newly_infected_people_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -304,6 +307,9 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                       end: Infinity,
                       label: locationDeaths.line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -151,6 +151,9 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                         end: Infinity,
                         label: text.linechart_legend_inaccurate_label,
                         shortLabel: siteText.common.incomplete,
+                        cutValuesForMetricProperties: [
+                          'admissions_on_date_of_admission_moving_average',
+                        ],
                       },
                     ],
                   }}

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -160,6 +160,9 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
                         text.section_deceased_rivm
                           .line_chart_covid_daily_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'covid_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -161,6 +161,9 @@ const ElderlyAtHomeNationalPage = (
                         text.section_deceased
                           .line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'positive_tested_daily_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -261,6 +264,9 @@ const ElderlyAtHomeNationalPage = (
                         text.section_deceased
                           .line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -141,6 +141,9 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                         positiveTestedPeopleText.line_chart_legend_inaccurate_label,
                       shortLabel:
                         positiveTestedPeopleText.tooltip_labels.inaccurate,
+                      cutValuesForMetricProperties: [
+                        'newly_infected_people_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -313,6 +316,9 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                       end: Infinity,
                       label: deceased.line_chart_legend_inaccurate_label,
                       shortLabel: deceased.tooltip_labels.inaccurate,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -233,6 +233,9 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                         end: Infinity,
                         label: text.linechart_legend_underreported_titel,
                         shortLabel: siteText.common.incomplete,
+                        cutValuesForMetricProperties: [
+                          'admissions_on_date_of_admission_moving_average',
+                        ],
                       },
                     ],
                   }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -143,6 +143,9 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                       label:
                         positiveTestPeopleText.line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'newly_infected_people_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -291,6 +294,9 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                       end: Infinity,
                       label: mortalityText.line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -176,6 +176,9 @@ const DeceasedRegionalPage = (props: StaticProps<typeof getStaticProps>) => {
                         text.section_deceased_rivm
                           .line_chart_covid_daily_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'covid_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -165,6 +165,9 @@ const ElderlyAtHomeRegionalPage = (
                         text.section_deceased
                           .line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'positive_tested_daily_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -246,6 +249,9 @@ const ElderlyAtHomeRegionalPage = (
                         text.section_deceased
                           .line_chart_legend_inaccurate_label,
                       shortLabel: siteText.common.incomplete,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -152,6 +152,9 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                         positiveTestedPeopleText.line_chart_legend_inaccurate_label,
                       shortLabel:
                         positiveTestedPeopleText.tooltip_labels.inaccurate,
+                      cutValuesForMetricProperties: [
+                        'newly_infected_people_moving_average',
+                      ],
                     },
                   ],
                 }}
@@ -300,6 +303,9 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                       end: Infinity,
                       label: deceased.line_chart_legend_inaccurate_label,
                       shortLabel: deceased.tooltip_labels.inaccurate,
+                      cutValuesForMetricProperties: [
+                        'deceased_daily_moving_average',
+                      ],
                     },
                   ],
                 }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -194,6 +194,9 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                         end: Infinity,
                         label: text.linechart_legend_underreported_titel,
                         shortLabel: siteText.common.incomplete,
+                        cutValuesForMetricProperties: [
+                          'admissions_on_date_of_admission_moving_average',
+                        ],
                       },
                     ],
                   }}


### PR DESCRIPTION
## Summary

This adds the option to configure a timespan annotation in the TimeSeriesChart to cut out any of the trends. It is currently limited to only single-value trends, like line, area and bar. Range and stacked-area are excluded, but I think that's reasonable. 

![image](https://user-images.githubusercontent.com/71320230/117029380-e0e97900-acfe-11eb-942b-b9816ff00980.png)
