### PR TITLE
Highlight markdown fields

### DIFF
--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { ExternalLink } from '~/components/external-link';
+import { useIntl } from '~/intl';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 import { Link } from '~/utils/link';
 import { DisplayOnMatchingQueryCode } from './display-on-matching-query-code';
@@ -53,5 +54,7 @@ const renderers = {
 };
 
 export function Markdown({ content }: MarkdownProps) {
-  return <ReactMarkdown source={content} renderers={renderers} />;
+  const { dataset } = useIntl();
+  const source = dataset === 'keys' ? `✅${content}` : content;
+  return <ReactMarkdown source={source} renderers={renderers} />;
 }

--- a/packages/app/src/intl/hooks/use-intl.ts
+++ b/packages/app/src/intl/hooks/use-intl.ts
@@ -1,6 +1,7 @@
 import { createFormatting } from '@corona-dashboard/common';
 import { useContext, useMemo } from 'react';
 import { SiteText, LanguageKey } from '~/locale';
+import { Dataset } from '~/locale/use-lokalize-text';
 import { IntlContext } from '..';
 
 // Adding the Europe/Amsterdam time zone manually since its the only being used.
@@ -29,7 +30,11 @@ const localeLanguageTagMap: Record<LanguageKey, string> = {
   en: 'en-GB',
 };
 
-export function useIntlHelperContext(locale: LanguageKey, siteText: SiteText) {
+export function useIntlHelperContext(
+  locale: LanguageKey,
+  siteText: SiteText,
+  dataset: Dataset
+) {
   return useMemo(() => {
     const languageTag = localeLanguageTagMap[locale];
 
@@ -44,6 +49,7 @@ export function useIntlHelperContext(locale: LanguageKey, siteText: SiteText) {
     } = createFormatting(languageTag, siteText.utils);
 
     return {
+      dataset,
       formatNumber,
       formatPercentage,
       formatDate,
@@ -54,7 +60,7 @@ export function useIntlHelperContext(locale: LanguageKey, siteText: SiteText) {
       siteText,
       locale,
     };
-  }, [locale, siteText]);
+  }, [locale, siteText, dataset]);
 }
 
 export function useIntl() {

--- a/packages/app/src/intl/intl-context.ts
+++ b/packages/app/src/intl/intl-context.ts
@@ -1,29 +1,6 @@
 import { createContext } from 'react';
-import { languages } from '~/locale';
 import { IntlContextProps } from './hooks/use-intl';
 
-export const IntlContext = createContext<IntlContextProps>({
-  siteText: languages['nl'],
-  locale: 'nl',
-  formatNumber: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatPercentage: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatDate: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatDateFromSeconds: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatDateFromMilliseconds: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatRelativeDate: () => {
-    throw new Error('Init format function should not be called');
-  },
-  formatDateSpan: () => {
-    throw new Error('Init format function should not be called');
-  },
-});
+export const IntlContext = createContext<IntlContextProps>(
+  undefined as unknown as IntlContextProps
+);

--- a/packages/app/src/locale/use-lokalize-text.tsx
+++ b/packages/app/src/locale/use-lokalize-text.tsx
@@ -16,6 +16,7 @@ import { LanguageKey, languages, SiteText } from '~/locale';
 import { LokalizeText } from '~/types/cms';
 
 const datasets = ['development', 'production', 'keys'] as const;
+export type Dataset = typeof datasets[number];
 
 const query = `*[_type == 'lokalizeText']`;
 const enableHotReload = process.env.NEXT_PUBLIC_PHASE === 'develop';
@@ -126,7 +127,7 @@ export function useLokalizeText(initialLocale: LanguageKey) {
     }
   }, [initialLocale, dataset, isActive, locale]);
 
-  return [text, toggleButton] as const;
+  return [text, toggleButton, dataset] as const;
 }
 
 /**

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -37,11 +37,11 @@ export default function App(props: AppProps) {
   // const { locale = 'nl' } = useRouter(); // if we replace this with process.env.NEXT_PUBLIC_LOCALE, next export should still be possible?
   const locale = (process.env.NEXT_PUBLIC_LOCALE || 'nl') as LanguageKey;
 
-  const [text, toggleHotReloadButton] = useLokalizeText(locale);
+  const [text, toggleHotReloadButton, dataset] = useLokalizeText(locale);
 
   assert(text, `Encountered unknown language: ${locale}`);
 
-  const intlContext = useIntlHelperContext(locale, text);
+  const intlContext = useIntlHelperContext(locale, text, dataset);
 
   useEffect(() => {
     const handleRouteChange = (pathname: string) => {


### PR DESCRIPTION
Prefix markdown fields so these are more discoverable. The emoji is only displayed during "key" mode of the sanity connector.

![image](https://user-images.githubusercontent.com/73584448/124884149-4fcea100-dfd2-11eb-8e1b-c303333b4b94.png)
