### PR TITLE
Remove css prop and add style prop to chart container

### DIFF
--- a/packages/app/src/components/time-series-chart/components/chart-container.tsx
+++ b/packages/app/src/components/time-series-chart/components/chart-container.tsx
@@ -79,7 +79,7 @@ export function ChartContainer({
       <Group
         left={padding.left}
         top={padding.top}
-        css={css({ pointerEvents: 'none' })}
+        style={{ pointerEvents: 'none' }}
       >
         {children}
       </Group>


### PR DESCRIPTION
Fixes the `Warning: Invalid value for prop `_css2` on <g> tag.` in the terminal