### PR TITLE
Create vaccine coverage over time chart w/mock data

### DIFF
--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -25,7 +25,8 @@
         "partially_vaccinated_percentage",
         "partially_or_fully_vaccinated_percentage",
         "date_of_insertion_unix",
-        "date_unix",
+        "date_start_unix",
+        "date_end_unix",
         "date_of_report_unix",
         "fully_vaccinated",
         "partially_vaccinated"
@@ -55,7 +56,10 @@
         "partially_or_fully_vaccinated_percentage": {
           "type": "number"
         },
-        "date_unix": {
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {

--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -25,8 +25,7 @@
         "partially_vaccinated_percentage",
         "partially_or_fully_vaccinated_percentage",
         "date_of_insertion_unix",
-        "date_start_unix",
-        "date_end_unix",
+        "date_unix",
         "date_of_report_unix",
         "fully_vaccinated",
         "partially_vaccinated"
@@ -56,10 +55,7 @@
         "partially_or_fully_vaccinated_percentage": {
           "type": "number"
         },
-        "date_start_unix": {
-          "type": "integer"
-        },
-        "date_end_unix": {
+        "date_unix": {
           "type": "integer"
         },
         "date_of_insertion_unix": {

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,7 +1,4 @@
-import {
-  NlVaccineCoveragePerAgeGroupValue,
-  NlVaccineCoverageValue,
-} from '@corona-dashboard/common';
+import { NlVaccineCoveragePerAgeGroupValue } from '@corona-dashboard/common';
 import VaccinatiesIcon from '~/assets/vaccinaties.svg';
 import { ArticleStrip } from '~/components/article-strip';
 import { ArticleSummary } from '~/components/article-teaser';
@@ -84,11 +81,6 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
     lastGenerated,
     deliveryAndAdministration,
   } = props;
-
-  /**
-   * @TODO cleanup mock function before merge to develop
-   */
-  data.vaccine_coverage = data.vaccine_coverage || mockVaccineCoverageData();
 
   const stockFeature = useFeature('vaccineStockPerSupplier');
 
@@ -399,50 +391,4 @@ function mockCoverageData(): { values: NlVaccineCoveragePerAgeGroupValue[] } {
       date_unix: 1616544000,
     };
   }
-}
-
-function mockVaccineCoverageData() {
-  const ONE_WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
-  const samples = 24;
-  let timestamp = Date.now() / 1000;
-  let partially_vaccinated = 0;
-  let fully_vaccinated = 0;
-
-  const values = Array(samples)
-    .fill(null)
-    .map(() => {
-      partially_vaccinated += Math.floor(Math.random() * 1000000);
-      fully_vaccinated += Math.floor(Math.random() * 1000000);
-
-      return { partially_vaccinated, fully_vaccinated };
-    })
-    .reverse()
-    .map<NlVaccineCoverageValue>(
-      ({ partially_vaccinated, fully_vaccinated }) => {
-        const total = partially_vaccinated + fully_vaccinated;
-        const partiallyPercentage = partially_vaccinated / total;
-        const fullyPercentage = fully_vaccinated / total;
-
-        const date_end_unix = timestamp;
-        const date_start_unix = (timestamp -= ONE_WEEK_IN_SECONDS);
-
-        return {
-          partially_vaccinated,
-          partially_vaccinated_percentage: partiallyPercentage,
-          fully_vaccinated,
-          fully_vaccinated_percentage: fullyPercentage,
-          partially_or_fully_vaccinated: total,
-          date_start_unix,
-          date_end_unix,
-          date_of_report_unix: date_end_unix,
-          date_of_insertion_unix: date_end_unix,
-        };
-      }
-    )
-    .reverse();
-
-  return {
-    values,
-    last_value: values[values.length - 1],
-  };
 }

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -91,7 +91,16 @@ export function selectNlData<T extends keyof National = never>(
     const { data } = getNlData();
 
     const selectedNlData = metrics.reduce(
-      (acc, p) => set(acc, p, data[p]),
+      (acc, p) =>
+        set(
+          acc,
+          p,
+          /**
+           * convert `undefined` values to `null` because nextjs cannot pass
+           * undefined values via initial props.
+           */
+          data[p] ?? null
+        ),
       {} as Pick<National, T>
     );
 

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,3 +9,12 @@ timestamp,action,key
 2021-06-07T14:22:50.606Z,add,common.foutmelding_is_gekopieerd
 2021-06-07T14:23:11.624Z,add,common.foutmelding_kon_niet_gekopieerd_worden
 2021-06-07T15:50:34.368Z,add,common.foutmelding_email_adres
+2021-06-14T10:57:59.405Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.titel
+2021-06-14T10:58:00.425Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.omschrijving
+2021-06-14T10:58:01.476Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.waarde_annotatie
+2021-06-14T10:58:02.457Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.label_totaal
+2021-06-14T10:58:03.523Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.label_gedeeltelijk
+2021-06-14T10:58:04.484Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.label_volledig
+2021-06-14T10:58:05.508Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.tooltip_label_totaal
+2021-06-14T10:58:06.519Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.tooltip_label_gedeeltelijk
+2021-06-14T10:58:07.619Z,add,vaccinaties.grafiek_gevaccineerd_door_de_tijd_heen.tooltip_label_volledig

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -103,13 +103,10 @@ export interface GmVaccineCoverage {
 }
 export interface GmVaccineCoverageValue {
   partially_vaccinated: number;
-  partially_vaccinated_percentage: number;
   fully_vaccinated: number;
-  fully_vaccinated_percentage: number;
   partially_or_fully_vaccinated: number;
   date_start_unix: number;
   date_end_unix: number;
-  date_of_report_unix: number;
   date_of_insertion_unix: number;
 }
 
@@ -652,13 +649,10 @@ export interface NlVaccineCoverage {
 }
 export interface NlVaccineCoverageValue {
   partially_vaccinated: number;
-  partially_vaccinated_percentage: number;
   fully_vaccinated: number;
-  fully_vaccinated_percentage: number;
   partially_or_fully_vaccinated: number;
   date_start_unix: number;
   date_end_unix: number;
-  date_of_report_unix: number;
   date_of_insertion_unix: number;
 }
 export interface NlVaccineDelivery {
@@ -1174,13 +1168,10 @@ export interface VrVaccineCoverage {
 }
 export interface VrVaccineCoverageValue {
   partially_vaccinated: number;
-  partially_vaccinated_percentage: number;
   fully_vaccinated: number;
-  fully_vaccinated_percentage: number;
   partially_or_fully_vaccinated: number;
   date_start_unix: number;
   date_end_unix: number;
-  date_of_report_unix: number;
   date_of_insertion_unix: number;
 }
 export interface VrSituations {


### PR DESCRIPTION
Create vaccine coverage over time chart;
![image](https://user-images.githubusercontent.com/73584448/121883516-1e83ed80-cd12-11eb-8b1f-cf288b87b2fa.png)

Before merge the mock data generator must be removed.