### PR TITLE
Add old_date_unix back as optional prop on national differences

### DIFF
--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -110,15 +110,14 @@
         "difference": {
           "type": "integer"
         },
+        "old_date_unix": {
+          "type": "integer"
+        },
         "new_date_unix": {
           "type": "integer"
         }
       },
-      "required": [
-        "old_value",
-        "difference",
-        "new_date_unix"
-      ],
+      "required": ["old_value", "difference", "new_date_unix"],
       "additionalProperties": false
     },
     "diff_decimal": {
@@ -135,11 +134,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "old_value",
-        "difference",
-        "new_date_unix"
-      ],
+      "required": ["old_value", "difference", "new_date_unix"],
       "additionalProperties": false
     }
   }

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -226,6 +226,7 @@ export interface DifferenceDecimal {
 export interface DifferenceInteger {
   old_value: number;
   difference: number;
+  old_date_unix?: number;
   new_date_unix: number;
 }
 export interface NationalDoctor {


### PR DESCRIPTION
## Summary

For the R-number on the national page we'll need to show the date difference between the current value and the previous one.
So, I've added back the `old_date_unix` property on the national `__difference.diff_integer` schema.

I reckoned that in the `Difference` component a check for the existence of the `old_date_unix` property can be added, and in that case, the exact difference between the current and new value can be rendered.

## Motivation

Feature request.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
