### PR TITLE
Fix zero state for charts

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -65,8 +65,11 @@ export function useScales<T extends TimestampedValue>(args: {
       round: true, // round the output values so we render on round pixels
     });
 
+    // For some reason vsix-scaleLinear doesn't handle een domain of [0,0] correctly.
+    // In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
+    // A work-around turns out to be setting the max value to Infinity.
     const yScale = scaleLinear({
-      domain: [0, maximumValue],
+      domain: [0, maximumValue > 0 ? maximumValue : Infinity],
       range: [bounds.height, 0],
       nice: numTicks,
       round: true, // round the output values so we render on round pixels

--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -65,7 +65,7 @@ export function useScales<T extends TimestampedValue>(args: {
       round: true, // round the output values so we render on round pixels
     });
 
-    /*
+    /**
     For some reason visx-scaleLinear doesn't handle een domain of [0,0] correctly.
     In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
     A work-around turns out to be setting the max value to Infinity.

--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -65,9 +65,11 @@ export function useScales<T extends TimestampedValue>(args: {
       round: true, // round the output values so we render on round pixels
     });
 
-    // For some reason vsix-scaleLinear doesn't handle een domain of [0,0] correctly.
-    // In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
-    // A work-around turns out to be setting the max value to Infinity.
+    /*
+    For some reason visx-scaleLinear doesn't handle een domain of [0,0] correctly.
+    In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
+    A work-around turns out to be setting the max value to Infinity.
+    */
     const yScale = scaleLinear({
       domain: [0, maximumValue > 0 ? maximumValue : Infinity],
       range: [bounds.height, 0],


### PR DESCRIPTION
## Summary

When given a domain of [0,0] the chart was rendered in a strange way.
It turned out that vsix scaleLinear doesn't handle this situation properly. When given [0,0] the resulting scale function will return the start range divided by two. Instead of just the whole number. This is why the chart is rendered like this:
![image](https://user-images.githubusercontent.com/69849293/117301191-ac023100-ae7a-11eb-8f4b-eabdcd7ea867.png)

Setting the max domain to infinity in the case of a domain of [0,0] turned out to fix it for now:
![image](https://user-images.githubusercontent.com/69849293/117301315-d0f6a400-ae7a-11eb-91a3-1fe1d870a79b.png)

Perhaps design can come up with some sort of 'empty state' for a chart like this. Because it does look a tad 'empty'...

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
