### PR TITLE
Add more grid lines behavior line chart to make y axes visible on mobile

### DIFF
--- a/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/redesign/behavior-line-chart-tile.tsx
@@ -103,7 +103,7 @@ export function BehaviorLineChartTile({
         dataOptions={{
           isPercentage: true,
         }}
-        numGridLines={0}
+        numGridLines={2}
         tickValues={[0, 25, 50, 75, 100]}
       />
     </ChartTile>


### PR DESCRIPTION
Hotfix: Seems that setting the grid lines on 0 will not show Y axes on mobile, adding 2 will fix it.