### PR TITLE
Sync local text additions to sanity

### DIFF
--- a/packages/cms/src/lokalize/logic/export.ts
+++ b/packages/cms/src/lokalize/logic/export.ts
@@ -7,13 +7,12 @@ import { LokalizeText } from '@corona-dashboard/app/src/types/cms';
 import { createFlatTexts } from '@corona-dashboard/common';
 import { unflatten } from 'flat';
 import fs from 'fs';
-import meow from 'meow';
 import path from 'path';
 import prettier from 'prettier';
 import { getClient } from '../../client';
 import { collapseTextMutations, readTextMutations } from '.';
 
-const localeDirectory = path.resolve(
+export const localeDirectory = path.resolve(
   __dirname,
   '..', // lokalize
   '..', // src

--- a/packages/cms/src/lokalize/logic/fetch.ts
+++ b/packages/cms/src/lokalize/logic/fetch.ts
@@ -1,5 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import flatten from 'flat';
 import { getClient } from '../../client';
 import { LokalizeText } from '../types';
+import { localeDirectory } from './export';
+import mapKeys from 'lodash/mapKeys';
 
 export async function fetchExistingKeys() {
   const client = getClient();
@@ -11,4 +16,19 @@ export async function fetchExistingKeys() {
     })) as LokalizeText[];
 
   return allTexts.map((x) => x.key);
+}
+
+export async function fetchLocalTextsFlatten() {
+  const texts = JSON.parse(
+    fs.readFileSync(path.join(localeDirectory, 'nl_export.json'), {
+      encoding: 'utf-8',
+    })
+  );
+
+  const flattenTexts = mapKeys(
+    flatten(texts) as Record<string, string>,
+    (_value, key) => (key.includes('.') ? key : `__root.${key}`)
+  );
+
+  return flattenTexts as Record<string, string>;
 }


### PR DESCRIPTION
This PR is an improved version of #2920, instead of manually pasting json this implementation will search for added keys in your local `nl_export.json` and list those for you to select.

This implementation might also be interesting as inspiration for moving keys.

`nl_export.json`
```diff
+  "accessibilitie": {
+    "grafieken": {
+      "intensive_care_opnames": "Deze grafiek toon de intensive care-opnames door de tijd heen.",
+      "ziekenhuisopnames": "Deze grafiek toont het aantal ziekenhuisopnames door de tijd heen."
+    },
+    "text_download": "Download de databron van \"{{subject}}\" op {{source}}",
+    "text_source": "Bekijk de databron van \"{{subject}}\" op {{source}}"
+  },
```

```
▶ yarn lokalize:add --sync
yarn run v1.22.4
$ ts-node src/lokalize/add-text.ts --sync
? Select the local keys to add to Sanity: ›  
Instructions:
    ↑/↓: Highlight option
    ←/→/[space]: Toggle selection
    a: Toggle all
    enter/return: Complete answer
◯   accessibilitie.grafieken.intensive_care_opnames: Deze grafiek toon de intensive care-opnames door de tijd heen.
◯   accessibilitie.grafieken.ziekenhuisopnames: Deze grafiek toont het aantal ziekenhuisopnames door de tijd heen.
◯   accessibilitie.text_download: Download de databron van "{{subject}}" op {{source}}
◯   accessibilitie.text_source: Bekijk de databron van "{{subject}}" op {{source}}
```
