### PR TITLE
Fix colors in behavior tooltip

### DIFF
--- a/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/region/behavior-tooltip.tsx
@@ -27,15 +27,16 @@ export function BehaviorTooltip({
 }: BehaviorTooltipProps) {
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
-  const thresholdKey = `${currentMetric}_${behaviorType}` as const;
+  const complianceThresholdKey = `${currentMetric}_compliance` as const;
+  const supportThresholdKey = `${currentMetric}_support` as const;
 
   const complianceFilteredThreshold = getFilteredThresholdValues(
-    regionThresholds.behavior[thresholdKey],
+    regionThresholds.behavior[complianceThresholdKey],
     currentComplianceValue
   );
 
   const supportFilteredThreshold = getFilteredThresholdValues(
-    regionThresholds.behavior[thresholdKey],
+    regionThresholds.behavior[supportThresholdKey],
     currentSupportValue
   );
 


### PR DESCRIPTION
## Summary

Fix colors in behavior tooltip

* compliance now always uses the compliance colors
* support ow always uses the support colors