### PR TITLE
Rename timeline event to be correct intensive care nice

### DIFF
--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -166,7 +166,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                   ],
                   timelineEvents: getTimelineEvents(
                     content.elements.timeSeries,
-                    'hospital_nice'
+                    'intensive_care_nice'
                   ),
                 }}
                 seriesConfig={[


### PR DESCRIPTION
There was a wrong timeline event name on the graph, renamed and it should show now.

<img width="780" alt="Screenshot 2021-07-16 at 15 04 25" src="https://user-images.githubusercontent.com/76471292/125952336-e9cf4e2c-f155-4831-9279-959d95f6a7af.png">
