### PR TITLE
Fix error-boundary build error

### DIFF
--- a/packages/app/src/components/error-boundary/index.tsx
+++ b/packages/app/src/components/error-boundary/index.tsx
@@ -8,7 +8,7 @@ import { Box } from '../base';
 import { Markdown } from '../markdown';
 import { InlineText } from '../typography';
 
-export function ErrorBoundary({ children }: { children: ReactNode }) {
+export function ErrorBoundary({ children = null }: { children: ReactNode }) {
   return (
     <ReactErrorBoundary FallbackComponent={ErrorFallback}>
       {children}


### PR DESCRIPTION
The error-boundary cannot handle `undefined` as child.