### PR TITLE
Remove margin button to fix the visual safari bug collapsible button

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-button.tsx
+++ b/packages/app/src/components/collapsible/collapsible-button.tsx
@@ -131,6 +131,7 @@ const Container = styled(Box).attrs({ as: 'section' })<{
 
     // Button
     '[data-reach-disclosure-button]': {
+      m: 0,
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',


### PR DESCRIPTION
Seems like there was still margin only visible on safari, this should fix it and align the borders properly again.
<img width="445" alt="Screenshot 2021-06-07 at 12 16 02" src="https://user-images.githubusercontent.com/76471292/121000097-21b73080-c78a-11eb-854c-efcc8aaa9967.png">
