### PR TITLE
Create markdown context dependent- and warning-component

### DIFF
--- a/packages/app/src/components/chart-tile.tsx
+++ b/packages/app/src/components/chart-tile.tsx
@@ -7,36 +7,6 @@ import { FullscreenChartTile } from './fullscreen-chart-tile';
 import { Markdown } from './markdown';
 import { MetadataProps } from './metadata';
 import { Heading } from './typography';
-interface ChartTileHeaderProps {
-  title: string;
-  description?: string;
-  children?: ReactNode;
-  descriptionIsMarkdown?: boolean;
-}
-
-function ChartTileHeader({
-  title,
-  description,
-  children,
-}: ChartTileHeaderProps) {
-  return (
-    <Box>
-      <Heading level={3}>{title}</Heading>
-      <Box>
-        {description && (
-          <Box maxWidth={560}>
-            <Markdown content={description} />
-          </Box>
-        )}
-        {children && (
-          <Box display="inline-table" alignSelf="flex-start" mb={3}>
-            {children}
-          </Box>
-        )}
-      </Box>
-    </Box>
-  );
-}
 
 type ChartTileProps = {
   title: string;
@@ -88,5 +58,41 @@ export function ChartTile({
           : children}
       </ErrorBoundary>
     </FullscreenChartTile>
+  );
+}
+
+interface ChartTileHeaderProps {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+  descriptionIsMarkdown?: boolean;
+}
+
+function ChartTileHeader({
+  title,
+  description,
+  children,
+}: ChartTileHeaderProps) {
+  return (
+    <Box
+      /**
+       * Outside margin is possible here, this header is only used in this module
+       */
+      mb={3}
+    >
+      <Heading level={3}>{title}</Heading>
+      <Box spacing={2}>
+        {description && (
+          <Box maxWidth={560}>
+            <Markdown content={description} />
+          </Box>
+        )}
+        {children && (
+          <Box display="inline-table" alignSelf="flex-start">
+            {children}
+          </Box>
+        )}
+      </Box>
+    </Box>
   );
 }

