### PR TITLE
Update scales sewage map with more steps

### DIFF
--- a/packages/app/src/components/choropleth-legenda.tsx
+++ b/packages/app/src/components/choropleth-legenda.tsx
@@ -29,7 +29,7 @@ export function ChoroplethLegenda({
         {thresholds.map(({ color, threshold, label, endLabel }, index) => {
           const isFirst = index === 0;
           const isLast = index === thresholds.length - 1;
-          const displayLabel = itemWidth > 40 || index % 2 === 0;
+          const displayLabel = itemWidth > 35 || index % 2 === 0;
 
           return (
             <Item

--- a/packages/app/src/components/choropleth/region-thresholds.ts
+++ b/packages/app/src/components/choropleth/region-thresholds.ts
@@ -122,22 +122,26 @@ const sewerThresholds: ChoroplethThresholdsValue[] = [
   },
   {
     color: colors.data.scale.blue[1],
-    threshold: 50,
+    threshold: 10,
   },
   {
     color: colors.data.scale.blue[2],
-    threshold: 250,
+    threshold: 50,
   },
   {
     color: colors.data.scale.blue[3],
-    threshold: 500,
+    threshold: 100,
   },
   {
     color: colors.data.scale.blue[4],
-    threshold: 750,
+    threshold: 250,
   },
   {
     color: colors.data.scale.blue[5],
+    threshold: 500,
+  },
+  {
+    color: colors.data.scale.blue[6],
     threshold: 1000,
   },
 ];


### PR DESCRIPTION
^title

I've lowered the threshold when labels need to be displayed by 5 pixels. I've checked some of the choropleths and it wouldn't make a difference. But it did make a difference for the scales I've changed.

**40 pixels** (current)           |  **35 pixels** (new)
:-------------------------:|:-------------------------:
<img width="415" alt="Screenshot 2021-07-02 at 13 01 09" src="https://user-images.githubusercontent.com/76471292/124265401-e82dd700-db35-11eb-9dc4-8eb334730a89.png"> | <img width="363" alt="Screenshot 2021-07-02 at 13 01 02" src="https://user-images.githubusercontent.com/76471292/124265419-eebc4e80-db35-11eb-8e3f-102797e17cf4.png">
