### PR TITLE
Re-enabled differences on GGD tiles

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -34,6 +34,7 @@ import { NationalLayout } from '~/domain/layout/national-layout';
 import { GNumberBarChartTile } from '~/domain/tested/g-number-bar-chart-tile';
 import { InfectedPerAgeGroup } from '~/domain/tested/infected-per-age-group';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import {
   createGetStaticProps,
@@ -48,7 +49,6 @@ import {
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
-import { useFeature } from '~/lib/features';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -89,6 +89,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   const dataOverallLastValue = data.tested_overall.last_value;
   const dataGgdAverageLastValue = data.tested_ggd_average.last_value;
   const dataGgdDailyValues = data.tested_ggd_daily.values;
+  const dataGgdDailyLastValue = data.tested_ggd_daily.last_value;
+  const differences = data.difference;
 
   const metadata = {
     ...siteText.nationaal_metadata,
@@ -130,9 +132,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
               <KpiValue
                 data-cy="infected"
                 absolute={dataOverallLastValue.infected}
-                difference={
-                  data.difference.tested_overall__infected_moving_average
-                }
+                difference={differences.tested_overall__infected_moving_average}
                 isMovingAverageDifference
               />
 
@@ -339,12 +339,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
             subtitle={ggdText.toelichting}
             metadata={{
               datumsText: ggdText.datums,
-              dateOrRange: {
-                start: dataGgdAverageLastValue.date_start_unix,
-                end: dataGgdAverageLastValue.date_end_unix,
-              },
-              dateOfInsertionUnix:
-                dataGgdAverageLastValue.date_of_insertion_unix,
+              dateOrRange: dataGgdDailyLastValue.date_unix,
+              dateOfInsertionUnix: dataGgdDailyLastValue.date_of_insertion_unix,
               dataSources: [ggdText.bronnen.rivm],
             }}
             reference={text.reference}
@@ -353,32 +349,34 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
             <KpiTile
               title={ggdText.totaal_getest_week_titel}
               metadata={{
-                date: [
-                  dataGgdAverageLastValue.date_start_unix,
-                  dataGgdAverageLastValue.date_end_unix,
-                ],
+                date: dataGgdDailyLastValue.date_unix,
                 source: ggdText.bronnen.rivm,
               }}
             >
               <KpiValue
                 data-cy="ggd_tested_total"
-                absolute={dataGgdAverageLastValue.tested_total}
+                absolute={dataGgdDailyLastValue.tested_total}
+                difference={
+                  differences.tested_ggd_average__tested_total_moving_average
+                }
+                isMovingAverageDifference
               />
               <Text>{ggdText.totaal_getest_week_uitleg}</Text>
             </KpiTile>
             <KpiTile
               title={ggdText.positief_getest_week_titel}
               metadata={{
-                date: [
-                  dataGgdAverageLastValue.date_start_unix,
-                  dataGgdAverageLastValue.date_end_unix,
-                ],
+                date: dataGgdDailyLastValue.date_unix,
                 source: ggdText.bronnen.rivm,
               }}
             >
               <KpiValue
                 data-cy="ggd_infected"
-                percentage={dataGgdAverageLastValue.infected_percentage}
+                percentage={dataGgdDailyLastValue.infected_percentage}
+                difference={
+                  differences.tested_ggd_average__infected_percentage_moving_average
+                }
+                isMovingAverageDifference
               />
               <Text>{ggdText.positief_getest_week_uitleg}</Text>
 
@@ -388,12 +386,12 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   {
                     numerator: (
                       <InlineText color="data.primary">
-                        {formatNumber(dataGgdAverageLastValue.infected)}
+                        {formatNumber(dataGgdDailyLastValue.infected)}
                       </InlineText>
                     ),
                     denominator: (
                       <InlineText color="data.primary">
-                        {formatNumber(dataGgdAverageLastValue.tested_total)}
+                        {formatNumber(dataGgdDailyLastValue.tested_total)}
                       </InlineText>
                     ),
                   }

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -90,7 +90,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   const dataGgdAverageLastValue = data.tested_ggd_average.last_value;
   const dataGgdDailyValues = data.tested_ggd_daily.values;
   const dataGgdDailyLastValue = data.tested_ggd_daily.last_value;
-  const differences = data.difference;
+  const difference = data.difference;
 
   const metadata = {
     ...siteText.nationaal_metadata,
@@ -132,7 +132,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
               <KpiValue
                 data-cy="infected"
                 absolute={dataOverallLastValue.infected}
-                difference={differences.tested_overall__infected_moving_average}
+                difference={difference.tested_overall__infected_moving_average}
                 isMovingAverageDifference
               />
 
@@ -357,7 +357,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="ggd_tested_total"
                 absolute={dataGgdDailyLastValue.tested_total}
                 difference={
-                  differences.tested_ggd_average__tested_total_moving_average
+                  difference.tested_ggd_average__tested_total_moving_average
                 }
                 isMovingAverageDifference
               />
@@ -374,7 +374,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="ggd_infected"
                 percentage={dataGgdDailyLastValue.infected_percentage}
                 difference={
-                  differences.tested_ggd_average__infected_percentage_moving_average
+                  difference.tested_ggd_average__infected_percentage_moving_average
                 }
                 isMovingAverageDifference
               />

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -79,7 +79,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   const dataGgdAverageLastValue = data.tested_ggd_average.last_value;
   const dataGgdDailyValues = data.tested_ggd_daily.values;
   const dataGgdDailyLastValue = data.tested_ggd_daily.last_value;
-  const differences = data.difference;
+  const difference = data.difference;
 
   const municipalCodes = gmCodesByVrCode[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
@@ -310,7 +310,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
               <KpiValue
                 absolute={dataGgdDailyLastValue.tested_total}
                 difference={
-                  differences.tested_ggd_average__tested_total_moving_average
+                  difference.tested_ggd_average__tested_total_moving_average
                 }
                 isMovingAverageDifference
               />
@@ -326,7 +326,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
               <KpiValue
                 percentage={dataGgdDailyLastValue.infected_percentage}
                 difference={
-                  differences.tested_ggd_average__infected_percentage_moving_average
+                  difference.tested_ggd_average__infected_percentage_moving_average
                 }
                 isMovingAverageDifference
               />

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -27,6 +27,7 @@ import { Layout } from '~/domain/layout/layout';
 import { SafetyRegionLayout } from '~/domain/layout/safety-region-layout';
 import { GNumberBarChartTile } from '~/domain/tested/g-number-bar-chart-tile';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import {
   createGetStaticProps,
@@ -43,7 +44,6 @@ import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 export { getStaticPaths } from '~/static-paths/vr';
-import { useFeature } from '~/lib/features';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -78,6 +78,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   const dataOverallLastValue = data.tested_overall.last_value;
   const dataGgdAverageLastValue = data.tested_ggd_average.last_value;
   const dataGgdDailyValues = data.tested_ggd_daily.values;
+  const dataGgdDailyLastValue = data.tested_ggd_daily.last_value;
+  const differences = data.difference;
 
   const municipalCodes = gmCodesByVrCode[data.code];
   const selectedMunicipalCode = municipalCodes ? municipalCodes[0] : undefined;
@@ -290,12 +292,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
             subtitle={ggdText.toelichting}
             metadata={{
               datumsText: ggdText.datums,
-              dateOfInsertionUnix:
-                dataGgdAverageLastValue.date_of_insertion_unix,
-              dateOrRange: {
-                start: dataGgdAverageLastValue.date_start_unix,
-                end: dataGgdAverageLastValue.date_end_unix,
-              },
+              dateOfInsertionUnix: dataGgdDailyLastValue.date_of_insertion_unix,
+              dateOrRange: dataGgdDailyLastValue.date_unix,
               dataSources: [ggdText.bronnen.rivm],
             }}
             reference={text.reference}
@@ -305,25 +303,32 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
             <KpiTile
               title={ggdText.totaal_getest_week_titel}
               metadata={{
-                date: [
-                  dataGgdAverageLastValue.date_start_unix,
-                  dataGgdAverageLastValue.date_end_unix,
-                ],
+                date: dataGgdDailyLastValue.date_unix,
                 source: ggdText.bronnen.rivm,
               }}
             >
-              <KpiValue absolute={dataGgdAverageLastValue.tested_total} />
+              <KpiValue
+                absolute={dataGgdDailyLastValue.tested_total}
+                difference={
+                  differences.tested_ggd_average__tested_total_moving_average
+                }
+                isMovingAverageDifference
+              />
               <Text>{ggdText.totaal_getest_week_uitleg}</Text>
             </KpiTile>
             <KpiTile
               title={ggdText.positief_getest_week_titel}
               metadata={{
-                date: dataGgdAverageLastValue.date_end_unix,
+                date: dataGgdDailyLastValue.date_unix,
                 source: ggdText.bronnen.rivm,
               }}
             >
               <KpiValue
-                percentage={dataGgdAverageLastValue.infected_percentage}
+                percentage={dataGgdDailyLastValue.infected_percentage}
+                difference={
+                  differences.tested_ggd_average__infected_percentage_moving_average
+                }
+                isMovingAverageDifference
               />
               <Text>{ggdText.positief_getest_week_uitleg}</Text>
               <Text fontWeight="bold">
@@ -332,12 +337,12 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   {
                     numerator: (
                       <InlineText color="data.primary">
-                        {formatNumber(dataGgdAverageLastValue.infected)}
+                        {formatNumber(dataGgdDailyLastValue.infected)}
                       </InlineText>
                     ),
                     denominator: (
                       <InlineText color="data.primary">
-                        {formatNumber(dataGgdAverageLastValue.tested_total)}
+                        {formatNumber(dataGgdDailyLastValue.tested_total)}
                       </InlineText>
                     ),
                   }


### PR DESCRIPTION
## Summary

As the title states. The KPI values now show the daily numbers, which are compared with the moving averages in the 'differences' texts.

![image](https://user-images.githubusercontent.com/69849293/118626447-2e6be880-b7cb-11eb-92e3-a5902eddc3f9.png)

## Motivation

Feature request.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
