### PR TITLE
Create useCollapsible hook

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-content.tsx
+++ b/packages/app/src/components/collapsible/collapsible-content.tsx
@@ -1,16 +1,33 @@
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@reach/disclosure';
 import { css } from '@styled-system/css';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
-import useResizeObserver from 'use-resize-observer';
 import { Box, BoxProps } from '~/components/base';
-import { useSetLinkTabbability } from './use-set-link-tabbability';
+import { useCollapsible } from '~/utils/use-collapsible';
 
-const Label = styled((props) => <DisclosureButton {...props} />)(
+interface CollapsibleContentProps extends BoxProps {
+  label: string;
+  children: ReactNode;
+}
+
+export function CollapsibleContent({
+  label,
+  children,
+}: CollapsibleContentProps) {
+  const collapsible = useCollapsible();
+
+  return (
+    <Box as="section">
+      {collapsible.button(
+        <Label>
+          {label} {collapsible.chevron}
+        </Label>
+      )}
+      {collapsible.content(children)}
+    </Box>
+  );
+}
+
+const Label = styled.button(
   css({
     display: 'flex',
     alignItems: 'flex-start',
@@ -35,85 +52,5 @@ const Label = styled((props) => <DisclosureButton {...props} />)(
       outlineStyle: 'dashed',
       outlineColor: 'blue',
     },
-
-    '&:active[data-state="collapsed"]': {
-      bg: 'shadow',
-    },
-
-    '&::after': {
-      backgroundImage: 'url("/images/chevron-down.svg")',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: '0.9em 0.55em',
-      content: '""',
-      flex: '0 0 1.9em',
-      height: '0.55em',
-      mr: -2,
-      mt: '0.35em',
-      py: 0,
-      transition: 'transform 0.4s',
-    },
-
-    '&[data-state="open"]:after': {
-      transform: 'rotate(180deg)',
-    },
   })
 );
-
-const Panel = styled((props) => <DisclosurePanel {...props} />)(
-  css({
-    display: 'block',
-    opacity: 0,
-    overflow: 'hidden',
-    py: 0,
-    transition: 'height 0.4s ease-in-out, opacity 0.4s ease-in-out',
-    '&[data-state="open"]': {
-      opacity: 1,
-    },
-  })
-);
-
-interface CollapsibleContentProps extends BoxProps {
-  label: string;
-  children: ReactNode;
-}
-
-export const CollapsibleContent = ({
-  label,
-  children,
-}: CollapsibleContentProps) => {
-  const [open, setOpen] = useState(false);
-  const { wrapperRef } = useSetLinkTabbability(open);
-
-  const { ref, height: contentHeight } = useResizeObserver();
-
-  return (
-    <Box as="section">
-      <Disclosure open={open} onChange={() => setOpen(!open)}>
-        <Label>{label}</Label>
-
-        <Panel
-          style={{
-            /* panel max height is only controlled when collapsed, or during animations */
-            height: open ? contentHeight : 0,
-          }}
-        >
-          <div ref={wrapperRef}>
-            <div
-              ref={ref}
-              css={css({
-                /**
-                 * Outside margins of children are breaking height calculations ヽ(ಠ_ಠ)ノ..
-                 * We'll add `overflow: hidden` in order to fix this.
-                 */
-                overflow: 'hidden',
-              })}
-            >
-              {children}
-            </div>
-          </div>
-        </Panel>
-      </Disclosure>
-    </Box>
-  );
-};

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -1,16 +1,87 @@
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@reach/disclosure';
 import { css } from '@styled-system/css';
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useEffect } from 'react';
 import styled from 'styled-components';
-import useResizeObserver from 'use-resize-observer';
 import { Box, BoxProps } from '~/components/base';
-import { useSetLinkTabbability } from './use-set-link-tabbability';
+import { useCollapsible } from '~/utils/use-collapsible';
 
