### PR TITLE
Add mixBlendMode to stacked area chart type

### DIFF
--- a/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-stacked-area-trend.tsx
@@ -1,3 +1,4 @@
+import { Property } from 'csstype';
 import { Bounds, SeriesDoubleValue, SeriesItem } from '../logic';
 import { useGappedSeries } from '../logic/use-gapped-series';
 import { StackedAreaTrend } from './stacked-area-trend';
@@ -7,6 +8,7 @@ type GappedStackedAreaTrendProps = {
   color: string;
   fillOpacity?: number;
   strokeWidth?: number;
+  mixBlendMode?: Property.MixBlendMode;
   bounds: Bounds;
   getX: (v: SeriesItem) => number;
   getY0: (v: SeriesDoubleValue) => number;
@@ -24,6 +26,7 @@ export function GappedStackedAreaTrend(props: GappedStackedAreaTrendProps) {
     color,
     fillOpacity,
     strokeWidth = 2,
+    mixBlendMode,
     id,
   } = props;
 
@@ -47,6 +50,7 @@ export function GappedStackedAreaTrend(props: GappedStackedAreaTrendProps) {
           getY1={getY1}
           bounds={bounds}
           fillOpacity={fillOpacity}
+          mixBlendMode={mixBlendMode}
           id={`${id}_${index}`}
         />
       ))}

--- a/packages/app/src/components/time-series-chart/components/series.tsx
+++ b/packages/app/src/components/time-series-chart/components/series.tsx
@@ -155,6 +155,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                   color={config.color}
                   fillOpacity={config.fillOpacity}
                   strokeWidth={config.strokeWidth}
+                  mixBlendMode={config.mixBlendMode}
                   getX={getX}
                   getY0={getY0}
                   getY1={getY1}
@@ -170,6 +171,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({
                   color={config.color}
                   fillOpacity={config.fillOpacity}
                   strokeWidth={config.strokeWidth}
+                  mixBlendMode={config.mixBlendMode}
                   getX={getX}
                   getY0={getY0}
                   getY1={getY1}

--- a/packages/app/src/components/time-series-chart/components/stacked-area-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/stacked-area-trend.tsx
@@ -1,9 +1,9 @@
 import { LinePath } from '@visx/shape';
 import { Threshold } from '@visx/threshold';
+import { Property } from 'csstype';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { Bounds, SeriesDoubleValue, SeriesItem } from '../logic';
-
 const DEFAULT_FILL_OPACITY = 0.6;
 
 type StackedAreaTrendProps = {
@@ -16,6 +16,7 @@ type StackedAreaTrendProps = {
   getY0: (v: SeriesDoubleValue) => number;
   getY1: (v: SeriesDoubleValue) => number;
   id: string;
+  mixBlendMode?: Property.MixBlendMode;
 };
 
 export function StackedAreaTrend({
@@ -28,6 +29,7 @@ export function StackedAreaTrend({
   fillOpacity = DEFAULT_FILL_OPACITY,
   strokeWidth = 2,
   id,
+  mixBlendMode,
 }: StackedAreaTrendProps) {
   const nonNullSeries = useMemo(
     () =>
@@ -51,6 +53,7 @@ export function StackedAreaTrend({
           fill: color,
           fillOpacity,
           id,
+          style: { mixBlendMode },
         }}
         /**
          * When "value a" becomes higher than "value b", this will render the fill
@@ -61,6 +64,7 @@ export function StackedAreaTrend({
         aboveAreaProps={{
           fill: color,
           fillOpacity,
+          style: { mixBlendMode },
         }}
       />
 

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -5,6 +5,7 @@ import {
   TimeframeOption,
   TimestampedValue,
 } from '@corona-dashboard/common';
+import { Property } from 'csstype';
 import { omit } from 'lodash';
 import { useMemo } from 'react';
 import { hasValueAtKey, isDefined, isPresent } from 'ts-is-present';
@@ -128,6 +129,7 @@ export interface StackedAreaSeriesDefinition<T extends TimestampedValue>
   fillOpacity?: number;
   strokeWidth?: number;
   isNonInteractive?: boolean;
+  mixBlendMode?: Property.MixBlendMode;
 }
 
 export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
@@ -141,6 +143,7 @@ export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
   fillOpacity?: number;
   strokeWidth?: number;
   isNonInteractive?: boolean;
+  mixBlendMode?: Property.MixBlendMode;
 }
 
 /**

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -197,6 +197,7 @@ function useSeriesConfig(
           shape: 'square',
           strokeWidth: 0,
           fillOpacity: 1,
+          mixBlendMode: 'multiply',
         };
       });
 
@@ -208,6 +209,7 @@ function useSeriesConfig(
       shape: 'square',
       color: colors.lightGray,
       strokeWidth: 0,
+      mixBlendMode: 'multiply',
     } as GappedStackedAreaSeriesDefinition<VariantChartValue>;
 
     const selectOptions = [...seriesConfig, otherConfig];


### PR DESCRIPTION
## Summary

As the title states once again, the blend mode is added to achieve this effect:

![image](https://user-images.githubusercontent.com/69849293/126636011-24c4d755-b46c-4c3f-b5f5-d8a81eb80bc2.png)

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
