### PR TITLE
Center value when there is only a value in the tooltip

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -169,9 +169,7 @@ function TooltipListItem({
             <VisuallyHidden>
               <InlineText mr={2}>{label}:</InlineText>
             </VisuallyHidden>
-            <TooltipEntryValue
-              displayTooltipValueOnly={displayTooltipValueOnly}
-            >
+            <TooltipEntryValue isCentered={displayTooltipValueOnly}>
               {children}
             </TooltipEntryValue>
           </TooltipEntryContainer>
@@ -188,9 +186,7 @@ function TooltipListItem({
           <Box flexGrow={1}>
             <TooltipEntryContainer>
               <InlineText mr={2}>{label}:</InlineText>
-              <TooltipEntryValue
-                displayTooltipValueOnly={displayTooltipValueOnly}
-              >
+              <TooltipEntryValue isCentered={displayTooltipValueOnly}>
                 {children}
               </TooltipEntryValue>
             </TooltipEntryContainer>
@@ -209,10 +205,10 @@ const TooltipEntryContainer = styled.span`
 `;
 
 const TooltipEntryValue = styled.span<{
-  displayTooltipValueOnly?: boolean;
+  isCentered?: boolean;
 }>((x) =>
   css({
-    textAlign: x.displayTooltipValueOnly ? 'center' : 'right',
+    textAlign: x.isCentered ? 'center' : 'right',
   })
 );
 

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -169,7 +169,11 @@ function TooltipListItem({
             <VisuallyHidden>
               <InlineText mr={2}>{label}:</InlineText>
             </VisuallyHidden>
-            <TooltipEntryValue>{children}</TooltipEntryValue>
+            <TooltipEntryValue
+              displayTooltipValueOnly={displayTooltipValueOnly}
+            >
+              {children}
+            </TooltipEntryValue>
           </TooltipEntryContainer>
         </Box>
       ) : (
@@ -184,7 +188,11 @@ function TooltipListItem({
           <Box flexGrow={1}>
             <TooltipEntryContainer>
               <InlineText mr={2}>{label}:</InlineText>
-              <TooltipEntryValue>{children}</TooltipEntryValue>
+              <TooltipEntryValue
+                displayTooltipValueOnly={displayTooltipValueOnly}
+              >
+                {children}
+              </TooltipEntryValue>
             </TooltipEntryContainer>
           </Box>
         </>
@@ -200,9 +208,13 @@ const TooltipEntryContainer = styled.span`
   align-items: flex-end;
 `;
 
-const TooltipEntryValue = styled.span`
-  text-align: right;
-`;
+const TooltipEntryValue = styled.span<{
+  displayTooltipValueOnly?: boolean;
+}>((x) =>
+  css({
+    textAlign: x.displayTooltipValueOnly ? 'center' : 'right',
+  })
+);
 
 export const TooltipList = styled.ol<{
   hasTwoColumns?: boolean;


### PR DESCRIPTION
The alignment of a single value in the tooltip was still `right`, when 4 or more numbers were in the tooltip it looked kinda odd.
This should `center` all the text in it when there is only a value.
This could be seen at the mini-trend tiles on the homepage.

New:
<img width="161" alt="Screenshot 2021-05-28 at 09 52 47" src="https://user-images.githubusercontent.com/76471292/119949774-80b2c380-bf9a-11eb-92b2-246f6d5dc311.png">

Old:
<img width="142" alt="Screenshot 2021-05-28 at 09 52 52" src="https://user-images.githubusercontent.com/76471292/119949806-89a39500-bf9a-11eb-814c-228107b92432.png">
