### PR TITLE
Optimize municipal data selection

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -79,12 +79,16 @@ const nextConfig = {
       new LodashModuleReplacementPlugin({
         // See https://github.com/lodash/lodash-webpack-plugin#feature-sets
         paths: true,
-      }),
-      new DuplicatePackageCheckerPlugin({
-        verbose: true,
-        showHelp: true,
       })
     );
+    if (process.env.NODE_ENV === 'production') {
+      config.plugins.push(
+        new DuplicatePackageCheckerPlugin({
+          verbose: true,
+          showHelp: true,
+        })
+      );
+    }
 
     return config;
   },

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -22,24 +22,11 @@ import { Link } from '~/utils/link';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 import { MunicipalityComboBox } from './components/municipality-combo-box';
 
-export const gmPageMetricNames = [
-  'code',
-  'tested_overall',
-  'deceased_rivm',
-  'hospital_nice',
-  'sewer',
-  'difference',
-] as const;
-
-export type GmPageMetricNames = typeof gmPageMetricNames[number];
-
 export type MunicipalSideBarData = {
-  code: string;
   tested_overall: Pick<Gm['tested_overall'], 'last_value'>;
   deceased_rivm: Pick<Gm['deceased_rivm'], 'last_value'>;
   hospital_nice: Pick<Gm['hospital_nice'], 'last_value'>;
   sewer: Pick<Gm['sewer'], 'last_value'>;
-  difference: GmDifference;
 };
 
 type MunicipalityLayoutProps = {
@@ -47,6 +34,8 @@ type MunicipalityLayoutProps = {
   children?: React.ReactNode;
 } & (
   | {
+      code: string;
+      difference: GmDifference;
       data: MunicipalSideBarData;
       municipalityName: string;
     }
@@ -55,7 +44,9 @@ type MunicipalityLayoutProps = {
        * the route `/gemeente` can render without sidebar and thus without `data`
        */
       isLandingPage: true;
+      code: string;
       data?: undefined;
+      difference?: undefined;
       municipalityName?: undefined;
     }
 );
@@ -77,12 +68,12 @@ type MunicipalityLayoutProps = {
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
 export function MunicipalityLayout(props: MunicipalityLayoutProps) {
-  const { children, data, municipalityName } = props;
+  const { children, data, municipalityName, code, difference } = props;
+  const sidebarData = { ...data, difference };
 
   const { siteText } = useIntl();
   const router = useRouter();
   const reverseRouter = useReverseRouter();
-  const code = router.query.code as string;
 
   const showMetricLinks = router.route !== '/gemeente';
 
@@ -157,7 +148,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                           }
                         >
                           <SidebarMetric
-                            data={data}
+                            data={sidebarData}
                             scope="gm"
                             metricName="hospital_nice"
                             metricProperty="admissions_on_date_of_reporting"
@@ -178,7 +169,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                           }
                         >
                           <SidebarMetric
-                            data={data}
+                            data={sidebarData}
                             scope="gm"
                             metricName="tested_overall"
                             metricProperty="infected"
@@ -195,7 +186,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                           }
                         >
                           <SidebarMetric
-                            data={data}
+                            data={sidebarData}
                             scope="gm"
                             metricName="deceased_rivm"
                             metricProperty="covid_daily"
