### PR TITLE
Fix g-number chart handling only negative numbers

### DIFF
--- a/packages/app/src/components/vertical-bar-chart/logic/series.tsx
+++ b/packages/app/src/components/vertical-bar-chart/logic/series.tsx
@@ -107,8 +107,11 @@ export function calculateSeriesExtremes<T extends TimestampedValue>(
      * The max needs to be clipped to a positive number, because otherwise
      * things get messed up with only negative values. We add a minimum of 10 to
      * always have a part of the y-axis with positive values.
+     *
+     * Adding a similar fix for when only positive numbers are used, but let's
+     * hope we never reach that point.
      */
     max: Math.max(...extremeValues, 10),
-    min: Math.min(...extremeValues),
+    min: Math.min(...extremeValues, -10),
   };
 }

--- a/packages/app/src/components/vertical-bar-chart/logic/series.tsx
+++ b/packages/app/src/components/vertical-bar-chart/logic/series.tsx
@@ -3,8 +3,8 @@ import {
   isDateSpanSeries,
   TimestampedValue,
 } from '@corona-dashboard/common';
-import { useMemo } from 'react';
 import { pick } from 'lodash';
+import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { SeriesSingleValue } from '~/components/time-series-chart/logic/series';
 
@@ -103,7 +103,12 @@ export function calculateSeriesExtremes<T extends TimestampedValue>(
     .flat();
 
   return {
-    max: Math.max(...extremeValues),
+    /**
+     * The max needs to be clipped to a positive number, because otherwise
+     * things get messed up with only negative values. We add a minimum of 10 to
+     * always have a part of the y-axis with positive values.
+     */
+    max: Math.max(...extremeValues, 10),
     min: Math.min(...extremeValues),
   };
 }


### PR DESCRIPTION
## Summary

This fix makes the g-number chart render correctly when only negative numbers are used as input.

<img width="939" alt="Screenshot 2021-06-18 at 11 57 10" src="https://user-images.githubusercontent.com/71320230/122544382-0a4f3180-d02d-11eb-8c52-f51f310629fb.png">
