### PR TITLE
Make non icon value in tooltip align to the left

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -172,7 +172,7 @@ function TooltipListItem({
   ) : (
     <Box
       as="li"
-      spacing={2}
+      spacing={icon ? 2 : 0}
       spacingHorizontal
       display="flex"
       alignItems="stretch"
@@ -195,7 +195,7 @@ function TooltipListItem({
               {icon}
             </Box>
           ) : (
-            <Box width="1em" mt={1} />
+            <Box width={0} mt={1} />
           )}
           <Box flexGrow={1}>
             <TooltipEntryContainer>

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list.tsx
@@ -190,12 +190,10 @@ function TooltipListItem({
         </Box>
       ) : (
         <>
-          {icon ? (
+          {icon && (
             <Box flexShrink={0} display="flex" alignItems="baseline" mt={1}>
               {icon}
             </Box>
-          ) : (
-            <Box width={0} mt={1} />
           )}
           <Box flexGrow={1}>
             <TooltipEntryContainer>

--- a/packages/app/src/domain/variants/logic/mock-data.ts
+++ b/packages/app/src/domain/variants/logic/mock-data.ts
@@ -32,7 +32,7 @@ function getVariantsDataValue(date_end_unix: number) {
     kappa_percentage: randomNumberFromTo(randomNumberFrom, randomNumberTo),
     kappa_occurrence: randomNumberFromTo(100, 1000),
     kappa_is_variant_of_concern: Math.random() > 0.5,
-    other_percentage: 0,
+    other_percentage: randomNumberFromTo(randomNumberFrom, randomNumberTo),
     other_occurrence: randomNumberFromTo(100, 1000),
     other_is_variant_of_concern: Math.random() > 0.5,
     sample_size: randomNumberFromTo(100, 1000),


### PR DESCRIPTION
Currently, when there is no icon selected the text will be aligned all the same in the tooltip. By this change, it will be aligned with the icons on the far left. The request was by changing it in the variants over time graph but I'm in favor of applying it everywhere where this pattern has been used.

**See example screenshots where the change is also applicable.**
<img width="196" alt="Screenshot 2021-06-23 at 08 22 51" src="https://user-images.githubusercontent.com/76471292/123047050-1b1cf000-d3fd-11eb-917e-85eb1525c525.png">
<img width="342" alt="Screenshot 2021-06-23 at 08 21 07" src="https://user-images.githubusercontent.com/76471292/123047053-1ce6b380-d3fd-11eb-862a-460705839064.png">
<img width="347" alt="Screenshot 2021-06-23 at 08 20 51" src="https://user-images.githubusercontent.com/76471292/123047056-1d7f4a00-d3fd-11eb-989b-fcc3c59a41f3.png">
