### PR TITLE
Add gapped stacked area definition type

### DIFF
--- a/packages/app/src/components/choropleth/path.tsx
+++ b/packages/app/src/components/choropleth/path.tsx
@@ -78,7 +78,10 @@ export function HoverPathLink({
       onClick={handleClick}
       onFocus={onFocus}
       onBlur={onBlur}
-      css={css({ outline: isDefined(href) ? undefined : 'none !important' })}
+      css={css({
+        outline: isDefined(href) ? undefined : 'none !important',
+        '&:focus': { outline: 'none' },
+      })}
     >
       <HoverPath isClickable={isDefined(href)} {...pathProps} />
     </a>

--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -1,7 +1,5 @@
-import { last } from 'lodash';
-import { useMemo } from 'react';
-import { isDefined } from 'ts-is-present';
 import { SeriesItem, SeriesSingleValue } from '../logic';
+import { useGappedSeries } from '../logic/use-gapped-series';
 import { LineTrend } from './line-trend';
 
 type GappedLinedTrendProps = {
@@ -23,25 +21,7 @@ export function GappedLinedTrend(props: GappedLinedTrendProps) {
    * new SeriesSingleValue array is created. Effectively creating separate lines
    * for each consecutive list of defined values.
    */
-  const gappedSeries = useMemo(
-    () =>
-      series.reduce<SeriesSingleValue[][]>(
-        (lists, item) => {
-          let currentList = last(lists) || [];
-          if (currentList.length && !isDefined(item.__value)) {
-            const newList: SeriesSingleValue[] = [];
-            lists.push(newList);
-            currentList = newList;
-          }
-          if (isDefined(item.__value)) {
-            currentList.push(item);
-          }
-          return lists;
-        },
-        [[]]
-      ),
-    [series]
-  );
+  const gappedSeries = useGappedSeries(series);
 
   return (
     <>

--- a/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
@@ -1,7 +1,5 @@
-import { last } from 'lodash';
-import { useMemo } from 'react';
-import { isDefined } from 'ts-is-present';
 import { Bounds, SeriesDoubleValue, SeriesItem } from '../logic';
+import { useGappedSeries } from '../logic/use-gapped-series';
 import { StackedAreaTrend } from './stacked-area-trend';
 
 type GappedStackedAreaTrendProps = {
@@ -34,25 +32,7 @@ export function GappedStackedAreaTrend(props: GappedStackedAreaTrendProps) {
    * new SeriesDoubleValue array is created. Effectively creating separate stacks
    * for each consecutive list of defined values.
    */
-  const gappedSeries = useMemo(
-    () =>
-      series.reduce<SeriesDoubleValue[][]>(
-        (lists, item) => {
-          let currentList = last(lists) || [];
-          if (currentList.length && !isDefined(item.__value_a)) {
-            const newList: SeriesDoubleValue[] = [];
-            lists.push(newList);
-            currentList = newList;
-          }
-          if (isDefined(item.__value_a)) {
-            currentList.push(item);
-          }
-          return lists;
-        },
-        [[]]
-      ),
-    [series]
-  );
+  const gappedSeries = useGappedSeries(series);
 
   return (
     <>

--- a/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
@@ -1,0 +1,75 @@
+import { last } from 'lodash';
+import { useMemo } from 'react';
+import { isDefined } from 'ts-is-present';
+import { Bounds, SeriesDoubleValue, SeriesItem } from '../logic';
+import { StackedAreaTrend } from './stacked-area-trend';
+
+type GappedStackedAreaTrendProps = {
+  series: SeriesDoubleValue[];
+  color: string;
+  fillOpacity?: number;
+  strokeWidth?: number;
+  bounds: Bounds;
+  getX: (v: SeriesItem) => number;
+  getY0: (v: SeriesDoubleValue) => number;
+  getY1: (v: SeriesDoubleValue) => number;
+  id: string;
+};
+
+export function GappedStackedAreaTrend(props: GappedStackedAreaTrendProps) {
+  const {
+    series,
+    getX,
+    getY0,
+    getY1,
+    bounds,
+    color,
+    fillOpacity,
+    strokeWidth = 2,
+    id,
+  } = props;
+
+  /**
+   * Here we loop through the series and each time a null value is encountered a
+   * new SeriesSingleValue array is created. Effectively creating separate lines
+   * for each consecutive list of defined values.
+   */
+  const gappedSeries = useMemo(
+    () =>
+      series.reduce<SeriesDoubleValue[][]>(
+        (lists, item) => {
+          let currentList = last(lists) || [];
+          if (currentList.length && !isDefined(item.__value_a)) {
+            const newList: SeriesDoubleValue[] = [];
+            lists.push(newList);
+            currentList = newList;
+          }
+          if (isDefined(item.__value_a)) {
+            currentList.push(item);
+          }
+          return lists;
+        },
+        [[]]
+      ),
+    [series]
+  );
+
+  return (
+    <>
+      {gappedSeries.map((series, index) => (
+        <StackedAreaTrend
+          key={index}
+          series={series}
+          color={color}
+          strokeWidth={strokeWidth}
+          getX={getX}
+          getY0={getY0}
+          getY1={getY1}
+          bounds={bounds}
+          fillOpacity={fillOpacity}
+          id={`${id}_${index}`}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
@@ -31,7 +31,7 @@ export function GappedStackedAreaTrend(props: GappedStackedAreaTrendProps) {
 
   /**
    * Here we loop through the series and each time a null value is encountered a
-   * new SeriesSingleValue array is created. Effectively creating separate lines
+   * new SeriesDoubleValue array is created. Effectively creating separate stacks
    * for each consecutive list of defined values.
    */
   const gappedSeries = useMemo(

--- a/packages/app/src/components/time-series-chart/components/series.tsx
+++ b/packages/app/src/components/time-series-chart/components/series.tsx
@@ -15,6 +15,7 @@ import {
   SeriesSingleValue,
 } from '../logic';
 import { GappedLinedTrend } from './gapped-line-trend';
+import { GappedStackedAreaTrend } from './gapped-stacked-area-trend';
 import { SplitAreaTrend } from './split-area-trend';
 import { SplitBarTrend } from './split-bar-trend';
 import { StackedAreaTrend } from './stacked-area-trend';
@@ -144,6 +145,21 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                   getY1={getY1}
                   bounds={bounds}
                   id={`${chartId}_${config.metricPropertyLow}_${config.metricPropertyHigh}`}
+                />
+              );
+            case 'gapped-stacked-area':
+              return (
+                <GappedStackedAreaTrend
+                  key={index}
+                  series={series as SeriesDoubleValue[]}
+                  color={config.color}
+                  fillOpacity={config.fillOpacity}
+                  strokeWidth={config.strokeWidth}
+                  getX={getX}
+                  getY0={getY0}
+                  getY1={getY1}
+                  bounds={bounds}
+                  id={`${chartId}_${config.metricProperty}`}
                 />
               );
             case 'stacked-area':

--- a/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
@@ -1,25 +1,25 @@
 import { last } from 'lodash';
 import { useMemo } from 'react';
-import { isDefined } from 'ts-is-present';
+import { isPresent } from 'ts-is-present';
 import {
   isSeriesSingleValue,
   SeriesDoubleValue,
   SeriesSingleValue,
 } from './series';
 
+/**
+ * This hook takes an array of SeriesSingleValues or SeriesDoubleValues and splits
+ * it up into multiple arrays whenever an item is encountered with null values.
+ * So a new array is created for each consecutive list of valid items.
+ */
 export function useGappedSeries<
   T extends SeriesSingleValue | SeriesDoubleValue
 >(series: T[]) {
   return useMemo(
     () =>
-      /**
-       * Here we loop through the series and each time a null value is encountered a
-       * new SeriesSingleValue array is created. Effectively creating separate lines
-       * for each consecutive list of defined values.
-       */
       series.reduce<T[][]>(
         (lists, item) => {
-          const hasItemValue = isDefined(
+          const hasItemValue = isPresent(
             isSeriesSingleValue(item) ? item.__value : item.__value_a
           );
 

--- a/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
@@ -23,7 +23,7 @@ export function useGappedSeries<
             isSeriesSingleValue(item) ? item.__value : item.__value_a
           );
 
-          let currentList = last(lists) || [];
+          let currentList = last(lists) ?? [];
           if (currentList.length && !hasItemValue) {
             const newList: T[] = [];
             lists.push(newList);

--- a/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-gapped-series.ts
@@ -1,0 +1,41 @@
+import { last } from 'lodash';
+import { useMemo } from 'react';
+import { isDefined } from 'ts-is-present';
+import {
+  isSeriesSingleValue,
+  SeriesDoubleValue,
+  SeriesSingleValue,
+} from './series';
+
+export function useGappedSeries<
+  T extends SeriesSingleValue | SeriesDoubleValue
+>(series: T[]) {
+  return useMemo(
+    () =>
+      /**
+       * Here we loop through the series and each time a null value is encountered a
+       * new SeriesSingleValue array is created. Effectively creating separate lines
+       * for each consecutive list of defined values.
+       */
+      series.reduce<T[][]>(
+        (lists, item) => {
+          const hasItemValue = isDefined(
+            isSeriesSingleValue(item) ? item.__value : item.__value_a
+          );
+
+          let currentList = last(lists) || [];
+          if (currentList.length && !hasItemValue) {
+            const newList: T[] = [];
+            lists.push(newList);
+            currentList = newList;
+          }
+          if (hasItemValue) {
+            currentList.push(item);
+          }
+          return lists;
+        },
+        [[]]
+      ),
+    [series]
+  );
+}


### PR DESCRIPTION
## Summary

As the title states. This new definition allows for gapped stacked area trends like this:

![image](https://user-images.githubusercontent.com/69849293/124148874-6172ee80-da90-11eb-9c26-3b3a3f437333.png)

## Motivation

Needed for upcoming international functionality.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
