### PR TITLE
Fix sync-after-feature early returns

### DIFF
--- a/packages/cms/src/lokalize/sync-after-feature.ts
+++ b/packages/cms/src/lokalize/sync-after-feature.ts
@@ -40,7 +40,7 @@ import { LokalizeText } from './types';
 async function syncAdditionsToProduction(additions: TextMutation[]) {
   if (additions.length === 0) {
     console.log('There are no mutations that result in keys to add');
-    process.exit(0);
+    return;
   }
 
   /**

--- a/packages/cms/src/lokalize/sync-after-feature.ts
+++ b/packages/cms/src/lokalize/sync-after-feature.ts
@@ -111,7 +111,7 @@ async function syncAdditionsToProduction(additions: TextMutation[]) {
 async function applyDeletionsToDevelopment(deletions: TextMutation[]) {
   if (deletions.length === 0) {
     console.log('There are no mutations that result in keys to delete');
-    process.exit(0);
+    return;
   }
 
   /**

--- a/packages/cms/src/schemas/documents/lokalize-text.tsx
+++ b/packages/cms/src/schemas/documents/lokalize-text.tsx
@@ -73,7 +73,7 @@ export const lokalizeText = {
        * list, but the path field is cleaner when browsing texts because it
        * avoids a lot of string duplication.
        */
-      title: 'path',
+      title: 'key',
       subtitle: 'text.nl',
     },
   },


### PR DESCRIPTION
## Summary

* Fix sync-after-features script to not exit but use regular early returns
* Use key property for lokalizeText previews, so that multiple documents with the same path are not rendering the same.