### PR TITLE
Fix Sanity action button order

### DIFF
--- a/packages/cms/src/resolve-document-actions.ts
+++ b/packages/cms/src/resolve-document-actions.ts
@@ -5,27 +5,58 @@ import defaultResolve, {
   PublishAction,
   UnpublishAction,
 } from 'part:@sanity/base/document-actions';
-import { PublishOrAcceptAction, DocumentActionProps } from './actions';
+import { DocumentActionProps, PublishOrAcceptAction } from './actions';
 import { onDocument$ } from './hooks/helper/document-subject';
+import * as pages from './schemas/documents';
 
+/**
+ * Actions are shown in this order, so the Publish button is the default
+ */
+const defaultPublishingActions = [
+  PublishAction,
+  DiscardChangesAction,
+  UnpublishAction,
+];
+
+/**
+ * Here we set the default actions on all documents
+ */
+const documentsWithDefaultActions = Object.values(pages).reduce(
+  (pages, schema) => ({ ...pages, [schema.name]: defaultPublishingActions }),
+  {}
+);
+
+/**
+ * And here we override some of them while constructing the actual lookup
+ */
 const actionsByDocumentType = {
+  ...documentsWithDefaultActions,
   article: [
-    DiscardChangesAction,
-    DeleteAction,
     PublishAction,
+    DiscardChangesAction,
     UnpublishAction,
     DuplicateAction,
+    DeleteAction,
   ],
-  topicalPage: [DiscardChangesAction, PublishAction, UnpublishAction],
-  overDitDashboard: [DiscardChangesAction, PublishAction, UnpublishAction],
-  veelgesteldeVragen: [DiscardChangesAction, PublishAction, UnpublishAction],
-  cijferVerantwoording: [DiscardChangesAction, PublishAction, UnpublishAction],
-  toegankelijkheid: [DiscardChangesAction, PublishAction, UnpublishAction],
   lokalizeText: [
     PublishOrAcceptAction,
     DiscardChangesAction,
     PublishAction,
     UnpublishAction,
+  ],
+  faqQuestion: [
+    PublishAction,
+    DiscardChangesAction,
+    UnpublishAction,
+    DuplicateAction,
+    DeleteAction,
+  ],
+  figureExplanationItem: [
+    PublishAction,
+    DiscardChangesAction,
+    UnpublishAction,
+    DuplicateAction,
+    DeleteAction,
   ],
 };
 
@@ -35,6 +66,7 @@ export default function resolveDocumentActions(document: DocumentActionProps) {
   /**
    * This is placing the current document on the observer that is driving
    * the useCurrentDocument hook. This hook is used for the language switcher.
+   *
    * At the time this was the only way to get a hold of the document. Possibly
    * there is now an official way to achieve this @TODO find out.
    */

--- a/packages/cms/src/resolve-document-actions.ts
+++ b/packages/cms/src/resolve-document-actions.ts
@@ -7,7 +7,7 @@ import defaultResolve, {
 } from 'part:@sanity/base/document-actions';
 import { DocumentActionProps, PublishOrAcceptAction } from './actions';
 import { onDocument$ } from './hooks/helper/document-subject';
-import * as pages from './schemas/documents';
+import * as documents from './schemas/documents';
 
 /**
  * Actions are shown in this order, so the Publish button is the default
@@ -21,7 +21,7 @@ const defaultPublishingActions = [
 /**
  * Here we set the default actions on all documents
  */
-const documentsWithDefaultActions = Object.values(pages).reduce(
+const documentsWithDefaultActions = Object.values(documents).reduce(
   (pages, schema) => ({ ...pages, [schema.name]: defaultPublishingActions }),
   {}
 );


### PR DESCRIPTION
## Summary

After a Sanity upgrade, the order for the actions dropdown in Sanity was changed and is now showing the buttons in the order in which they are received from the resolveDocumentActions methods.
This PR now makes sure the buttons are shown in the order that team comm requested:
![image](https://user-images.githubusercontent.com/69849293/117655367-432af980-b197-11eb-8d79-7071311d9433.png)

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
