### PR TITLE
Fix sanity validation

### DIFF
--- a/packages/cms/src/schemas/fields/article-fields.ts
+++ b/packages/cms/src/schemas/fields/article-fields.ts
@@ -46,7 +46,8 @@ export const ARTICLE_FIELDS = [
       'Dit is een korte samenvatting van het artikel die getoond wordt in de artikelblokken op de overzichtspagina.',
     name: 'summary',
     type: 'localeText',
-    validation: localeStringValidation((rule) => rule.required().max(120)),
+    // @Todo Align with content team about migrating content, and then enforce max length of 120.
+    validation: localeValidation((rule) => rule.required()),
   },
   {
     title: 'Intro',


### PR DESCRIPTION
## Summary

Fix sanity validation

* I don't think the max length validation prior to recent changes worked well (given some very lengthy summaries in the DB)
* The new `localeStringValidation` validator is not compatible with the type `localeText`