### PR TITLE
Add custom location tooltip for sewer chart

### DIFF
--- a/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
+++ b/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
@@ -43,28 +43,6 @@ export function LocationTooltip({
   );
 }
 
-// const TooltipList = styled.ol`
-//   margin: 0;
-//   padding: 0;
-//   list-style: none;
-// `;
-
-// const TooltipListItem = styled.li<{ mt?: number }>((props: { mt?: number }) =>
-//   css({
-//     display: 'flex',
-//     alignItems: 'center',
-//     justifyContent: 'space-between',
-//     mt: props.mt,
-//   })
-// );
-
-// const TooltipValueContainer = styled.span(
-//   css({
-//     fontWeight: 'bold',
-//     ml: '1em',
-//   })
-// );
-
 const StyledLocationIcon = styled.span(
   css({
     whiteSpace: 'nowrap',
@@ -75,7 +53,6 @@ const StyledLocationIcon = styled.span(
       pt: '3px',
       color: 'black',
       width: '1em',
-      // border: '1px solid hotpink',
     },
   })
 );

--- a/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
+++ b/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
@@ -33,7 +33,7 @@ export function LocationTooltip({
           <Locatie />
         </StyledLocationIcon>
         <b>{config.label}</b>
-        <Box mx={2}>{'per 100k inwnsajf'}:</Box>
+        <Box mx={2}>{siteText.waarde_annotaties.per_100_000_inwoners}:</Box>
 
         <strong>
           {formatNumber(data.value.selected_installation_rna_normalized)}

--- a/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
+++ b/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
@@ -1,0 +1,81 @@
+import { assert } from '@corona-dashboard/common';
+import css from '@styled-system/css';
+import styled from 'styled-components';
+import Locatie from '~/assets/locatie.svg';
+import { Box } from '~/components/base';
+import { TooltipData } from '~/components/time-series-chart/components';
+import { VisuallyHidden } from '~/components/visually-hidden';
+import { useIntl } from '~/intl';
+import { MergedSewerType } from '../new-logic';
+
+/**
+ * A specific tooltip for when you've selected a location. It contains an icon
+ * and some extra text.
+ */
+export function LocationTooltip({
+  data,
+}: {
+  data: TooltipData<MergedSewerType>;
+}) {
+  const { siteText, formatNumber, formatDateFromSeconds } = useIntl();
+
+  const config = data.config.find((x) => x.type === 'line');
+
+  assert(config, 'Failed to find line configuration in location tooltip');
+
+  const dateString = formatDateFromSeconds(data.value.date_unix, 'day-month');
+
+  return (
+    <>
+      <VisuallyHidden>{dateString}</VisuallyHidden>
+      <Box fontSize={1} display="flex" alignItems="center">
+        <StyledLocationIcon>
+          <Locatie />
+        </StyledLocationIcon>
+        <b>{config.label}</b>
+        <Box mx={2}>{'per 100k inwnsajf'}:</Box>
+
+        <strong>
+          {formatNumber(data.value.selected_installation_rna_normalized)}
+        </strong>
+      </Box>
+    </>
+  );
+}
+
+// const TooltipList = styled.ol`
+//   margin: 0;
+//   padding: 0;
+//   list-style: none;
+// `;
+
+// const TooltipListItem = styled.li<{ mt?: number }>((props: { mt?: number }) =>
+//   css({
+//     display: 'flex',
+//     alignItems: 'center',
+//     justifyContent: 'space-between',
+//     mt: props.mt,
+//   })
+// );
+
+// const TooltipValueContainer = styled.span(
+//   css({
+//     fontWeight: 'bold',
+//     ml: '1em',
+//   })
+// );
+
+const StyledLocationIcon = styled.span(
+  css({
+    whiteSpace: 'nowrap',
+    display: 'inline-block',
+    mr: 2,
+
+    svg: {
+      pt: '3px',
+      color: 'black',
+      width: '1em',
+      // border: '1px solid hotpink',
+    },
+  })
+);

--- a/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
+++ b/packages/app/src/components/sewer-chart/components/location-tooltip.tsx
@@ -35,9 +35,7 @@ export function LocationTooltip({
         <b>{config.label}</b>
         <Box mx={2}>{siteText.waarde_annotaties.per_100_000_inwoners}:</Box>
 
-        <strong>
-          {formatNumber(data.value.selected_installation_rna_normalized)}
-        </strong>
+        <b>{formatNumber(data.value.selected_installation_rna_normalized)}</b>
       </Box>
     </>
   );

--- a/packages/app/src/components/sewer-chart/logic.ts
+++ b/packages/app/src/components/sewer-chart/logic.ts
@@ -1,3 +1,7 @@
+/**
+ * All of this file can go once we release the new split sewer chart
+ */
+
 import { SewerPerInstallationData } from '@corona-dashboard/common';
 import { Point } from '@visx/point';
 import { scaleLinear, scaleTime } from '@visx/scale';
@@ -9,7 +13,6 @@ import { SelectProps } from '~/components/select';
 import { useCurrentDate } from '~/utils/current-date-context';
 import { getFilteredValues, TimeframeOption } from '~/utils/timeframe';
 import { SewerChartData } from './sewer-chart';
-
 export interface Dimensions {
   bounds: Record<'width' | 'height', number>;
   padding: Record<'top' | 'right' | 'bottom' | 'left', number>;

--- a/packages/app/src/components/sewer-chart/new-logic.ts
+++ b/packages/app/src/components/sewer-chart/new-logic.ts
@@ -1,0 +1,86 @@
+import {
+  assert,
+  MunicipalSewer,
+  RegionalSewer,
+  SewerPerInstallationData,
+} from '@corona-dashboard/common';
+import { set } from 'lodash';
+
+type MergedValue = {
+  average: number | null;
+  selected_installation_rna_normalized: number | null;
+};
+
+type MergedValuesByTimestamp = Record<number, MergedValue>;
+
+export type MergedSewerType = ReturnType<typeof mergeData>[number];
+/**
+ * Calling this new-logic to keep it separated from ./logic.ts which should be
+ * deleted later. I think we can move some more logic from the new-sewer-chart
+ * here later and rename it to logic.
+ */
+export function mergeData(
+  dataAverages: RegionalSewer | MunicipalSewer,
+  dataPerInstallation: SewerPerInstallationData,
+  selectedInstallation: string
+) {
+  const valuesForInstallation = dataPerInstallation.values.find(
+    (x) => x.rwzi_awzi_name === selectedInstallation
+  )?.values;
+
+  assert(
+    valuesForInstallation,
+    `Failed to find data for rwzi_awzi_name ${selectedInstallation}`
+  );
+
+  const mergedValuesByTimestamp =
+    valuesForInstallation.reduce<MergedValuesByTimestamp>(
+      (acc, v) =>
+        set(acc, v.date_unix, {
+          selected_installation_rna_normalized: v.rna_normalized,
+          average: null,
+        }),
+      {}
+    );
+
+  for (const value of dataAverages.values) {
+    /**
+     * For averages pick the date in the middle of the week, because that's how
+     * the values are displayed when just viewing averages, but for this merged
+     * set we'll need to use day timestamps.
+     */
+    const date_unix =
+      value.date_start_unix + (value.date_end_unix - value.date_start_unix) / 2;
+
+    const existingValue = mergedValuesByTimestamp[date_unix] as
+      | MergedValue
+      | undefined;
+
+    /**
+     * If we happen to fall exactly on an existing installation timestamp we
+     * want to combine the two property values.
+     */
+    if (existingValue) {
+      mergedValuesByTimestamp[date_unix] = {
+        average: value.average,
+        selected_installation_rna_normalized:
+          existingValue.selected_installation_rna_normalized,
+      };
+    } else {
+      mergedValuesByTimestamp[date_unix] = {
+        average: value.average,
+        selected_installation_rna_normalized: null,
+      };
+    }
+  }
+
+  /**
+   * Convert the map to a series of sorted timestamped values.
+   */
+  return Object.entries(mergedValuesByTimestamp)
+    .map(([date_unix, obj]) => ({
+      date_unix: Number(date_unix),
+      ...obj,
+    }))
+    .sort((a, b) => a.date_unix - b.date_unix);
+}

--- a/packages/app/src/components/sewer-chart/new-logic.ts
+++ b/packages/app/src/components/sewer-chart/new-logic.ts
@@ -1,7 +1,7 @@
 /**
- * Calling this new-logic to keep it separated from ./logic.ts which should be
- * deleted later. I think we can move some more logic from the new-sewer-chart
- * here later and rename it to logic.
+ * This file is called new-logic to keep it separated from ./logic.ts which
+ * should be deleted later. I think we can move some more logic from the
+ * new-sewer-chart here later and rename it to logic.
  */
 
 import {

--- a/packages/app/src/components/sewer-chart/new-logic.ts
+++ b/packages/app/src/components/sewer-chart/new-logic.ts
@@ -1,3 +1,9 @@
+/**
+ * Calling this new-logic to keep it separated from ./logic.ts which should be
+ * deleted later. I think we can move some more logic from the new-sewer-chart
+ * here later and rename it to logic.
+ */
+
 import {
   assert,
   MunicipalSewer,
@@ -14,10 +20,11 @@ type MergedValue = {
 type MergedValuesByTimestamp = Record<number, MergedValue>;
 
 export type MergedSewerType = ReturnType<typeof mergeData>[number];
+
 /**
- * Calling this new-logic to keep it separated from ./logic.ts which should be
- * deleted later. I think we can move some more logic from the new-sewer-chart
- * here later and rename it to logic.
+ * Data for averages and per installations are two completely separate sources
+ * with different formats. In order to display them in the chart together we
+ * need to convert them to format with the same type of timestamps.
  */
 export function mergeData(
   dataAverages: RegionalSewer | MunicipalSewer,
@@ -46,8 +53,8 @@ export function mergeData(
   for (const value of dataAverages.values) {
     /**
      * For averages pick the date in the middle of the week, because that's how
-     * the values are displayed when just viewing averages, but for this merged
-     * set we'll need to use day timestamps.
+     * the values are displayed when just viewing averages, and for this merged
+     * set we'll need to use single dates.
      */
     const date_unix =
       value.date_start_unix + (value.date_end_unix - value.date_start_unix) / 2;

--- a/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
+++ b/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
@@ -1,10 +1,8 @@
 import {
-  assert,
   MunicipalSewer,
   RegionalSewer,
   SewerPerInstallationData,
 } from '@corona-dashboard/common';
-import { set } from 'lodash';
 import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { Select } from '~/components/select';
@@ -12,7 +10,7 @@ import { useSewerStationSelectPropsSimplified } from '~/components/sewer-chart/l
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { colors } from '~/style/theme';
 import { LocationTooltip } from './components/location-tooltip';
-import { mergeData, MergedSewerType } from './new-logic';
+import { mergeData } from './new-logic';
 
 export function NewSewerChart({
   dataAverages,

--- a/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
+++ b/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
@@ -5,12 +5,14 @@ import {
   SewerPerInstallationData,
 } from '@corona-dashboard/common';
 import { set } from 'lodash';
+import { Box } from '~/components/base';
+import { ChartTile } from '~/components/chart-tile';
 import { Select } from '~/components/select';
 import { useSewerStationSelectPropsSimplified } from '~/components/sewer-chart/logic';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { colors } from '~/style/theme';
-import { Box } from '../base';
-import { ChartTile } from '../chart-tile';
+import { LocationTooltip } from './components/location-tooltip';
+import { mergeData, MergedSewerType } from './new-logic';
 
 export function NewSewerChart({
   dataAverages,
@@ -138,6 +140,7 @@ export function NewSewerChart({
                     isNonInteractive: true,
                   },
                 ]}
+                formatTooltip={(data) => <LocationTooltip data={data} />}
               />
             ) : (
               <TimeSeriesChart
@@ -158,77 +161,4 @@ export function NewSewerChart({
       )}
     </ChartTile>
   );
-}
-
-function mergeData(
-  dataAverages: RegionalSewer | MunicipalSewer,
-  dataPerInstallation: SewerPerInstallationData,
-  selectedInstallation: string
-) {
-  const valuesForInstallation = dataPerInstallation.values.find(
-    (x) => x.rwzi_awzi_name === selectedInstallation
-  )?.values;
-
-  assert(
-    valuesForInstallation,
-    `Failed to find data for rwzi_awzi_name ${selectedInstallation}`
-  );
-
-  type MergedValue = {
-    average: number | null;
-    selected_installation_rna_normalized: number | null;
-  };
-
-  type MergedValuesByTimestamp = Record<number, MergedValue>;
-
-  const mergedValuesByTimestamp =
-    valuesForInstallation.reduce<MergedValuesByTimestamp>(
-      (acc, v) =>
-        set(acc, v.date_unix, {
-          selected_installation_rna_normalized: v.rna_normalized,
-          average: null,
-        }),
-      {}
-    );
-
-  for (const value of dataAverages.values) {
-    /**
-     * For averages pick the date in the middle of the week, because that's how
-     * the values are displayed when just viewing averages, but for this merged
-     * set we'll need to use day timestamps.
-     */
-    const date_unix =
-      value.date_start_unix + (value.date_end_unix - value.date_start_unix) / 2;
-
-    const existingValue = mergedValuesByTimestamp[date_unix] as
-      | MergedValue
-      | undefined;
-
-    /**
-     * If we happen to fall exactly on an existing installation timestamp we
-     * want to combine the two property values.
-     */
-    if (existingValue) {
-      mergedValuesByTimestamp[date_unix] = {
-        average: value.average,
-        selected_installation_rna_normalized:
-          existingValue.selected_installation_rna_normalized,
-      };
-    } else {
-      mergedValuesByTimestamp[date_unix] = {
-        average: value.average,
-        selected_installation_rna_normalized: null,
-      };
-    }
-  }
-
-  /**
-   * Convert the map to a series of sorted timestamped values.
-   */
-  return Object.entries(mergedValuesByTimestamp)
-    .map(([date_unix, obj]) => ({
-      date_unix: Number(date_unix),
-      ...obj,
-    }))
-    .sort((a, b) => a.date_unix - b.date_unix);
 }

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -74,3 +74,4 @@ timestamp,action,key
 2021-06-16T14:52:34.060Z,add,covid_varianten.varianten_tabel.verschil.meer
 2021-06-16T14:52:35.078Z,add,covid_varianten.varianten_tabel.verschil.minder
 2021-06-16T14:52:36.093Z,add,covid_varianten.varianten_tabel.verschil.gelijk
+2021-06-18T06:09:22.572Z,add,waarde_annotaties.per_100_000_inwoners


### PR DESCRIPTION
## Summary

When selecting a location we only show the location data, and the tooltip contains some non-standard elements.

<img width="928" alt="Screenshot 2021-06-18 at 08 11 17" src="https://user-images.githubusercontent.com/71320230/122514920-f562a600-d00c-11eb-8304-25dcc3d86449.png">
