### PR TITLE
Remove user added query parameters from HTML

### DIFF
--- a/packages/app/src/components/layout/components/language-switcher.tsx
+++ b/packages/app/src/components/layout/components/language-switcher.tsx
@@ -7,10 +7,12 @@ export function LanguageSwitcher() {
   const router = useRouter();
   const { locale = 'nl' } = router;
 
+  const [currentPath] = router.asPath.split('?');
+
   return (
     <Box height={55} mt={-55} textAlign="right">
       <LanguageLink
-        href={`https://coronadashboard.rijksoverheid.nl${router.asPath}`}
+        href={`https://coronadashboard.rijksoverheid.nl${currentPath}`}
         lang="nl"
         hrefLang="nl"
         isActive={locale === 'nl'}
@@ -22,7 +24,7 @@ export function LanguageSwitcher() {
       <Separator />
 
       <LanguageLink
-        href={`https://coronadashboard.government.nl${router.asPath}`}
+        href={`https://coronadashboard.government.nl${currentPath}`}
         lang="en-GB"
         hrefLang="en-GB"
         isActive={locale?.startsWith('en') ?? false}


### PR DESCRIPTION
## Summary

Remove user added query parameters from HTML.

`asPath` gives all query parameters, also ones not defined/used by us in the route. Without this fix, going to an article URL with appended `?foo=<script>...` it would (HTML-endcoded) end up in the HTML. This fix just completely removes it.