### PR TITLE
Add metadata on choropleth and table international page

### DIFF
--- a/packages/app/src/components/metadata.tsx
+++ b/packages/app/src/components/metadata.tsx
@@ -3,15 +3,17 @@ import { ExternalLink } from '~/components/external-link';
 import { useIntl } from '~/intl';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { Box } from './base';
-import { Text } from './typography';
+import { InlineText, Text } from './typography';
 
+type source = {
+  text: string;
+  href: string;
+  aria_text?: string;
+};
 export interface MetadataProps extends MarginBottomProps {
   date?: number | [number, number];
-  source?: {
-    text: string;
-    href: string;
-    aria_text?: string;
-  };
+  source?: source;
+  dataSources?: source[];
   obtained?: number;
   isTileFooter?: boolean;
   datumsText?: string;
@@ -24,6 +26,7 @@ export function Metadata({
   isTileFooter,
   datumsText,
   mb,
+  dataSources,
 }: MetadataProps) {
   const { siteText, formatDateFromSeconds } = useIntl();
 
@@ -69,9 +72,21 @@ export function Metadata({
                     }
                   )}`}
                 {dateString && source ? ' · ' : null}
-                {source
-                  ? `${siteText.common.metadata.source}: ${source.text}`
-                  : null}
+
+                {source ? (
+                  `${siteText.common.metadata.source}: ${source.text}`
+                ) : dataSources ? (
+                  <>
+                    {`. ${siteText.common.metadata.source}: `}
+                    {dataSources.map((item, index) => (
+                      <InlineText key={index}>
+                        {index > 0 &&
+                          (index !== dataSources.length - 1 ? ' , ' : ' & ')}
+                        {item.text}
+                      </InlineText>
+                    ))}
+                  </>
+                ) : null}
               </>
             )}
           </Text>

--- a/packages/app/src/components/metadata.tsx
+++ b/packages/app/src/components/metadata.tsx
@@ -77,7 +77,7 @@ export function Metadata({
                   `${siteText.common.metadata.source}: ${source.text}`
                 ) : dataSources ? (
                   <>
-                    {`. ${siteText.common.metadata.source}: `}
+                    {` • ${siteText.common.metadata.source}: `}
                     {dataSources.map((item, index) => (
                       <InlineText key={index}>
                         {index > 0 &&

--- a/packages/app/src/domain/international/infected-table-tile/infected-table-tile.tsx
+++ b/packages/app/src/domain/international/infected-table-tile/infected-table-tile.tsx
@@ -4,6 +4,7 @@ import { matchSorter } from 'match-sorter';
 import { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
+import { Metadata, MetadataProps } from '~/components/metadata';
 import { SearchInput } from '~/components/search-input';
 import { Select } from '~/components/select';
 import { Tile } from '~/components/tile';
@@ -16,10 +17,10 @@ import {
   positiveTestedSortOptions,
   SortIdentifier,
 } from './logic/sort-options';
-
 interface InfectedTableTileProps {
   data: InCollectionTestedOverall[];
   countryNames: Record<string, string>;
+  metadata: MetadataProps;
 }
 
 export type FilterArrayType = {
@@ -30,6 +31,7 @@ export type FilterArrayType = {
 export function InfectedTableTile({
   data,
   countryNames,
+  metadata,
 }: InfectedTableTileProps) {
   const { siteText } = useIntl();
   const text = siteText.internationaal_positief_geteste_personen.land_tabel;
@@ -157,6 +159,8 @@ export function InfectedTableTile({
           </ExpandButton>
         </Box>
       )}
+
+      <Metadata {...metadata} isTileFooter />
     </Tile>
   );
 }

--- a/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
@@ -158,6 +158,11 @@ export default function PositiefGetesteMensenPage(
             }}
             metadata={{
               source: text.bronnen.rivm,
+              date: [
+                internationalMetadataDatums.dateOrRange.start,
+                internationalMetadataDatums.dateOrRange.end,
+              ],
+              obtained: internationalMetadataDatums.dateOfInsertionUnix,
             }}
           >
             <EuropeChoropleth
@@ -222,6 +227,13 @@ export default function PositiefGetesteMensenPage(
           <InfectedTableTile
             data={choroplethData}
             countryNames={countryNames}
+            metadata={{
+              date: [
+                internationalMetadataDatums.dateOrRange.start,
+                internationalMetadataDatums.dateOrRange.end,
+              ],
+              obtained: internationalMetadataDatums.dateOfInsertionUnix,
+            }}
           />
         </TileList>
       </InternationalLayout>

--- a/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
@@ -157,12 +157,11 @@ export default function PositiefGetesteMensenPage(
               title: text.choropleth.legenda_titel,
             }}
             metadata={{
-              source: text.bronnen.rivm,
+              dataSources: [text.bronnen.rivm, text.bronnen.ecdc],
               date: [
                 internationalMetadataDatums.dateOrRange.start,
                 internationalMetadataDatums.dateOrRange.end,
               ],
-              obtained: internationalMetadataDatums.dateOfInsertionUnix,
             }}
           >
             <EuropeChoropleth
@@ -228,11 +227,11 @@ export default function PositiefGetesteMensenPage(
             data={choroplethData}
             countryNames={countryNames}
             metadata={{
+              dataSources: [text.bronnen.rivm, text.bronnen.ecdc],
               date: [
                 internationalMetadataDatums.dateOrRange.start,
                 internationalMetadataDatums.dateOrRange.end,
               ],
-              obtained: internationalMetadataDatums.dateOfInsertionUnix,
             }}
           />
         </TileList>


### PR DESCRIPTION
Add metadata to the choropleth and the table to make it clear when the data is.

Edit: removed the date of insertion (decision from design) and added support for multiple sources in the metadata.

<img width="457" alt="Screenshot 2021-07-09 at 12 40 01" src="https://user-images.githubusercontent.com/76471292/125066100-e83c5280-e0b2-11eb-8f8e-065a37c464a2.png">

