### PR TITLE
Fix gapped stacked area tooltip icons

### DIFF
--- a/packages/app/src/components/time-series-chart/components/series-icon.tsx
+++ b/packages/app/src/components/time-series-chart/components/series-icon.tsx
@@ -46,6 +46,7 @@ export function SeriesIcon<T extends TimestampedValue>({
         />
       );
     case 'stacked-area':
+    case 'gapped-stacked-area':
       return (
         <StackedAreaTrendIcon
           color={config.color}


### PR DESCRIPTION
## Summary

As the title states. The variant stacked area chart didn;t show colored icons in the tooltip, this was because the `gapped-stacked-area` type wasn't added to the seriesicon component yet. 

## Motivation

Bug fix.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
