### PR TITLE
Add visual feedback situations table on VR level

### DIFF
--- a/packages/app/src/domain/situations/situations-table-tile.tsx
+++ b/packages/app/src/domain/situations/situations-table-tile.tsx
@@ -52,7 +52,11 @@ export function SituationsTableTile({
               <HeaderCell> {text.soort_situatie}</HeaderCell>
               <HeaderCell
                 css={css({
-                  width: asResponsiveArray({ _: 150, md: 350 }),
+                  width: asResponsiveArray({
+                    xs: 150,
+                    sm: 200,
+                    lg: 350,
+                  }),
                 })}
               >
                 {text.laatste_onderzoek}
@@ -134,11 +138,15 @@ function PercentageBar({ amount, color }: PercentageBarProps) {
 
   return (
     <Box display="flex" alignItems="center">
-      <InlineText css={css({ minWidth: 40 })}>{`${formatPercentage(
-        amount
-      )}%`}</InlineText>
+      <InlineText
+        textAlign="right"
+        css={css({ minWidth: 40 })}
+        mr={2}
+      >{`${formatPercentage(amount, {
+        minimumFractionDigits: 1,
+      })}%`}</InlineText>
       <Box width="100%" pr={4}>
-        <Box width={`${amount * 2}%`} height={12} backgroundColor={color} />
+        <Box width={`${amount}%`} height={12} backgroundColor={color} />
       </Box>
     </Box>
   );

--- a/packages/common/src/intl/create-formatting.ts
+++ b/packages/common/src/intl/create-formatting.ts
@@ -72,7 +72,8 @@ export function createFormatting(
   function formatPercentage(
     value: number,
     options?: {
-      maximumFractionDigits: number;
+      maximumFractionDigits?: number;
+      minimumFractionDigits?: number;
     }
   ) {
     return new Intl.NumberFormat(languageTag, options).format(value);


### PR DESCRIPTION
- Removed the *2 multiplier on the percentage bar, who would think that was a good idea
- More breakpoints for the table
- Always show 1 decimal even when it is 1% (added `minimumFractionDigits` to the `formatPercetage`)
- Align the numbers to the right 