### PR TITLE
Variants table QA tweaks

### DIFF
--- a/packages/app/src/components/percentage-bar.tsx
+++ b/packages/app/src/components/percentage-bar.tsx
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import { css } from '@styled-system/css';
+import styled from 'styled-components';
 
 interface PercentageProps {
   percentage: number;
@@ -17,6 +17,7 @@ const Bar = styled.div<{ height?: number | string }>((x) =>
   css({
     backgroundColor: 'currentcolor',
     height: x.height ?? '0.8em',
+    minWidth: '2px',
   })
 );
 

--- a/packages/app/src/domain/variants/logic/mock-data.ts
+++ b/packages/app/src/domain/variants/logic/mock-data.ts
@@ -29,7 +29,7 @@ function getVariantsDataValue(date_end_unix: number) {
     kappa_percentage: randomNumberFromTo(1, 100),
     kappa_occurrence: randomNumberFromTo(100, 1000),
     kappa_is_variant_of_concern: Math.random() > 0.5,
-    other_percentage: randomNumberFromTo(1, 100),
+    other_percentage: 0,
     other_occurrence: randomNumberFromTo(100, 1000),
     other_is_variant_of_concern: Math.random() > 0.5,
     sample_size: randomNumberFromTo(100, 1000),

--- a/packages/app/src/domain/variants/variants-table-tile/components/desktop-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/desktop-variants-table.tsx
@@ -13,10 +13,10 @@ import { VariantRow } from '../logic/use-variants-table-data';
 
 const columnKeys = [
   'variant_titel',
-  'eerst_gevonden',
-  'aantal_monsters',
   'percentage',
   'vorige_meeting',
+  'aantal_monsters',
+  'eerst_gevonden',
 ] as const;
 
 type DesktopVariantsTableProps = {
@@ -43,7 +43,13 @@ export function DesktopVariantsTable(props: DesktopVariantsTableProps) {
           <tr key={row.variant}>
             <VariantNameCell variant={row.variant} text={text} />
             <Cell>
-              <InlineText>{row.countryOfOrigin}</InlineText>
+              <PercentageBarWithNumber
+                percentage={row.percentage}
+                color={row.color}
+              />
+            </Cell>
+            <Cell>
+              {row.difference && <VariantDifference value={row.difference} />}
             </Cell>
             <Cell>
               <NumberOfSamples
@@ -52,13 +58,7 @@ export function DesktopVariantsTable(props: DesktopVariantsTableProps) {
               />
             </Cell>
             <Cell>
-              <PercentageBarWithNumber
-                percentage={row.percentage}
-                color={row.color}
-              />
-            </Cell>
-            <Cell>
-              {row.difference && <VariantDifference value={row.difference} />}
+              <InlineText>{row.countryOfOrigin}</InlineText>
             </Cell>
           </tr>
         ))}

--- a/packages/app/src/domain/variants/variants-table-tile/components/desktop-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/desktop-variants-table.tsx
@@ -1,3 +1,4 @@
+import { Box } from '~/components/base';
 import { InlineText } from '~/components/typography';
 import { SiteText } from '~/locale';
 import {
@@ -43,10 +44,12 @@ export function DesktopVariantsTable(props: DesktopVariantsTableProps) {
           <tr key={row.variant}>
             <VariantNameCell variant={row.variant} text={text} />
             <Cell>
-              <PercentageBarWithNumber
-                percentage={row.percentage}
-                color={row.color}
-              />
+              <Box maxWidth="20em">
+                <PercentageBarWithNumber
+                  percentage={row.percentage}
+                  color={row.color}
+                />
+              </Box>
             </Cell>
             <Cell>
               {row.difference && <VariantDifference value={row.difference} />}

--- a/packages/app/src/domain/variants/variants-table-tile/components/mobile-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/mobile-variants-table.tsx
@@ -62,7 +62,7 @@ function MobileVariantRow(props: MobileVariantRowProps) {
 
   function handleRowClick(event: MouseEvent) {
     if (event.target !== chevronRef.current) {
-      chevronRef.current?.click();
+      setIsOpen((x) => !x);
     }
   }
 
@@ -126,7 +126,7 @@ const Chevron = styled(
     alignItems: 'flex-end',
     m: 0,
     p: 0,
-    py: 2,
+    pb: 3,
     overflow: 'visible',
     bg: 'transparent',
     border: 'none',

--- a/packages/app/src/domain/variants/variants-table-tile/components/mobile-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/mobile-variants-table.tsx
@@ -4,7 +4,7 @@ import {
   DisclosurePanel,
 } from '@reach/disclosure';
 import css from '@styled-system/css';
-import { useState } from 'react';
+import { forwardRef, MouseEvent, useRef, useState } from 'react';
 import styled from 'styled-components';
 import useResizeObserver from 'use-resize-observer';
 import { Box } from '~/components/base';
@@ -58,9 +58,17 @@ function MobileVariantRow(props: MobileVariantRowProps) {
   const { ref, height: contentHeight } = useResizeObserver();
   const columnNames = text.varianten_tabel.kolommen;
 
+  const chevronRef = useRef<HTMLButtonElement>();
+
+  function handleRowClick(event: MouseEvent) {
+    if (event.target !== chevronRef.current) {
+      chevronRef.current?.click();
+    }
+  }
+
   return (
     <>
-      <tr>
+      <tr onClick={handleRowClick}>
         <VariantNameCell variant={row.variant} text={text} compact />
         <Cell>
           <PercentageBarWithNumber
@@ -68,14 +76,14 @@ function MobileVariantRow(props: MobileVariantRowProps) {
             color={row.color}
           />
         </Cell>
-        <Cell style={{ maxWidth: '1.2rem' }}>
+        <Cell alignRight>
           <Disclosure
             open={isOpen}
             onChange={() => {
               setIsOpen((x) => !x);
             }}
           >
-            <Chevron />
+            <Chevron ref={chevronRef as any} />
           </Disclosure>
         </Cell>
       </tr>
@@ -110,19 +118,20 @@ function MobileVariantRow(props: MobileVariantRowProps) {
   );
 }
 
-const Chevron = styled((props) => <DisclosureButton {...props} />)(
+const Chevron = styled(
+  forwardRef((props, ref) => <DisclosureButton {...(props as any)} ref={ref} />)
+)(
   css({
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'flex-end',
     m: 0,
-    pr: 4,
+    p: 0,
     py: 2,
     overflow: 'visible',
     bg: 'transparent',
     border: 'none',
     color: 'lightGray',
     fontSize: '1.25rem',
-    position: 'relative',
     cursor: 'pointer',
 
     '&::after': {
@@ -131,7 +140,7 @@ const Chevron = styled((props) => <DisclosureButton {...props} />)(
       backgroundRepeat: 'no-repeat',
       backgroundSize: '0.9em 0.55em',
       content: '""',
-      flex: '0 0 0.9em',
+      width: '0.9em',
       height: '0.55em',
       mt: '0.35em',
       p: 0,

--- a/packages/app/src/domain/variants/variants-table-tile/components/number-of-samples.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/number-of-samples.tsx
@@ -12,8 +12,8 @@ export function NumberOfSamples({
 
   return (
     <>
-      <InlineText fontWeight="bold">{formatNumber(occurrence)}</InlineText>
-      <InlineText>/{formatNumber(sampleSize)}</InlineText>
+      <InlineText fontWeight="bold">{formatNumber(occurrence)}</InlineText>/
+      <InlineText>{formatNumber(sampleSize)}</InlineText>
     </>
   );
 }

--- a/packages/app/src/domain/variants/variants-table-tile/components/shared-table-components.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/shared-table-components.tsx
@@ -17,10 +17,15 @@ export const HeaderCell = styled.th(
   })
 );
 
-export const Cell = styled.td<{ compact?: boolean; border?: boolean }>((x) =>
+export const Cell = styled.td<{
+  compact?: boolean;
+  border?: boolean;
+  alignRight?: boolean;
+}>((x) =>
   css({
     p: 0,
     py: 2,
+    float: x.alignRight ? 'right' : undefined,
     maxWidth: x.compact ? '2rem' : undefined,
     borderBottom: x.border ? '1px solid' : undefined,
     borderBottomColor: x.border ? 'lightGray' : undefined,

--- a/packages/app/src/domain/variants/variants-table-tile/components/shared-table-components.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/shared-table-components.tsx
@@ -14,6 +14,7 @@ export const HeaderCell = styled.th(
     fontWeight: 'normal',
     borderBottom: '1px solid',
     borderBottomColor: 'lightGray',
+    verticalAlign: 'top',
   })
 );
 
@@ -29,5 +30,6 @@ export const Cell = styled.td<{
     maxWidth: x.compact ? '2rem' : undefined,
     borderBottom: x.border ? '1px solid' : undefined,
     borderBottomColor: x.border ? 'lightGray' : undefined,
+    verticalAlign: 'top',
   })
 );

--- a/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import Gelijk from '~/assets/gelijk.svg';
 import PijlOmhoog from '~/assets/pijl-omhoog.svg';
 import PijlOmlaag from '~/assets/pijl-omlaag.svg';
+import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 
@@ -23,7 +24,8 @@ export function VariantDifference({ value }: { value: DifferenceDecimal }) {
     return (
       <Difference color={colors.body}>
         <PijlOmhoog />
-        {formatPercentage(value.difference, options)}% {diffText.meer}
+        <InlineText>{formatPercentage(value.difference, options)}% </InlineText>
+        <InlineText>{diffText.meer}</InlineText>
       </Difference>
     );
   }
@@ -31,7 +33,10 @@ export function VariantDifference({ value }: { value: DifferenceDecimal }) {
     return (
       <Difference color={colors.body}>
         <PijlOmlaag />
-        {formatPercentage(-value.difference, options)}% {diffText.minder}
+        <InlineText>
+          {formatPercentage(-value.difference, options)}%{' '}
+        </InlineText>
+        <InlineText>{diffText.minder}</InlineText>
       </Difference>
     );
   }
@@ -43,11 +48,8 @@ export function VariantDifference({ value }: { value: DifferenceDecimal }) {
   );
 }
 
-const Difference = styled.span<{ color: string }>((x) =>
+const Difference = styled.div<{ color: string }>((x) =>
   css({
-    whiteSpace: 'nowrap',
-    display: 'inline-block',
-
     svg: {
       color: x.color,
       mr: 1,

--- a/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import Gelijk from '~/assets/gelijk.svg';
 import PijlOmhoog from '~/assets/pijl-omhoog.svg';
 import PijlOmlaag from '~/assets/pijl-omlaag.svg';
-import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 
@@ -24,8 +23,7 @@ export function VariantDifference({ value }: { value: DifferenceDecimal }) {
     return (
       <Difference color={colors.body}>
         <PijlOmhoog />
-        <InlineText>{formatPercentage(value.difference, options)}% </InlineText>
-        <InlineText>{diffText.meer}</InlineText>
+        {formatPercentage(value.difference, options)}% {diffText.meer}
       </Difference>
     );
   }
@@ -33,10 +31,7 @@ export function VariantDifference({ value }: { value: DifferenceDecimal }) {
     return (
       <Difference color={colors.body}>
         <PijlOmlaag />
-        <InlineText>
-          {formatPercentage(-value.difference, options)}%{' '}
-        </InlineText>
-        <InlineText>{diffText.minder}</InlineText>
+        {formatPercentage(-value.difference, options)}% {diffText.minder}
       </Difference>
     );
   }


### PR DESCRIPTION
## Summary

- Changed the column order on desktop view
- Added a min-width of 2px to the percentage chart so that very small percentages are still visible
- Added a max-width of 20em to the percentage chart
- On mobile the entire row is now clickable. I've had to jump through a few hoops there in order to keep the Disclosure button in (we want to use that for its accessibility features), so if you're wondering why I'm fiddling with a forwardRef there. Well, that's why.
- Aligned the chevron to the right on mobile view.
- Gave all cells and headers a top vertical alignment so things look nice when content is wrapping.

## Motivation

QA comments.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
