### PR TITLE
Reverse behavior choropleth scales and remove gridlines behavior line chart

### DIFF
--- a/packages/app/src/components/choropleth/region-thresholds.ts
+++ b/packages/app/src/components/choropleth/region-thresholds.ts
@@ -172,62 +172,62 @@ const behaviorThresholds: ChoroplethThresholdsValue[] = [
 
 const behaviorComplianceThresholds: ChoroplethThresholdsValue[] = [
   {
-    color: colors.data.behavior.scale.cyan[0],
+    color: colors.data.scale.blue[6],
     threshold: 0,
   },
   {
-    color: colors.data.behavior.scale.cyan[1],
+    color: colors.data.scale.blue[5],
     threshold: 40,
   },
   {
-    color: colors.data.behavior.scale.cyan[2],
+    color: colors.data.scale.blue[4],
     threshold: 50,
   },
   {
-    color: colors.data.behavior.scale.cyan[3],
+    color: colors.data.scale.blue[3],
     threshold: 60,
   },
   {
-    color: colors.data.behavior.scale.cyan[4],
+    color: colors.data.scale.blue[2],
     threshold: 70,
   },
   {
-    color: colors.data.behavior.scale.cyan[5],
+    color: colors.data.scale.blue[1],
     threshold: 80,
   },
   {
-    color: colors.data.behavior.scale.cyan[6],
+    color: colors.data.scale.blue[0],
     threshold: 90,
   },
 ];
 
 const behaviorSupportThresholds: ChoroplethThresholdsValue[] = [
   {
-    color: colors.data.behavior.scale.yellow[0],
+    color: colors.data.scale.yellow[6],
     threshold: 0,
   },
   {
-    color: colors.data.behavior.scale.yellow[1],
+    color: colors.data.scale.yellow[5],
     threshold: 40,
   },
   {
-    color: colors.data.behavior.scale.yellow[2],
+    color: colors.data.scale.yellow[4],
     threshold: 50,
   },
   {
-    color: colors.data.behavior.scale.yellow[3],
+    color: colors.data.scale.yellow[3],
     threshold: 60,
   },
   {
-    color: colors.data.behavior.scale.yellow[4],
+    color: colors.data.scale.yellow[2],
     threshold: 70,
   },
   {
-    color: colors.data.behavior.scale.yellow[5],
+    color: colors.data.scale.yellow[1],
     threshold: 80,
   },
   {
-    color: colors.data.behavior.scale.yellow[6],
+    color: colors.data.scale.yellow[0],
     threshold: 90,
   },
 ];

--- a/packages/app/src/components/layout/app-footer.tsx
+++ b/packages/app/src/components/layout/app-footer.tsx
@@ -136,9 +136,11 @@ const ListItem = styled.li(
 const linkStyle = css({
   color: 'inherit',
   textDecoration: 'none',
+
   '&:hover': {
     textDecoration: 'underline',
   },
+
   '&:focus': {
     outline: '2px dotted white',
   },

--- a/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
@@ -97,7 +97,7 @@ export function BehaviorLineChartTile({
             label: chartText.support_label,
             shortLabel: chartText.support_short_label,
             strokeWidth: 3,
-            color: colors.data.emphasis,
+            color: colors.data.yellow,
           },
         ]}
         dataOptions={{

--- a/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
@@ -103,6 +103,7 @@ export function BehaviorLineChartTile({
         dataOptions={{
           isPercentage: true,
         }}
+        numGridLines={0}
         tickValues={[0, 25, 50, 75, 100]}
       />
     </ChartTile>

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -159,6 +159,15 @@ export const colors = {
         '#001d45',
       ],
       magenta: ['#F291BC', '#D95790', '#A11050', '#68032F', '#000000'],
+      yellow: [
+        '#FFF2CC',
+        '#FFE699',
+        '#FFD34D',
+        '#FABC00',
+        '#E5A400',
+        '#C98600',
+        '#9E6900',
+      ],
     },
     gradient: {
       green: '#69c253',
@@ -167,29 +176,6 @@ export const colors = {
     },
 
     multiseries,
-
-    behavior: {
-      scale: {
-        cyan: [
-          '#e9f5fc',
-          '#bce1f7',
-          '#90cdf2',
-          '#219be5',
-          '#1779b6',
-          '#1a618f',
-          '#005082',
-        ],
-        yellow: [
-          '#FFF2CC',
-          '#FFE699',
-          '#FFD34D',
-          '#FABC00',
-          '#E5A400',
-          '#C98600',
-          '#9E6900',
-        ],
-      },
-    },
 
     vaccines: {
       bio_n_tech_pfizer: multiseries.cyan,


### PR DESCRIPTION
Moved the scales in the theme and use the one we already have. 
Removed grid lines for the line chart