### PR TITLE
Add percentages KPI differences

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -8,11 +8,19 @@ import { Container, IconContainer } from './containers';
 
 export function TileAverageDifference({
   value,
+  isPercentage,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
+  isPercentage?: boolean;
 }) {
   const { difference, old_value } = value;
   const { siteText, formatNumber } = useIntl();
+
+  const Value = (
+    <InlineText fontWeight="bold">{` (${formatNumber(old_value)}${
+      isPercentage ? '%' : ''
+    })`}</InlineText>
+  );
 
   if (difference > 0)
     return (
@@ -25,9 +33,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          <InlineText fontWeight="bold">{` (${formatNumber(
-            old_value
-          )})`}</InlineText>
+          {Value}
         </InlineText>
       </Container>
     );
@@ -43,9 +49,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          <InlineText fontWeight="bold">{` (${formatNumber(
-            old_value
-          )})`}</InlineText>
+          {Value}
         </InlineText>
       </Container>
     );
@@ -60,9 +64,7 @@ export function TileAverageDifference({
       </InlineText>
       <InlineText>
         {siteText.toe_en_afname.zeven_daags_gemiddelde}
-        <InlineText fontWeight="bold">{` (${formatNumber(
-          old_value
-        )})`}</InlineText>
+        {Value}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -16,7 +16,7 @@ export function TileAverageDifference({
   const { difference, old_value } = value;
   const { siteText, formatNumber } = useIntl();
 
-  const valueText = (
+  const oldValue = (
     <InlineText fontWeight="bold">{` (${formatNumber(old_value)}${
       isPercentage ? '%' : ''
     })`}</InlineText>
@@ -33,7 +33,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          {valueText}
+          {oldValue}
         </InlineText>
       </Container>
     );
@@ -49,7 +49,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          {valueText}
+          {oldValue}
         </InlineText>
       </Container>
     );
@@ -64,7 +64,7 @@ export function TileAverageDifference({
       </InlineText>
       <InlineText>
         {siteText.toe_en_afname.zeven_daags_gemiddelde}
-        {valueText}
+        {oldValue}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -16,7 +16,7 @@ export function TileAverageDifference({
   const { difference, old_value } = value;
   const { siteText, formatNumber } = useIntl();
 
-  const Value = (
+  const valueText = (
     <InlineText fontWeight="bold">{` (${formatNumber(old_value)}${
       isPercentage ? '%' : ''
     })`}</InlineText>
@@ -33,7 +33,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          {Value}
+          {valueText}
         </InlineText>
       </Container>
     );
@@ -49,7 +49,7 @@ export function TileAverageDifference({
         </InlineText>
         <InlineText>
           {siteText.toe_en_afname.zeven_daags_gemiddelde}
-          {Value}
+          {valueText}
         </InlineText>
       </Container>
     );
@@ -64,7 +64,7 @@ export function TileAverageDifference({
       </InlineText>
       <InlineText>
         {siteText.toe_en_afname.zeven_daags_gemiddelde}
-        {Value}
+        {valueText}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -11,11 +11,13 @@ export function TileDifference({
   isDecimal,
   staticTimespan,
   maximumFractionDigits,
+  isPercentage,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
   isDecimal?: boolean;
   maximumFractionDigits?: number;
   staticTimespan?: string;
+  isPercentage?: boolean;
 }) {
   const { siteText, formatNumber, formatPercentage } = useIntl();
   const text = siteText.toe_en_afname;
@@ -40,7 +42,8 @@ export function TileDifference({
           <IconUp />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {differenceFormattedString} {splitText[0]}
+          {differenceFormattedString}
+          {isPercentage ? '%' : ''} {splitText[0]}
         </InlineText>{' '}
         <InlineText color="annotation">
           {splitText[1]} {timespanTextNode}
@@ -58,7 +61,8 @@ export function TileDifference({
           <IconDown />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {differenceFormattedString} {splitText[0]}
+          {differenceFormattedString}
+          {isPercentage ? '%' : ''} {splitText[0]}
         </InlineText>{' '}
         <InlineText>
           {splitText[1]} {timespanTextNode}
@@ -73,7 +77,8 @@ export function TileDifference({
         <IconGelijk />
       </IconContainer>
       <InlineText>
-        {text.gelijk} {timespanTextNode}
+        {text.gelijk}
+        {isPercentage ? '%' : ''} {timespanTextNode}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -82,13 +82,13 @@ export function KpiValue({
         (isMovingAverageDifference ? (
           <TileAverageDifference
             value={difference}
-            isPercentage={percentage ? true : false}
+            isPercentage={isDefined(percentage)}
           />
         ) : (
           <TileDifference
             value={difference}
             staticTimespan={differenceStaticTimespan}
-            isPercentage={percentage ? true : false}
+            isPercentage={isDefined(percentage)}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -62,7 +62,7 @@ export function KpiValue({
     <Box mb={3}>
       {isDefined(percentage) && isDefined(absolute) ? (
         <StyledValue color={color} {...otherProps}>
-          {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}as
+          {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}
         </StyledValue>
       ) : isDefined(percentage) ? (
         <StyledValue color={color} {...otherProps}>

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -62,7 +62,7 @@ export function KpiValue({
     <Box mb={3}>
       {isDefined(percentage) && isDefined(absolute) ? (
         <StyledValue color={color} {...otherProps}>
-          {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}
+          {`${formatNumber(absolute)} (${formatPercentage(percentage)}%)`}as
         </StyledValue>
       ) : isDefined(percentage) ? (
         <StyledValue color={color} {...otherProps}>
@@ -88,6 +88,7 @@ export function KpiValue({
           <TileDifference
             value={difference}
             staticTimespan={differenceStaticTimespan}
+            isPercentage={percentage ? true : false}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -80,7 +80,10 @@ export function KpiValue({
 
       {isDefined(difference) &&
         (isMovingAverageDifference ? (
-          <TileAverageDifference value={difference} />
+          <TileAverageDifference
+            value={difference}
+            isPercentage={percentage ? true : false}
+          />
         ) : (
           <TileDifference
             value={difference}

--- a/packages/app/src/components/layout/app-footer.tsx
+++ b/packages/app/src/components/layout/app-footer.tsx
@@ -66,6 +66,9 @@ export function AppFooter() {
                 <Item href={reverseRouter.algemeen.over()}>
                   {text.nav.links.over}
                 </Item>
+                <Item href={reverseRouter.algemeen.toegankelijkheid()}>
+                  {text.nav.links.toegankelijkheid}
+                </Item>
                 <Item href={reverseRouter.algemeen.veelgesteldeVragen()}>
                   {text.nav.links.veelgestelde_vragen}
                 </Item>
@@ -74,9 +77,6 @@ export function AppFooter() {
                 </Item>
                 <Item href={reverseRouter.algemeen.overRisiconiveaus()}>
                   {text.nav.links.over_risiconiveaus}
-                </Item>
-                <Item href={reverseRouter.algemeen.toegankelijkheid()}>
-                  {text.nav.links.toegankelijkheid}
                 </Item>
                 <Item href={text.nav.links.meer_href} isExternal>
                   {text.nav.links.meer}


### PR DESCRIPTION
When there was a difference with a percentage it didn't show the `%`. in the text. This should fix that for the moving average as well the normal difference. 

<img width="819" alt="Screenshot 2021-07-19 at 14 42 37" src="https://user-images.githubusercontent.com/76471292/126170582-84b7e438-3775-4ff6-ab35-61f821ded9ca.png">
