### PR TITLE
Improve tooltip column layout

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -127,7 +127,7 @@ export function TooltipSeriesList<T extends TimestampedValue>({
                     <SeriesIcon
                       config={x}
                       value={
-                        (value[x.metricProperty] as unknown) as number | null
+                        value[x.metricProperty] as unknown as number | null
                       }
                     />
                   }
@@ -220,6 +220,8 @@ export const TooltipList = styled.ol<{
 }>((x) =>
   css({
     columns: x.hasTwoColumns ? 2 : 1,
+    columnRule: x.hasTwoColumns ? `1px solid ${colors.lightGray}` : 'unset',
+    columnGap: x.hasTwoColumns ? '2em' : 'unset',
     m: 0,
     p: 0,
     listStyle: 'none',

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-wrapper.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-wrapper.tsx
@@ -209,7 +209,7 @@ export const TooltipChildren = styled.div<{ hasTitle?: boolean }>(
 const StyledTooltipContent = styled.div((x) =>
   css({
     color: 'body',
-    maxWidth: 350,
+    maxWidth: 375,
     borderRadius: 1,
     cursor: x.onClick ? 'pointer' : 'default',
     fontSize: 1,


### PR DESCRIPTION
## Summary

Improve the layout of the tooltip with two columns

## Motivation

The values of the first column where too close to the labels of the second which was confusing 

## Detailed design

Applied some column styling to help separate the columns

