### PR TITLE
Move doses per minute calculation to the BE

### DIFF
--- a/packages/app/schema/nl/vaccine_administered_rate_moving_average.json
+++ b/packages/app/schema/nl/vaccine_administered_rate_moving_average.json
@@ -6,6 +6,7 @@
       "required": [
         "doses_per_day",
         "doses_per_second",
+        "doses_per_minute",
         "seconds_per_dose",
         "date_start_unix",
         "date_end_unix",
@@ -17,6 +18,9 @@
           "type": "number"
         },
         "doses_per_second": {
+          "type": "number"
+        },
+        "doses_per_minute": {
           "type": "number"
         },
         "seconds_per_dose": {

--- a/packages/app/src/domain/vaccine/components/vaccine-ticker.tsx
+++ b/packages/app/src/domain/vaccine/components/vaccine-ticker.tsx
@@ -23,7 +23,7 @@ interface VaccineTickerProps {
 export function VaccineTicker({ data }: VaccineTickerProps) {
   const { siteText, formatNumber } = useIntl();
 
-  const dosesPerMinute = data.doses_per_second * 60;
+  const dosesPerMinute = data.doses_per_minute;
 
   const isMountedRef = useIsMountedRef();
   const [animationProgress, setAnimationProgress] = useState(0);

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -776,6 +776,7 @@ export interface NlVaccineAdministeredRateMovingAverage {
 export interface NlVaccineAdministeredRateMovingAverageValue {
   doses_per_day: number;
   doses_per_second: number;
+  doses_per_minute: number;
   seconds_per_dose: number;
   date_start_unix: number;
   date_end_unix: number;


### PR DESCRIPTION
Due to rounded numbers the client-side calculation could be off by a couple of doses.