### PR TITLE
Increase mini trend charts y axis nice resolution

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -76,7 +76,14 @@ export function useScales<T extends TimestampedValue>(args: {
     const yScale = scaleLinear({
       domain: [0, maximumValue > 0 ? maximumValue : maximumDomainValue],
       range: [bounds.height, 0],
-      nice: numTicks < 3 ? numTicks * 2 : numTicks,
+      /**
+       * Mini trend tiles only use 2 ticks, but that would result in max values
+       * stetching by 100% every time, which is too much in most cases. So here
+       * we increase the nice resolution only for those charts. The number 5 is
+       * chosen so that the max value will still be fairly close to the top grid
+       * line.
+       */
+      nice: numTicks < 3 ? numTicks * 5 : numTicks,
       round: true, // round the output values so we render on round pixels
     });
 

--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -76,7 +76,7 @@ export function useScales<T extends TimestampedValue>(args: {
     const yScale = scaleLinear({
       domain: [0, maximumValue > 0 ? maximumValue : maximumDomainValue],
       range: [bounds.height, 0],
-      nice: numTicks,
+      nice: numTicks < 3 ? numTicks * 2 : numTicks,
       round: true, // round the output values so we render on round pixels
     });
 


### PR DESCRIPTION
## Summary

This increases the nice resolution of the y-scale, but only for mini tend tiles that use 2 grid lines. This prevents the max value  from jumping from 20k to 40k. Instead now it will jump from 20k to 22k.

<img width="1440" alt="Screenshot 2021-07-22 at 10 44 36" src="https://user-images.githubusercontent.com/71320230/126620729-58cf4148-cfd9-4c03-8ebd-5bfef11eee31.png">

