### PR TITLE
Add fallback to nl for feature metric scopes

### DIFF
--- a/packages/cli/src/scripts/validate-features.ts
+++ b/packages/cli/src/scripts/validate-features.ts
@@ -114,15 +114,15 @@ async function validateFeatureData(feature: Feature, schemaInfo: SchemaInfo) {
    * case we only check the properties and do not enforce existence/absence of
    * the full metric.
    */
-  const { metricScopes, metricName, metricProperties, name, isEnabled } =
-    feature;
+  const {
+    metricScopes = ['nl'],
+    metricName,
+    metricProperties,
+    name,
+    isEnabled,
+  } = feature;
 
   if (metricProperties) {
-    assert(
-      metricScopes,
-      `Missing metricScopes configuration for feature ${name}`
-    );
-
     assert(
       metricName,
       'If a feature defines metricProperties it should also have a metricName'


### PR DESCRIPTION
## Summary

When mericName is set for a feature definition metricScopes was expected, but not strictly typed. I think a fallback to nl is an easier solution. Usually a feature applies to nl anyway and if it doesn't match the data things will still break in the validation.
