### PR TITLE
Add a safeguard when a region collapsible has a null or not

### DIFF
--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -30,11 +30,11 @@ function EscalationLevelExplanation(props: EscalationLevelExplanationProps) {
   );
 }
 interface escalationLevelExplanationsProps {
-  hasUnknown: boolean;
+  hasUnknownLevel: boolean;
 }
 
 export function EscalationLevelExplanations({
-  hasUnknown,
+  hasUnknownLevel,
 }: escalationLevelExplanationsProps) {
   const { siteText } = useIntl();
 
@@ -59,7 +59,7 @@ export function EscalationLevelExplanations({
             explanation={siteText.escalatie_niveau.types['4'].toelichting}
           />
 
-          {hasUnknown && (
+          {hasUnknownLevel && (
             <EscalationLevelExplanation
               level={null}
               explanation={siteText.escalatie_niveau.types.onbekend.toelichting}

--- a/packages/app/src/domain/topical/escalation-level-explanations.tsx
+++ b/packages/app/src/domain/topical/escalation-level-explanations.tsx
@@ -1,12 +1,12 @@
 import css from '@styled-system/css';
 import { ArrowIconRight } from '~/components/arrow-icon';
 import { Box } from '~/components/base';
+import { CollapsibleButton } from '~/components/collapsible';
 import { EscalationLevelInfoLabel } from '~/components/escalation-level';
 import { LinkWithIcon } from '~/components/link-with-icon';
 import { Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { EscalationLevel } from '../restrictions/type';
-import { CollapsibleButton } from '~/components/collapsible';
 
 type EscalationLevelExplanationProps = {
   level: EscalationLevel;
@@ -29,8 +29,13 @@ function EscalationLevelExplanation(props: EscalationLevelExplanationProps) {
     </Box>
   );
 }
+interface escalationLevelExplanationsProps {
+  hasUnknown: boolean;
+}
 
-export function EscalationLevelExplanations() {
+export function EscalationLevelExplanations({
+  hasUnknown,
+}: escalationLevelExplanationsProps) {
   const { siteText } = useIntl();
 
   return (
@@ -53,10 +58,14 @@ export function EscalationLevelExplanations() {
             level={4}
             explanation={siteText.escalatie_niveau.types['4'].toelichting}
           />
-          <EscalationLevelExplanation
-            level={null}
-            explanation={siteText.escalatie_niveau.types.onbekend.toelichting}
-          />
+
+          {hasUnknown && (
+            <EscalationLevelExplanation
+              level={null}
+              explanation={siteText.escalatie_niveau.types.onbekend.toelichting}
+            />
+          )}
+
           <Box my={4}>
             <LinkWithIcon
               href="/over-risiconiveaus"

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -6,9 +6,10 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { isEmpty } from 'lodash';
+import { isEmpty, some } from 'lodash';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { isPresent } from 'ts-is-present';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
 import { ArticleSummary } from '~/components/article-teaser';
@@ -360,11 +361,10 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
 
               <Box mt={4}>
                 <EscalationLevelExplanations
-                  hasUnknown={
-                    choropleth.vr.escalation_levels.filter(
-                      (item) => item.level === null
-                    ).length > 0
-                  }
+                  hasUnknownLevel={some(
+                    choropleth.vr.escalation_levels,
+                    (x) => !isPresent(x)
+                  )}
                 />
               </Box>
             </TopicalTile>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -359,7 +359,13 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
               </ChoroplethTwoColumnLayout>
 
               <Box mt={4}>
-                <EscalationLevelExplanations />
+                <EscalationLevelExplanations
+                  hasUnknown={
+                    choropleth.vr.escalation_levels.filter(
+                      (item) => item.level === null
+                    ).length > 0
+                  }
+                />
               </Box>
             </TopicalTile>
 

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -6,9 +6,10 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { isEmpty } from 'lodash';
+import { isEmpty, some } from 'lodash';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import { isPresent } from 'ts-is-present';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
 import { ArticleSummary } from '~/components/article-teaser';
@@ -324,11 +325,10 @@ const TopicalSafetyRegion = (props: StaticProps<typeof getStaticProps>) => {
 
               <Box mt={4}>
                 <EscalationLevelExplanations
-                  hasUnknown={
-                    choropleth.vr.escalation_levels.filter(
-                      (item) => item.level === null
-                    ).length > 0
-                  }
+                  hasUnknownLevel={some(
+                    choropleth.vr.escalation_levels,
+                    (x) => !isPresent(x)
+                  )}
                 />
               </Box>
             </TopicalTile>

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -323,7 +323,13 @@ const TopicalSafetyRegion = (props: StaticProps<typeof getStaticProps>) => {
               </ChoroplethTwoColumnLayout>
 
               <Box mt={4}>
-                <EscalationLevelExplanations />
+                <EscalationLevelExplanations
+                  hasUnknown={
+                    choropleth.vr.escalation_levels.filter(
+                      (item) => item.level === null
+                    ).length > 0
+                  }
+                />
               </Box>
             </TopicalTile>
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -8,6 +8,7 @@ import {
 import css from '@styled-system/css';
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
+import GrafiekIcon from '~/assets/chart.svg';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
 import { ArticleSummary } from '~/components/article-teaser';
@@ -64,9 +65,8 @@ import {
 import { createDate } from '~/utils/create-date';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
-import { useReverseRouter } from '~/utils/use-reverse-router';
-import GrafiekIcon from '~/assets/chart.svg';
 import { useEscalationColor } from '~/utils/use-escalation-color';
+import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -284,7 +284,13 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
               </ChoroplethTwoColumnLayout>
 
               <Box mt={4}>
-                <EscalationLevelExplanations />
+                <EscalationLevelExplanations
+                  hasUnknown={
+                    choropleth.vr.escalation_levels.filter(
+                      (item) => item.level === null
+                    ).length > 0
+                  }
+                />
               </Box>
             </TopicalTile>
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -6,8 +6,9 @@ import {
   SafetyRegionProperties,
 } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { isEmpty } from 'lodash';
+import { isEmpty, some } from 'lodash';
 import { useState } from 'react';
+import { isPresent } from 'ts-is-present';
 import GrafiekIcon from '~/assets/chart.svg';
 import GetestIcon from '~/assets/test.svg';
 import ZiekenhuisIcon from '~/assets/ziekenhuis.svg';
@@ -285,11 +286,10 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
 
               <Box mt={4}>
                 <EscalationLevelExplanations
-                  hasUnknown={
-                    choropleth.vr.escalation_levels.filter(
-                      (item) => item.level === null
-                    ).length > 0
-                  }
+                  hasUnknownLevel={some(
+                    choropleth.vr.escalation_levels,
+                    (x) => !isPresent(x)
+                  )}
                 />
               </Box>
             </TopicalTile>


### PR DESCRIPTION
On the live site, it shows an "Onbekend" in the collapsible. Didn't want to remove the functionality completely so I've added a check when one or more region includes a `null` in the data, it should show depending on that. (and then we can add the appreciate text in Lokalise for example if needed).

Problem:
![Screenshot 2021-06-22 at 16 48 15](https://user-images.githubusercontent.com/76471292/122946437-a5237500-d379-11eb-9728-e40758e1eab7.png)
