### PR TITLE
Set correct segments and add value annotation

### DIFF
--- a/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
+++ b/packages/app/src/components/sewer-chart/new-sewer-chart.tsx
@@ -28,13 +28,13 @@ export function NewSewerChart({
     };
     selectPlaceholder?: string;
     splitLabels: {
-      waarde_0_200: string;
-      waarde_200_400: string;
-      waarde_400_600: string;
-      waarde_600_800: string;
-      waarde_800_plus: string;
+      segment_0: string;
+      segment_1: string;
+      segment_2: string;
+      segment_3: string;
     };
     averagesDataLabel: string;
+    valueAnnotation: string;
   };
 }) {
   const {
@@ -60,29 +60,24 @@ export function NewSewerChart({
 
   const averageSplitPoints = [
     {
-      value: 200,
+      value: 10,
       color: colors.data.scale.blue[0],
-      label: text.splitLabels.waarde_0_200,
+      label: text.splitLabels.segment_0,
     },
     {
-      value: 400,
+      value: 50,
       color: colors.data.scale.blue[1],
-      label: text.splitLabels.waarde_200_400,
+      label: text.splitLabels.segment_1,
     },
     {
-      value: 600,
+      value: 100,
       color: colors.data.scale.blue[2],
-      label: text.splitLabels.waarde_400_600,
-    },
-    {
-      value: 800,
-      color: colors.data.scale.blue[3],
-      label: text.splitLabels.waarde_600_800,
+      label: text.splitLabels.segment_2,
     },
     {
       value: Infinity,
-      color: colors.data.scale.blue[4],
-      label: text.splitLabels.waarde_800_plus,
+      color: colors.data.scale.blue[3],
+      label: text.splitLabels.segment_3,
     },
   ];
 
@@ -139,6 +134,7 @@ export function NewSewerChart({
                   },
                 ]}
                 formatTooltip={(data) => <LocationTooltip data={data} />}
+                dataOptions={{ valueAnnotation: text.valueAnnotation }}
               />
             ) : (
               <TimeSeriesChart
@@ -152,6 +148,7 @@ export function NewSewerChart({
                     splitPoints: averageSplitPoints,
                   },
                 ]}
+                dataOptions={{ valueAnnotation: text.valueAnnotation }}
               />
             )
           }

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -202,6 +202,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 selectPlaceholder: text.graph_selected_rwzi_placeholder,
                 splitLabels: siteText.rioolwater_metingen.split_labels,
                 averagesDataLabel: siteText.common.weekgemiddelde,
+                valueAnnotation: siteText.waarde_annotaties.riool_normalized,
               }}
             />
           ) : (

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -2,7 +2,7 @@ import {
   MunicipalityProperties,
   MunicipalSewerValue,
   RegionalSewerValue,
-  SafetyRegionProperties
+  SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import { useState } from 'react';
 import ExperimenteelIcon from '~/assets/experimenteel.svg';
@@ -33,13 +33,13 @@ import { useFeature } from '~/lib/features';
 import { createPageArticlesQuery } from '~/queries/create-page-articles-query';
 import {
   createGetStaticProps,
-  StaticProps
+  StaticProps,
 } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
   createGetContent,
   getLastGeneratedDate,
-  selectNlPageMetricData
+  selectNlPageMetricData,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
@@ -167,6 +167,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 description: text.linechart_description,
                 splitLabels: siteText.rioolwater_metingen.split_labels,
                 averagesDataLabel: siteText.common.weekgemiddelde,
+                valueAnnotation: siteText.waarde_annotaties.riool_normalized,
               }}
             />
           ) : (

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -162,6 +162,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 selectPlaceholder: text.graph_selected_rwzi_placeholder,
                 splitLabels: siteText.rioolwater_metingen.split_labels,
                 averagesDataLabel: siteText.common.weekgemiddelde,
+                valueAnnotation: siteText.waarde_annotaties.riool_normalized,
               }}
             />
           ) : (

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -76,3 +76,12 @@ timestamp,action,key
 2021-06-16T14:52:36.093Z,add,covid_varianten.varianten_tabel.verschil.gelijk
 2021-06-18T06:09:22.572Z,add,waarde_annotaties.per_100_000_inwoners
 2021-06-18T10:02:49.320Z,delete,over_risiconiveaus.scoreboard.sort_option.location_z_to_a
+2021-06-18T12:48:34.141Z,add,rioolwater_metingen.split_labels.segment_0
+2021-06-18T12:48:35.161Z,add,rioolwater_metingen.split_labels.segment_1
+2021-06-18T12:48:36.089Z,add,rioolwater_metingen.split_labels.segment_2
+2021-06-18T12:48:37.106Z,add,rioolwater_metingen.split_labels.segment_3
+2021-06-18T12:50:25.164Z,delete,rioolwater_metingen.split_labels.waarde_400_600
+2021-06-18T12:50:25.164Z,delete,rioolwater_metingen.split_labels.waarde_200_400
+2021-06-18T12:50:25.165Z,delete,rioolwater_metingen.split_labels.waarde_600_800
+2021-06-18T12:50:25.165Z,delete,rioolwater_metingen.split_labels.waarde_800_plus
+2021-06-18T12:50:25.165Z,delete,rioolwater_metingen.split_labels.waarde_0_200


### PR DESCRIPTION
## Summary

Sets correct thresholds for the sewer split chart and add missing value annotation.

<img width="935" alt="Screenshot 2021-06-18 at 14 57 26" src="https://user-images.githubusercontent.com/71320230/122564552-c7e61e80-d045-11eb-9c34-a1b99ae41237.png">
