### PR TITLE
Revert tab icon

### DIFF
--- a/packages/app/src/components/seo-head.tsx
+++ b/packages/app/src/components/seo-head.tsx
@@ -133,7 +133,6 @@ export function SEOHead(props: SEOHeadProps) {
         type="font/woff"
       />
 
-      <link rel="icon" href="/images/touch-icon.png" />
       <link rel="apple-touch-icon" href="/images/touch-icon.png" />
 
       <meta key="description" name="description" content={description} />


### PR DESCRIPTION
## Summary

The addition of the apple touch icon also updated the tab icon. I've removed the extra icon configuration that caused this unintentional change

