### PR TITLE
Remove click handler from row to save tooltip

### DIFF
--- a/packages/app/src/domain/vaccine/components/coverage-row.tsx
+++ b/packages/app/src/domain/vaccine/components/coverage-row.tsx
@@ -34,12 +34,7 @@ function MobileCoverageRow(props: RowProps) {
   const children = React.Children.toArray(props.children);
 
   return (
-    <Row
-      width="100%"
-      display="flex"
-      flexDirection="column"
-      onClick={() => setIsOpen(!isOpen)}
-    >
+    <Row width="100%" display="flex" flexDirection="column">
       <Box display="flex">
         <Box flex={1}>{children[0]}</Box>
         <Box

--- a/packages/app/src/domain/vaccine/components/coverage-row.tsx
+++ b/packages/app/src/domain/vaccine/components/coverage-row.tsx
@@ -42,6 +42,7 @@ function MobileCoverageRow(props: RowProps) {
           display="flex"
           justifyContent="flex-end"
           pr={{ _: 2, xs: 4 }}
+          onClick={() => setIsOpen(!isOpen)}
         >
           {children[1]}
         </Box>


### PR DESCRIPTION
## Summary

Adding a click handler to the whole table row obscures any possible inline tooltip interaction, so I'm removing it again.