### PR TITLE
Release 2.22.5

### DIFF
--- a/packages/app/src/components/vertical-bar-chart/logic/series.tsx
+++ b/packages/app/src/components/vertical-bar-chart/logic/series.tsx
@@ -3,8 +3,8 @@ import {
   isDateSpanSeries,
   TimestampedValue,
 } from '@corona-dashboard/common';
-import { useMemo } from 'react';
 import { pick } from 'lodash';
+import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { SeriesSingleValue } from '~/components/time-series-chart/logic/series';
 
@@ -103,7 +103,15 @@ export function calculateSeriesExtremes<T extends TimestampedValue>(
     .flat();
 
   return {
-    max: Math.max(...extremeValues),
-    min: Math.min(...extremeValues),
+    /**
+     * The max needs to be clipped to a positive number, because otherwise
+     * things get messed up with only negative values. We add a minimum of 10 to
+     * always have a part of the y-axis with positive values.
+     *
+     * Adding a similar fix for when only positive numbers are used, but let's
+     * hope we never reach that point.
+     */
+    max: Math.max(...extremeValues, 10),
+    min: Math.min(...extremeValues, -10),
   };
 }


### PR DESCRIPTION
* Fix g-number chart handling only negative numbers (#3020)
