### PR TITLE
Remove wrong moving average flag from deceased and hospital kpis

### DIFF
--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -93,7 +93,6 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="covid_daily"
                 absolute={dataRivm.last_value.covid_daily}
                 difference={data.difference.deceased_rivm__covid_daily}
-                isMovingAverageDifference
               />
               <Text>
                 {text.section_deceased_rivm.kpi_covid_daily_description}

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -146,7 +146,6 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                   difference={
                     data.difference.hospital_lcps__beds_occupied_covid
                   }
-                  isMovingAverageDifference
                 />
               )}
             </KpiTile>


### PR DESCRIPTION
## Summary

Found two more flags that are incorrect according to the data used.