### PR TITLE
Update collapsible that it works without javascript

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-button.tsx
+++ b/packages/app/src/components/collapsible/collapsible-button.tsx
@@ -220,7 +220,6 @@ const Container = styled(Box).attrs({ as: 'section' })<{
 
         to: {
           maxHeight: '100%',
-          clipPath: 'none',
         },
       },
     },


### PR DESCRIPTION
Using the same technique as the menu, when the class `has-no-js` isn't removed we could safely assume there is no JS enabled on the page. Then the animation will trigger that will forever collapse the content down.

Also unsettling the before element and setting the height of the content `max-height` to 0 it will solve the problem when loading the page.

How it looks without Javascript:
<img width="1199" alt="Screenshot 2021-05-27 at 14 45 39" src="https://user-images.githubusercontent.com/76471292/119828620-a1c3d780-befa-11eb-8fde-5e4eb93d446c.png">
