### PR TITLE
Behavior page improvements

### DIFF
--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -48,9 +48,9 @@ export function BehaviorChoroplethsTile({
    * Lastly we remove all the duplicates in the array and add it to all the keys without data
    */
   const idsThatContainNull = Object.keys(firstRegionData)
-    .filter((key) => firstRegionData[key as keyof RegionsBehavior] === null) // check if a value has null
-    .map((item) => item.slice(0, item.indexOf('_'))) // Slice everything after the underscore to find the behaviorIdentifier
-    .filter((item, pos) => item.indexOf(item) == pos); // Remove duplicate names
+    .filter((key) => firstRegionData[key as keyof RegionsBehavior] === null)
+    .map((item) => item.slice(0, item.indexOf('_')))
+    .filter((item, pos) => item.indexOf(item) == pos);
 
   keysWithoutData.push(...(idsThatContainNull as BehaviorIdentifier[]));
 

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -36,14 +36,14 @@ export function BehaviorChoroplethsTile({
   const { siteText } = useIntl();
   const firstRegionData = data[0];
 
-  // Find all the keys that doesn't exist on VR level but does on NL
+  // Find all the keys that don't exist on VR level but do on NL
   const keysWithoutData = behaviorIdentifiers.filter(
     (item) => !Object.keys(firstRegionData).find((a) => a.includes(item))
   );
 
   /**
    * Since e.g. the curfew has no data anymore and returns null that also needs to be filtered out
-   * First we check if there are some keys that contains a value of null
+   * First we check if there are some keys that contain a value of null
    * Second we slice everything before the underscore, since only the id name is important and not _support or _compliance
    * Lastly we remove all the duplicates in the array and add it to all the keys without data
    */

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -34,11 +34,25 @@ export function BehaviorChoroplethsTile({
   setCurrentId,
 }: BehaviorChoroplethsTileProps) {
   const { siteText } = useIntl();
+  const firstRegionData = data[0];
 
   // Find all the keys that doesn't exist on VR level but does on NL
   const keysWithoutData = behaviorIdentifiers.filter(
-    (item) => !Object.keys(data[0]).find((a) => a.includes(item))
+    (item) => !Object.keys(firstRegionData).find((a) => a.includes(item))
   );
+
+  /**
+   * Since e.g. the curfew has no data anymore and returns null that's also needs to be filtered out
+   * First we check if there are some keys and values that contain null
+   * Second we slice everything before the underscore since only the id name is important and not _support or _compliance
+   * Lastly we remove all the duplicates in the array and add it to all the keys without data
+   */
+  const idsThatContainNull = Object.keys(firstRegionData)
+    .filter((key) => firstRegionData[key as keyof RegionsBehavior] === null) // check if a value has null
+    .map((item) => item.slice(0, item.indexOf('_'))) // Slice everything after the underscore to find the behaviorIdentifier
+    .filter((item, pos) => item.indexOf(item) == pos); // Remove duplicate names
+
+  keysWithoutData.push(...(idsThatContainNull as BehaviorIdentifier[]));
 
   const behaviorIndentifiersData = behaviorIdentifiers.map((id) => {
     const label = siteText.gedrag_onderwerpen[id];
@@ -64,7 +78,7 @@ export function BehaviorChoroplethsTile({
         />
       </Box>
 
-      <Box display="flex" flexWrap="wrap">
+      <Box display="flex" flexWrap="wrap" spacing={{ _: 4, lg: undefined }}>
         <ChoroplethBlock
           title={siteText.nl_gedrag.verdeling_in_nederland.compliance_title}
           data={{ behavior_compliance: data }}

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -35,7 +35,7 @@ export function BehaviorChoroplethsTile({
 }: BehaviorChoroplethsTileProps) {
   const { siteText } = useIntl();
 
-  // Find all the keys that only doesn't exist on VR level but does on NL
+  // Find all the keys that doesn't exist on VR level but does on NL
   const keysWithoutData = behaviorIdentifiers.filter(
     (item) => !Object.keys(data[0]).find((a) => a.includes(item))
   );

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -42,9 +42,9 @@ export function BehaviorChoroplethsTile({
   );
 
   /**
-   * Since e.g. the curfew has no data anymore and returns null that's also needs to be filtered out
-   * First we check if there are some keys and values that contain null
-   * Second we slice everything before the underscore since only the id name is important and not _support or _compliance
+   * Since e.g. the curfew has no data anymore and returns null that also needs to be filtered out
+   * First we check if there are some keys that contains a value of null
+   * Second we slice everything before the underscore, since only the id name is important and not _support or _compliance
    * Lastly we remove all the duplicates in the array and add it to all the keys without data
    */
   const idsThatContainNull = Object.keys(firstRegionData)

--- a/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
@@ -156,9 +156,7 @@ function DescriptionWithIcon({
   const splittedWords = description.split(' ');
 
   const buttonClickHandler = () => {
-    scrollIntoView(scrollRef.current as Element, {
-      behavior: 'smooth',
-    });
+    scrollIntoView(scrollRef.current as Element);
     setCurrentId(id);
   };
 

--- a/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
@@ -44,7 +44,9 @@ export function BehaviorTableTile({
   return (
     <Tile>
       <Heading level={3}>{title}</Heading>
-      <Text mb={4}>{description}</Text>
+      <Box maxWidth="maxWidthText">
+        <Text mb={4}>{description}</Text>
+      </Box>
       <Box display="flex" flexWrap="wrap" mb={{ _: 2, xs: 4 }}>
         <Box mr={3} mb={1}>
           <ExplanationBox background={colors.data.cyan} />
@@ -161,11 +163,18 @@ function DescriptionWithIcon({
   return (
     <Button onClick={buttonClickHandler}>
       {splittedWords.map((word, index) => (
-        <InlineText key={index} css={css({ whiteSpace: 'pre-wrap' })}>
+        <InlineText
+          key={index}
+          css={css({
+            whiteSpace: 'pre-wrap',
+            fontFamily: 'body',
+            fontSize: '1rem',
+          })}
+        >
           {splittedWords.length - 1 === index ? (
             <InlineText css={css({ display: 'flex', position: 'relative' })}>
               {word}
-              <Box position="absolute" right={-12} top={-1}>
+              <Box position="absolute" right={-14}>
                 <ChevronIcon width="7px" />
               </Box>
             </InlineText>

--- a/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
@@ -12,7 +12,7 @@ import { colors } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { BehaviorIcon } from '../components/behavior-icon';
 import { BehaviorTrend } from '../components/behavior-trend';
-import maybeScrollIntoView from 'scroll-into-view-if-needed';
+import scrollIntoView from 'scroll-into-view-if-needed';
 import { BehaviorIdentifier } from '../behavior-types';
 
 interface BehaviorTableTileProps {
@@ -156,7 +156,7 @@ function DescriptionWithIcon({
   const splittedWords = description.split(' ');
 
   const buttonClickHandler = () => {
-    maybeScrollIntoView(scrollRef.current as Element, {
+    scrollIntoView(scrollRef.current as Element, {
       behavior: 'smooth',
     });
     setCurrentId(id);

--- a/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-table-tile.tsx
@@ -12,7 +12,7 @@ import { colors } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { BehaviorIcon } from '../components/behavior-icon';
 import { BehaviorTrend } from '../components/behavior-trend';
-import scrollIntoView from 'scroll-into-view-if-needed';
+import maybeScrollIntoView from 'scroll-into-view-if-needed';
 import { BehaviorIdentifier } from '../behavior-types';
 
 interface BehaviorTableTileProps {
@@ -156,7 +156,9 @@ function DescriptionWithIcon({
   const splittedWords = description.split(' ');
 
   const buttonClickHandler = () => {
-    scrollIntoView(scrollRef.current as Element);
+    maybeScrollIntoView(scrollRef.current as Element, {
+      behavior: 'smooth',
+    });
     setCurrentId(id);
   };
 
@@ -174,7 +176,7 @@ function DescriptionWithIcon({
           {splittedWords.length - 1 === index ? (
             <InlineText css={css({ display: 'flex', position: 'relative' })}>
               {word}
-              <Box position="absolute" right={-14}>
+              <Box position="absolute" right={-14} top={0}>
                 <ChevronIcon width="7px" />
               </Box>
             </InlineText>


### PR DESCRIPTION
Back from QA there were several improvements
- The curfew returns null from the backend, there is a filter in place that adds the key name that contains null to the `keysWithoutData` for the choropleth
- Add spacing between choropleths on smaller screens
- Rules the table are now in the correct font