### PR TITLE
Decrease top navigation font size

### DIFF
--- a/packages/app/src/components/layout/components/top-navigation.tsx
+++ b/packages/app/src/components/layout/components/top-navigation.tsx
@@ -195,7 +195,7 @@ const NavLink = styled.a<{ isActive: boolean }>((x) =>
     display: 'block',
     whiteSpace: 'nowrap',
     textDecoration: 'none',
-    fontSize: '1.1rem',
+    fontSize: '1rem',
     color: 'white',
 
     // The span is a narrower element to position the underline to


### PR DESCRIPTION
This allows the EN top navigation to fit without breakpoint troubles.