@@ -218,7 +209,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                     >
                       {data?.sewer ? (
                         <SidebarMetric
-                          data={data}
+                          data={sidebarData}
                           scope="gm"
                           metricName="sewer"
                           metricProperty="average"

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -1,4 +1,4 @@
-import { Gm } from '@corona-dashboard/common';
+import { Gm, GmDifference } from '@corona-dashboard/common';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
@@ -33,14 +33,21 @@ export const gmPageMetricNames = [
 
 export type GmPageMetricNames = typeof gmPageMetricNames[number];
 
-export type MunicipalPageMetricData = Pick<Gm, GmPageMetricNames>;
+export type MunicipalSideBarData = {
+  code: string;
+  tested_overall: Pick<Gm['tested_overall'], 'last_value'>;
+  deceased_rivm: Pick<Gm['deceased_rivm'], 'last_value'>;
+  hospital_nice: Pick<Gm['hospital_nice'], 'last_value'>;
+  sewer: Pick<Gm['sewer'], 'last_value'>;
+  difference: GmDifference;
+};
 
 type MunicipalityLayoutProps = {
   lastGenerated: string;
   children?: React.ReactNode;
 } & (
   | {
-      data: MunicipalPageMetricData;
+      data: MunicipalSideBarData;
       municipalityName: string;
     }
   | {

--- a/packages/app/src/domain/layout/municipality-layout.tsx
+++ b/packages/app/src/domain/layout/municipality-layout.tsx
@@ -1,6 +1,7 @@
 import { Gm, GmDifference } from '@corona-dashboard/common';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 import RioolwaterMonitoring from '~/assets/rioolwater-monitoring.svg';
 import GetestIcon from '~/assets/test.svg';
 import VirusIcon from '~/assets/virus.svg';
@@ -69,7 +70,10 @@ type MunicipalityLayoutProps = {
  */
 export function MunicipalityLayout(props: MunicipalityLayoutProps) {
   const { children, data, municipalityName, code, difference } = props;
-  const sidebarData = { ...data, difference };
+  const sidebarData = useMemo(
+    () => ({ ...data, difference }),
+    [data, difference]
+  );
 
   const { siteText } = useIntl();
   const router = useRouter();
@@ -134,7 +138,7 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                   )}
                 </Box>
                 <Menu>
-                  {data && (
+                  {sidebarData && (
                     <>
                       <CategoryMenu
                         title={siteText.gemeente_layout.headings.ziekenhuizen}
@@ -201,13 +205,15 @@ export function MunicipalityLayout(props: MunicipalityLayoutProps) {
                     title={siteText.gemeente_layout.headings.vroege_signalen}
                   >
                     <MetricMenuItemLink
-                      href={data?.sewer && reverseRouter.gm.rioolwater(code)}
+                      href={
+                        sidebarData?.sewer && reverseRouter.gm.rioolwater(code)
+                      }
                       icon={<RioolwaterMonitoring />}
                       title={
                         siteText.gemeente_rioolwater_metingen.titel_sidebar
                       }
                     >
-                      {data?.sewer ? (
+                      {sidebarData?.sewer ? (
                         <SidebarMetric
                           data={sidebarData}
                           scope="gm"

--- a/packages/app/src/pages/gemeente/[code]/index.tsx
+++ b/packages/app/src/pages/gemeente/[code]/index.tsx
@@ -21,7 +21,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const Municipality = (props: StaticProps<typeof getStaticProps>) => {
-  const { selectedGmData: data, lastGenerated, municipalityName } = props;
+  const { lastGenerated, municipalityName, sideBarData } = props;
   const router = useRouter();
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
@@ -34,7 +34,7 @@ const Municipality = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
-        data={data}
+        data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       />

--- a/packages/app/src/pages/gemeente/[code]/index.tsx
+++ b/packages/app/src/pages/gemeente/[code]/index.tsx
@@ -17,11 +17,12 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData()
+  selectGmPageMetricData('code', 'difference')
 );
 
 const Municipality = (props: StaticProps<typeof getStaticProps>) => {
-  const { lastGenerated, municipalityName, sideBarData } = props;
+  const { lastGenerated, municipalityName, sideBarData, selectedGmData } =
+    props;
   const router = useRouter();
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
@@ -34,6 +35,8 @@ const Municipality = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
+        code={selectedGmData.code}
+        difference={selectedGmData.difference}
         data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -48,7 +48,12 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData('static_values'),
+  selectGmPageMetricData(
+    'static_values',
+    'tested_overall',
+    'difference',
+    'code'
+  ),
   createGetChoroplethData({
     gm: ({ tested_overall }) => ({ tested_overall }),
   }),
@@ -67,6 +72,7 @@ export const getStaticProps = createGetStaticProps(
 const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   const {
     selectedGmData: data,
+    sideBarData,
     choropleth,
     municipalityName,
     content,
@@ -92,7 +98,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
-        data={data}
+        data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -102,6 +102,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
         data={sideBarData}
+        code={data.code}
+        difference={data.difference}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -40,6 +40,7 @@ import {
   getLastGeneratedDate,
   selectGmPageMetricData,
 } from '~/static-props/get-data';
+import { filterByRegionMunicipals } from '~/static-props/utils/filter-by-region-municipals';
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -55,7 +56,9 @@ export const getStaticProps = createGetStaticProps(
     'code'
   ),
   createGetChoroplethData({
-    gm: ({ tested_overall }) => ({ tested_overall }),
+    gm: ({ tested_overall }, context) => ({
+      tested_overall: filterByRegionMunicipals(tested_overall, context),
+    }),
   }),
   createGetContent<{
     fix_this: ArticlesQueryResult;

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -40,7 +40,7 @@ import {
   getLastGeneratedDate,
   selectGmPageMetricData,
 } from '~/static-props/get-data';
-import { filterByRegionMunicipals } from '~/static-props/utils/filter-by-region-municipals';
+import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
 import { colors } from '~/style/theme';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -57,7 +57,7 @@ export const getStaticProps = createGetStaticProps(
   ),
   createGetChoroplethData({
     gm: ({ tested_overall }, context) => ({
-      tested_overall: filterByRegionMunicipals(tested_overall, context),
+      tested_overall: filterByRegionMunicipalities(tested_overall, context),
     }),
   }),
   createGetContent<{

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -34,7 +34,12 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData('sewer_per_installation', 'static_values'),
+  selectGmPageMetricData(
+    'sewer_per_installation',
+    'static_values',
+    'sewer',
+    'difference'
+  ),
   createGetContent<{
     articles?: ArticleSummary[];
   }>(() => {
@@ -46,6 +51,7 @@ export const getStaticProps = createGetStaticProps(
 const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
   const {
     selectedGmData: data,
+    sideBarData,
     municipalityName,
     content,
     lastGenerated,
@@ -81,7 +87,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
-        data={data}
+        data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -38,7 +38,8 @@ export const getStaticProps = createGetStaticProps(
     'sewer_per_installation',
     'static_values',
     'sewer',
-    'difference'
+    'difference',
+    'code'
   ),
   createGetContent<{
     articles?: ArticleSummary[];
@@ -88,6 +89,8 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
         data={sideBarData}
+        code={data.code}
+        difference={data.difference}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -30,7 +30,7 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData('deceased_rivm', 'difference'),
+  selectGmPageMetricData('deceased_rivm', 'difference', 'code'),
   createGetContent<{
     articles?: ArticleSummary[];
   }>(() => {
@@ -43,7 +43,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
   const {
     sideBarData,
     municipalityName,
-    selectedGmData: { deceased_rivm: dataRivm, difference },
+    selectedGmData: { deceased_rivm: dataRivm, difference, code },
     content,
     lastGenerated,
   } = props;
@@ -69,6 +69,8 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
         data={sideBarData}
+        code={code}
+        difference={difference}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -30,7 +30,7 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData(),
+  selectGmPageMetricData('deceased_rivm', 'difference'),
   createGetContent<{
     articles?: ArticleSummary[];
   }>(() => {
@@ -41,7 +41,7 @@ export const getStaticProps = createGetStaticProps(
 
 const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
   const {
-    selectedGmData: data,
+    sideBarData,
     municipalityName,
     selectedGmData: { deceased_rivm: dataRivm, difference },
     content,
@@ -68,7 +68,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
-        data={data}
+        data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -42,7 +42,7 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmPageMetricData(),
+  selectGmPageMetricData('hospital_nice', 'difference', 'code'),
   createGetChoroplethData({
     gm: ({ hospital_nice }) => ({ hospital_nice }),
   }),
@@ -62,6 +62,7 @@ export const getStaticProps = createGetStaticProps(
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   const {
     selectedGmData: data,
+    sideBarData,
     choropleth,
     municipalityName,
     content,
@@ -92,7 +93,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
-        data={data}
+        data={sideBarData}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -34,7 +34,7 @@ import {
   getLastGeneratedDate,
   selectGmPageMetricData,
 } from '~/static-props/get-data';
-import { filterByRegionMunicipals } from '~/static-props/utils/filter-by-region-municipals';
+import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -46,7 +46,7 @@ export const getStaticProps = createGetStaticProps(
   selectGmPageMetricData('hospital_nice', 'difference', 'code'),
   createGetChoroplethData({
     gm: ({ hospital_nice }, context) => ({
-      hospital_nice: filterByRegionMunicipals(hospital_nice, context),
+      hospital_nice: filterByRegionMunicipalities(hospital_nice, context),
     }),
   }),
   createGetContent<{

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -34,6 +34,7 @@ import {
   getLastGeneratedDate,
   selectGmPageMetricData,
 } from '~/static-props/get-data';
+import { filterByRegionMunicipals } from '~/static-props/utils/filter-by-region-municipals';
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -44,7 +45,9 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectGmPageMetricData('hospital_nice', 'difference', 'code'),
   createGetChoroplethData({
-    gm: ({ hospital_nice }) => ({ hospital_nice }),
+    gm: ({ hospital_nice }, context) => ({
+      hospital_nice: filterByRegionMunicipals(hospital_nice, context),
+    }),
   }),
   createGetContent<{
     fix_this: ArticlesQueryResult;

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -97,6 +97,8 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <MunicipalityLayout
         data={sideBarData}
+        code={data.code}
+        difference={data.difference}
         municipalityName={municipalityName}
         lastGenerated={lastGenerated}
       >

--- a/packages/app/src/pages/gemeente/index.tsx
+++ b/packages/app/src/pages/gemeente/index.tsx
@@ -1,7 +1,8 @@
+import { useRouter } from 'next/router';
 import { Box } from '~/components/base';
-import { Heading, Text } from '~/components/typography';
 import { MunicipalityNavigationMap } from '~/components/choropleth/municipality-navigation-map';
 import { TooltipContent } from '~/components/choropleth/tooltips/tooltip-content';
+import { Heading, Text } from '~/components/typography';
 import { MunicipalityComboBox } from '~/domain/layout/components/municipality-combo-box';
 import { Layout } from '~/domain/layout/layout';
 import { MunicipalityLayout } from '~/domain/layout/municipality-layout';
@@ -11,8 +12,8 @@ import {
   StaticProps,
 } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
-import { useReverseRouter } from '~/utils/use-reverse-router';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
@@ -20,6 +21,8 @@ const Municipality = (props: StaticProps<typeof getStaticProps>) => {
   const { lastGenerated } = props;
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
+  const router = useRouter();
+  const code = router.query.code as string;
 
   const breakpoints = useBreakpoints();
 
@@ -29,7 +32,11 @@ const Municipality = (props: StaticProps<typeof getStaticProps>) => {
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
-      <MunicipalityLayout isLandingPage lastGenerated={lastGenerated}>
+      <MunicipalityLayout
+        isLandingPage
+        lastGenerated={lastGenerated}
+        code={code}
+      >
         {!breakpoints.md && (
           <Box bg="white">
             <MunicipalityComboBox />

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -303,20 +303,20 @@ export function getGmData(context: GetStaticPropsContext) {
 const NOOP = () => null;
 
 export function createGetChoroplethData<T1, T2, T3>(settings?: {
-  vr?: (collection: VrCollection) => T1;
-  gm?: (collection: GmCollection) => T2;
-  in?: (collection: InCollection) => T3;
+  vr?: (collection: VrCollection, context: GetStaticPropsContext) => T1;
+  gm?: (collection: GmCollection, context: GetStaticPropsContext) => T2;
+  in?: (collection: InCollection, context: GetStaticPropsContext) => T3;
 }) {
-  return () => {
+  return (context: GetStaticPropsContext) => {
     const filterVr = settings?.vr ?? NOOP;
     const filterGm = settings?.gm ?? NOOP;
     const filterIn = settings?.in ?? NOOP;
 
     return {
       choropleth: {
-        vr: filterVr(json.vrCollection) as T1,
-        gm: filterGm(json.gmCollection) as T2,
-        in: filterIn(json.inCollection) as T3,
+        vr: filterVr(json.vrCollection, context) as T1,
+        gm: filterGm(json.gmCollection, context) as T2,
+        in: filterIn(json.inCollection, context) as T3,
       },
     };
   };

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -10,18 +10,13 @@ import {
   VrCollection,
 } from '@corona-dashboard/common';
 import { SanityClient } from '@sanity/client';
-import { isObject } from 'lodash';
 import set from 'lodash/set';
 import { GetStaticPropsContext } from 'next';
 import { AsyncWalkBuilder } from 'walkjs';
 import { gmData } from '~/data/gm';
 import { vrData } from '~/data/vr';
 import { CountryCode } from '~/domain/international/select-countries/country-code';
-import {
-  gmPageMetricNames,
-  GmPageMetricNames,
-  MunicipalSideBarData,
-} from '~/domain/layout/municipality-layout';
+import { MunicipalSideBarData } from '~/domain/layout/municipality-layout';
 import {
   NlPageMetricNames,
   nlPageMetricNames,
@@ -239,14 +234,10 @@ export function loadAndSortVrData(vrcode: string) {
  * be added to the output
  *
  */
-export function selectGmPageMetricData<T extends keyof Gm = GmPageMetricNames>(
+export function selectGmPageMetricData<T extends keyof Gm>(
   ...additionalMetrics: T[]
 ) {
   return selectGmData(...additionalMetrics);
-}
-
-function hasLastValue(item: unknown): item is { last_value: unknown } {
-  return isObject(item) && 'last_value' in item;
 }
 
 /**
@@ -257,19 +248,12 @@ export function selectGmData<T extends keyof Gm = never>(...metrics: T[]) {
   return (context: GetStaticPropsContext) => {
     const gmData = getGmData(context);
 
-    const data = gmData.data as unknown as Record<
-      string,
-      { last_value: unknown } | string | number
-    >;
-    const sideBarData = gmPageMetricNames.reduce((aggr, name) => {
-      const item = data[name];
-      if (hasLastValue(item)) {
-        aggr[name] = { last_value: item.last_value };
-      } else {
-        aggr[name] = item;
-      }
-      return aggr;
-    }, {} as any) as MunicipalSideBarData;
+    const sideBarData: MunicipalSideBarData = {
+      deceased_rivm: { last_value: gmData.data.deceased_rivm.last_value },
+      hospital_nice: { last_value: gmData.data.hospital_nice.last_value },
+      tested_overall: { last_value: gmData.data.tested_overall.last_value },
+      sewer: { last_value: gmData.data.sewer.last_value },
+    };
 
     const selectedGmData = metrics.reduce(
       (acc, p) => set(acc, p, gmData.data[p]),

--- a/packages/app/src/static-props/utils/filter-by-region-municipalities.ts
+++ b/packages/app/src/static-props/utils/filter-by-region-municipalities.ts
@@ -3,11 +3,11 @@ import { GetStaticPropsContext } from 'next';
 import { isDefined } from 'ts-is-present';
 import { getSafetyRegionMunicipalsForMunicipalCode } from '~/utils/get-safety-region-municipals-for-Mmunicipal-code';
 
-export function filterByRegionMunicipals<T extends { gmcode: string }>(
+export function filterByRegionMunicipalities<T extends { gmcode: string }>(
   choroplethData: T[],
   context: GetStaticPropsContext
 ) {
-  const municipalCode = context.params?.code as string;
+  const municipalCode = context.params?.code as string | undefined;
 
   assert(isDefined(municipalCode), 'No municipalCode in context params');
 

--- a/packages/app/src/static-props/utils/filter-by-region-municipals.ts
+++ b/packages/app/src/static-props/utils/filter-by-region-municipals.ts
@@ -8,8 +8,12 @@ export function filterByRegionMunicipals<T extends { gmcode: string }>(
   context: GetStaticPropsContext
 ) {
   const municipalCode = context.params?.code as string;
+
   assert(isDefined(municipalCode), 'No municipalCode in context params');
+
   const regionCodes = getSafetyRegionMunicipalsForMunicipalCode(municipalCode);
+
   assert(isDefined(regionCodes), `No regionCodes found for ${municipalCode}`);
+
   return choroplethData.filter((x) => regionCodes.includes(x.gmcode));
 }

--- a/packages/app/src/static-props/utils/filter-by-region-municipals.ts
+++ b/packages/app/src/static-props/utils/filter-by-region-municipals.ts
@@ -1,0 +1,15 @@
+import { assert } from '@corona-dashboard/common';
+import { GetStaticPropsContext } from 'next';
+import { isDefined } from 'ts-is-present';
+import { getSafetyRegionMunicipalsForMunicipalCode } from '~/utils/get-safety-region-municipals-for-Mmunicipal-code';
+
+export function filterByRegionMunicipals<T extends { gmcode: string }>(
+  choroplethData: T[],
+  context: GetStaticPropsContext
+) {
+  const municipalCode = context.params?.code as string;
+  assert(isDefined(municipalCode), 'No municipalCode in context params');
+  const regionCodes = getSafetyRegionMunicipalsForMunicipalCode(municipalCode);
+  assert(isDefined(regionCodes), `No regionCodes found for ${municipalCode}`);
+  return choroplethData.filter((x) => regionCodes.includes(x.gmcode));
+}


### PR DESCRIPTION
## Summary

- Only select the `last_value` for all the metrics that are only used in the sidebar. Municipal code and differences are selected separately and passed on the municipal sidebar. This makes the selection a little bit more verbose, but not in a way that doesn't scale anymore.
- Split the data selection into sidebar and page data. (Mixing the two gets really messy IMHO, this makes it a lot clearer)
- Filter the choropleth data to only contain the actual municipals that are shown on the map: ![image](https://user-images.githubusercontent.com/69849293/124893138-c4a5d900-dfda-11eb-9164-3de366c902d9.png)

These changes combined result in a build that is around 1.55Gb.

## Motivation

Image size reduction.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
