### PR TITLE
Fix article list rendering

### DIFF
--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -1,5 +1,4 @@
 import { ArrowIconLeft } from '~/components/arrow-icon';
-
 import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
 import { Heading, InlineText } from '~/components/typography';
@@ -9,6 +8,7 @@ import { ContentImage } from './cms/content-image';
 import { RichContent } from './cms/rich-content';
 import { LinkWithIcon } from './link-with-icon';
 import { PublicationDate } from './publication-date';
+
 interface ArticleDetailProps {
   article: Article;
 }
@@ -48,13 +48,14 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
       </ContentBlock>
 
       {!!article.content?.length && (
-        <Box fontSize="1.125rem">
-          <RichContent
-            blocks={article.content}
-            contentWrapper={ContentBlock}
-            imageSizes={imageSizes}
-          />
-        </Box>
+        <ContentBlock>
+          <Box fontSize="1.125rem">
+            <RichContent
+              blocks={article.content}
+              contentWrapper={ContentBlock}
+            />
+          </Box>
+        </ContentBlock>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary

Wrap article content in `ContentBlock ` as well to make sure that lists are rendered nicely in the middle of the page instead of all the way to the left.

## Motivation

Bug fix

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
