### PR TITLE
Place interactive legend above -per-age-group graphs

### DIFF
--- a/packages/app/src/domain/hospital/admissions-per-age-group/admissions-per-age-group.tsx
+++ b/packages/app/src/domain/hospital/admissions-per-age-group/admissions-per-age-group.tsx
@@ -1,6 +1,6 @@
 import {
-  NlIntensiveCareNicePerAgeGroupValue,
   NlHospitalNicePerAgeGroupValue,
+  NlIntensiveCareNicePerAgeGroupValue,
 } from '@corona-dashboard/common';
 import {
   InteractiveLegend,
@@ -13,8 +13,8 @@ import { LineSeriesDefinition } from '~/components/time-series-chart/logic';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
-import { useList } from '~/utils/use-list';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useList } from '~/utils/use-list';
 import { BASE_SERIES_CONFIG } from './series-config';
 
 type NLHospitalAdmissionPerAgeGroupValue =
@@ -94,6 +94,13 @@ export function AdmissionsPerAgeGroup({
 
   return (
     <>
+      <InteractiveLegend
+        helpText={text.legend_help_text}
+        selectOptions={interactiveLegendOptions}
+        selection={list}
+        onToggleItem={toggle}
+        onReset={clear}
+      />
       <TimeSeriesChart
         values={values}
         timeframe={timeframe}
@@ -113,13 +120,6 @@ export function AdmissionsPerAgeGroup({
             },
           ],
         }}
-      />
-      <InteractiveLegend
-        helpText={text.legend_help_text}
-        selectOptions={interactiveLegendOptions}
-        selection={list}
-        onToggleItem={toggle}
-        onReset={clear}
       />
       <Legend items={staticLegendItems} />
     </>

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -10,8 +10,8 @@ import { LineSeriesDefinition } from '~/components/time-series-chart/logic';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
-import { useList } from '~/utils/use-list';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useList } from '~/utils/use-list';
 import { BASE_SERIES_CONFIG } from './series-config';
 
 interface InfectedPerAgeGroup {
@@ -89,6 +89,13 @@ export function InfectedPerAgeGroup({
 
   return (
     <>
+      <InteractiveLegend
+        helpText={text.legend_help_text}
+        selectOptions={interactiveLegendOptions}
+        selection={list}
+        onToggleItem={toggle}
+        onReset={clear}
+      />
       <TimeSeriesChart
         values={values}
         timeframe={timeframe}
@@ -108,13 +115,6 @@ export function InfectedPerAgeGroup({
             },
           ],
         }}
-      />
-      <InteractiveLegend
-        helpText={text.legend_help_text}
-        selectOptions={interactiveLegendOptions}
-        selection={list}
-        onToggleItem={toggle}
-        onReset={clear}
       />
       <Legend items={staticLegendItems} />
     </>


### PR DESCRIPTION
## Summary

As the title states. This is what it looks like now:
![image](https://user-images.githubusercontent.com/69849293/117169614-879a4c00-adc9-11eb-8f20-b4784b02f74e.png)

## Motivation

Feature request

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