--- a/packages/app/src/components/chart-tile.tsx
+++ b/packages/app/src/components/chart-tile.tsx
@@ -65,7 +65,6 @@ interface ChartTileHeaderProps {
   title: string;
   description?: string;
   children?: ReactNode;
-  descriptionIsMarkdown?: boolean;
 }
 
 function ChartTileHeader({

--- a/packages/app/src/components/display-for-query-code.tsx
+++ b/packages/app/src/components/display-for-query-code.tsx
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router';
+import { ReactNode } from 'react';
+
+/**
+ * This components reads the `code` value from the router's query. The children
+ * will be rendered when that `code` matches the `code` on the props.
+ *
+ * It can be used for conditionally rendering components for a safety region or
+ * municipality.
+ */
+export function DisplayForQueryCode({
+  children,
+  code,
+}: {
+  children: ReactNode;
+  code: string;
+}) {
+  const codes = code.toLowerCase().split(',');
+  const codeFromQuery = (
+    (useRouter().query.code as string) || ''
+  ).toLowerCase();
+  const isMatchingCode = codes.some((x) => codeFromQuery === x);
+
+  return isMatchingCode ? <>{children}</> : null;
+}

--- a/packages/app/src/components/display-on-matching-query-code.tsx
+++ b/packages/app/src/components/display-on-matching-query-code.tsx
@@ -8,7 +8,7 @@ import { ReactNode } from 'react';
  * It can be used for conditionally rendering components for a safety region or
  * municipality.
  */
-export function DisplayForQueryCode({
+export function DisplayOnMatchingQueryCode({
   children,
   code,
 }: {

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '~/components/external-link';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 import { Link } from '~/utils/link';
-import { DisplayForQueryCode } from './display-for-query-code';
+import { DisplayOnMatchingQueryCode } from './display-on-matching-query-code';
 import { Message } from './message';
 
 interface MarkdownProps {
@@ -33,9 +33,9 @@ const renderers = {
    *     ````
    */
   code: ({ language = '', value }: { language: string; value: string }) => (
-    <DisplayForQueryCode code={language}>
+    <DisplayOnMatchingQueryCode code={language}>
       <Markdown content={value} />
-    </DisplayForQueryCode>
+    </DisplayOnMatchingQueryCode>
   ),
 
   /**

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '~/components/external-link';
-import { Link } from '~/utils/link';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
+import { Link } from '~/utils/link';
+import { DisplayForQueryCode } from './display-for-query-code';
+import { Message } from './message';
+
 interface MarkdownProps {
   content: string;
 }
@@ -20,6 +23,27 @@ const renderers = {
         <a>{props.children}</a>
       </Link>
     ),
+
+  /**
+   * The code element is hijacked to display context-aware pieces of content.
+   * usage:
+   *
+   *     ```VR09,VR16
+   *     This will only be displayed on routes with a code equal to VR09 or VR16.
+   *     ````
+   */
+  code: ({ language = '', value }: { language: string; value: string }) => (
+    <DisplayForQueryCode code={language}>
+      <Markdown content={value} />
+    </DisplayForQueryCode>
+  ),
+
+  /**
+   * The blockquote element is hijacked for displaying "warning" messages.
+   */
+  blockquote: (props: any) => {
+    return <Message variant="warning">{props.children}</Message>;
+  },
 };
 
 export function Markdown({ content }: MarkdownProps) {

--- a/packages/app/src/components/message.tsx
+++ b/packages/app/src/components/message.tsx
@@ -1,0 +1,36 @@
+import css from '@styled-system/css';
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+import { spacingStyle } from '~/style/functions/spacing';
+
+type Variant = 'warning';
+
+interface MessageProps {
+  children: ReactNode;
+  variant: Variant;
+}
+
+const theme: Record<Variant, { backgroundColor: string; borderColor: string }> =
+  {
+    warning: {
+      backgroundColor: '#FFFADE',
+      borderColor: '#FFE766',
+    },
+  };
+
+export function Message({ children, variant }: MessageProps) {
+  return <StyledMessage variant={variant}>{children}</StyledMessage>;
+}
+
+const StyledMessage = styled.div<{ variant: Variant }>((x) =>
+  css({
+    py: 2,
+    px: 3,
+    borderLeft: '7px solid',
+    backgroundColor: theme[x.variant].backgroundColor,
+    borderLeftColor: theme[x.variant].borderColor,
+
+    '& > *': { m: 0 },
+    ...spacingStyle(2),
+  })
+);

--- a/packages/app/src/style/functions/spacing.ts
+++ b/packages/app/src/style/functions/spacing.ts
@@ -11,13 +11,20 @@ export interface SpacingProps {
 
 export const spacing: styleFn = (x: SpacingProps) => {
   if (isDefined(x.spacing)) {
-    const value = asResponsiveArray(x.spacing);
-
-    return css({
-      '& > *:not(:last-child)': {
-        marginRight: x.spacingHorizontal ? value : null,
-        marginBottom: !x.spacingHorizontal ? value : null,
-      },
-    });
+    return css(spacingStyle(x.spacing, x.spacingHorizontal));
   }
 };
+
+export function spacingStyle(
+  spacing: ResponsiveValue<SpaceValue>,
+  spacingHorizontal?: boolean
+) {
+  const value = asResponsiveArray(spacing);
+
+  return {
+    '& > *:not(:last-child)': {
+      marginRight: spacingHorizontal ? value : null,
+      marginBottom: !spacingHorizontal ? value : null,
+    },
+  };
+}


### PR DESCRIPTION
Two new markdown features;

## 1. a quote in markdown will be displayed as a warning message
  ```
Dit getal is een berekening van hoeveel prikken in totaal zijn gezet. De GGD-cijfers worden gemeld door de GGD-GHOR. Voor de ziekenhuizen, de huisartspraktijken en langdurige zorginstellingen maakt het RIVM een berekening door te kijken naar hoeveel vaccins er zijn bezorgd bij priklocaties. Lees meer over de berekening in de 'Cijferverantwoording'..

> Door een storing vallen de mussen vandaag van het dak
```
![image](https://user-images.githubusercontent.com/73584448/123979832-58ffb280-d9c1-11eb-9218-18fd6fc95cd9.png)

## 2. "code" in markdown can be used to conditionally display markdown for a specific `VRxx` or `GMxx` code
```
Dit is het risiconiveau dat nu geldt in deze regio. Het risiconiveau wordt elke twee weken bepaald op basis van het aantal ziekenhuisopnames en het aantal positieve testen van dat moment.

~~~VR09
### With markdown [support](#)

> Utka 
~~~
```
![image](https://user-images.githubusercontent.com/73584448/123980863-2c986600-d9c2-11eb-8d76-aa201ae2b13f.png)

