### PR TITLE
Fix crash in moving averages validation

### DIFF
--- a/packages/cli/src/schema/custom-validations/moving-averages.ts
+++ b/packages/cli/src/schema/custom-validations/moving-averages.ts
@@ -7,7 +7,7 @@ function hasValuesProperty(
   input: [string, JSONValue]
 ): input is [string, { values: Record<string, JSONValue>[] }] {
   const value = input[1];
-  return isObject(value) && 'values' in value;
+  return !Array.isArray(value) && isObject(value) && 'values' in value;
 }
 
 export function validateMovingAverages(input: JSONObject) {


### PR DESCRIPTION
## Summary

The check that makes sure a json value is an object AND contains a property called "values"
didn't explicitly check for the value NOT to be an array either.
Apparently `"values" in []` resolves to true...

## Motivation

Crash fix.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
