### PR TITLE
Fix collapsibles not opening when linked to from the same page

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -92,6 +92,10 @@ const Panel = styled((props) => <DisclosurePanel {...props} />)(
   })
 );
 
+function locationHashEquals(id?: string) {
+  return window.location.hash === `#${id}`;
+}
+
 interface CollapsibleSectionProps extends BoxProps {
   summary: string;
   children: ReactNode;
@@ -116,12 +120,8 @@ export const CollapsibleSection = ({
    * If so, the collapsible needs to be opened.
    */
   useEffect(() => {
-    function isOpenedByHash() {
-      return window.location.hash.substr(1) === id;
-    }
-
     function handleHashChange() {
-      if (isOpenedByHash()) {
+      if (locationHashEquals(id)) {
         setIsOpen(true);
       }
     }
@@ -129,10 +129,10 @@ export const CollapsibleSection = ({
     window.addEventListener('hashchange', handleHashChange);
 
     /**
-     * Since we are open by default, we need to close
-     * all sections which are not opened by a hash now
+     * Since we are open by default, we need to close all sections which are not
+     * opened by a hash now
      */
-    setIsOpen(isOpenedByHash());
+    setIsOpen(locationHashEquals(id));
 
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, [id]);

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -92,7 +92,7 @@ const Panel = styled((props) => <DisclosurePanel {...props} />)(
   })
 );
 
-function locationHashEquals(id?: string) {
+function locationHashEquals(id: string) {
   return window.location.hash === `#${id}`;
 }
 
@@ -121,7 +121,7 @@ export const CollapsibleSection = ({
    */
   useEffect(() => {
     function handleHashChange() {
-      if (locationHashEquals(id)) {
+      if (id && locationHashEquals(id)) {
         setIsOpen(true);
       }
     }
@@ -132,7 +132,7 @@ export const CollapsibleSection = ({
      * Since we are open by default, we need to close all sections which are not
      * opened by a hash now
      */
-    setIsOpen(locationHashEquals(id));
+    setIsOpen(!!id && locationHashEquals(id));
 
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, [id]);

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -105,7 +105,7 @@ export const CollapsibleSection = ({
   id,
   hideBorder,
 }: CollapsibleSectionProps) => {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
   const { wrapperRef } = useSetLinkTabbability(open);
 
   const { ref, height: contentHeight } = useResizeObserver();
@@ -115,8 +115,18 @@ export const CollapsibleSection = ({
    * If so, the collapsible needs to be opened.
    */
   useEffect(() => {
-    const isOpenedByQueryParam = window.location.hash.substr(1) === id;
-    setOpen(isOpenedByQueryParam);
+    const onHashChange = function () {
+      const isOpenedByQueryParam = window.location.hash.substr(1) === id;
+
+      if (isOpenedByQueryParam) {
+        setOpen(true);
+      }
+    };
+
+    window.addEventListener('hashchange', onHashChange);
+    onHashChange();
+
+    return () => window.removeEventListener('hashchange', onHashChange);
   }, [id]);
 
   return (

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -105,8 +105,8 @@ export const CollapsibleSection = ({
   id,
   hideBorder,
 }: CollapsibleSectionProps) => {
-  const [open, setOpen] = useState(false);
-  const { wrapperRef } = useSetLinkTabbability(open);
+  const [isOpen, setIsOpen] = useState(false);
+  const { wrapperRef } = useSetLinkTabbability(isOpen);
 
   const { ref, height: contentHeight } = useResizeObserver();
 
@@ -115,18 +115,18 @@ export const CollapsibleSection = ({
    * If so, the collapsible needs to be opened.
    */
   useEffect(() => {
-    const onHashChange = function () {
-      const isOpenedByQueryParam = window.location.hash.substr(1) === id;
+    function handleHashChange() {
+      const isOpenedByHash = window.location.hash.substr(1) === id;
 
-      if (isOpenedByQueryParam) {
-        setOpen(true);
+      if (isOpenedByHash) {
+        setIsOpen(true);
       }
-    };
+    }
 
-    window.addEventListener('hashchange', onHashChange);
-    onHashChange();
+    window.addEventListener('hashchange', handleHashChange);
+    handleHashChange();
 
-    return () => window.removeEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
   }, [id]);
 
   return (
@@ -136,7 +136,7 @@ export const CollapsibleSection = ({
       borderTopColor={hideBorder ? undefined : 'lightGray'}
       id={id}
     >
-      <Disclosure open={open} onChange={() => setOpen(!open)}>
+      <Disclosure open={isOpen} onChange={() => setIsOpen(!isOpen)}>
         <Summary>
           {summary}
           {id && (
@@ -149,7 +149,7 @@ export const CollapsibleSection = ({
         <Panel
           style={{
             /* panel max height is only controlled when collapsed, or during animations */
-            height: open ? contentHeight : 0,
+            height: isOpen ? contentHeight : 0,
           }}
         >
           <div ref={wrapperRef}>

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -105,7 +105,8 @@ export const CollapsibleSection = ({
   id,
   hideBorder,
 }: CollapsibleSectionProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  /* Start in an open state so it is open when JS is disabled */
+  const [isOpen, setIsOpen] = useState(true);
   const { wrapperRef } = useSetLinkTabbability(isOpen);
 
   const { ref, height: contentHeight } = useResizeObserver();
@@ -115,16 +116,23 @@ export const CollapsibleSection = ({
    * If so, the collapsible needs to be opened.
    */
   useEffect(() => {
-    function handleHashChange() {
-      const isOpenedByHash = window.location.hash.substr(1) === id;
+    function isOpenedByHash() {
+      return window.location.hash.substr(1) === id;
+    }
 
-      if (isOpenedByHash) {
+    function handleHashChange() {
+      if (isOpenedByHash()) {
         setIsOpen(true);
       }
     }
 
     window.addEventListener('hashchange', handleHashChange);
-    handleHashChange();
+
+    /**
+     * Since we are open by default, we need to close
+     * all sections which are not opened by a hash now
+     */
+    setIsOpen(isOpenedByHash());
 
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, [id]);


### PR DESCRIPTION
Collapsible sections currently only open if their hash is already present on page load. If there is a link to a collapsible section on the same page, clicking that link moves to the section, but does not open the collapsible. This PR makes sure collapsibles also open in those cases.

You can find such a link in the development data on the `/verantwoording` page, within 'Vaccinaties', click on 'gedragsonderzoek van het RIVM'.