### PR TITLE
Fix initial SSR size of choropleth

### DIFF
--- a/packages/app/src/components/choropleth/choropleth.tsx
+++ b/packages/app/src/components/choropleth/choropleth.tsx
@@ -139,8 +139,8 @@ const ChoroplethMap: <T1, T3>(
     hoverRef,
     description,
     renderHighlight,
-    initialWidth = 850,
     minHeight = 500,
+    initialWidth = 0.9 * minHeight,
     showTooltipOnFocus,
   } = props;
 


### PR DESCRIPTION
## Summary

The choropleths on the situations overview were initially rendered on a very small scale. This was because the minHeight was set, but not the initialWidth accordingly. So, for example, a height of 280 was set, yet the initial width had a default of 850, resulting in a tiny map.

I've fixed this by making the initialWidth a multiplication of the minHeight and 0.9. (I think the ratio for the maps is between 0.8/0.9 to 1, so I chose to round up)

## Unresolved questions

Optional, but suggested for bigger features. What parts of the design are still
TBD or not implemented? How will you deal with that in the future?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