-const Summary = styled((props) => <DisclosureButton {...props} />)(
+interface CollapsibleSectionProps extends BoxProps {
+  summary: string;
+  children: ReactNode;
+  id?: string;
+  hideBorder?: boolean;
+}
+
+export const CollapsibleSection = ({
+  summary,
+  children,
+  id,
+  hideBorder,
+}: CollapsibleSectionProps) => {
+  const collapsible = useCollapsible();
+  const { toggle } = collapsible;
+
+  useEffect(() => {
+    /**
+     * Checks the hash part of the URL to see if it matches the id.
+     * If so, the collapsible needs to be opened.
+     */
+    function handleHashChange() {
+      if (id && window.location.hash === `#${id}`) {
+        toggle(true);
+      }
+    }
+
+    handleHashChange();
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, [toggle, id]);
+
+  return (
+    <Box
+      as="section"
+      borderTop={hideBorder ? undefined : '1px solid'}
+      borderTopColor={hideBorder ? undefined : 'lightGray'}
+      id={id}
+    >
+      {collapsible.button(
+        <Summary>
+          {summary}
+          {id && (
+            <AnchorLink
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={(e) => e.stopPropagation()}
+              href={`#${id}`}
+            >
+              #
+            </AnchorLink>
+          )}
+          {collapsible.chevron}
+        </Summary>
+      )}
+
+      {collapsible.content(<Box px={3}>{children}</Box>)}
+    </Box>
+  );
+};
+
+const AnchorLink = styled.a(
+  css({
+    color: 'lightGray',
+    px: 3,
+    py: 1,
+    fontSize: 2,
+    textDecoration: 'none',
+    position: 'absolute',
+    right: '100%',
+    '&:hover, &:focus': {
+      color: 'blue',
+    },
+  })
+);
+
+const Summary = styled.button(
   css({
     display: 'flex',
     alignItems: 'flex-start',
@@ -35,147 +106,10 @@ const Summary = styled((props) => <DisclosureButton {...props} />)(
       outlineColor: 'blue',
     },
 
-    '&:active[data-state="collapsed"]': {
-      bg: 'shadow',
-    },
+    [AnchorLink]: { opacity: 0 },
 
-    '&::after': {
-      backgroundImage: 'url("/images/chevron-down.svg")',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: '0.9em 0.55em',
-      content: '""',
-      flex: '0 0 1.9em',
-      height: '0.55em',
-      ml: 'auto',
-      mr: -2,
-      mt: '0.35em',
-      py: 0,
-    },
-
-    '&[data-state="open"]:after': {
-      transform: 'rotate(180deg)',
+    '&:focus, &:hover': {
+      [AnchorLink]: { opacity: 1 },
     },
   })
 );
-
-const AnchorLink = styled.a(
-  css({
-    color: 'lightGray',
-    px: 3,
-    py: 1,
-    transition: 'opacity 0.3s',
-    fontSize: 2,
-    textDecoration: 'none',
-    position: 'absolute',
-    right: '100%',
-    '&:hover, &:focus': {
-      color: 'blue',
-    },
-    '[data-state="collapsed"] &': {
-      opacity: 0,
-    },
-  })
-);
-
-const Panel = styled((props) => <DisclosurePanel {...props} />)(
-  css({
-    display: 'block',
-    opacity: 0,
-    overflow: 'hidden',
-    px: 3,
-    py: 0,
-    transition: 'height 0.4s ease-in-out, opacity 0.4s ease-in-out',
-    '&[data-state="open"]': {
-      opacity: 1,
-    },
-  })
-);
-
-function locationHashEquals(id: string) {
-  return window.location.hash === `#${id}`;
-}
-
-interface CollapsibleSectionProps extends BoxProps {
-  summary: string;
-  children: ReactNode;
-  id?: string;
-  hideBorder?: boolean;
-}
-
-export const CollapsibleSection = ({
-  summary,
-  children,
-  id,
-  hideBorder,
-}: CollapsibleSectionProps) => {
-  /* Start in an open state so it is open when JS is disabled */
-  const [isOpen, setIsOpen] = useState(true);
-  const { wrapperRef } = useSetLinkTabbability(isOpen);
-
-  const { ref, height: contentHeight } = useResizeObserver();
-
-  /**
-   * Checks the hash part of the URL to see if it matches this instances id.
-   * If so, the collapsible needs to be opened.
-   */
-  useEffect(() => {
-    function handleHashChange() {
-      if (id && locationHashEquals(id)) {
-        setIsOpen(true);
-      }
-    }
-
-    window.addEventListener('hashchange', handleHashChange);
-
-    /**
-     * Since we are open by default, we need to close all sections which are not
-     * opened by a hash now
-     */
-    setIsOpen(!!id && locationHashEquals(id));
-
-    return () => window.removeEventListener('hashchange', handleHashChange);
-  }, [id]);
-
-  return (
-    <Box
-      as="section"
-      borderTop={hideBorder ? undefined : '1px solid'}
-      borderTopColor={hideBorder ? undefined : 'lightGray'}
-      id={id}
-    >
-      <Disclosure open={isOpen} onChange={() => setIsOpen(!isOpen)}>
-        <Summary>
-          {summary}
-          {id && (
-            <AnchorLink onClick={(e) => e.stopPropagation()} href={`#${id}`}>
-              #
-            </AnchorLink>
-          )}
-        </Summary>
-
-        <Panel
-          style={{
-            /* panel max height is only controlled when collapsed, or during animations */
-            height: isOpen ? contentHeight : 0,
-          }}
-        >
-          <div ref={wrapperRef}>
-            <div
-              ref={ref}
-              css={css({
-                /**
-                 * Outside margins of children are breaking height calculations ヽ(ಠ_ಠ)ノ..
-                 * We'll add `overflow: hidden` in order to fix this.
-                 */
-                overflow: 'hidden',
-              })}
-            >
-              {children}
-            </div>
-          </div>
-        </Panel>
-      </Disclosure>
-    </Box>
-  );
-};

--- a/packages/app/src/components/icon-button.tsx
+++ b/packages/app/src/components/icon-button.tsx
@@ -1,10 +1,10 @@
 import css from '@styled-system/css';
-import { forwardRef, ReactNode } from 'react';
+import { cloneElement, forwardRef, ReactElement } from 'react';
 import styled from 'styled-components';
 import { VisuallyHidden } from './visually-hidden';
 
 interface IconButtonProps {
-  children: ReactNode;
+  children: ReactElement;
   size: number;
   title: string;
   color?: string;
@@ -14,7 +14,15 @@ interface IconButtonProps {
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
   (
-    { children, size, title, color = 'currentColor', onClick, padding },
+    {
+      children,
+      size,
+      title,
+      color = 'currentColor',
+      onClick,
+      padding,
+      ...ariaProps
+    },
     ref
   ) => {
     return (
@@ -26,9 +34,10 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         size={size}
         color={color}
         padding={padding}
+        {...ariaProps}
       >
         <VisuallyHidden>{title}</VisuallyHidden>
-        {children}
+        {cloneElement(children, { 'aria-hidden': 'true' })}
       </StyledIconButton>
     );
   }
@@ -47,7 +56,7 @@ const StyledIconButton = styled.button<{
     display: 'block',
     cursor: 'pointer',
     color: x.color,
-    '& > svg': {
+    '& svg': {
       display: 'block',
       width: x.size,
       height: x.size,

--- a/packages/app/src/components/layout/components/top-navigation.tsx
+++ b/packages/app/src/components/layout/components/top-navigation.tsx
@@ -1,7 +1,6 @@
 import css from '@styled-system/css';
-import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Close from '~/assets/close.svg';
 import Menu from '~/assets/menu.svg';
@@ -10,7 +9,7 @@ import { VisuallyHidden } from '~/components/visually-hidden';
 import { useIntl } from '~/intl';
 import { useFeature } from '~/lib/features';
 import { Link } from '~/utils/link';
-import { useIsMounted } from '~/utils/use-is-mounted';
+import { useCollapsible } from '~/utils/use-collapsible';
 import { useMediaQuery } from '~/utils/use-media-query';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
@@ -19,14 +18,14 @@ const wideNavBreakpoint = 'screen and (min-width: 1024px)';
 export function TopNavigation() {
   const isWideNav = useMediaQuery(wideNavBreakpoint);
   const router = useRouter();
-  const isMounted = useIsMounted();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const reverseRouter = useReverseRouter();
   const { siteText } = useIntl();
+  const collapsible = useCollapsible({
+    isOpen: isWideNav,
+    isOpenInitial: true,
+  });
 
   const internationalFeature = useFeature('inHomePage');
-
-  const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
 
   return (
     <>
@@ -37,74 +36,63 @@ export function TopNavigation() {
           '.has-no-js &': { display: 'none' },
         })}
       >
-        <NavToggle
-          onClick={toggleMenu}
-          aria-expanded={isMenuOpen}
-          aria-controls="main-navigation"
-        >
-          {isMenuOpen ? <Close /> : <Menu />}
-          <VisuallyHidden>
-            {isMenuOpen
-              ? siteText.nav.menu.close_menu
-              : siteText.nav.menu.open_menu}
-          </VisuallyHidden>
-        </NavToggle>
+        {collapsible.button(
+          <NavToggle>
+            {collapsible.isOpen ? <Close /> : <Menu />}
+            <VisuallyHidden>
+              {collapsible.isOpen
+                ? siteText.nav.menu.close_menu
+                : siteText.nav.menu.open_menu}
+            </VisuallyHidden>
+          </NavToggle>
+        )}
       </div>
 
       <NavWrapper
         key={isWideNav ? 1 : 0}
-        id="main-navigation"
         role="navigation"
         aria-label={siteText.aria_labels.pagina_keuze}
-        initial={{
-          height: 0,
-          opacity: 1,
-        }}
-        animate={
-          isMounted && {
-            height: isMenuOpen || isWideNav ? 'auto' : 0,
-            opacity: isMenuOpen || isWideNav ? 1 : 0,
-          }
-        }
       >
-        <MaxWidth>
-          <NavList>
-            <NavItem
-              href="/"
-              isActive={
-                router.pathname === '/' ||
-                router.pathname.startsWith('/actueel')
-              }
-            >
-              {siteText.nav.links.actueel}
-            </NavItem>
-            <NavItem
-              href={reverseRouter.nl.index()}
-              isActive={router.pathname.startsWith('/landelijk')}
-            >
-              {siteText.nav.links.index}
-            </NavItem>
-            <NavItem href={reverseRouter.vr.index()}>
-              {siteText.nav.links.veiligheidsregio}
-            </NavItem>
-            <NavItem href={reverseRouter.gm.index()}>
-              {siteText.nav.links.gemeente}
-            </NavItem>
-
-            {internationalFeature.isEnabled ? (
+        {collapsible.content(
+          <MaxWidth>
+            <NavList>
               <NavItem
-                href={reverseRouter.in.index()}
-                isActive={router.pathname.startsWith('/internationaal')}
+                href="/"
+                isActive={
+                  router.pathname === '/' ||
+                  router.pathname.startsWith('/actueel')
+                }
               >
-                {siteText.nav.links.internationaal}
+                {siteText.nav.links.actueel}
               </NavItem>
-            ) : null}
+              <NavItem
+                href={reverseRouter.nl.index()}
+                isActive={router.pathname.startsWith('/landelijk')}
+              >
+                {siteText.nav.links.index}
+              </NavItem>
+              <NavItem href={reverseRouter.vr.index()}>
+                {siteText.nav.links.veiligheidsregio}
+              </NavItem>
+              <NavItem href={reverseRouter.gm.index()}>
+                {siteText.nav.links.gemeente}
+              </NavItem>
 
-            <NavItem href={reverseRouter.algemeen.over()}>
-              {siteText.nav.links.over}
-            </NavItem>
-          </NavList>
-        </MaxWidth>
+              {internationalFeature.isEnabled ? (
+                <NavItem
+                  href={reverseRouter.in.index()}
+                  isActive={router.pathname.startsWith('/internationaal')}
+                >
+                  {siteText.nav.links.internationaal}
+                </NavItem>
+              ) : null}
+
+              <NavItem href={reverseRouter.algemeen.over()}>
+                {siteText.nav.links.over}
+              </NavItem>
+            </NavList>
+          </MaxWidth>
+        )}
       </NavWrapper>
     </>
   );
@@ -149,31 +137,13 @@ const NavToggle = styled.button(
   })
 );
 
-const NavWrapper = styled(motion.nav)(
+const NavWrapper = styled.nav(
   css({
     display: 'block',
     width: '100%',
     borderTopWidth: '1px',
     p: 0,
     overflow: 'hidden',
-
-    '.has-no-js &': {
-      height: 'auto !important',
-      maxHeight: 0,
-      opacity: 0,
-      animation: `show-menu 1s forwards`,
-      animationDelay: '1s',
-    },
-
-    [`@keyframes show-menu`]: {
-      from: {
-        maxHeight: 0,
-      },
-      to: {
-        opacity: 1,
-        maxHeight: '1000px',
-      },
-    },
 
     [`@media ${wideNavBreakpoint}`]: {
       height: 'auto !important',

--- a/packages/app/src/domain/escalation-level/scoreboard/components/vr-group.tsx
+++ b/packages/app/src/domain/escalation-level/scoreboard/components/vr-group.tsx
@@ -1,17 +1,16 @@
 import css from '@styled-system/css';
-import { ReactNode, useState } from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
-import useResizeObserver from 'use-resize-observer';
 import { Box } from '~/components/base';
-import { useSetLinkTabbability } from '~/components/collapsible/use-set-link-tabbability';
 import {
   EscalationLevelInfoLabel,
-  EscalationLevelLabel,
+  EscalationLevelLabel
 } from '~/components/escalation-level';
 import { EscalationLevelIcon } from '~/components/escalation-level-icon';
 import { EscalationLevel } from '~/domain/restrictions/type';
 import { asResponsiveArray } from '~/style/utils';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useCollapsible } from '~/utils/use-collapsible';
 import { RegionCubes } from './region-cubes';
 
 type VrGroupProps = {
@@ -22,76 +21,45 @@ type VrGroupProps = {
 
 export function VrGroup(props: VrGroupProps) {
   const { level, rowCount, children } = props;
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  const { ref, height: contentHeight } = useResizeObserver();
-
   const breakpoints = useBreakpoints(true);
-  const { wrapperRef } = useSetLinkTabbability(isOpen);
+  const collapsible = useCollapsible();
+
+  const headerContent = (
+    <>
+      <Box color="black" minWidth={{ _: '2rem', sm: '13.5rem', lg: '15.5rem' }}>
+        {breakpoints.sm ? (
+          <EscalationLevelInfoLabel level={level} fontSize={3} size="medium" />
+        ) : (
+          level !== null && <EscalationLevelIcon level={level} size="medium" />
+        )}
+      </Box>
+      <Box ml={2} color="black">
+        {!breakpoints.sm && <EscalationLevelLabel level={level} fontSize={2} />}
+        <RegionCubes count={rowCount} level={level} />
+      </Box>
+    </>
+  );
 
   return (
     <Box borderTopColor="lightGray" borderTopStyle="solid" borderTopWidth="1px">
-      <Header
-        open={isOpen}
-        onClick={rowCount > 0 ? () => setIsOpen((x) => !x) : undefined}
-        showChevron={rowCount > 0}
-      >
-        <Box
-          color="black"
-          minWidth={{ _: '2rem', sm: '13.5rem', lg: '15.5rem' }}
-        >
-          {breakpoints.sm ? (
-            <EscalationLevelInfoLabel
-              level={level}
-              fontSize={3}
-              size="medium"
-            />
-          ) : (
-            level !== null && (
-              <EscalationLevelIcon level={level} size="medium" />
-            )
+      {rowCount > 0 ? (
+        <>
+          {collapsible.button(
+            <Header open={collapsible.isOpen}>
+              {headerContent}
+              <Box ml="auto">{collapsible.chevron}</Box>
+            </Header>
           )}
-        </Box>
-        <Box ml={2} color="black">
-          {!breakpoints.sm && (
-            <EscalationLevelLabel level={level} fontSize={2} />
-          )}
-          <RegionCubes count={rowCount} level={level} />
-        </Box>
-      </Header>
-      {rowCount > 0 && (
-        <Panel
-          open={isOpen}
-          style={{
-            /* panel max height is only controlled when collapsed, or during animations */
-            height: isOpen ? contentHeight : 0,
-          }}
-        >
-          <div
-            ref={ref}
-            css={css({
-              overflow: 'hidden',
-            })}
-          >
-            <div ref={wrapperRef}>{children}</div>
-          </div>
-        </Panel>
+          {collapsible.content(children)}
+        </>
+      ) : (
+        <Header as="div">{headerContent}</Header>
       )}
     </Box>
   );
 }
 
-const Panel = styled.div<{ open: boolean }>((props) =>
-  css({
-    display: 'block',
-    overflow: 'hidden',
-    transition: 'height 0.4s ease-in-out, opacity 0.4s ease-in-out',
-    opacity: props.open ? 1 : 0,
-  })
-);
-
-const Header = styled.button<{ showChevron: boolean; open: boolean }>((props) =>
+const Header = styled.button<{ open?: boolean }>((props) =>
   css({
     display: 'flex',
     alignItems: 'center',
@@ -106,27 +74,8 @@ const Header = styled.button<{ showChevron: boolean; open: boolean }>((props) =>
     fontFamily: 'body',
     fontSize: '1.25rem',
     textAlign: 'left',
-    cursor: props.showChevron ? 'pointer' : 'default',
+    cursor: props.onClick ? 'pointer' : 'default',
     borderBottom: '1px solid',
     borderBottomColor: props.open ? 'lightGray' : 'transparent',
-
-    '&::after': props.showChevron
-      ? {
-          backgroundImage: 'url("/images/chevron-down.svg")',
-          backgroundPosition: 'center',
-          backgroundRepeat: 'no-repeat',
-          transform: props.open ? 'rotate(180deg)' : 'rotate(0deg)',
-          transition: 'transform 0.4s ease-in-out',
-          content: '""',
-          flex: '0 0 3rem',
-          height: '1.25rem',
-          marginLeft: 'auto',
-          py: 0,
-        }
-      : {
-          content: '""',
-          height: '1.25rem',
-          flex: '0 0 3rem',
-        },
   })
 );

--- a/packages/app/src/domain/vaccine/components/coverage-row.tsx
+++ b/packages/app/src/domain/vaccine/components/coverage-row.tsx
@@ -1,9 +1,9 @@
 import css from '@styled-system/css';
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
-import { colors } from '~/style/theme';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useCollapsible } from '~/utils/use-collapsible';
 
 type RowProps = {
   children: ReactNode;
@@ -30,29 +30,29 @@ export function HeaderRow(props: RowProps) {
 }
 
 function MobileCoverageRow(props: RowProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const collapsible = useCollapsible();
   const children = React.Children.toArray(props.children);
 
   return (
-    <Row width="100%" display="flex" flexDirection="column">
-      <Box display="flex">
+    <Row
+      width="100%"
+      display="flex"
+      flexDirection="column"
+      onClick={collapsible.toggle}
+    >
+      <Box display="flex" alignItems="center">
         <Box flex={1}>{children[0]}</Box>
         <Box
           flex={1}
           display="flex"
           justifyContent="flex-end"
           pr={{ _: 2, xs: 4 }}
-          onClick={() => setIsOpen(!isOpen)}
         >
           {children[1]}
         </Box>
-        <Box flex={0.2}>
-          <Button onClick={() => setIsOpen(!isOpen)}>
-            <Chevron isOpen={isOpen} color={colors.blue} />
-          </Button>
-        </Box>
+        <Box flex={0.2}>{collapsible.button()}</Box>
       </Box>
-      <CollapsiblePanel isOpen={isOpen}>{children[2]}</CollapsiblePanel>
+      {collapsible.content(<Box pt={2}>{children[2]}</Box>)}
     </Row>
   );
 }
@@ -122,45 +122,5 @@ const Row = styled(Box)(
     borderBottomStyle: 'solid',
     borderBottomWidth: '1px',
     py: 3,
-  })
-);
-
-const Button = styled.button(
-  css({
-    border: 'none',
-    bg: 'transparent',
-    height: '100%',
-    width: '100%',
-    '&:focus': { outline: 0 },
-  })
-);
-
-const Chevron = styled.div<{
-  isOpen: boolean;
-}>((x) =>
-  css({
-    backgroundImage: 'url("/images/chevron-down-blue.svg")',
-    backgroundSize: '1.4em 0.9em',
-    backgroundPosition: '0 50%',
-    backgroundRepeat: 'no-repeat',
-    height: '0.9em',
-    width: '1.5em',
-    display: 'inline-block',
-    transitionProperty: 'transform',
-    transitionDuration: '0.5s',
-    transform: x.isOpen ? 'rotate(-180deg)' : '',
-  })
-);
-
-const CollapsiblePanel = styled.div<{ isOpen: boolean }>((x) =>
-  css({
-    transitionProperty: 'opacity, height, padding',
-    transitionDuration: '0.5s',
-    transitionTimingFunction: 'ease-out',
-    width: '100%',
-    overflow: 'hidden',
-    height: x.isOpen ? 'auto' : 0,
-    opacity: x.isOpen ? 1 : 0,
-    pt: x.isOpen ? 2 : 0,
   })
 );

--- a/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
@@ -1,20 +1,15 @@
 import { DifferenceDecimal } from '@corona-dashboard/common';
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@reach/disclosure';
 import css from '@styled-system/css';
-import { forwardRef, MouseEvent, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import styled from 'styled-components';
 import { isPresent } from 'ts-is-present';
-import useResizeObserver from 'use-resize-observer';
 import { Box } from '~/components/base';
 import { InlineText } from '~/components/typography';
 import { TableText } from '~/domain/variants/variants-table-tile';
 import { useIntl } from '~/intl';
 import { VariantRow } from '~/static-props/variants/get-variant-table-data';
 import { getMaximumNumberOfDecimals } from '~/utils/get-maximum-number-of-decimals';
+import { useCollapsible } from '~/utils/use-collapsible';
 import {
   Cell,
   HeaderCell,
@@ -77,18 +72,9 @@ type MobileVariantRowProps = {
 
 function MobileVariantRow(props: MobileVariantRowProps) {
   const { row, text, formatValue } = props;
-  const [isOpen, setIsOpen] = useState(false);
-  const { ref, height: contentHeight } = useResizeObserver();
+  const collapsible = useCollapsible();
 
   const columnNames = text.kolommen;
-
-  const chevronRef = useRef<HTMLButtonElement>();
-
-  function handleRowClick(event: MouseEvent) {
-    if (event.target !== chevronRef.current) {
-      setIsOpen((x) => !x);
-    }
-  }
 
   const [, variantDescription] = useVariantNameAndDescription(
     row.variant,
@@ -98,7 +84,7 @@ function MobileVariantRow(props: MobileVariantRowProps) {
 
   return (
     <>
-      <tr onClick={handleRowClick} style={{ cursor: 'pointer' }}>
+      <tr style={{ cursor: 'pointer' }} onClick={collapsible.toggle}>
         <VariantNameCell
           variant={row.variant}
           text={text}
@@ -118,26 +104,14 @@ function MobileVariantRow(props: MobileVariantRowProps) {
           )}
         </Cell>
         <Cell mobile alignRight>
-          <Disclosure
-            open={isOpen}
-            onChange={() => {
-              setIsOpen((x) => !x);
-            }}
-          >
-            <Chevron ref={chevronRef as any} />
-          </Disclosure>
+          {collapsible.button()}
         </Cell>
       </tr>
       <tr>
         <MobileCell colSpan={3}>
-          <Panel
-            style={{
-              height: isOpen ? contentHeight : 0,
-              marginBottom: isOpen ? '1rem' : 0,
-            }}
-          >
-            <div ref={ref}>
-              <Box mb={1} display="flex" flexDirection="row">
+          {collapsible.content(
+            <Box spacing={2} css={css({ pb: 3 })}>
+              <Box display="flex" flexDirection="row">
                 <InlineText mr={1}>{columnNames.vorige_meeting}:</InlineText>
                 {isPresent(row.difference) &&
                 isPresent(row.difference.difference) &&
@@ -149,65 +123,19 @@ function MobileVariantRow(props: MobileVariantRowProps) {
                   '-'
                 )}
               </Box>
-              <Box css={css({ color: 'annotation', fontSize: 2, mt: 2 })}>
+              <Box css={css({ color: 'annotation', fontSize: 2 })}>
                 {variantDescription}
               </Box>
-            </div>
-          </Panel>
+            </Box>
+          )}
         </MobileCell>
       </tr>
     </>
   );
 }
 
-const Chevron = styled(
-  forwardRef((props, ref) => <DisclosureButton {...(props as any)} ref={ref} />)
-)(
-  css({
-    display: 'flex',
-    alignItems: 'flex-end',
-    m: 0,
-    p: 0,
-    pb: 0,
-    overflow: 'visible',
-    bg: 'transparent',
-    border: 'none',
-    color: 'lightGray',
-    fontSize: '1.25rem',
-    cursor: 'pointer',
-
-    '&::after': {
-      backgroundImage: 'url("/images/chevron-down.svg")',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: '0.9em 0.55em',
-      content: '""',
-      width: '0.9em',
-      height: '0.55em',
-      mt: '0.35em',
-      p: 0,
-      transition: 'transform 0.4s ease-in-out',
-    },
-
-    '&[data-state="open"]:after': {
-      transform: 'rotate(180deg)',
-    },
-  })
-);
-
-const Panel = styled((props) => <DisclosurePanel {...props} />)(
-  css({
-    display: 'block',
-    opacity: 1,
-    overflow: 'hidden',
-    p: 0,
-    transition: 'height 0.4s ease-in-out, opacity 0.4s ease-in-out',
-  })
-);
-
 const MobileCell = styled.td(
   css({
-    p: 0,
     borderBottom: '1px solid',
     borderBottomColor: 'lightGray',
   })

--- a/packages/app/src/utils/use-collapsible.tsx
+++ b/packages/app/src/utils/use-collapsible.tsx
@@ -1,0 +1,135 @@
+import css from '@styled-system/css';
+import { motion } from 'framer-motion';
+import { isBoolean } from 'lodash';
+import {
+  cloneElement,
+  MouseEvent,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+import ChevronIcon from '~/assets/chevron.svg';
+import { Box, MotionBox } from '~/components/base';
+import { IconButton } from '~/components/icon-button';
+import { useUniqueId } from '~/utils/use-unique-id';
+
+export function useCollapsible(
+  options: { isOpen?: boolean; isOpenInitial?: boolean } = {
+    isOpen: false,
+    isOpenInitial: false,
+  }
+) {
+  const id = useUniqueId();
+  const [isOpen, setIsOpen] = useState(options.isOpen);
+
+  useEffect(() => setIsOpen(options.isOpen), [options.isOpen]);
+
+  const toggle = useCallback(
+    (isOpen?: true | false | unknown) =>
+      setIsOpen((x) => (isBoolean(isOpen) ? isOpen : !x)),
+    []
+  );
+
+  const chevron = (
+    <Box
+      as="span"
+      display="inline-block"
+      transform="rotate(90deg)"
+      css={css({ '.has-no-js &': { display: 'none' } })}
+    >
+      <MotionChevron animate={{ rotateY: isOpen ? 180 : 0 }} />
+    </Box>
+  );
+
+  const defaultButton = (
+    <IconButton title="toggle content" size={18}>
+      {chevron}
+    </IconButton>
+  );
+
+  const button = (x: ReactElement = defaultButton) =>
+    cloneElement(x, {
+      'aria-controls': id,
+      'aria-expanded': isOpen ? ('true' as const) : ('false' as const),
+      style: {
+        ...x.props.style,
+        userSelect: 'none',
+      },
+      onClick: (evt: MouseEvent) => {
+        evt.stopPropagation();
+        setIsOpen((x) => !x);
+
+        if (x?.props?.onClick) {
+          return x.props.onClick(evt);
+        }
+      },
+    });
+
+  const content = (children: ReactNode) => (
+    <MotionBox
+      id={id}
+      aria-hidden={isOpen ? 'false' : 'true'}
+      width="100%"
+      overflow="hidden"
+      animate={isOpen ? 'open' : 'rest'}
+      initial={options.isOpenInitial ? 'open' : undefined}
+      css={css({
+        height: 0,
+        opacity: 0,
+        '.has-no-js &': {
+          height: 'auto !important',
+          maxHeight: 0,
+          opacity: 0,
+          animation: `show-menu 1s forwards`,
+          animationDelay: '1s',
+        },
+        [`@keyframes show-menu`]: {
+          from: {
+            maxHeight: 0,
+          },
+          to: {
+            opacity: 1,
+            maxHeight: '99999px',
+          },
+        },
+      })}
+      variants={{
+        rest: {
+          opacity: 0,
+          height: 0,
+          transitionEnd: { display: 'none' },
+        },
+        open: {
+          opacity: 1,
+          height: 'auto',
+          display: 'block',
+        },
+      }}
+    >
+      {children}
+    </MotionBox>
+  );
+
+  return {
+    button,
+    content,
+    chevron,
+    toggle,
+    isOpen,
+  };
+}
+
+const MotionChevron = styled(motion(ChevronIcon))(
+  css({
+    backgroundSize: '1.4em 0.9em',
+    backgroundPosition: '0 50%',
+    backgroundRepeat: 'no-repeat',
+    height: '0.9em',
+    width: '1.5em',
+    display: 'inline-block',
+    color: 'blue',
+  })
+);

--- a/packages/app/src/utils/use-collapsible.tsx
+++ b/packages/app/src/utils/use-collapsible.tsx
@@ -18,6 +18,7 @@ import { useUniqueId } from '~/utils/use-unique-id';
 
 /**
  * Generic hook for collapsing content. Core features:
+ *
  * - SSR will always display content
  * - a11y aria props are taken care of
  * - will animate out of the box
@@ -25,8 +26,9 @@ import { useUniqueId } from '~/utils/use-unique-id';
  * Usage:
  *
  * The hook exposes the following:
+ *
  * - `content(children: ReactNode)`
- *   - wrap the collapsible content with this functions
+ *   - wrap the collapsible content with this function
  *
  * - `button(children?: ReactNode)`
  *   - wrap an element (probably a button) with this function which will set

--- a/packages/app/src/utils/use-collapsible.tsx
+++ b/packages/app/src/utils/use-collapsible.tsx
@@ -16,6 +16,30 @@ import { Box, MotionBox } from '~/components/base';
 import { IconButton } from '~/components/icon-button';
 import { useUniqueId } from '~/utils/use-unique-id';
 
+/**
+ * Generic hook for collapsing content. Core features:
+ * - SSR will always display content
+ * - a11y aria props are taken care of
+ * - will animate out of the box
+ *
+ * Usage:
+ *
+ * The hook exposes the following:
+ * - `content(children: ReactNode)`
+ *   - wrap the collapsible content with this functions
+ *
+ * - `button(children?: ReactNode)`
+ *   - wrap an element (probably a button) with this function which will set
+ *     aria props and a click handler
+ *   - the child is optional, when it's empty it will render a button with a
+ *     chevron
+ *
+ * - `chevron`
+ *   - a chevron-svg which will animate based on internal open/close state
+ *
+ * - `isOpen`
+ *   - current open/close state
+ */
 export function useCollapsible(
   options: { isOpen?: boolean; isOpenInitial?: boolean } = {
     isOpen: false,


### PR DESCRIPTION
Generic hook for collapsing content. Core features:

  - SSR will always display content
  - a11y aria props are taken care of
  - will animate out of the box

Usage:

The hook exposes the following:
  - `content(children: ReactNode)`
    - wrap the collapsible content with this function
  - `button(children?: ReactNode)`
    - wrap an element (probably a button) with this function which will set
      aria props and a click handler
    - the child is optional, when it's empty it will render a button with a
      chevron
  - `chevron`
    - a chevron-svg which will animate based on internal open/close state
  - `isOpen`
    - current open/close state
