### PR TITLE
Add space between difference and annotation, fixes #2910

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -52,9 +52,6 @@ export function TileDifference({
   if (difference < 0) {
     const splitText = text.afname.split(' ');
 
-    console.log('differenceFormattedString', differenceFormattedString);
-    console.log('splitText[0]', splitText[0]);
-
     return (
       <Container>
         <IconContainer color="data.primary" mr={1}>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -2,9 +2,9 @@ import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
 import IconGelijk from '~/assets/gelijk.svg';
 import IconUp from '~/assets/pijl-omhoog.svg';
 import IconDown from '~/assets/pijl-omlaag.svg';
+import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
-import { InlineText } from '~/components/typography';
 
 export function TileDifference({
   value,
@@ -41,7 +41,7 @@ export function TileDifference({
         </IconContainer>
         <InlineText fontWeight="bold">
           {differenceFormattedString} {splitText[0]}
-        </InlineText>
+        </InlineText>{' '}
         <InlineText color="annotation">
           {splitText[1]} {timespanTextNode}
         </InlineText>
@@ -52,6 +52,9 @@ export function TileDifference({
   if (difference < 0) {
     const splitText = text.afname.split(' ');
 
+    console.log('differenceFormattedString', differenceFormattedString);
+    console.log('splitText[0]', splitText[0]);
+
     return (
       <Container>
         <IconContainer color="data.primary" mr={1}>
@@ -59,7 +62,7 @@ export function TileDifference({
         </IconContainer>
         <InlineText fontWeight="bold">
           {differenceFormattedString} {splitText[0]}
-        </InlineText>
+        </InlineText>{' '}
         <InlineText>
           {splitText[1]} {timespanTextNode}
         </InlineText>

--- a/packages/app/src/components/page-barscale.tsx
+++ b/packages/app/src/components/page-barscale.tsx
@@ -6,6 +6,8 @@ import {
 import { get } from 'lodash';
 import { isDefined } from 'ts-is-present';
 import { BarScale } from '~/components/bar-scale';
+import { useIntl } from '~/intl';
+import { SiteText } from '~/locale';
 import { assert } from '~/utils/assert';
 import {
   DataScope,
@@ -14,8 +16,6 @@ import {
 } from '../metric-config';
 import { Box } from './base';
 import { TileAverageDifference, TileDifference } from './difference-indicator';
-import { useIntl } from '~/intl';
-import { SiteText } from '~/locale';
 
 /**
  * This component originated from SidebarBarScale, but is used on pages and


### PR DESCRIPTION
## Summary

As the title states, it now correctly displays the value and annotation:
![image](https://user-images.githubusercontent.com/69849293/120158902-e9957800-c1f4-11eb-92ff-745d097268d4.png)

## Motivation

Fix.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
