### PR TITLE
Add new moving averages

### DIFF
--- a/packages/app/schema/gm/hospital_nice.json
+++ b/packages/app/schema/gm/hospital_nice.json
@@ -8,6 +8,7 @@
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
         "admissions_on_date_of_reporting",
+        "admissions_on_date_of_reporting_moving_average",
         "date_unix",
         "date_of_insertion_unix"
       ],
@@ -23,6 +24,9 @@
         },
         "admissions_on_date_of_reporting": {
           "type": "integer"
+        },
+        "admissions_on_date_of_reporting_moving_average": {
+          "type": ["number", "null"]
         },
         "date_of_insertion_unix": {
           "type": "integer"

--- a/packages/app/schema/nl/hospital_nice.json
+++ b/packages/app/schema/nl/hospital_nice.json
@@ -29,6 +29,9 @@
         "admissions_on_date_of_reporting": {
           "type": "integer"
         },
+        "admissions_on_date_of_reporting_moving_average": {
+          "type": ["number", "null"]
+        },
         "date_unix": {
           "type": "integer"
         },
@@ -39,6 +42,7 @@
       "required": [
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
+        "admissions_on_date_of_reporting_moving_average",
         "admissions_on_date_of_reporting",
         "date_unix",
         "date_of_insertion_unix"

--- a/packages/app/schema/nl/intensive_care_nice.json
+++ b/packages/app/schema/nl/intensive_care_nice.json
@@ -8,6 +8,7 @@
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
         "admissions_on_date_of_reporting",
+        "admissions_on_date_of_reporting_moving_average",
         "date_unix",
         "date_of_insertion_unix"
       ],
@@ -20,6 +21,9 @@
         },
         "admissions_on_date_of_reporting": {
           "type": "integer"
+        },
+        "admissions_on_date_of_reporting_moving_average": {
+          "type": ["number", "null"]
         },
         "date_unix": {
           "type": "integer"

--- a/packages/app/schema/vr/hospital_nice.json
+++ b/packages/app/schema/vr/hospital_nice.json
@@ -29,6 +29,9 @@
         "admissions_on_date_of_reporting": {
           "type": "integer"
         },
+        "admissions_on_date_of_reporting_moving_average": {
+          "type": ["number", "null"]
+        },
         "date_unix": {
           "type": "integer"
         },
@@ -40,6 +43,7 @@
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
         "admissions_on_date_of_reporting",
+        "admissions_on_date_of_reporting_moving_average",
         "date_unix",
         "date_of_insertion_unix"
       ],

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -60,6 +60,7 @@ export interface GmHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
   admissions_on_date_of_reporting: number;
+  admissions_on_date_of_reporting_moving_average: number | null;
   date_of_insertion_unix: number;
 }
 export interface GmTestedOverall {
@@ -312,6 +313,7 @@ export interface NlIntensiveCareNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
   admissions_on_date_of_reporting: number;
+  admissions_on_date_of_reporting_moving_average: number | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -396,6 +398,7 @@ export interface NlHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
   admissions_on_date_of_reporting: number;
+  admissions_on_date_of_reporting_moving_average: number | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -1000,6 +1003,7 @@ export interface VrHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
   admissions_on_date_of_reporting: number;
+  admissions_on_date_of_reporting_moving_average: number | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }


### PR DESCRIPTION
## Summary

- Add `admissions_on_date_of_reporting_moving_average` to both hospital_nice and intensive_care_nice.json

## Unresolved questions

In `__difference.json` files (nl, vr and gm) a key called `hospital_nice__admissions_on_date_of_reporting_moving_average` and `intensive_care_nice__admissions_on_date_of_reporting_moving_average` already existed.
While I would have expected a `**__admissions_on_date_of_admission_moving_average` to be there. So, I'm a bit confused and hope that the people who worked on the moving averages schema's can shed some light in this.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
