### PR TITLE
Make sidebar date wrap on a new line 

### DIFF
--- a/packages/app/src/components/sidebar-metric/sidebar-kpi-value.tsx
+++ b/packages/app/src/components/sidebar-metric/sidebar-kpi-value.tsx
@@ -1,10 +1,10 @@
+import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
 import { isDefined } from 'ts-is-present';
 import { ValueAnnotation } from '~/components/value-annotation';
-import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
+import { useIntl } from '~/intl';
 import { Box } from '../base';
 import { SidebarDifference } from '../difference-indicator';
 import { Heading, InlineText } from '../typography';
-import { useIntl } from '~/intl';
 
 type SidebarKpiValueProps = {
   title: string;
@@ -36,7 +36,12 @@ export function SidebarKpiValue(props: SidebarKpiValueProps) {
       <Heading level={4} fontSize={2} fontWeight="normal" m={0} as="div">
         {title}
       </Heading>
-      <Box display="flex" alignItems="center" justifyContent="flex-start">
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="flex-start"
+        flexWrap="wrap"
+      >
         {isDefined(value) && (
           <InlineText
             fontSize={3}


### PR DESCRIPTION
Now when the value in the sidebar gets too big and the date doesn't fit next to it anymore, it jumps to a new line.

Screenshot:
<img width="364" alt="Screenshot 2021-06-18 at 09 29 27" src="https://user-images.githubusercontent.com/76471292/122523774-ae2de280-d017-11eb-982e-83d50cc079d2.png">
