### PR TITLE
Fix empty attachment link handling

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -79,6 +79,8 @@ function InlineAttachmentMark(props: {
   children: ReactNode;
   mark: InlineAttachment;
 }) {
+  if (!props.mark.asset) return <>{props.children}</>;
+
   return (
     <a download href={getFileSrc(props.mark.asset)}>
       {props.children}
@@ -89,7 +91,7 @@ function InlineAttachmentMark(props: {
 function InlineLinkMark(props: { children: ReactNode; mark: InlineLink }) {
   const { mark, children } = props;
 
-  if (!mark.href) return null;
+  if (!mark.href) return <>{children}</>;
 
   return isAbsoluteUrl(mark.href) ? (
     <ExternalLink href={mark.href}>{children}</ExternalLink>

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -30,7 +30,7 @@ export interface SanityImageProps {
 
 export interface InlineAttachment {
   _type: 'inlineAttachment';
-  asset: SanityFileProps;
+  asset?: SanityFileProps;
 }
 
 export type Editorial = Record<string, never> & Article;


### PR DESCRIPTION
Apparently Sanity allows attachment links to link to an undefined asset. The changes in this PR won't validate that weird input but it will just render plain text when it sees no attached asset.
