### PR TITLE
Rename vaccine support-schema and behavior-property

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -31,7 +31,7 @@
     "tested_ggd_average",
     "tested_overall",
     "tested_per_age_group",
-    "vaccine_support",
+    "vaccinated_or_vaccine_support",
     "vaccine_delivery",
     "vaccine_delivery_estimate",
     "vaccine_administered",
@@ -144,8 +144,8 @@
     "elderly_at_home": {
       "$ref": "elderly_at_home.json"
     },
-    "vaccine_support": {
-      "$ref": "vaccine_support.json"
+    "vaccinated_or_vaccine_support": {
+      "$ref": "vaccinated_or_vaccine_support.json"
     },
     "corona_melder_app": {
       "$ref": "corona_melder_app.json"

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -31,7 +31,7 @@
     "tested_ggd_average",
     "tested_overall",
     "tested_per_age_group",
-    "vaccinated_or_vaccine_support",
+    "vaccine_vaccinated_or_support",
     "vaccine_delivery",
     "vaccine_delivery_estimate",
     "vaccine_administered",
@@ -144,8 +144,8 @@
     "elderly_at_home": {
       "$ref": "elderly_at_home.json"
     },
-    "vaccinated_or_vaccine_support": {
-      "$ref": "vaccinated_or_vaccine_support.json"
+    "vaccine_vaccinated_or_support": {
+      "$ref": "vaccine_vaccinated_or_support.json"
     },
     "corona_melder_app": {
       "$ref": "corona_melder_app.json"

--- a/packages/app/schema/nl/behavior.json
+++ b/packages/app/schema/nl/behavior.json
@@ -64,10 +64,10 @@
         "avoid_crowds_compliance_trend": {
           "$ref": "#/definitions/value_trend"
         },
-        "symptoms_stay_home_compliance": {
+        "symptoms_stay_home_if_necessary_compliance": {
           "type": ["integer", "null"]
         },
-        "symptoms_stay_home_compliance_trend": {
+        "symptoms_stay_home_if_necessary_compliance_trend": {
           "$ref": "#/definitions/value_trend"
         },
         "symptoms_get_tested_compliance": {
@@ -130,10 +130,10 @@
         "avoid_crowds_support_trend": {
           "$ref": "#/definitions/value_trend"
         },
-        "symptoms_stay_home_support": {
+        "symptoms_stay_home_if_necessary_support": {
           "type": ["integer", "null"]
         },
-        "symptoms_stay_home_support_trend": {
+        "symptoms_stay_home_if_necessary_support_trend": {
           "$ref": "#/definitions/value_trend"
         },
         "symptoms_get_tested_support": {

--- a/packages/app/schema/nl/behavior.json
+++ b/packages/app/schema/nl/behavior.json
@@ -64,10 +64,10 @@
         "avoid_crowds_compliance_trend": {
           "$ref": "#/definitions/value_trend"
         },
-        "symptoms_stay_home_if_necessary_compliance": {
+        "symptoms_stay_home_if_mandatory_compliance": {
           "type": ["integer", "null"]
         },
-        "symptoms_stay_home_if_necessary_compliance_trend": {
+        "symptoms_stay_home_if_mandatory_compliance_trend": {
           "$ref": "#/definitions/value_trend"
         },
         "symptoms_get_tested_compliance": {
@@ -130,10 +130,10 @@
         "avoid_crowds_support_trend": {
           "$ref": "#/definitions/value_trend"
         },
-        "symptoms_stay_home_if_necessary_support": {
+        "symptoms_stay_home_if_mandatory_support": {
           "type": ["integer", "null"]
         },
-        "symptoms_stay_home_if_necessary_support_trend": {
+        "symptoms_stay_home_if_mandatory_support_trend": {
           "$ref": "#/definitions/value_trend"
         },
         "symptoms_get_tested_support": {

--- a/packages/app/schema/nl/behavior_per_age_group.json
+++ b/packages/app/schema/nl/behavior_per_age_group.json
@@ -6,9 +6,6 @@
     "avoid_crowds_compliance": { "$ref": "#/definitions/value" },
     "avoid_crowds_support": { "$ref": "#/definitions/value" },
 
-    "curfew_compliance": { "$ref": "#/definitions/value" },
-    "curfew_support": { "$ref": "#/definitions/value" },
-
     "keep_distance_compliance": { "$ref": "#/definitions/value" },
     "keep_distance_support": { "$ref": "#/definitions/value" },
 
@@ -34,8 +31,6 @@
   "required": [
     "avoid_crowds_compliance",
     "avoid_crowds_support",
-    "curfew_compliance",
-    "curfew_support",
     "keep_distance_compliance",
     "keep_distance_support",
     "max_visitors_compliance",

--- a/packages/app/schema/nl/vaccinated_or_vaccine_support.json
+++ b/packages/app/schema/nl/vaccinated_or_vaccine_support.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_vaccine_support",
+  "title": "nl_vaccinated_or_vaccine_support",
   "type": "object",
   "properties": {
     "values": {
@@ -17,7 +17,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "nl_vaccine_support_value",
+      "title": "nl_vaccinated_or_vaccine_support_value",
       "type": "object",
       "properties": {
         "percentage_average": {

--- a/packages/app/schema/nl/vaccine_vaccinated_or_support.json
+++ b/packages/app/schema/nl/vaccine_vaccinated_or_support.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_vaccinated_or_vaccine_support",
+  "title": "nl_vaccine_vaccinated_or_support",
   "type": "object",
   "properties": {
     "values": {
@@ -17,7 +17,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "nl_vaccinated_or_vaccine_support_value",
+      "title": "nl_vaccine_vaccinated_or_support_value",
       "type": "object",
       "properties": {
         "percentage_average": {

--- a/packages/app/src/domain/behavior/behavior-types.ts
+++ b/packages/app/src/domain/behavior/behavior-types.ts
@@ -4,7 +4,7 @@ export const behaviorIdentifiers = [
   'keep_distance',
   'work_from_home',
   'avoid_crowds',
-  'symptoms_stay_home',
+  'symptoms_stay_home_if_necessary',
   'symptoms_get_tested',
   'wear_mask_public_indoors',
   'wear_mask_public_transport',

--- a/packages/app/src/domain/behavior/behavior-types.ts
+++ b/packages/app/src/domain/behavior/behavior-types.ts
@@ -4,7 +4,7 @@ export const behaviorIdentifiers = [
   'keep_distance',
   'work_from_home',
   'avoid_crowds',
-  'symptoms_stay_home_if_necessary',
+  'symptoms_stay_home_if_mandatory',
   'symptoms_get_tested',
   'wear_mask_public_indoors',
   'wear_mask_public_transport',

--- a/packages/app/src/domain/behavior/components/behavior-icon.tsx
+++ b/packages/app/src/domain/behavior/components/behavior-icon.tsx
@@ -3,7 +3,7 @@ import wash_hands from '~/assets/gedrag/wash_hands.svg';
 import keep_distance from '~/assets/gedrag/keep_distance.svg';
 import work_from_home from '~/assets/gedrag/work_from_home.svg';
 import avoid_crowds from '~/assets/gedrag/avoid_crowds.svg';
-import symptoms_stay_home_if_necessary from '~/assets/gedrag/symptoms_stay_home.svg';
+import symptoms_stay_home_if_mandatory from '~/assets/gedrag/symptoms_stay_home.svg';
 import symptoms_get_tested from '~/assets/gedrag/symptoms_get_tested.svg';
 import wear_mask_public_indoors from '~/assets/gedrag/wear_mask_public_indoors.svg';
 import wear_mask_public_transport from '~/assets/gedrag/wear_mask_public_transport.svg';
@@ -17,7 +17,7 @@ const icons: Record<BehaviorIdentifier, typeof curfew> = {
   keep_distance,
   work_from_home,
   avoid_crowds,
-  symptoms_stay_home_if_necessary,
+  symptoms_stay_home_if_mandatory,
   symptoms_get_tested,
   wear_mask_public_indoors,
   wear_mask_public_transport,

--- a/packages/app/src/domain/behavior/components/behavior-icon.tsx
+++ b/packages/app/src/domain/behavior/components/behavior-icon.tsx
@@ -3,7 +3,7 @@ import wash_hands from '~/assets/gedrag/wash_hands.svg';
 import keep_distance from '~/assets/gedrag/keep_distance.svg';
 import work_from_home from '~/assets/gedrag/work_from_home.svg';
 import avoid_crowds from '~/assets/gedrag/avoid_crowds.svg';
-import symptoms_stay_home from '~/assets/gedrag/symptoms_stay_home.svg';
+import symptoms_stay_home_if_necessary from '~/assets/gedrag/symptoms_stay_home.svg';
 import symptoms_get_tested from '~/assets/gedrag/symptoms_get_tested.svg';
 import wear_mask_public_indoors from '~/assets/gedrag/wear_mask_public_indoors.svg';
 import wear_mask_public_transport from '~/assets/gedrag/wear_mask_public_transport.svg';
@@ -17,7 +17,7 @@ const icons: Record<BehaviorIdentifier, typeof curfew> = {
   keep_distance,
   work_from_home,
   avoid_crowds,
-  symptoms_stay_home,
+  symptoms_stay_home_if_necessary,
   symptoms_get_tested,
   wear_mask_public_indoors,
   wear_mask_public_transport,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -47,7 +47,7 @@ export const getStaticProps = createGetStaticProps(
   selectNlPageMetricData(
     'vaccine_stock',
     'vaccine_delivery_per_supplier',
-    'vaccinated_or_vaccine_support',
+    'vaccine_vaccinated_or_support',
     'vaccine_administered_total',
     'vaccine_administered_planned',
     'vaccine_administered_rate_moving_average',
@@ -143,10 +143,10 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             metadata={{
               datumsText: text.bereidheid_datums,
               dateOrRange:
-                data.vaccinated_or_vaccine_support.last_value
+                data.vaccine_vaccinated_or_support.last_value
                   .date_of_insertion_unix,
               dateOfInsertionUnix:
-                data.vaccinated_or_vaccine_support.last_value
+                data.vaccine_vaccinated_or_support.last_value
                   .date_of_insertion_unix,
               dataSources: [],
             }}
@@ -158,15 +158,15 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             metadata={{
               datumsText: siteText.vaccinaties.grafiek_draagvlak.metadata_tekst,
               date: [
-                data.vaccinated_or_vaccine_support.last_value.date_start_unix,
-                data.vaccinated_or_vaccine_support.last_value.date_end_unix,
+                data.vaccine_vaccinated_or_support.last_value.date_start_unix,
+                data.vaccine_vaccinated_or_support.last_value.date_end_unix,
               ],
             }}
           >
             <section>
               <KpiValue
                 percentage={
-                  data.vaccinated_or_vaccine_support.last_value
+                  data.vaccine_vaccinated_or_support.last_value
                     .percentage_average
                 }
               />
@@ -175,8 +175,8 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
 
             <TimeSeriesChart
               tooltipTitle={text.grafiek_draagvlak.titel}
-              ariaLabelledBy="chart_vaccinated_or_vaccine_support"
-              values={data.vaccinated_or_vaccine_support.values}
+              ariaLabelledBy="chart_vaccine_vaccinated_or_support"
+              values={data.vaccine_vaccinated_or_support.values}
               numGridLines={20}
               tickValues={[0, 25, 50, 75, 100]}
               dataOptions={{

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -47,7 +47,7 @@ export const getStaticProps = createGetStaticProps(
   selectNlPageMetricData(
     'vaccine_stock',
     'vaccine_delivery_per_supplier',
-    'vaccine_support',
+    'vaccinated_or_vaccine_support',
     'vaccine_administered_total',
     'vaccine_administered_planned',
     'vaccine_administered_rate_moving_average',
@@ -143,9 +143,11 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             metadata={{
               datumsText: text.bereidheid_datums,
               dateOrRange:
-                data.vaccine_support.last_value.date_of_insertion_unix,
+                data.vaccinated_or_vaccine_support.last_value
+                  .date_of_insertion_unix,
               dateOfInsertionUnix:
-                data.vaccine_support.last_value.date_of_insertion_unix,
+                data.vaccinated_or_vaccine_support.last_value
+                  .date_of_insertion_unix,
               dataSources: [],
             }}
           />
@@ -156,22 +158,25 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             metadata={{
               datumsText: siteText.vaccinaties.grafiek_draagvlak.metadata_tekst,
               date: [
-                data.vaccine_support.last_value.date_start_unix,
-                data.vaccine_support.last_value.date_end_unix,
+                data.vaccinated_or_vaccine_support.last_value.date_start_unix,
+                data.vaccinated_or_vaccine_support.last_value.date_end_unix,
               ],
             }}
           >
             <section>
               <KpiValue
-                percentage={data.vaccine_support.last_value.percentage_average}
+                percentage={
+                  data.vaccinated_or_vaccine_support.last_value
+                    .percentage_average
+                }
               />
               <Text mt={0}>{text.grafiek_draagvlak.kpi_omschrijving}</Text>
             </section>
 
             <TimeSeriesChart
               tooltipTitle={text.grafiek_draagvlak.titel}
-              ariaLabelledBy="chart_vaccine_support"
-              values={data.vaccine_support.values}
+              ariaLabelledBy="chart_vaccinated_or_vaccine_support"
+              values={data.vaccinated_or_vaccine_support.values}
               numGridLines={20}
               tickValues={[0, 25, 50, 75, 100]}
               dataOptions={{

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -586,3 +586,5 @@ timestamp,action,key
 2021-05-17T11:46:06.331Z,delete,ziekenhuisopnames_per_dag.chloropleth_legenda.geen_meldingen
 2021-05-17T11:46:06.331Z,delete,ziekenhuisopnames_per_dag.tijdelijk_onbeschikbaar
 2021-05-17T11:46:06.332Z,delete,ziekenhuisopnames_per_dag.tijdelijk_onbeschikbaar_titel
+2021-05-18T09:18:05.608Z,add,gedrag_onderwerpen.symptoms_stay_home_if_necessary
+2021-05-18T09:19:53.053Z,delete,gedrag_onderwerpen.symptoms_stay_home

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -586,5 +586,7 @@ timestamp,action,key
 2021-05-17T11:46:06.331Z,delete,ziekenhuisopnames_per_dag.chloropleth_legenda.geen_meldingen
 2021-05-17T11:46:06.331Z,delete,ziekenhuisopnames_per_dag.tijdelijk_onbeschikbaar
 2021-05-17T11:46:06.332Z,delete,ziekenhuisopnames_per_dag.tijdelijk_onbeschikbaar_titel
-2021-05-18T09:18:05.608Z,add,gedrag_onderwerpen.symptoms_stay_home_if_necessary
+2021-05-18T09:18:05.608Z,add,gedrag_onderwerpen.symptoms_stay_home_if_mandatory
 2021-05-18T09:19:53.053Z,delete,gedrag_onderwerpen.symptoms_stay_home
+2021-05-18T12:30:34.009Z,delete,gedrag_onderwerpen.symptoms_stay_home_if_necessary
+2021-05-18T12:31:34.675Z,add,gedrag_onderwerpen.symptoms_stay_home_if_mandatory

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -175,7 +175,7 @@ export interface National {
   deceased_rivm_per_age_group: NlDeceasedRivmPerAgeGroup;
   deceased_cbs: NationalDeceasedCbs;
   elderly_at_home: NationalElderlyAtHome;
-  vaccine_support: NlVaccineSupport;
+  vaccinated_or_vaccine_support: NlVaccinatedOrVaccineSupport;
   corona_melder_app: NlCoronaMelderApp;
   vaccine_coverage?: NlVaccineCoverage;
   vaccine_delivery: NlVaccineDelivery;
@@ -614,11 +614,11 @@ export interface NationalElderlyAtHomeValue {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlVaccineSupport {
-  values: NlVaccineSupportValue[];
-  last_value: NlVaccineSupportValue;
+export interface NlVaccinatedOrVaccineSupport {
+  values: NlVaccinatedOrVaccineSupportValue[];
+  last_value: NlVaccinatedOrVaccineSupportValue;
 }
-export interface NlVaccineSupportValue {
+export interface NlVaccinatedOrVaccineSupportValue {
   percentage_average: number;
   percentage_70_plus: number | null;
   percentage_55_69: number | null;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -485,8 +485,8 @@ export interface NationalBehaviorValue {
   work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
   avoid_crowds_compliance: number | null;
   avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_compliance?: number | null;
-  symptoms_stay_home_compliance_trend?: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_if_necessary_compliance?: number | null;
+  symptoms_stay_home_if_necessary_compliance_trend?: ("up" | "down" | "equal") | null;
   symptoms_get_tested_compliance?: number | null;
   symptoms_get_tested_compliance_trend?: ("up" | "down" | "equal") | null;
   wear_mask_public_indoors_compliance: number | null;
@@ -507,8 +507,8 @@ export interface NationalBehaviorValue {
   work_from_home_support_trend: ("up" | "down" | "equal") | null;
   avoid_crowds_support: number | null;
   avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_support?: number | null;
-  symptoms_stay_home_support_trend?: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_if_necessary_support?: number | null;
+  symptoms_stay_home_if_necessary_support_trend?: ("up" | "down" | "equal") | null;
   symptoms_get_tested_support?: number | null;
   symptoms_get_tested_support_trend?: ("up" | "down" | "equal") | null;
   wear_mask_public_indoors_support: number | null;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -526,8 +526,6 @@ export interface NationalBehaviorValue {
 export interface NlBehaviorPerAgeGroup {
   avoid_crowds_compliance: NlBehaviorPerAgeGroupValue;
   avoid_crowds_support: NlBehaviorPerAgeGroupValue;
-  curfew_compliance: NlBehaviorPerAgeGroupValue;
-  curfew_support: NlBehaviorPerAgeGroupValue;
   keep_distance_compliance: NlBehaviorPerAgeGroupValue;
   keep_distance_support: NlBehaviorPerAgeGroupValue;
   max_visitors_compliance: NlBehaviorPerAgeGroupValue;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -175,7 +175,7 @@ export interface National {
   deceased_rivm_per_age_group: NlDeceasedRivmPerAgeGroup;
   deceased_cbs: NationalDeceasedCbs;
   elderly_at_home: NationalElderlyAtHome;
-  vaccinated_or_vaccine_support: NlVaccinatedOrVaccineSupport;
+  vaccine_vaccinated_or_support: NlVaccineVaccinatedOrSupport;
   corona_melder_app: NlCoronaMelderApp;
   vaccine_coverage?: NlVaccineCoverage;
   vaccine_delivery: NlVaccineDelivery;
@@ -485,8 +485,8 @@ export interface NationalBehaviorValue {
   work_from_home_compliance_trend: ("up" | "down" | "equal") | null;
   avoid_crowds_compliance: number | null;
   avoid_crowds_compliance_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_if_necessary_compliance?: number | null;
-  symptoms_stay_home_if_necessary_compliance_trend?: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_if_mandatory_compliance?: number | null;
+  symptoms_stay_home_if_mandatory_compliance_trend?: ("up" | "down" | "equal") | null;
   symptoms_get_tested_compliance?: number | null;
   symptoms_get_tested_compliance_trend?: ("up" | "down" | "equal") | null;
   wear_mask_public_indoors_compliance: number | null;
@@ -507,8 +507,8 @@ export interface NationalBehaviorValue {
   work_from_home_support_trend: ("up" | "down" | "equal") | null;
   avoid_crowds_support: number | null;
   avoid_crowds_support_trend: ("up" | "down" | "equal") | null;
-  symptoms_stay_home_if_necessary_support?: number | null;
-  symptoms_stay_home_if_necessary_support_trend?: ("up" | "down" | "equal") | null;
+  symptoms_stay_home_if_mandatory_support?: number | null;
+  symptoms_stay_home_if_mandatory_support_trend?: ("up" | "down" | "equal") | null;
   symptoms_get_tested_support?: number | null;
   symptoms_get_tested_support_trend?: ("up" | "down" | "equal") | null;
   wear_mask_public_indoors_support: number | null;
@@ -614,11 +614,11 @@ export interface NationalElderlyAtHomeValue {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlVaccinatedOrVaccineSupport {
-  values: NlVaccinatedOrVaccineSupportValue[];
-  last_value: NlVaccinatedOrVaccineSupportValue;
+export interface NlVaccineVaccinatedOrSupport {
+  values: NlVaccineVaccinatedOrSupportValue[];
+  last_value: NlVaccineVaccinatedOrSupportValue;
 }
-export interface NlVaccinatedOrVaccineSupportValue {
+export interface NlVaccineVaccinatedOrSupportValue {
   percentage_average: number;
   percentage_70_plus: number | null;
   percentage_55_69: number | null;


### PR DESCRIPTION
## Summary

- Rename schema `vaccine_support` to `vaccinated_or_vaccine_support`
- Rename behavior property `symptoms_stay_home` to `symptoms_stay_home_if_necessary`