### PR TITLE
Add Cyprus to list of bounding box countries

### DIFF
--- a/packages/app/src/components/choropleth/europe-choropleth.tsx
+++ b/packages/app/src/components/choropleth/europe-choropleth.tsx
@@ -27,7 +27,7 @@ import { europeGeo } from './topology';
  * List of countries to define the boundingbox. These are countries on the outer edges
  * of the group of countries that are shown.
  */
-const boundingBoxCodes = ['ISL', 'NOR', 'ESP', 'GRC'];
+const boundingBoxCodes = ['ISL', 'NOR', 'ESP', 'GRC', 'CYP'];
 
 const boundingBoxEurope: EuropeGeoJSON = {
   ...europeGeo,


### PR DESCRIPTION
Add Cyprus to list of bounding box countries to make sure it's always visible.