### PR TITLE
Ensure zip is available in JSON folder

### DIFF
--- a/packages/app/infra/download.js
+++ b/packages/app/infra/download.js
@@ -2,6 +2,7 @@ const path = require('path');
 const config = { path: path.resolve('.env.local') };
 require('dotenv').config(config);
 const download = require('download');
+const decompress = require('decompress');
 
 const API_URL =
   process.env.API_URL ||
@@ -10,9 +11,16 @@ const API_URL =
 // eslint-disable-next-line no-console
 console.log(`Downloading json data from this location: ${API_URL}`);
 
+const filename = 'latest-data.zip';
+const jsonPath = path.join('.', 'public', 'json');
+const zipPath = path.join(jsonPath, filename);
+
 (async () => {
-  await download(API_URL, './public/json', {
-    extract: true,
-    strip: 1, // strip `/protos`-directory
+  await download(API_URL, jsonPath, {
+    filename: filename,
+  });
+
+  await decompress(zipPath, jsonPath, {
+    strip: 1,
   });
 })();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -105,6 +105,7 @@
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-styled-components": "^1.11.1",
     "cross-env": "^7.0.3",
+    "decompress": "^4.2.1",
     "download": "^8.0.0",
     "download-cli": "^1.1.1",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11551,7 +11551,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.4:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==


### PR DESCRIPTION
## Summary

Ensure zip is available in JSON folder

To not break the `yarn download` for anyone. Since the dockerfile will use a different mechanism of placing the JSONs, `yarn download` in the build needs to preserve a zip named `latest-data.zip` for `yarn download` outside the build.

The `decompress` package was already used by the `download` package, the commands are merely chained to preserve the ZIP.