### PR TITLE
Filter timespan annotation from legend when it isn't visible on the chart

### DIFF
--- a/packages/app/src/components/legend.tsx
+++ b/packages/app/src/components/legend.tsx
@@ -7,8 +7,13 @@ type LegendLineStyle = 'solid' | 'dashed';
 
 export type LegendItem = {
   label: string;
+  hidden?: boolean;
 } & (
-  | { shape: LegendShape; color: string; style?: LegendLineStyle }
+  | {
+      shape: LegendShape;
+      color: string;
+      style?: LegendLineStyle;
+    }
   | { shape: 'custom'; shapeComponent: ReactNode }
 );
 
@@ -19,27 +24,29 @@ interface LegendProps {
 export function Legend({ items }: LegendProps) {
   return (
     <List>
-      {items.map((item, i) => {
-        if (item.shape === 'custom') {
+      {items
+        .filter((item) => !item.hidden)
+        .map((item, i) => {
+          if (item.shape === 'custom') {
+            return (
+              <Item key={i}>
+                {item.label}
+                <CustomShape>{item.shapeComponent}</CustomShape>
+              </Item>
+            );
+          }
+
           return (
             <Item key={i}>
               {item.label}
-              <CustomShape>{item.shapeComponent}</CustomShape>
+              {item.shape === 'square' && <Square color={item.color} />}
+              {item.shape === 'line' && (
+                <Line color={item.color} lineStyle={item.style ?? 'solid'} />
+              )}
+              {item.shape === 'circle' && <Circle color={item.color} />}
             </Item>
           );
-        }
-
-        return (
-          <Item key={i}>
-            {item.label}
-            {item.shape === 'square' && <Square color={item.color} />}
-            {item.shape === 'line' && (
-              <Line color={item.color} lineStyle={item.style ?? 'solid'} />
-            )}
-            {item.shape === 'circle' && <Circle color={item.color} />}
-          </Item>
-        );
-      })}
+        })}
     </List>
   );
 }

--- a/packages/app/src/components/legend.tsx
+++ b/packages/app/src/components/legend.tsx
@@ -7,7 +7,6 @@ type LegendLineStyle = 'solid' | 'dashed';
 
 export type LegendItem = {
   label: string;
-  hidden?: boolean;
 } & (
   | {
       shape: LegendShape;
@@ -24,29 +23,27 @@ interface LegendProps {
 export function Legend({ items }: LegendProps) {
   return (
     <List>
-      {items
-        .filter((item) => !item.hidden)
-        .map((item, i) => {
-          if (item.shape === 'custom') {
-            return (
-              <Item key={i}>
-                {item.label}
-                <CustomShape>{item.shapeComponent}</CustomShape>
-              </Item>
-            );
-          }
-
+      {items.map((item, i) => {
+        if (item.shape === 'custom') {
           return (
             <Item key={i}>
               {item.label}
-              {item.shape === 'square' && <Square color={item.color} />}
-              {item.shape === 'line' && (
-                <Line color={item.color} lineStyle={item.style ?? 'solid'} />
-              )}
-              {item.shape === 'circle' && <Circle color={item.color} />}
+              <CustomShape>{item.shapeComponent}</CustomShape>
             </Item>
           );
-        })}
+        }
+
+        return (
+          <Item key={i}>
+            {item.label}
+            {item.shape === 'square' && <Square color={item.color} />}
+            {item.shape === 'line' && (
+              <Line color={item.color} lineStyle={item.style ?? 'solid'} />
+            )}
+            {item.shape === 'circle' && <Circle color={item.color} />}
+          </Item>
+        );
+      })}
     </List>
   );
 }

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -25,7 +25,8 @@ export function useLegendItems<T extends TimestampedValue>(
     if (dataOptions?.timespanAnnotations) {
       for (const annotation of dataOptions.timespanAnnotations) {
         const annotationVisible =
-          first(domain) <= annotation.end && annotation.start <= last(domain);
+          (first(domain) as number) <= annotation.end &&
+          annotation.start <= (last(domain) as number);
 
         items.push({
           label: annotation.label,

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -20,9 +20,17 @@ export function useLegendItems<T extends TimestampedValue>(
     }));
 
     /**
+     * Maximum number of legend items
+     *
+     * Used to determine if there are enough items to render a legend
+     */
+    let maxNumItems: number = items.length;
+
+    /**
      * Add annotations to the legend
      */
     if (dataOptions?.timespanAnnotations) {
+      maxNumItems += dataOptions?.timespanAnnotations.length;
       for (const annotation of dataOptions.timespanAnnotations) {
         const annotationVisible =
           (first(domain) as number) <= annotation.end &&
@@ -46,10 +54,7 @@ export function useLegendItems<T extends TimestampedValue>(
      * This prevents us from having to manually set (and possibly forget to set)
      * a boolean on the chart props.
      */
-    const numAnnotations = dataOptions?.timespanAnnotations
-      ? dataOptions?.timespanAnnotations.length
-      : 0;
-    return items.length + numAnnotations > 1 ? items : [];
+    return maxNumItems > 1 ? items : [];
   }, [config, dataOptions, domain]);
 
   return legendItems;

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -32,11 +32,11 @@ export function useLegendItems<T extends TimestampedValue>(
     if (dataOptions?.timespanAnnotations) {
       maxNumItems += dataOptions?.timespanAnnotations.length;
       for (const annotation of dataOptions.timespanAnnotations) {
-        const annotationVisible =
+        const isAnnotationVisible =
           (first(domain) as number) <= annotation.end &&
           annotation.start <= (last(domain) as number);
 
-        if (annotationVisible) {
+        if (isAnnotationVisible) {
           items.push({
             label: annotation.label,
             shape: 'custom',

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -28,12 +28,13 @@ export function useLegendItems<T extends TimestampedValue>(
           (first(domain) as number) <= annotation.end &&
           annotation.start <= (last(domain) as number);
 
-        items.push({
-          label: annotation.label,
-          shape: 'custom',
-          shapeComponent: <TimespanAnnotationIcon />,
-          hidden: !annotationVisible,
-        } as LegendItem);
+        if (annotationVisible) {
+          items.push({
+            label: annotation.label,
+            shape: 'custom',
+            shapeComponent: <TimespanAnnotationIcon />,
+          } as LegendItem);
+        }
       }
     }
 
@@ -45,7 +46,10 @@ export function useLegendItems<T extends TimestampedValue>(
      * This prevents us from having to manually set (and possibly forget to set)
      * a boolean on the chart props.
      */
-    return items.length > 1 ? items : [];
+    const numAnnotations = dataOptions?.timespanAnnotations
+      ? dataOptions?.timespanAnnotations.length
+      : 0;
+    return items.length + numAnnotations > 1 ? items : [];
   }, [config, dataOptions, domain]);
 
   return legendItems;

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -4,8 +4,10 @@ import { LegendItem } from '~/components/legend';
 import { SeriesIcon, TimespanAnnotationIcon } from '../components';
 import { DataOptions } from './common';
 import { SeriesConfig, isVisible } from './series';
+import { first, last } from 'lodash';
 
 export function useLegendItems<T extends TimestampedValue>(
+  domain: number[],
   config: SeriesConfig<T>,
   dataOptions?: DataOptions
 ) {
@@ -22,10 +24,14 @@ export function useLegendItems<T extends TimestampedValue>(
      */
     if (dataOptions?.timespanAnnotations) {
       for (const annotation of dataOptions.timespanAnnotations) {
+        const annotationVisible =
+          first(domain) <= annotation.end && annotation.start <= last(domain);
+
         items.push({
           label: annotation.label,
           shape: 'custom',
           shapeComponent: <TimespanAnnotationIcon />,
+          hidden: !annotationVisible,
         } as LegendItem);
       }
     }
@@ -39,7 +45,7 @@ export function useLegendItems<T extends TimestampedValue>(
      * a boolean on the chart props.
      */
     return items.length > 1 ? items : [];
-  }, [config, dataOptions]);
+  }, [config, dataOptions, domain]);
 
   return legendItems;
 }

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -172,8 +172,6 @@ export function TimeSeriesChart<
     paddingLeft,
   });
 
-  const legendItems = useLegendItems(seriesConfig, dataOptions);
-
   const values = useValuesInTimeframe(allValues, timeframe);
 
   const cutValuesConfig = useMemo(
@@ -203,6 +201,12 @@ export function TimeSeriesChart<
       bounds,
       numTicks: yTickValues?.length || numGridLines,
     }
+  );
+
+  const legendItems = useLegendItems(
+    xScale.domain(),
+    seriesConfig,
+    dataOptions
   );
 
   const today = useCurrentDate();


### PR DESCRIPTION
## Summary

Removing the timespan annotation from the legend when it doesn't overlap with the chart domain

## Motivation

Client wanted to remove the timespan annotation from the legend on IC hospital beds

## Detailed design

Updated the `useLegendItems` hook to accept a domain which is used to determine whether the timespanAnnotation is visible. Used a `maxNumItems` variable that collects all of the potential items (so not filtering out items based on the domain) to determine if the legend should be rendered 

