### PR TITLE
Change tooltip info order based on metric name behavior page

### DIFF
--- a/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
@@ -41,6 +41,22 @@ export function BehaviorTooltip({
     currentSupportValue
   );
 
+  const complianceTooltipInfo = (
+    <TooltipInfo
+      title={siteText.nl_gedrag.tooltip_labels.compliance}
+      value={currentComplianceValue}
+      background={complianceFilteredThreshold.color}
+    />
+  );
+
+  const supportTooltipInfo = (
+    <TooltipInfo
+      title={siteText.nl_gedrag.tooltip_labels.support}
+      value={currentSupportValue}
+      background={supportFilteredThreshold.color}
+    />
+  );
+
   return (
     <TooltipContent
       title={context.vrname}
@@ -54,29 +70,13 @@ export function BehaviorTooltip({
         {/* Change order of the info based on the metric name */}
         {metricName === 'compliance' ? (
           <>
-            <TooltipInfo
-              title={siteText.nl_gedrag.tooltip_labels.compliance}
-              value={currentComplianceValue}
-              background={complianceFilteredThreshold.color}
-            />
-            <TooltipInfo
-              title={siteText.nl_gedrag.tooltip_labels.support}
-              value={currentSupportValue}
-              background={supportFilteredThreshold.color}
-            />
+            {complianceTooltipInfo}
+            {supportTooltipInfo}
           </>
         ) : (
           <>
-            <TooltipInfo
-              title={siteText.nl_gedrag.tooltip_labels.support}
-              value={currentSupportValue}
-              background={supportFilteredThreshold.color}
-            />
-            <TooltipInfo
-              title={siteText.nl_gedrag.tooltip_labels.compliance}
-              value={currentComplianceValue}
-              background={complianceFilteredThreshold.color}
-            />
+            {supportTooltipInfo}
+            {complianceTooltipInfo}
           </>
         )}
       </Box>

--- a/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
@@ -18,6 +18,7 @@ interface BehaviorTooltipProps {
   currentMetric: BehaviorIdentifier;
   currentComplianceValue: number;
   currentSupportValue: number;
+  metricName: 'compliance' | 'support';
 }
 
 export function BehaviorTooltip({
@@ -25,6 +26,7 @@ export function BehaviorTooltip({
   currentMetric,
   currentComplianceValue,
   currentSupportValue,
+  metricName,
 }: BehaviorTooltipProps) {
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
@@ -48,16 +50,35 @@ export function BehaviorTooltip({
         <Text m={0} mb={2} fontWeight="bold">
           {siteText.gedrag_onderwerpen[currentMetric]}
         </Text>
-        <TooltipInfo
-          title={siteText.nl_gedrag.tooltip_labels.compliance}
-          value={currentComplianceValue}
-          background={complianceFilteredThreshold.color}
-        />
-        <TooltipInfo
-          title={siteText.nl_gedrag.tooltip_labels.support}
-          value={currentSupportValue}
-          background={supportFilteredThreshold.color}
-        />
+
+        {/* Change order of the info based on the metric name */}
+        {metricName === 'compliance' ? (
+          <>
+            <TooltipInfo
+              title={siteText.nl_gedrag.tooltip_labels.compliance}
+              value={currentComplianceValue}
+              background={complianceFilteredThreshold.color}
+            />
+            <TooltipInfo
+              title={siteText.nl_gedrag.tooltip_labels.support}
+              value={currentSupportValue}
+              background={supportFilteredThreshold.color}
+            />
+          </>
+        ) : (
+          <>
+            <TooltipInfo
+              title={siteText.nl_gedrag.tooltip_labels.support}
+              value={currentSupportValue}
+              background={supportFilteredThreshold.color}
+            />
+            <TooltipInfo
+              title={siteText.nl_gedrag.tooltip_labels.compliance}
+              value={currentComplianceValue}
+              background={complianceFilteredThreshold.color}
+            />
+          </>
+        )}
       </Box>
     </TooltipContent>
   );

--- a/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
@@ -18,7 +18,7 @@ interface BehaviorTooltipProps {
   currentMetric: BehaviorIdentifier;
   currentComplianceValue: number;
   currentSupportValue: number;
-  metricPropertyGroup: 'compliance' | 'support';
+  behaviorType: 'compliance' | 'support';
 }
 
 export function BehaviorTooltip({
@@ -26,7 +26,7 @@ export function BehaviorTooltip({
   currentMetric,
   currentComplianceValue,
   currentSupportValue,
-  metricPropertyGroup,
+  behaviorType,
 }: BehaviorTooltipProps) {
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
@@ -68,7 +68,7 @@ export function BehaviorTooltip({
         </Text>
 
         {/* Change order of the info based on the metric name */}
-        {metricPropertyGroup === 'compliance' ? (
+        {behaviorType === 'compliance' ? (
           <>
             {complianceTooltipInfo}
             {supportTooltipInfo}

--- a/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
@@ -18,7 +18,7 @@ interface BehaviorTooltipProps {
   currentMetric: BehaviorIdentifier;
   currentComplianceValue: number;
   currentSupportValue: number;
-  metricName: 'compliance' | 'support';
+  metricPropertyGroup: 'compliance' | 'support';
 }
 
 export function BehaviorTooltip({
@@ -26,7 +26,7 @@ export function BehaviorTooltip({
   currentMetric,
   currentComplianceValue,
   currentSupportValue,
-  metricName,
+  metricPropertyGroup,
 }: BehaviorTooltipProps) {
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
@@ -68,7 +68,7 @@ export function BehaviorTooltip({
         </Text>
 
         {/* Change order of the info based on the metric name */}
-        {metricName === 'compliance' ? (
+        {metricPropertyGroup === 'compliance' ? (
           <>
             {complianceTooltipInfo}
             {supportTooltipInfo}

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -83,7 +83,7 @@ export function BehaviorChoroplethsTile({
         <ChoroplethBlock
           title={siteText.nl_gedrag.verdeling_in_nederland.compliance_title}
           data={{ behavior_compliance: data }}
-          metricPropertyGroup="compliance"
+          behaviorType="compliance"
           currentId={currentId}
           keysWithoutData={keysWithoutData}
           thresholds={regionThresholds.behavior_compliance}
@@ -92,7 +92,7 @@ export function BehaviorChoroplethsTile({
         <ChoroplethBlock
           title={siteText.nl_gedrag.verdeling_in_nederland.support_title}
           data={{ behavior_support: data }}
-          metricPropertyGroup="support"
+          behaviorType="support"
           currentId={currentId}
           keysWithoutData={keysWithoutData}
           thresholds={regionThresholds.behavior_support}
@@ -105,7 +105,7 @@ export function BehaviorChoroplethsTile({
 interface ChoroplethBlockProps {
   data: { [key: string]: RegionsBehavior[] };
   keysWithoutData: BehaviorIdentifier[];
-  metricPropertyGroup: 'compliance' | 'support';
+  behaviorType: 'compliance' | 'support';
   currentId: BehaviorIdentifier;
   title: string;
   thresholds: ChoroplethThresholdsValue[];
@@ -114,7 +114,7 @@ interface ChoroplethBlockProps {
 function ChoroplethBlock({
   data,
   keysWithoutData,
-  metricPropertyGroup,
+  behaviorType,
   currentId,
   title,
   thresholds,
@@ -150,8 +150,8 @@ function ChoroplethBlock({
         <SafetyRegionChoropleth
           data={data as { behavior: RegionsBehavior[] }}
           getLink={reverseRouter.vr.gedrag}
-          metricName={`behavior_${metricPropertyGroup}` as 'behavior'}
-          metricProperty={`${currentId}_${metricPropertyGroup}`}
+          metricName={`behavior_${behaviorType}` as 'behavior'}
+          metricProperty={`${currentId}_${behaviorType}`}
           minHeight={!isSmallScreen ? 350 : 400}
           noDataFillColor={colors.page}
           tooltipContent={(
@@ -167,7 +167,7 @@ function ChoroplethBlock({
 
             return (
               <BehaviorTooltip
-                metricPropertyGroup={metricPropertyGroup}
+                behaviorType={behaviorType}
                 context={context}
                 currentMetric={currentId}
                 currentComplianceValue={

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -167,6 +167,7 @@ function ChoroplethBlock({
 
             return (
               <BehaviorTooltip
+                metricName={metricName}
                 context={context}
                 currentMetric={currentId}
                 currentComplianceValue={

--- a/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-choropleths-tile.tsx
@@ -83,7 +83,7 @@ export function BehaviorChoroplethsTile({
         <ChoroplethBlock
           title={siteText.nl_gedrag.verdeling_in_nederland.compliance_title}
           data={{ behavior_compliance: data }}
-          metricName="compliance"
+          metricPropertyGroup="compliance"
           currentId={currentId}
           keysWithoutData={keysWithoutData}
           thresholds={regionThresholds.behavior_compliance}
@@ -92,7 +92,7 @@ export function BehaviorChoroplethsTile({
         <ChoroplethBlock
           title={siteText.nl_gedrag.verdeling_in_nederland.support_title}
           data={{ behavior_support: data }}
-          metricName="support"
+          metricPropertyGroup="support"
           currentId={currentId}
           keysWithoutData={keysWithoutData}
           thresholds={regionThresholds.behavior_support}
@@ -105,7 +105,7 @@ export function BehaviorChoroplethsTile({
 interface ChoroplethBlockProps {
   data: { [key: string]: RegionsBehavior[] };
   keysWithoutData: BehaviorIdentifier[];
-  metricName: 'compliance' | 'support';
+  metricPropertyGroup: 'compliance' | 'support';
   currentId: BehaviorIdentifier;
   title: string;
   thresholds: ChoroplethThresholdsValue[];
@@ -114,7 +114,7 @@ interface ChoroplethBlockProps {
 function ChoroplethBlock({
   data,
   keysWithoutData,
-  metricName,
+  metricPropertyGroup,
   currentId,
   title,
   thresholds,
@@ -150,8 +150,8 @@ function ChoroplethBlock({
         <SafetyRegionChoropleth
           data={data as { behavior: RegionsBehavior[] }}
           getLink={reverseRouter.vr.gedrag}
-          metricName={`behavior_${metricName}` as 'behavior'}
-          metricProperty={`${currentId}_${metricName}`}
+          metricName={`behavior_${metricPropertyGroup}` as 'behavior'}
+          metricProperty={`${currentId}_${metricPropertyGroup}`}
           minHeight={!isSmallScreen ? 350 : 400}
           noDataFillColor={colors.page}
           tooltipContent={(
@@ -167,7 +167,7 @@ function ChoroplethBlock({
 
             return (
               <BehaviorTooltip
-                metricName={metricName}
+                metricPropertyGroup={metricPropertyGroup}
                 context={context}
                 currentMetric={currentId}
                 currentComplianceValue={


### PR DESCRIPTION
By request from design based on the current active metric, the info of the tooltip should switch order (the active one should show up first).