### PR TITLE
Implement time series chart gapped line

### DIFF
--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -17,6 +17,11 @@ type GappedLinedTrendProps = {
 export function GappedLinedTrend(props: GappedLinedTrendProps) {
   const { series, color, style, strokeWidth, getX, getY, curve, id } = props;
 
+  /**
+   * Here we loop through the series and each time a null value is encountered a
+   * new SeriesSingleValue array is created. Effectively creating separate lines
+   * for each consecutive list of defined values.
+   */
   const gappedSeries = series.reduce<SeriesSingleValue[][]>(
     (list, item) => {
       let currentList = last(list) || [];

--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -23,17 +23,17 @@ export function GappedLinedTrend(props: GappedLinedTrendProps) {
    * for each consecutive list of defined values.
    */
   const gappedSeries = series.reduce<SeriesSingleValue[][]>(
-    (list, item) => {
-      let currentList = last(list) || [];
+    (lists, item) => {
+      let currentList = last(lists) || [];
       if (currentList.length && !isDefined(item.__value)) {
         const newList: SeriesSingleValue[] = [];
-        list.push(newList);
+        lists.push(newList);
         currentList = newList;
       }
       if (isDefined(item.__value)) {
         currentList.push(item);
       }
-      return list;
+      return lists;
     },
     [[]]
   );

--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -16,12 +16,14 @@ type GappedLinedTrendProps = {
 
 export function GappedLinedTrend(props: GappedLinedTrendProps) {
   const { series, color, style, strokeWidth, getX, getY, curve, id } = props;
+
   const gappedSeries = series.reduce<SeriesSingleValue[][]>(
     (list, item) => {
       let currentList = last(list) || [];
       if (currentList.length && !isDefined(item.__value)) {
-        list.push([]);
-        currentList = last(list) || [];
+        const newList: SeriesSingleValue[] = [];
+        list.push(newList);
+        currentList = newList;
       }
       if (isDefined(item.__value)) {
         currentList.push(item);
@@ -30,8 +32,6 @@ export function GappedLinedTrend(props: GappedLinedTrendProps) {
     },
     [[]]
   );
-
-  console.dir(gappedSeries);
 
   return (
     <>

--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -1,0 +1,50 @@
+import { last } from 'lodash';
+import { SeriesItem, SeriesSingleValue } from '../logic';
+import { LineTrend } from './line-trend';
+
+type GappedLinedTrendProps = {
+  series: SeriesSingleValue[];
+  color: string;
+  style?: 'solid' | 'dashed';
+  strokeWidth?: number;
+  getX: (v: SeriesItem) => number;
+  getY: (v: SeriesSingleValue) => number;
+  curve?: 'linear' | 'step';
+  id: string;
+};
+
+export function GappedLinedTrend(props: GappedLinedTrendProps) {
+  const { series, color, style, strokeWidth, getX, getY, curve, id } = props;
+  const gappedSeries = series.reduce<SeriesSingleValue[][]>(
+    (list, item) => {
+      let currentList = last(list) || [];
+      if (currentList.length && item.__value === null) {
+        list.push([]);
+        currentList = last(list) || [];
+      }
+      if (item.__value !== null) {
+        currentList.push(item);
+      }
+      return list;
+    },
+    [[]]
+  );
+
+  return (
+    <>
+      {gappedSeries.map((series, index) => (
+        <LineTrend
+          key={index}
+          series={series}
+          color={color}
+          style={style}
+          strokeWidth={strokeWidth}
+          curve={curve}
+          getX={getX}
+          getY={getY}
+          id={id}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -1,4 +1,5 @@
 import { last } from 'lodash';
+import { isDefined } from 'ts-is-present';
 import { SeriesItem, SeriesSingleValue } from '../logic';
 import { LineTrend } from './line-trend';
 
@@ -18,17 +19,19 @@ export function GappedLinedTrend(props: GappedLinedTrendProps) {
   const gappedSeries = series.reduce<SeriesSingleValue[][]>(
     (list, item) => {
       let currentList = last(list) || [];
-      if (currentList.length && item.__value === null) {
+      if (currentList.length && !isDefined(item.__value)) {
         list.push([]);
         currentList = last(list) || [];
       }
-      if (item.__value !== null) {
+      if (isDefined(item.__value)) {
         currentList.push(item);
       }
       return list;
     },
     [[]]
   );
+
+  console.dir(gappedSeries);
 
   return (
     <>

--- a/packages/app/src/components/time-series-chart/components/line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/line-trend.tsx
@@ -34,6 +34,10 @@ export function LineTrend({
     [series]
   );
 
+  if (!nonNullSeries.length) {
+    return null;
+  }
+
   return (
     <LinePath
       data={nonNullSeries}

--- a/packages/app/src/components/time-series-chart/components/series-icon.tsx
+++ b/packages/app/src/components/time-series-chart/components/series-icon.tsx
@@ -1,11 +1,11 @@
 import { TimestampedValue } from '@corona-dashboard/common';
+import { isPresent } from 'ts-is-present';
 import { findSplitPointForValue, SeriesConfig } from '../logic';
 import { AreaTrendIcon } from './area-trend';
+import { BarTrendIcon } from './bar-trend';
 import { LineTrendIcon } from './line-trend';
 import { RangeTrendIcon } from './range-trend';
 import { StackedAreaTrendIcon } from './stacked-area-trend';
-import { BarTrendIcon } from './bar-trend';
-import { isPresent } from 'ts-is-present';
 
 interface SeriesIconProps<T extends TimestampedValue> {
   config: SeriesConfig<T>[number];
@@ -24,6 +24,7 @@ export function SeriesIcon<T extends TimestampedValue>({
 }: SeriesIconProps<T>) {
   switch (config.type) {
     case 'line':
+    case 'gapped-line':
       return (
         <LineTrendIcon
           color={config.color}

--- a/packages/app/src/components/time-series-chart/components/series.tsx
+++ b/packages/app/src/components/time-series-chart/components/series.tsx
@@ -14,6 +14,7 @@ import {
   SeriesList,
   SeriesSingleValue,
 } from '../logic';
+import { GappedLinedTrend } from './gapped-line-trend';
 import { SplitBarTrend } from './split-bar-trend';
 import { StackedAreaTrend } from './stacked-area-trend';
 
@@ -58,6 +59,20 @@ function SeriesUnmemoized<T extends TimestampedValue>({
           const config = seriesConfig[index];
 
           switch (config.type) {
+            case 'gapped-line':
+              return (
+                <GappedLinedTrend
+                  key={index}
+                  series={series as SeriesSingleValue[]}
+                  color={config.color}
+                  style={config.style}
+                  strokeWidth={config.strokeWidth}
+                  curve={config.curve}
+                  getX={getX}
+                  getY={getY}
+                  id={`${chartId}_${config.metricProperty}`}
+                />
+              );
             case 'line':
               return (
                 <LineTrend

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -78,6 +78,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
 
           switch (x.type) {
             case 'stacked-area':
+            case 'gapped-line':
             case 'line':
             case 'area':
             case 'bar':
@@ -125,7 +126,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
                     <SeriesIcon
                       config={x}
                       value={
-                        value[x.metricProperty] as unknown as number | null
+                        (value[x.metricProperty] as unknown) as number | null
                       }
                     />
                   }

--- a/packages/app/src/components/time-series-chart/logic/hover-state.ts
+++ b/packages/app/src/components/time-series-chart/logic/hover-state.ts
@@ -238,6 +238,7 @@ export function useHoverState<T extends TimestampedValue>({
 
         switch (config.type) {
           case 'line':
+          case 'gapped-line':
           case 'area':
             return {
               seriesValue,

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -19,7 +19,19 @@ export type SeriesConfig<T extends TimestampedValue> = (
   | BarSeriesDefinition<T>
   | SplitBarSeriesDefinition<T>
   | InvisibleSeriesDefinition<T>
+  | GappedLineSeriesDefinition<T>
 )[];
+
+export type GappedLineSeriesDefinition<T extends TimestampedValue> = {
+  type: 'gapped-line';
+  metricProperty: keyof T;
+  label: string;
+  shortLabel?: string;
+  color: string;
+  style?: 'solid' | 'dashed';
+  strokeWidth?: number;
+  curve?: 'linear' | 'step';
+};
 
 export type LineSeriesDefinition<T extends TimestampedValue> = {
   type: 'line';
@@ -128,10 +140,11 @@ export function useSeriesList<T extends TimestampedValue>(
   seriesConfig: SeriesConfig<T>,
   cutValuesConfig?: CutValuesConfig[]
 ) {
-  return useMemo(
-    () => getSeriesList(values, seriesConfig, cutValuesConfig),
-    [values, seriesConfig, cutValuesConfig]
-  );
+  return useMemo(() => getSeriesList(values, seriesConfig, cutValuesConfig), [
+    values,
+    seriesConfig,
+    cutValuesConfig,
+  ]);
 }
 
 export function useValuesInTimeframe<T extends TimestampedValue>(
@@ -139,10 +152,11 @@ export function useValuesInTimeframe<T extends TimestampedValue>(
   timeframe: TimeframeOption
 ) {
   const today = useCurrentDate();
-  return useMemo(
-    () => getValuesInTimeframe(values, timeframe, today),
-    [values, timeframe, today]
-  );
+  return useMemo(() => getValuesInTimeframe(values, timeframe, today), [
+    values,
+    timeframe,
+    today,
+  ]);
 }
 
 /**

--- a/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
@@ -1,8 +1,8 @@
-import { useIntl } from '~/intl';
+import { TimestampedValue } from '@corona-dashboard/common';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
+import { useIntl } from '~/intl';
 import { SeriesConfig } from './series';
-import { TimestampedValue } from '@corona-dashboard/common';
 
 export function useFormatSeriesValue() {
   const intl = useIntl();
@@ -34,19 +34,14 @@ export function useFormatSeriesValue() {
       isPercentage?: boolean
     ) {
       switch (config.type) {
-        case 'line':
-        case 'area':
-        case 'bar':
-        case 'split-bar':
-        case 'stacked-area':
-        case 'invisible':
-          return getValueString(value[config.metricProperty], isPercentage);
         case 'range':
           return getRangeValueString(
             value[config.metricPropertyLow],
             value[config.metricPropertyHigh],
             isPercentage
           );
+        default:
+          return getValueString(value[config.metricProperty], isPercentage);
       }
     }
 

--- a/packages/app/src/components/tooltip.tsx
+++ b/packages/app/src/components/tooltip.tsx
@@ -1,5 +1,12 @@
 import css from '@styled-system/css';
-import { MouseEvent, ReactNode, useCallback, useRef, useState } from 'react';
+import {
+  MouseEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Box } from '~/components/base';
 
 export interface TooltipCoordinates {
@@ -49,6 +56,14 @@ export function useTooltip<T>({
     coordinates,
     value,
   };
+
+  useEffect(() => {
+    return () => {
+      if (timer.current > -1) {
+        window.clearTimeout(timer.current);
+      }
+    };
+  }, []);
 
   // This timeout smoothens the display of the tooltip for mouse users
   function debounceMouseEvents(callback: () => void) {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -191,7 +191,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               }}
               seriesConfig={[
                 {
-                  type: 'gapped-line',
+                  type: 'line',
                   metricProperty: 'percentage_70_plus',
                   label: replaceVariablesInText(
                     text.grafiek_draagvlak.leeftijd_jaar,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -191,7 +191,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               }}
               seriesConfig={[
                 {
-                  type: 'line',
+                  type: 'gapped-line',
                   metricProperty: 'percentage_70_plus',
                   label: replaceVariablesInText(
                     text.grafiek_draagvlak.leeftijd_jaar,


### PR DESCRIPTION
## Summary

Add a new time series type: 'gapped-line'
This type is consumed by the `GappedLineTrend` component which divides the given trend line into separate regular trend lines and renders those.

Plus, one small bugfix in the tooltip where the setTimeout wasn't cleared on unmount.

## Motivation

This is the first work to implement the 'gapped' lines needed for the situations chart.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
