### PR TITLE
Add schema for international tested overall

### DIFF
--- a/packages/app/schema/in/__index.json
+++ b/packages/app/schema/in/__index.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "in",
+  "required": ["last_generated", "proto_name", "code", "tested_overall"],
+  "additionalProperties": false,
+  "properties": {
+    "last_generated": {
+      "type": "string"
+    },
+    "proto_name": {
+      "type": "string",
+      "//": "We might want to use an enum here with country codes. We need the IN_ prefix for validation because all files end up in the same folder",
+      "pattern": "^IN_[A-Z]+$"
+    },
+    "country_code": {
+      "type": "string",
+      "const": { "$data": "1/proto_name" }
+    },
+    "tested_overall": {
+      "$ref": "tested_overall.json"
+    }
+  }
+}

--- a/packages/app/schema/in/__index.json
+++ b/packages/app/schema/in/__index.json
@@ -2,7 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "in",
-  "required": ["last_generated", "proto_name", "code", "tested_overall"],
+  "required": [
+    "last_generated",
+    "proto_name",
+    "country_code",
+    "tested_overall"
+  ],
   "additionalProperties": false,
   "properties": {
     "last_generated": {

--- a/packages/app/schema/in/__index.json
+++ b/packages/app/schema/in/__index.json
@@ -5,7 +5,8 @@
   "required": [
     "last_generated",
     "proto_name",
-    "country_code",
+    "name",
+    "code",
     "tested_overall"
   ],
   "additionalProperties": false,
@@ -18,9 +19,14 @@
       "//": "We might want to use an enum here with country codes. We need the IN_ prefix for validation because all files end up in the same folder",
       "pattern": "^IN_[A-Z]+$"
     },
-    "country_code": {
+    "name": {
       "type": "string",
       "const": { "$data": "1/proto_name" }
+    },
+    "code": {
+      "type": "string",
+      "//": "We might want to use an enum here with country codes. This would be the filename without the IN_ prefix, so the country ISO code",
+      "pattern": "^[A-Z]+$"
     },
     "tested_overall": {
       "$ref": "tested_overall.json"

--- a/packages/app/schema/in/tested_overall.json
+++ b/packages/app/schema/in/tested_overall.json
@@ -4,20 +4,20 @@
       "title": "in_tested_overall_value",
       "additionalProperties": false,
       "required": [
-        "date_unix",
-        "infected",
-        "infected_per_100k",
+        "infected_per_100k_average",
+        "date_start_unix",
+        "date_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
-        "date_unix": {
+        "infected_per_100k_average": {
+          "type": "number"
+        },
+        "date_start_unix": {
           "type": "integer"
         },
-        "infected": {
-          "type": "number"
-        },
-        "infected_per_100k": {
-          "type": "number"
+        "date_end_unix": {
+          "type": "integer"
         },
         "date_of_insertion_unix": {
           "type": "integer"

--- a/packages/app/schema/in/tested_overall.json
+++ b/packages/app/schema/in/tested_overall.json
@@ -4,12 +4,16 @@
       "title": "in_tested_overall_value",
       "additionalProperties": false,
       "required": [
+        "infected",
         "infected_per_100k_average",
         "date_start_unix",
         "date_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
+        "infected": {
+          "type": "integer"
+        },
         "infected_per_100k_average": {
           "type": "number"
         },

--- a/packages/app/schema/in/tested_overall.json
+++ b/packages/app/schema/in/tested_overall.json
@@ -1,0 +1,44 @@
+{
+  "definitions": {
+    "value": {
+      "title": "in_tested_overall_value",
+      "additionalProperties": false,
+      "required": [
+        "date_unix",
+        "infected",
+        "infected_per_100k",
+        "date_of_insertion_unix"
+      ],
+      "properties": {
+        "date_unix": {
+          "type": "integer"
+        },
+        "infected": {
+          "type": "number"
+        },
+        "infected_per_100k": {
+          "type": "number"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "in_tested_overall",
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  }
+}

--- a/packages/app/schema/in/tested_overall.json
+++ b/packages/app/schema/in/tested_overall.json
@@ -4,14 +4,14 @@
       "title": "in_tested_overall_value",
       "additionalProperties": false,
       "required": [
-        "infected_average",
+        "infected",
         "infected_per_100k_average",
         "date_start_unix",
         "date_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
-        "infected_average": {
+        "infected": {
           "type": "integer"
         },
         "infected_per_100k_average": {

--- a/packages/app/schema/in/tested_overall.json
+++ b/packages/app/schema/in/tested_overall.json
@@ -4,14 +4,14 @@
       "title": "in_tested_overall_value",
       "additionalProperties": false,
       "required": [
-        "infected",
+        "infected_average",
         "infected_per_100k_average",
         "date_start_unix",
         "date_end_unix",
         "date_of_insertion_unix"
       ],
       "properties": {
-        "infected": {
+        "infected_average": {
           "type": "integer"
         },
         "infected_per_100k_average": {

--- a/packages/app/schema/in_collection/__index.json
+++ b/packages/app/schema/in_collection/__index.json
@@ -3,7 +3,13 @@
   "type": "object",
   "title": "in_collection",
   "additionalProperties": false,
-  "required": ["last_generated", "proto_name", "tested_overall"],
+  "required": [
+    "last_generated",
+    "proto_name",
+    "name",
+    "code",
+    "tested_overall"
+  ],
   "properties": {
     "last_generated": {
       "type": "string"
@@ -11,6 +17,14 @@
     "proto_name": {
       "type": "string",
       "enum": ["IN_COLLECTION"]
+    },
+    "name": {
+      "type": "string",
+      "const": { "$data": "1/proto_name" }
+    },
+    "code": {
+      "type": "string",
+      "const": { "$data": "1/proto_name" }
     },
     "tested_overall": {
       "type": "array",

--- a/packages/app/schema/in_collection/__index.json
+++ b/packages/app/schema/in_collection/__index.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "in_collection",
+  "additionalProperties": false,
+  "required": ["last_generated", "proto_name", "tested_overall"],
+  "properties": {
+    "last_generated": {
+      "type": "string"
+    },
+    "proto_name": {
+      "type": "string",
+      "enum": ["IN_COLLECTION"]
+    },
+    "tested_overall": {
+      "type": "array",
+      "//": "@TODO set min/maxItems to the number of countries",
+      "minItems": 0,
+      "maxItems": 999,
+      "items": {
+        "$ref": "tested_overall.json"
+      }
+    }
+  }
+}

--- a/packages/app/schema/in_collection/tested_overall.json
+++ b/packages/app/schema/in_collection/tested_overall.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "required": [
     "country_code",
-    "infected_average",
+    "infected",
     "infected_per_100k_average",
     "date_start_unix",
     "date_end_unix",
@@ -16,7 +16,7 @@
       "type": "string",
       "pattern": "^[A-Z]+$"
     },
-    "infected_average": {
+    "infected": {
       "type": "integer"
     },
     "infected_per_100k_average": {

--- a/packages/app/schema/in_collection/tested_overall.json
+++ b/packages/app/schema/in_collection/tested_overall.json
@@ -5,7 +5,7 @@
   "additionalProperties": false,
   "required": [
     "country_code",
-    "infected",
+    "infected_average",
     "infected_per_100k_average",
     "date_start_unix",
     "date_end_unix",
@@ -16,7 +16,7 @@
       "type": "string",
       "pattern": "^[A-Z]+$"
     },
-    "infected": {
+    "infected_average": {
       "type": "integer"
     },
     "infected_per_100k_average": {

--- a/packages/app/schema/in_collection/tested_overall.json
+++ b/packages/app/schema/in_collection/tested_overall.json
@@ -1,27 +1,27 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "title": "regions_tested_overall",
+  "title": "in_tested_overall",
   "additionalProperties": false,
   "required": [
-    "date_unix",
     "country_code",
-    "infected",
-    "infected_per_100k",
+    "infected_per_100k_average",
+    "date_start_unix",
+    "date_end_unix",
     "date_of_insertion_unix"
   ],
   "properties": {
-    "date_unix": {
-      "type": "integer"
-    },
     "country_code": {
       "type": "string",
       "pattern": "^[A-Z]+$"
     },
-    "infected_per_100k": {
+    "infected_per_100k_average": {
       "type": "number"
     },
-    "infected": {
+    "date_start_unix": {
+      "type": "integer"
+    },
+    "date_end_unix": {
       "type": "integer"
     },
     "date_of_insertion_unix": {

--- a/packages/app/schema/in_collection/tested_overall.json
+++ b/packages/app/schema/in_collection/tested_overall.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "regions_tested_overall",
+  "additionalProperties": false,
+  "required": [
+    "date_unix",
+    "country_code",
+    "infected",
+    "infected_per_100k",
+    "date_of_insertion_unix"
+  ],
+  "properties": {
+    "date_unix": {
+      "type": "integer"
+    },
+    "country_code": {
+      "type": "string",
+      "pattern": "^[A-Z]+$"
+    },
+    "infected_per_100k": {
+      "type": "number"
+    },
+    "infected": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
+    }
+  }
+}

--- a/packages/app/schema/in_collection/tested_overall.json
+++ b/packages/app/schema/in_collection/tested_overall.json
@@ -5,6 +5,7 @@
   "additionalProperties": false,
   "required": [
     "country_code",
+    "infected",
     "infected_per_100k_average",
     "date_start_unix",
     "date_end_unix",
@@ -14,6 +15,9 @@
     "country_code": {
       "type": "string",
       "pattern": "^[A-Z]+$"
+    },
+    "infected": {
+      "type": "integer"
     },
     "infected_per_100k_average": {
       "type": "number"

--- a/packages/cli/src/schema/schema-info.ts
+++ b/packages/cli/src/schema/schema-info.ts
@@ -26,6 +26,18 @@ export function getSchemaInfo(
   const fileList = fs.readdirSync(jsonDirectory);
 
   return {
+    in: {
+      files: getFileNames(fileList, /^IN_[A-Z]+.json$/),
+      basePath: jsonDirectory,
+      customValidations: [
+        createChoroplethValidation(
+          path.join(defaultJsonDirectory, 'IN_COLLECTION.json'),
+          'vrcode'
+        ),
+        validateMovingAverages,
+      ],
+    },
+    in_collection: { files: ['IN_COLLECTION.json'], basePath: jsonDirectory },
     nl: { files: ['NL.json'], basePath: jsonDirectory },
     vr: {
       files: getFileNames(fileList, /^VR[0-9]+.json$/),
@@ -38,6 +50,7 @@ export function getSchemaInfo(
         validateMovingAverages,
       ],
     },
+    vr_collection: { files: ['VR_COLLECTION.json'], basePath: jsonDirectory },
     gm: {
       files: getFileNames(fileList, /^GM[0-9]+.json$/),
       basePath: jsonDirectory,
@@ -50,6 +63,5 @@ export function getSchemaInfo(
       ],
     },
     gm_collection: { files: ['GM_COLLECTION.json'], basePath: jsonDirectory },
-    vr_collection: { files: ['VR_COLLECTION.json'], basePath: jsonDirectory },
   };
 }

--- a/packages/cli/src/schema/schema-info.ts
+++ b/packages/cli/src/schema/schema-info.ts
@@ -32,7 +32,7 @@ export function getSchemaInfo(
       customValidations: [
         createChoroplethValidation(
           path.join(defaultJsonDirectory, 'IN_COLLECTION.json'),
-          'vrcode'
+          'country_code'
         ),
         validateMovingAverages,
       ],

--- a/packages/common/src/domain/feature-flags/types.ts
+++ b/packages/common/src/domain/feature-flags/types.ts
@@ -40,8 +40,10 @@ export interface Feature {
 }
 
 export type MetricScope =
+  | 'in'
+  | 'in_collection'
   | 'nl'
   | 'vr'
-  | 'gm'
   | 'vr_collection'
+  | 'gm'
   | 'gm_collection';

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -153,7 +153,7 @@ export interface InTestedOverall {
   last_value: InTestedOverallValue;
 }
 export interface InTestedOverallValue {
-  infected_average: number;
+  infected: number;
   infected_per_100k_average: number;
   date_start_unix: number;
   date_end_unix: number;
@@ -167,7 +167,7 @@ export interface InCollection {
 }
 export interface InTestedOverall {
   country_code: string;
-  infected_average: number;
+  infected: number;
   infected_per_100k_average: number;
   date_start_unix: number;
   date_end_unix: number;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -145,7 +145,7 @@ export interface MunicipalitiesSewer {
 export interface In {
   last_generated: string;
   proto_name: string;
-  country_code?: string;
+  country_code: string;
   tested_overall: InTestedOverall;
 }
 export interface InTestedOverall {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -142,6 +142,38 @@ export interface MunicipalitiesSewer {
   date_of_insertion_unix: number;
 }
 
+export interface In {
+  last_generated: string;
+  proto_name: string;
+  country_code?: string;
+  tested_overall: InTestedOverall;
+}
+export interface InTestedOverall {
+  values: InTestedOverallValue[];
+  last_value: InTestedOverallValue;
+}
+export interface InTestedOverallValue {
+  infected_average: number;
+  infected_per_100k_average: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  date_of_insertion_unix: number;
+}
+
+export interface InCollection {
+  last_generated: string;
+  proto_name: "IN_COLLECTION";
+  tested_overall: InTestedOverall[];
+}
+export interface InTestedOverall {
+  country_code: string;
+  infected_average: number;
+  infected_per_100k_average: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  date_of_insertion_unix: number;
+}
+
 export interface National {
   last_generated: string;
   proto_name: "NL";


### PR DESCRIPTION
## Summary

These are the first schema definitions for international data. Currently only for `tested_overall.infected_per_100k` aka confirmed cases.

- Time series data is split into a single file per country, similar to what we do already with VR and GM
- Country files have a `IN_` prefix because everything ends up in one folder, and otherwise we have no way to pick out just the country specific files.
- Choropleth data is defined in IN_COLLECTION.json similar to what we do already with VR and GM

## TODO after this PR:

- Define a fixed list of countries and their codes, to enforce them in filenames via enum.