### PR TITLE
Add spacing for category bar scale text

### DIFF
--- a/packages/app/src/components/categorical-bar-scale.tsx
+++ b/packages/app/src/components/categorical-bar-scale.tsx
@@ -54,7 +54,12 @@ export function CategoricalBarScale({
 
   return (
     <>
-      <Box position="relative" width="100%" display="flex">
+      <Box
+        position="relative"
+        width="100%"
+        display="flex"
+        mb={hideLegend ? undefined : 4}
+      >
         {barPieces.map((category, index) => (
           <Box
             style={{ width: `${(category.width / maxValue) * 100}%` }}
@@ -96,7 +101,7 @@ export function CategoricalBarScale({
       </Box>
 
       {!hideLegend && (
-        <Box mb={3} mt={4}>
+        <Box mb={3}>
           {barPieces.map((category) => (
             <Fragment key={category.name}>
               {/* 0.25px offset is used for sharper rendering of the circle */}

--- a/packages/app/src/components/categorical-bar-scale.tsx
+++ b/packages/app/src/components/categorical-bar-scale.tsx
@@ -96,7 +96,7 @@ export function CategoricalBarScale({
       </Box>
 
       {!hideLegend && (
-        <Box mb={3}>
+        <Box mb={3} mt={4}>
           {barPieces.map((category) => (
             <Fragment key={category.name}>
               {/* 0.25px offset is used for sharper rendering of the circle */}


### PR DESCRIPTION
Somewhere along the line, the spacing was gone for the text, but adding this bit of margin should bring it back to how it is currently live.

<img width="464" alt="Screenshot 2021-06-08 at 09 14 34" src="https://user-images.githubusercontent.com/76471292/121141186-fdfff300-c83a-11eb-9115-6cb85e35dc48.png">
