### PR TITLE
Revert "Change schema keys to round with integers instead of decimals…

### DIFF
--- a/packages/app/schema/gm/__difference.json
+++ b/packages/app/schema/gm/__difference.json
@@ -7,10 +7,10 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "tested_overall__infected_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "hospital_nice__admissions_on_date_of_reporting_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "sewer__average": {
       "$ref": "#/definitions/diff_decimal"

--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -7,7 +7,7 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "tested_overall__infected_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "tested_ggd_daily__tested_total": {
       "$ref": "#/definitions/diff_integer"
@@ -16,7 +16,7 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "tested_ggd_average__tested_total_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "tested_ggd_average__infected_percentage_moving_average": {
       "$ref": "#/definitions/diff_decimal"
@@ -25,13 +25,13 @@
       "$ref": "#/definitions/diff_integer"
     },
     "hospital_nice__admissions_on_date_of_reporting_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "hospital_lcps__beds_occupied_covid": {
       "$ref": "#/definitions/diff_integer"
     },
     "intensive_care_nice__admissions_on_date_of_reporting_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "intensive_care_lcps__beds_occupied_covid": {
       "$ref": "#/definitions/diff_integer"

--- a/packages/app/schema/vr/__difference.json
+++ b/packages/app/schema/vr/__difference.json
@@ -7,10 +7,10 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "tested_overall__infected_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "tested_ggd_average__tested_total_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "tested_ggd_average__infected_percentage_moving_average": {
       "$ref": "#/definitions/diff_decimal"
@@ -22,7 +22,7 @@
       "$ref": "#/definitions/diff_decimal"
     },
     "hospital_nice__admissions_on_date_of_reporting_moving_average": {
-      "$ref": "#/definitions/diff_integer"
+      "$ref": "#/definitions/diff_decimal"
     },
     "sewer__average": {
       "$ref": "#/definitions/diff_decimal"

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -34,8 +34,8 @@ export interface GmDeceasedRivmValue {
 }
 export interface MunicipalDifference {
   tested_overall__infected_per_100k_moving_average: DifferenceDecimal;
-  tested_overall__infected_moving_average: DifferenceInteger;
-  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceInteger;
+  tested_overall__infected_moving_average: DifferenceDecimal;
+  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   sewer__average?: DifferenceDecimal;
   deceased_rivm__covid_daily: DifferenceInteger;
 }
@@ -195,15 +195,15 @@ export interface National {
 }
 export interface NationalDifference {
   tested_overall__infected_per_100k_moving_average: DifferenceDecimal;
-  tested_overall__infected_moving_average: DifferenceInteger;
+  tested_overall__infected_moving_average: DifferenceDecimal;
   tested_ggd_daily__tested_total: DifferenceInteger;
   tested_ggd_daily__infected_percentage: DifferenceDecimal;
-  tested_ggd_average__tested_total_moving_average: DifferenceInteger;
+  tested_ggd_average__tested_total_moving_average: DifferenceDecimal;
   tested_ggd_average__infected_percentage_moving_average: DifferenceDecimal;
   infectious_people__estimate: DifferenceInteger;
-  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceInteger;
+  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   hospital_lcps__beds_occupied_covid: DifferenceInteger;
-  intensive_care_nice__admissions_on_date_of_reporting_moving_average: DifferenceInteger;
+  intensive_care_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   intensive_care_lcps__beds_occupied_covid: DifferenceInteger;
   doctor__covid_symptoms_per_100k: DifferenceDecimal;
   doctor__covid_symptoms: DifferenceInteger;
@@ -860,12 +860,12 @@ export interface VrStaticValues {
 }
 export interface RegionalDifference {
   tested_overall__infected_per_100k_moving_average: DifferenceDecimal;
-  tested_overall__infected_moving_average: DifferenceInteger;
-  tested_ggd_average__tested_total_moving_average: DifferenceInteger;
+  tested_overall__infected_moving_average: DifferenceDecimal;
+  tested_ggd_average__tested_total_moving_average: DifferenceDecimal;
   tested_ggd_average__infected_percentage_moving_average: DifferenceDecimal;
   tested_ggd_daily__tested_total: DifferenceInteger;
   tested_ggd_daily__infected_percentage: DifferenceDecimal;
-  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceInteger;
+  hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   sewer__average: DifferenceDecimal;
   nursing_home__newly_infected_people: DifferenceInteger;
   nursing_home__infected_locations_total: DifferenceInteger;


### PR DESCRIPTION
… for certain difference keys (#2925)"

This reverts commit fe424174354b5fd3e1bbf5a263ef3d2495b99416.

## Summary

The data for this is expected to be available on Tuesday, so these changes shouldn't have been merged today as they break the validation.