### PR TITLE
Update choropleth municipality tab button to be visible

### DIFF
--- a/packages/app/src/components/choropleth/hooks/use-tab-interactive-button.tsx
+++ b/packages/app/src/components/choropleth/hooks/use-tab-interactive-button.tsx
@@ -59,6 +59,7 @@ const SkipButton = styled.button<{ isActive: boolean }>((x) =>
     py: 2,
     cursor: 'pointer',
     textDecoration: 'none',
+    zIndex: 9,
     /**
      * we'll toggle the opacity because for some reason firefox will not keep
      * the toggle button in the viewport, instead it will scroll entirely to the

--- a/packages/app/src/components/choropleth/municipality-choropleth.tsx
+++ b/packages/app/src/components/choropleth/municipality-choropleth.tsx
@@ -6,6 +6,7 @@ import {
 import css from '@styled-system/css';
 import { Feature, MultiPolygon } from 'geojson';
 import { ReactNode, useCallback } from 'react';
+import { Box } from '~/components/base';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { DataProps } from '~/types/attributes';
@@ -184,19 +185,23 @@ export function MunicipalityChoropleth<T, K extends MunicipalitiesMetricName>(
   };
 
   return (
-    <div css={css({ bg: 'transparent', position: 'relative', height: '100%' })}>
+    <Box position="relative">
       {tabInteractiveButton}
-      <Choropleth
-        description={dataDescription}
-        featureCollection={municipalGeo}
-        hovers={hasData ? municipalGeo : undefined}
-        boundingBox={boundingbox || countryGeo}
-        renderFeature={renderFeature}
-        renderHover={renderHover}
-        getTooltipContent={getTooltipContent}
-        tooltipPlacement={tooltipPlacement}
-        showTooltipOnFocus={isTabInteractive}
-      />
-    </div>
+      <div
+        css={css({ bg: 'transparent', position: 'relative', height: '100%' })}
+      >
+        <Choropleth
+          description={dataDescription}
+          featureCollection={municipalGeo}
+          hovers={hasData ? municipalGeo : undefined}
+          boundingBox={boundingbox || countryGeo}
+          renderFeature={renderFeature}
+          renderHover={renderHover}
+          getTooltipContent={getTooltipContent}
+          tooltipPlacement={tooltipPlacement}
+          showTooltipOnFocus={isTabInteractive}
+        />
+      </div>
+    </Box>
   );
 }


### PR DESCRIPTION
The tab component wasn't visible on municipality choropleth, moved a little higher in the tree so it falls above the choropleth.

Old:
![image](https://user-images.githubusercontent.com/76471292/121667707-da42e400-caaa-11eb-84d5-4efbcad5b1a9.png)
New:
<img width="601" alt="Screenshot 2021-06-11 at 11 49 21" src="https://user-images.githubusercontent.com/76471292/121667930-1118fa00-caab-11eb-94ab-e9e0c57c5daf.png">

