### PR TITLE
fix: Limit amount of articles queried to 3

### DIFF
--- a/packages/app/src/queries/topical-page-query.ts
+++ b/packages/app/src/queries/topical-page-query.ts
@@ -18,7 +18,7 @@ export function getTopicalPageQuery(_context: GetStaticPropsContext) {
         ...cover,
         "asset": cover.asset->
       }
-    }[0..3],
+    }[0..2],
     'weeklyHighlight': *[_type == 'editorial'] | order(publicationDate desc) {
       "title":title.${locale},
       slug,


### PR DESCRIPTION
## Summary

Changing the spread of `0..3` to `0..2` which should reduce the amount of articles shown on the `actueel` page from 4 to 3.