### PR TITLE
Reduce choropleth path length

### DIFF
--- a/packages/app/src/components/choropleth/choropleth.tsx
+++ b/packages/app/src/components/choropleth/choropleth.tsx
@@ -319,7 +319,20 @@ function MercatorGroup<G extends Geometry, P>(props: MercatorGroupProps<G, P>) {
       {({ features }) => (
         <g>
           {features.map(
-            ({ feature, path, index }) => path && render(feature, path, index)
+            ({ feature, path, index }) =>
+              path &&
+              render(
+                feature,
+                /**
+                 * Cut off an unnecessary level of detail of the paths strings.
+                 * A path value of `M177.08821511867188` becomes `M177`.
+                 */
+                path.replace(
+                  /\d+\.\d+/g,
+                  (x) => Math.round(parseFloat(x)) + ''
+                ),
+                index
+              )
           )}
         </g>
       )}


### PR DESCRIPTION
Cut off an unnecessary level of detail of the paths strings. A path value of `M177.08821511867188` becomes `M177`.
This change reduces the size of an entire (single language) export with ~800MB. Some pages are 60% down in size. The homepage is 50% down in size. 💥 ✨ 