### PR TITLE
Remove boolean indicating average from ic lcps kpi

### DIFF
--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -123,7 +123,6 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                     difference={
                       data.difference.intensive_care_lcps__beds_occupied_covid
                     }
-                    isMovingAverageDifference
                   />
                 )}
               <Text>{text.kpi_bedbezetting.description}</Text>


### PR DESCRIPTION
## Summary

This should not have been set, since the difference data is not about moving averages.