### PR TITLE
Change how dates are displayed on variants sidebar and table

### DIFF
--- a/packages/app/src/domain/variants/variants-sidebar-metric.tsx
+++ b/packages/app/src/domain/variants/variants-sidebar-metric.tsx
@@ -28,8 +28,9 @@ export function VariantsSidebarMetric({ data }: VariantsSidebarMetricProps) {
     (x) => x.value
   );
 
-  const dateText = replaceVariablesInText(commonText.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(data.date_end_unix, 'medium'),
+  const dateText = replaceVariablesInText(commonText.dateRangeOfReport, {
+    startDate: formatDateFromSeconds(data.date_start_unix, 'axis'),
+    endDate: formatDateFromSeconds(data.date_end_unix, 'axis'),
   });
 
   return (

--- a/packages/app/src/domain/variants/variants-table-tile/index.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/index.tsx
@@ -31,8 +31,9 @@ export function VariantsTableTile({
   );
 
   const metadata: MetadataProps = {
-    date: data.date_of_insertion_unix,
+    date: [data.date_start_unix, data.date_end_unix],
     source: text.bronnen.rivm,
+    obtained: data.date_of_insertion_unix,
   };
 
   return (


### PR DESCRIPTION
The dates on the variants page weren't correctly shown (the table and sidebar), this should be hotfixed to master today.

![Screenshot 2021-06-29 at 10 21 05](https://user-images.githubusercontent.com/76471292/123763494-2623c480-d8c4-11eb-8ac2-f2b008d36ef3.png)
