### PR TITLE
Update sidebar to have a max-width on smaller screens

### DIFF
--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -17,7 +17,7 @@ type Url = UrlObject | string;
 
 export function Menu({ children }: { children: ReactNode }) {
   return (
-    <Box as="ul" m={0} p={0} py={0} css={css({ listStyle: 'none' })}>
+    <Box as="ul" m={0} p={0} css={css({ listStyle: 'none' })}>
       {children}
     </Box>
   );

--- a/packages/app/src/components/layout/app-content.tsx
+++ b/packages/app/src/components/layout/app-content.tsx
@@ -5,6 +5,7 @@ import { ArrowIconLeft } from '~/components/arrow-icon';
 import { Box } from '~/components/base';
 import { MaxWidth } from '~/components/max-width';
 import { useIntl } from '~/intl';
+import { asResponsiveArray } from '~/style/utils';
 import { LinkWithIcon } from '../link-with-icon';
 
 interface AppContentProps {
@@ -118,7 +119,7 @@ const StyledAppContent = styled.main(
 
 const StyledSidebar = styled.aside(
   css({
-    bg: 'white',
+    bg: asResponsiveArray({ _: 'page', md: 'white' }),
     zIndex: 3,
     minHeight: [null, null, null, null, '35em'],
     width: [null, null, null, '25em'],

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -101,16 +101,28 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
       </Head>
       <AppContent
         hideMenuButton={isMainRoute}
-        searchComponent={<MunicipalityComboBox />}
+        searchComponent={
+          <Box
+            backgroundColor="white"
+            maxWidth={{ _: '38rem', md: undefined }}
+            mx="auto"
+          >
+            <MunicipalityComboBox />
+          </Box>
+        }
         sidebarComponent={
           <>
             {showMetricLinks && (
-              <nav
+              <Box
+                as="nav"
                 /** re-mount when route changes in order to blur anchors */
                 key={router.asPath}
-                role="navigation"
                 id="metric-navigation"
                 aria-label={siteText.aria_labels.metriek_navigatie}
+                role="navigation"
+                backgroundColor="white"
+                maxWidth={{ _: '38rem', md: undefined }}
+                mx="auto"
               >
                 <Box>
                   <Category>{municipalityName}</Category>
@@ -213,7 +225,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                     </MetricMenuItemLink>
                   </CategoryMenu>
                 </Menu>
-              </nav>
+              </Box>
             )}
           </>
         }

--- a/packages/app/src/domain/layout/national-layout.tsx
+++ b/packages/app/src/domain/layout/national-layout.tsx
@@ -114,6 +114,9 @@ export function NationalLayout(props: NationalLayoutProps) {
             aria-label={siteText.aria_labels.metriek_navigatie}
             role="navigation"
             pt={4}
+            backgroundColor="white"
+            maxWidth={{ _: '38rem', md: undefined }}
+            mx="auto"
           >
             <Menu>
               <MetricMenuButtonLink

--- a/packages/app/src/domain/layout/safety-region-layout.tsx
+++ b/packages/app/src/domain/layout/safety-region-layout.tsx
@@ -116,7 +116,15 @@ export function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
 
       <AppContent
         hideMenuButton={isMainRoute}
-        searchComponent={<SafetyRegionComboBox />}
+        searchComponent={
+          <Box
+            backgroundColor="white"
+            maxWidth={{ _: '38rem', md: undefined }}
+            mx="auto"
+          >
+            <SafetyRegionComboBox />
+          </Box>
+        }
         sidebarComponent={
           <>
             {/**
@@ -132,6 +140,9 @@ export function SafetyRegionLayout(props: SafetyRegionLayoutProps) {
                 aria-label={siteText.aria_labels.metriek_navigatie}
                 role="navigation"
                 spacing={3}
+                backgroundColor="white"
+                maxWidth={{ _: '38rem', md: undefined }}
+                mx="auto"
               >
                 <Text fontSize={3} fontWeight="bold" px={3} m={0}>
                   {safetyRegionName}


### PR DESCRIPTION
When going to iPad format the sidebar was too long, this adds a maxWidth and centers the sidebar. 

Screenshot:
<img width="899" alt="Screenshot 2021-06-11 at 12 36 17" src="https://user-images.githubusercontent.com/76471292/121673906-b505a400-cab1-11eb-9d31-63c82a3982a7.png">
