### PR TITLE
Add metric back to coronamelder in sidebar

### DIFF
--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -367,7 +367,9 @@ export function NationalLayout(props: NationalLayoutProps) {
                     data={data}
                     scope="nl"
                     metricName="corona_melder_app"
+                    metricProperty="warned_daily"
                     localeTextKey="corona_melder_app"
+                    differenceKey="corona_melder_app__warned_daily"
                   />
                 </MetricMenuItemLink>
               </CategoryMenu>


### PR DESCRIPTION
## Summary

Add metric back to coronamelder in sidebar