### PR TITLE
Recursively find reference objects and replace them with their documents

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -115,7 +115,8 @@
     "react-refresh": "^0.9.0",
     "start-server-and-test": "^1.12.0",
     "ts-jest": "^26.5.0",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "walkjs": "^3.1.10"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -1,6 +1,5 @@
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 import { Fragment, FunctionComponent, ReactNode } from 'react';
-import { isPresent } from 'ts-is-present';
 import { getFileSrc, PortableText } from '~/lib/sanity';
 import {
   CollapsibleList,

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -47,13 +47,17 @@ export function RichContent({
         />
       ),
       collapsible: (props: { node: CollapsibleList }) => {
-        return isPresent(props.node.content) ? (
-          <CollapsibleSection summary={props.node.title}>
-            <Box mt={3}>
-              <RichContent blocks={props.node.content} />
-            </Box>
-          </CollapsibleSection>
-        ) : null;
+        if (!props.node.content) return null;
+
+        return (
+          <ContentWrapper>
+            <CollapsibleSection summary={props.node.title}>
+              <Box mt={3}>
+                <RichContent blocks={props.node.content} />
+              </Box>
+            </CollapsibleSection>
+          </ContentWrapper>
+        );
       },
     },
     marks: {

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   Municipal,
   Municipalities,
   National,
@@ -6,8 +7,10 @@ import {
   Regions,
   sortTimeSeriesInDataInPlace,
 } from '@corona-dashboard/common';
+import { SanityClient } from '@sanity/client';
 import set from 'lodash/set';
 import { GetStaticPropsContext } from 'next';
+import { AsyncWalkBuilder } from 'walkjs';
 import { gmData } from '~/data/gm';
 import { vrData } from '~/data/vr';
 import {
@@ -53,19 +56,51 @@ export function createGetContent<T>(
   queryOrQueryGetter: string | ((context: GetStaticPropsContext) => string)
 ) {
   return async (context: GetStaticPropsContext) => {
+    const client = await getClient();
     const query =
       typeof queryOrQueryGetter === 'function'
         ? queryOrQueryGetter(context)
         : queryOrQueryGetter;
-    const rawContent = await (await getClient()).fetch<T>(query);
 
+    const rawContent = await client.fetch<T>(query);
     //@TODO We need to switch this from process.env to context as soon as we use i18n routing
     // const { locale } = context;
     const locale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
-    const content = localize(rawContent ?? {}, [locale, 'nl']) as T;
 
+    await replaceReferences(client, rawContent);
+
+    const content = localize(rawContent ?? {}, [locale, 'nl']) as T;
     return { content };
   };
+}
+
+/**
+ * This function will mutate an object which is a reference to another document.
+ * The reference-object's keys will be deleted and all reference document-keys
+ * will be added.
+ * eg:
+ * { _type: 'reference', _ref: 'abc' }
+ * becomes:
+ * { _type: 'document', id: 'abc', title: 'foo', body: 'bar' }
+ */
+async function replaceReferences(client: SanityClient, input: any) {
+  await new AsyncWalkBuilder()
+    .withGlobalFilter((x) => x.val?._type === 'reference')
+    .withSimpleCallback(async (node) => {
+      const refId = node.val._ref;
+
+      assert(typeof refId === 'string', 'node.val._ref is not set');
+
+      const reference = await client.fetch(`*[_id == '${refId}']{...}[0]`);
+
+      /**
+       * Here we'll mutate the original reference object by clearing the
+       * existing keys and adding all keys of the reference itself.
+       */
+      Object.keys(node.val).forEach((key) => delete node.val[key]);
+      Object.keys(reference).forEach((key) => (node.val[key] = reference[key]));
+    })
+    .walk(input);
 }
 
 /**

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -92,14 +92,14 @@ async function replaceReferences(client: SanityClient, input: any) {
 
       assert(typeof refId === 'string', 'node.val._ref is not set');
 
-      const reference = await client.fetch(`*[_id == '${refId}']{...}[0]`);
+      const document = await client.fetch(`*[_id == '${refId}']{...}[0]`);
 
       /**
        * Here we'll mutate the original reference object by clearing the
        * existing keys and adding all keys of the reference itself.
        */
       Object.keys(node.val).forEach((key) => delete node.val[key]);
-      Object.keys(reference).forEach((key) => (node.val[key] = reference[key]));
+      Object.keys(document).forEach((key) => (node.val[key] = document[key]));
     })
     .walk(input);
 }

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -67,6 +67,7 @@ export function createGetContent<T>(
     // const { locale } = context;
     const locale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
 
+    // this function call will mutate `rawContent`
     await replaceReferences(client, rawContent);
 
     const content = localize(rawContent ?? {}, [locale, 'nl']) as T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16999,6 +16999,13 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+walkjs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/walkjs/-/walkjs-3.1.10.tgz#cd5788e5803bb0adfaa71d7900e245fe16032cdb"
+  integrity sha512-QwyS6qnbqV4DwZ1NyBJSjDduY47x1leiOpyMHTk/hmaxZ3OFAI/uM4Bb+ikbAqT5ATqbW/EW7yRmNH0AwD/FBg==
+  dependencies:
+    typescript "^4.2.4"
+
 warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"


### PR DESCRIPTION
This PR implements an escape hatch for any forgotten dereferenced references. It defeats the need of manually deep-diving into sanity structures in order to assign references to de-reference.

In short: it will walk recursively through the resolved data from Sanity. Whenever it detects a "reference" object it will replace all keys in that object with the data of the reference instead.