### PR TITLE
Prevent use of path field in lokalize text

### DIFF
--- a/packages/cms/src/migrations/sprint27/remove-path-field.ts
+++ b/packages/cms/src/migrations/sprint27/remove-path-field.ts
@@ -1,0 +1,27 @@
+import { LokalizeText } from '@corona-dashboard/app/src/types/cms';
+import { getClient } from '../../client';
+
+/**
+ * The path field in LokalizeText is no longer used. The key and subject fields
+ * gives us enough information to work with. This script strips the path from
+ * existing documents. It will need to be executed once on development and once
+ * on the production dataset after the next release.
+ *
+ * Then it can be deleted.
+ */
+(async function run() {
+  const client = getClient('development');
+
+  const documents = (await client.fetch(
+    `*[_type == 'lokalizeText']`
+  )) as LokalizeText[];
+
+  const transaction = client.transaction();
+
+  documents.forEach((doc) => transaction.patch(doc._id, { unset: ['path'] }));
+
+  await transaction.commit();
+})().catch((err) => {
+  console.error(`Transaction failed: ${err.message}`);
+  process.exit(1);
+});

--- a/packages/common/src/domain/lokalize/index.ts
+++ b/packages/common/src/domain/lokalize/index.ts
@@ -1,6 +1,12 @@
 import { LokalizeText } from '@corona-dashboard/app/src/types/cms';
 
 /**
+ * The id prefix is a string which will join a lokalize key with its sanity ID.
+ * This string will be used to extract an id from a lokalize key.
+ */
+export const ID_PREFIX = '__@__';
+
+/**
  * Create a flat structure from which the JSON is rebuilt. Here we filter out
  * any deleted keys from the mutations file, so that any  deletions that
  * happened locally in your branch (but are not committed to the dataset yet)
@@ -45,12 +51,17 @@ export function createFlatTexts(
   return { nl, en };
 }
 
-export function parseLocaleTextDocument(document: LokalizeText) {
+export function parseLocaleTextDocument(
+  document: LokalizeText,
+  appendDocumentIdToKey = false
+) {
   /**
    * Paths inside the `__root` subject should be placed under the path in the
    * root of the exported json
    */
-  const jsonKey = document.subject === '__root' ? document.path : document.key;
+  const jsonKey =
+    document.key.replace('__root.', '') +
+    (appendDocumentIdToKey ? ID_PREFIX + document._id : '');
 
   const nl = document.should_display_empty
     ? ''


### PR DESCRIPTION
## Summary

Path field got removed from lokalize text documents. This PR fixes the code to not depend on it.