### PR TITLE
Update Tooltip style

### DIFF
--- a/packages/app/src/lib/tooltip.tsx
+++ b/packages/app/src/lib/tooltip.tsx
@@ -13,8 +13,7 @@ const StyledTippy = styled(Tippy)(
   css({
     backgroundColor: 'white',
     color: 'black',
-    boxShadow:
-      '0 0 20px 4px rgb(154 161 177 / 15%), 0 4px 80px -8px rgb(36 40 47 / 25%), 0 4px 4px -2px rgb(91 94 105 / 15%)',
+    boxShadow: 'tile',
     '.tippy-arrow': {
       color: 'white',
     },
@@ -37,7 +36,7 @@ export function WithTooltip(props: Omit<TippyProps, 'theme'>) {
     <StyledTippy
       appendTo={getBody}
       onMount={handleMount}
-      maxWidth={breakpoints.sm ? '285px' : '350px'}
+      maxWidth={breakpoints.sm ? '260px' : '285px'}
       {...props}
     />
   );

--- a/packages/app/src/lib/tooltip.tsx
+++ b/packages/app/src/lib/tooltip.tsx
@@ -18,14 +18,14 @@ const StyledTippy = styled(Tippy)(
       color: 'white',
     },
   })
-);
+) as typeof Tippy;
 
 /**
  * Usage:
  *     <WithTooltip content={<p>message</p>}><button>foo</button></WithTooltip>
  */
 
-export function WithTooltip(props: Omit<TippyProps, 'theme'>) {
+export function WithTooltip(props: TippyProps) {
   const breakpoints = useBreakpoints();
 
   if (!isDefined(props.content)) {
@@ -35,8 +35,8 @@ export function WithTooltip(props: Omit<TippyProps, 'theme'>) {
   return (
     <StyledTippy
       appendTo={getBody}
-      onMount={handleMount}
       maxWidth={breakpoints.sm ? '260px' : '285px'}
+      {...(handleMount ? { onMount: handleMount } : {})}
       {...props}
     />
   );

--- a/packages/app/src/lib/tooltip.tsx
+++ b/packages/app/src/lib/tooltip.tsx
@@ -26,7 +26,7 @@ const StyledTippy = styled(Tippy)(
  */
 
 export function WithTooltip(props: Omit<TippyProps, 'theme'>) {
-  const breakpoints = useBreakpoints(true);
+  const breakpoints = useBreakpoints();
 
   if (!isDefined(props.content)) {
     return <>{props.children}</>;

--- a/packages/app/src/lib/tooltip.tsx
+++ b/packages/app/src/lib/tooltip.tsx
@@ -1,10 +1,25 @@
 import Tippy, { TippyProps } from '@tippyjs/react';
 import { Instance } from 'tippy.js';
 import 'tippy.js/dist/tippy.css';
-import 'tippy.js/themes/light.css';
+import styled from 'styled-components';
+import css from '@styled-system/css';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+
 import { isDefined } from 'ts-is-present';
 
 let handleMount: undefined | ((tippyInstance: Instance) => void);
+
+const StyledTippy = styled(Tippy)(
+  css({
+    backgroundColor: 'white',
+    color: 'black',
+    boxShadow:
+      '0 0 20px 4px rgb(154 161 177 / 15%), 0 4px 80px -8px rgb(36 40 47 / 25%), 0 4px 4px -2px rgb(91 94 105 / 15%)',
+    '.tippy-arrow': {
+      color: 'white',
+    },
+  })
+) as any;
 
 /**
  * Usage:
@@ -12,12 +27,19 @@ let handleMount: undefined | ((tippyInstance: Instance) => void);
  */
 
 export function WithTooltip(props: TippyProps) {
+  const breakpoints = useBreakpoints(true);
+
   if (!isDefined(props.content)) {
     return <>{props.children}</>;
   }
 
   return (
-    <Tippy theme="light" appendTo={getBody} onMount={handleMount} {...props} />
+    <StyledTippy
+      appendTo={getBody}
+      onMount={handleMount}
+      maxWidth={breakpoints.sm ? '285px' : '350px'}
+      {...props}
+    />
   );
 }
 

--- a/packages/app/src/lib/tooltip.tsx
+++ b/packages/app/src/lib/tooltip.tsx
@@ -19,14 +19,14 @@ const StyledTippy = styled(Tippy)(
       color: 'white',
     },
   })
-) as any;
+);
 
 /**
  * Usage:
  *     <WithTooltip content={<p>message</p>}><button>foo</button></WithTooltip>
  */
 
-export function WithTooltip(props: TippyProps) {
+export function WithTooltip(props: Omit<TippyProps, 'theme'>) {
   const breakpoints = useBreakpoints(true);
 
   if (!isDefined(props.content)) {


### PR DESCRIPTION
## Summary

Updating the tooltip style

## Motivation

Design tweak

## Detailed design

Making the Tippy tooltip into a styled component to apply the proper boxShadow and used `useBreakpoints` to apply max width since that style gets overridden by Tippy by default.

## Unresolved questions

Would we still prefer to use rem instead of px for this?

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
