### PR TITLE
Patch next i18n domain detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,16 @@
     "generate-typescript": "yarn workspace @corona-dashboard/cli generate-typescript",
     "e2e": "yarn workspace @corona-dashboard/e2e e2e",
     "e2e:ci": "yarn workspace @corona-dashboard/e2e e2e:ci",
-    "cms": "yarn workspace @corona-dashboard/cms start"
+    "cms": "yarn workspace @corona-dashboard/cms start",
+    "postinstall": "patch-package"
   },
   "workspaces": {
     "packages": [
       "packages/*"
     ]
   },
-  "dependencies": {}
+  "dependencies": {
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0"
+  }
 }

--- a/packages/app/next.domains.config.js
+++ b/packages/app/next.domains.config.js
@@ -21,6 +21,14 @@ module.exports = [
     defaultLocale: 'en',
   },
   {
+    domain: 'localhost',
+    defaultLocale: 'nl',
+  },
+  {
+    domain: 'localhost-en',
+    defaultLocale: 'en',
+  },
+  {
     domain: 'master-en-covid19-data-dashboard.vercel.app',
     defaultLocale: 'en',
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
     "http-proxy-middleware": "^2.0.0",
     "lodash": "^4.17.20",
     "match-sorter": "^6.2.0",
-    "next": "^11.0.1",
+    "next": "11.0.1",
     "polished": "^4.1.3",
     "proxy-polyfill": "^0.3.2",
     "react": "^17.0.1",

--- a/patches/next+11.0.1.patch
+++ b/patches/next+11.0.1.patch
@@ -1,0 +1,1523 @@
+diff --git a/node_modules/next/dist/next-server/lib/i18n/detect-domain-locale.js b/node_modules/next/dist/next-server/lib/i18n/detect-domain-locale.js
+index 8c76a68..342de0e 100644
+--- a/node_modules/next/dist/next-server/lib/i18n/detect-domain-locale.js
++++ b/node_modules/next/dist/next-server/lib/i18n/detect-domain-locale.js
+@@ -1,3 +1,31 @@
+-"use strict";exports.__esModule=true;exports.detectDomainLocale=detectDomainLocale;function detectDomainLocale(domainItems,hostname,detectedLocale){let domainItem;if(domainItems){if(detectedLocale){detectedLocale=detectedLocale.toLowerCase();}for(const item of domainItems){var _item$domain,_item$locales;// remove port if present
+-const domainHostname=(_item$domain=item.domain)==null?void 0:_item$domain.split(':')[0].toLowerCase();if(hostname===domainHostname||detectedLocale===item.defaultLocale.toLowerCase()||(_item$locales=item.locales)!=null&&_item$locales.some(locale=>locale.toLowerCase()===detectedLocale)){domainItem=item;break;}}}return domainItem;}
++"use strict";
++
++exports.__esModule = true;
++exports.detectDomainLocale = detectDomainLocale;
++
++function detectDomainLocale(domainItems, hostname, detectedLocale) {
++  let domainItem;
++
++  if (domainItems) {
++    var _domainItems$find;
++
++    if (detectedLocale) {
++      detectedLocale = detectedLocale.toLowerCase();
++    }
++
++    domainItem = // Check whether current hostname is defined in domains and return it
++    (_domainItems$find = domainItems.find(item => {
++      var _item$domain;
++
++      return hostname === ((_item$domain = item.domain) == null ? void 0 : _item$domain.split(':')[0].toLowerCase());
++    })) != null ? _domainItems$find : // Check for domain item that uses the detected locale
++    domainItems.find(item => {
++      var _item$locales;
++
++      return detectedLocale === item.defaultLocale.toLowerCase() || ((_item$locales = item.locales) == null ? void 0 : _item$locales.some(locale => locale.toLowerCase() === detectedLocale));
++    });
++  }
++
++  return domainItem;
++}
+ //# sourceMappingURL=detect-domain-locale.js.map
+diff --git a/node_modules/next/dist/next-server/lib/router/router.js b/node_modules/next/dist/next-server/lib/router/router.js
+index d265358..a8ff782 100644
+--- a/node_modules/next/dist/next-server/lib/router/router.js
++++ b/node_modules/next/dist/next-server/lib/router/router.js
+@@ -1,178 +1,1322 @@
+-"use strict";exports.__esModule=true;exports.getDomainLocale=getDomainLocale;exports.addLocale=addLocale;exports.delLocale=delLocale;exports.hasBasePath=hasBasePath;exports.addBasePath=addBasePath;exports.delBasePath=delBasePath;exports.isLocalURL=isLocalURL;exports.interpolateAs=interpolateAs;exports.resolveHref=resolveHref;exports.default=void 0;var _normalizeTrailingSlash=require("../../../client/normalize-trailing-slash");var _routeLoader=require("../../../client/route-loader");var _denormalizePagePath=require("../../server/denormalize-page-path");var _normalizeLocalePath=require("../i18n/normalize-locale-path");var _mitt=_interopRequireDefault(require("../mitt"));var _utils=require("../utils");var _isDynamic=require("./utils/is-dynamic");var _parseRelativeUrl=require("./utils/parse-relative-url");var _querystring=require("./utils/querystring");var _resolveRewrites=_interopRequireDefault(require("./utils/resolve-rewrites"));var _routeMatcher=require("./utils/route-matcher");var _routeRegex=require("./utils/route-regex");function _interopRequireDefault(obj){return obj&&obj.__esModule?obj:{default:obj};}// tslint:disable:no-console
+-let detectDomainLocale;if(process.env.__NEXT_I18N_SUPPORT){detectDomainLocale=require('../i18n/detect-domain-locale').detectDomainLocale;}const basePath=process.env.__NEXT_ROUTER_BASEPATH||'';function buildCancellationError(){return Object.assign(new Error('Route Cancelled'),{cancelled:true});}function addPathPrefix(path,prefix){return prefix&&path.startsWith('/')?path==='/'?(0,_normalizeTrailingSlash.normalizePathTrailingSlash)(prefix):`${prefix}${pathNoQueryHash(path)==='/'?path.substring(1):path}`:path;}function getDomainLocale(path,locale,locales,domainLocales){if(process.env.__NEXT_I18N_SUPPORT){locale=locale||(0,_normalizeLocalePath.normalizeLocalePath)(path,locales).detectedLocale;const detectedDomain=detectDomainLocale(domainLocales,undefined,locale);if(detectedDomain){return`http${detectedDomain.http?'':'s'}://${detectedDomain.domain}${basePath||''}${locale===detectedDomain.defaultLocale?'':`/${locale}`}${path}`;}return false;}return false;}function addLocale(path,locale,defaultLocale){if(process.env.__NEXT_I18N_SUPPORT){const pathname=pathNoQueryHash(path);const pathLower=pathname.toLowerCase();const localeLower=locale&&locale.toLowerCase();return locale&&locale!==defaultLocale&&!pathLower.startsWith('/'+localeLower+'/')&&pathLower!=='/'+localeLower?addPathPrefix(path,'/'+locale):path;}return path;}function delLocale(path,locale){if(process.env.__NEXT_I18N_SUPPORT){const pathname=pathNoQueryHash(path);const pathLower=pathname.toLowerCase();const localeLower=locale&&locale.toLowerCase();return locale&&(pathLower.startsWith('/'+localeLower+'/')||pathLower==='/'+localeLower)?(pathname.length===locale.length+1?'/':'')+path.substr(locale.length+1):path;}return path;}function pathNoQueryHash(path){const queryIndex=path.indexOf('?');const hashIndex=path.indexOf('#');if(queryIndex>-1||hashIndex>-1){path=path.substring(0,queryIndex>-1?queryIndex:hashIndex);}return path;}function hasBasePath(path){path=pathNoQueryHash(path);return path===basePath||path.startsWith(basePath+'/');}function addBasePath(path){// we only add the basepath on relative urls
+-return addPathPrefix(path,basePath);}function delBasePath(path){path=path.slice(basePath.length);if(!path.startsWith('/'))path=`/${path}`;return path;}/**
++"use strict";
++
++exports.__esModule = true;
++exports.getDomainLocale = getDomainLocale;
++exports.addLocale = addLocale;
++exports.delLocale = delLocale;
++exports.hasBasePath = hasBasePath;
++exports.addBasePath = addBasePath;
++exports.delBasePath = delBasePath;
++exports.isLocalURL = isLocalURL;
++exports.interpolateAs = interpolateAs;
++exports.resolveHref = resolveHref;
++exports.default = void 0;
++
++var _normalizeTrailingSlash = require("../../../client/normalize-trailing-slash");
++
++var _routeLoader = require("../../../client/route-loader");
++
++var _denormalizePagePath = require("../../server/denormalize-page-path");
++
++var _normalizeLocalePath = require("../i18n/normalize-locale-path");
++
++var _mitt = _interopRequireDefault(require("../mitt"));
++
++var _utils = require("../utils");
++
++var _isDynamic = require("./utils/is-dynamic");
++
++var _parseRelativeUrl = require("./utils/parse-relative-url");
++
++var _querystring = require("./utils/querystring");
++
++var _resolveRewrites = _interopRequireDefault(require("./utils/resolve-rewrites"));
++
++var _routeMatcher = require("./utils/route-matcher");
++
++var _routeRegex = require("./utils/route-regex");
++
++function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
++
++// tslint:disable:no-console
++let detectDomainLocale;
++
++if (process.env.__NEXT_I18N_SUPPORT) {
++  detectDomainLocale = require('../i18n/detect-domain-locale').detectDomainLocale;
++}
++
++const basePath = process.env.__NEXT_ROUTER_BASEPATH || '';
++
++function buildCancellationError() {
++  return Object.assign(new Error('Route Cancelled'), {
++    cancelled: true
++  });
++}
++
++function addPathPrefix(path, prefix) {
++  return prefix && path.startsWith('/') ? path === '/' ? (0, _normalizeTrailingSlash.normalizePathTrailingSlash)(prefix) : `${prefix}${pathNoQueryHash(path) === '/' ? path.substring(1) : path}` : path;
++}
++
++function getDomainLocale(path, locale, locales, domainLocales) {
++  if (process.env.__NEXT_I18N_SUPPORT) {
++    locale = locale || (0, _normalizeLocalePath.normalizeLocalePath)(path, locales).detectedLocale;
++    const detectedDomain = detectDomainLocale(domainLocales, undefined, locale);
++
++    if (detectedDomain) {
++      return `http${detectedDomain.http ? '' : 's'}://${detectedDomain.domain}${basePath || ''}${locale === detectedDomain.defaultLocale ? '' : `/${locale}`}${path}`;
++    }
++
++    return false;
++  }
++
++  return false;
++}
++
++function addLocale(path, locale, defaultLocale) {
++  if (process.env.__NEXT_I18N_SUPPORT) {
++    const pathname = pathNoQueryHash(path);
++    const pathLower = pathname.toLowerCase();
++    const localeLower = locale && locale.toLowerCase();
++    return locale && locale !== defaultLocale && !pathLower.startsWith('/' + localeLower + '/') && pathLower !== '/' + localeLower ? addPathPrefix(path, '/' + locale) : path;
++  }
++
++  return path;
++}
++
++function delLocale(path, locale) {
++  if (process.env.__NEXT_I18N_SUPPORT) {
++    const pathname = pathNoQueryHash(path);
++    const pathLower = pathname.toLowerCase();
++    const localeLower = locale && locale.toLowerCase();
++    return locale && (pathLower.startsWith('/' + localeLower + '/') || pathLower === '/' + localeLower) ? (pathname.length === locale.length + 1 ? '/' : '') + path.substr(locale.length + 1) : path;
++  }
++
++  return path;
++}
++
++function pathNoQueryHash(path) {
++  const queryIndex = path.indexOf('?');
++  const hashIndex = path.indexOf('#');
++
++  if (queryIndex > -1 || hashIndex > -1) {
++    path = path.substring(0, queryIndex > -1 ? queryIndex : hashIndex);
++  }
++
++  return path;
++}
++
++function hasBasePath(path) {
++  path = pathNoQueryHash(path);
++  return path === basePath || path.startsWith(basePath + '/');
++}
++
++function addBasePath(path) {
++  // we only add the basepath on relative urls
++  return addPathPrefix(path, basePath);
++}
++
++function delBasePath(path) {
++  path = path.slice(basePath.length);
++  if (!path.startsWith('/')) path = `/${path}`;
++  return path;
++}
++/**
+  * Detects whether a given url is routable by the Next.js router (browser only).
+- */function isLocalURL(url){// prevent a hydration mismatch on href for url with anchor refs
+-if(url.startsWith('/')||url.startsWith('#')||url.startsWith('?'))return true;try{// absolute urls can be local if they are on the same origin
+-const locationOrigin=(0,_utils.getLocationOrigin)();const resolved=new URL(url,locationOrigin);return resolved.origin===locationOrigin&&hasBasePath(resolved.pathname);}catch(_){return false;}}function interpolateAs(route,asPathname,query){let interpolatedRoute='';const dynamicRegex=(0,_routeRegex.getRouteRegex)(route);const dynamicGroups=dynamicRegex.groups;const dynamicMatches=// Try to match the dynamic route against the asPath
+-(asPathname!==route?(0,_routeMatcher.getRouteMatcher)(dynamicRegex)(asPathname):'')||// Fall back to reading the values from the href
+-// TODO: should this take priority; also need to change in the router.
+-query;interpolatedRoute=route;const params=Object.keys(dynamicGroups);if(!params.every(param=>{let value=dynamicMatches[param]||'';const{repeat,optional}=dynamicGroups[param];// support single-level catch-all
+-// TODO: more robust handling for user-error (passing `/`)
+-let replaced=`[${repeat?'...':''}${param}]`;if(optional){replaced=`${!value?'/':''}[${replaced}]`;}if(repeat&&!Array.isArray(value))value=[value];return(optional||param in dynamicMatches)&&(// Interpolate group into data URL if present
+-interpolatedRoute=interpolatedRoute.replace(replaced,repeat?value.map(// these values should be fully encoded instead of just
+-// path delimiter escaped since they are being inserted
+-// into the URL and we expect URL encoded segments
+-// when parsing dynamic route params
+-segment=>encodeURIComponent(segment)).join('/'):encodeURIComponent(value))||'/');})){interpolatedRoute='';// did not satisfy all requirements
+-// n.b. We ignore this error because we handle warning for this case in
+-// development in the `<Link>` component directly.
+-}return{params,result:interpolatedRoute};}function omitParmsFromQuery(query,params){const filteredQuery={};Object.keys(query).forEach(key=>{if(!params.includes(key)){filteredQuery[key]=query[key];}});return filteredQuery;}/**
++ */
++
++
++function isLocalURL(url) {
++  // prevent a hydration mismatch on href for url with anchor refs
++  if (url.startsWith('/') || url.startsWith('#') || url.startsWith('?')) return true;
++
++  try {
++    // absolute urls can be local if they are on the same origin
++    const locationOrigin = (0, _utils.getLocationOrigin)();
++    const resolved = new URL(url, locationOrigin);
++    return resolved.origin === locationOrigin && hasBasePath(resolved.pathname);
++  } catch (_) {
++    return false;
++  }
++}
++
++function interpolateAs(route, asPathname, query) {
++  let interpolatedRoute = '';
++  const dynamicRegex = (0, _routeRegex.getRouteRegex)(route);
++  const dynamicGroups = dynamicRegex.groups;
++  const dynamicMatches = // Try to match the dynamic route against the asPath
++  (asPathname !== route ? (0, _routeMatcher.getRouteMatcher)(dynamicRegex)(asPathname) : '') || // Fall back to reading the values from the href
++  // TODO: should this take priority; also need to change in the router.
++  query;
++  interpolatedRoute = route;
++  const params = Object.keys(dynamicGroups);
++
++  if (!params.every(param => {
++    let value = dynamicMatches[param] || '';
++    const {
++      repeat,
++      optional
++    } = dynamicGroups[param]; // support single-level catch-all
++    // TODO: more robust handling for user-error (passing `/`)
++
++    let replaced = `[${repeat ? '...' : ''}${param}]`;
++
++    if (optional) {
++      replaced = `${!value ? '/' : ''}[${replaced}]`;
++    }
++
++    if (repeat && !Array.isArray(value)) value = [value];
++    return (optional || param in dynamicMatches) && ( // Interpolate group into data URL if present
++    interpolatedRoute = interpolatedRoute.replace(replaced, repeat ? value.map( // these values should be fully encoded instead of just
++    // path delimiter escaped since they are being inserted
++    // into the URL and we expect URL encoded segments
++    // when parsing dynamic route params
++    segment => encodeURIComponent(segment)).join('/') : encodeURIComponent(value)) || '/');
++  })) {
++    interpolatedRoute = ''; // did not satisfy all requirements
++    // n.b. We ignore this error because we handle warning for this case in
++    // development in the `<Link>` component directly.
++  }
++
++  return {
++    params,
++    result: interpolatedRoute
++  };
++}
++
++function omitParmsFromQuery(query, params) {
++  const filteredQuery = {};
++  Object.keys(query).forEach(key => {
++    if (!params.includes(key)) {
++      filteredQuery[key] = query[key];
++    }
++  });
++  return filteredQuery;
++}
++/**
+  * Resolves a given hyperlink with a certain router state (basePath not included).
+  * Preserves absolute urls.
+- */function resolveHref(router,href,resolveAs){// we use a dummy base url for relative urls
+-let base;const urlAsString=typeof href==='string'?href:(0,_utils.formatWithValidation)(href);try{base=new URL(urlAsString.startsWith('#')?router.asPath:router.pathname,'http://n');}catch(_){// fallback to / for invalid asPath values e.g. //
+-base=new URL('/','http://n');}// Return because it cannot be routed by the Next.js router
+-if(!isLocalURL(urlAsString)){return resolveAs?[urlAsString]:urlAsString;}try{const finalUrl=new URL(urlAsString,base);finalUrl.pathname=(0,_normalizeTrailingSlash.normalizePathTrailingSlash)(finalUrl.pathname);let interpolatedAs='';if((0,_isDynamic.isDynamicRoute)(finalUrl.pathname)&&finalUrl.searchParams&&resolveAs){const query=(0,_querystring.searchParamsToUrlQuery)(finalUrl.searchParams);const{result,params}=interpolateAs(finalUrl.pathname,finalUrl.pathname,query);if(result){interpolatedAs=(0,_utils.formatWithValidation)({pathname:result,hash:finalUrl.hash,query:omitParmsFromQuery(query,params)});}}// if the origin didn't change, it means we received a relative href
+-const resolvedHref=finalUrl.origin===base.origin?finalUrl.href.slice(finalUrl.origin.length):finalUrl.href;return resolveAs?[resolvedHref,interpolatedAs||resolvedHref]:resolvedHref;}catch(_){return resolveAs?[urlAsString]:urlAsString;}}function stripOrigin(url){const origin=(0,_utils.getLocationOrigin)();return url.startsWith(origin)?url.substring(origin.length):url;}function prepareUrlAs(router,url,as){// If url and as provided as an object representation,
+-// we'll format them into the string version here.
+-let[resolvedHref,resolvedAs]=resolveHref(router,url,true);const origin=(0,_utils.getLocationOrigin)();const hrefHadOrigin=resolvedHref.startsWith(origin);const asHadOrigin=resolvedAs&&resolvedAs.startsWith(origin);resolvedHref=stripOrigin(resolvedHref);resolvedAs=resolvedAs?stripOrigin(resolvedAs):resolvedAs;const preparedUrl=hrefHadOrigin?resolvedHref:addBasePath(resolvedHref);const preparedAs=as?stripOrigin(resolveHref(router,as)):resolvedAs||resolvedHref;return{url:preparedUrl,as:asHadOrigin?preparedAs:addBasePath(preparedAs)};}function resolveDynamicRoute(pathname,pages){const cleanPathname=(0,_normalizeTrailingSlash.removePathTrailingSlash)((0,_denormalizePagePath.denormalizePagePath)(pathname));if(cleanPathname==='/404'||cleanPathname==='/_error'){return pathname;}// handle resolving href for dynamic routes
+-if(!pages.includes(cleanPathname)){// eslint-disable-next-line array-callback-return
+-pages.some(page=>{if((0,_isDynamic.isDynamicRoute)(page)&&(0,_routeRegex.getRouteRegex)(page).re.test(cleanPathname)){pathname=page;return true;}});}return(0,_normalizeTrailingSlash.removePathTrailingSlash)(pathname);}const manualScrollRestoration=process.env.__NEXT_SCROLL_RESTORATION&&typeof window!=='undefined'&&'scrollRestoration'in window.history&&!!function(){try{let v='__next';// eslint-disable-next-line no-sequences
+-return sessionStorage.setItem(v,v),sessionStorage.removeItem(v),true;}catch(n){}}();const SSG_DATA_NOT_FOUND=Symbol('SSG_DATA_NOT_FOUND');function fetchRetry(url,attempts){return fetch(url,{// Cookies are required to be present for Next.js' SSG "Preview Mode".
+-// Cookies may also be required for `getServerSideProps`.
+-//
+-// > `fetch` won’t send cookies, unless you set the credentials init
+-// > option.
+-// https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
+-//
+-// > For maximum browser compatibility when it comes to sending &
+-// > receiving cookies, always supply the `credentials: 'same-origin'`
+-// > option instead of relying on the default.
+-// https://github.com/github/fetch#caveats
+-credentials:'same-origin'}).then(res=>{if(!res.ok){if(attempts>1&&res.status>=500){return fetchRetry(url,attempts-1);}if(res.status===404){return res.json().then(data=>{if(data.notFound){return{notFound:SSG_DATA_NOT_FOUND};}throw new Error(`Failed to load static props`);});}throw new Error(`Failed to load static props`);}return res.json();});}function fetchNextData(dataHref,isServerRender){return fetchRetry(dataHref,isServerRender?3:1).catch(err=>{// We should only trigger a server-side transition if this was caused
+-// on a client-side transition. Otherwise, we'd get into an infinite
+-// loop.
+-if(!isServerRender){(0,_routeLoader.markAssetError)(err);}throw err;});}class Router{/**
++ */
++
++
++function resolveHref(router, href, resolveAs) {
++  // we use a dummy base url for relative urls
++  let base;
++  const urlAsString = typeof href === 'string' ? href : (0, _utils.formatWithValidation)(href);
++
++  try {
++    base = new URL(urlAsString.startsWith('#') ? router.asPath : router.pathname, 'http://n');
++  } catch (_) {
++    // fallback to / for invalid asPath values e.g. //
++    base = new URL('/', 'http://n');
++  } // Return because it cannot be routed by the Next.js router
++
++
++  if (!isLocalURL(urlAsString)) {
++    return resolveAs ? [urlAsString] : urlAsString;
++  }
++
++  try {
++    const finalUrl = new URL(urlAsString, base);
++    finalUrl.pathname = (0, _normalizeTrailingSlash.normalizePathTrailingSlash)(finalUrl.pathname);
++    let interpolatedAs = '';
++
++    if ((0, _isDynamic.isDynamicRoute)(finalUrl.pathname) && finalUrl.searchParams && resolveAs) {
++      const query = (0, _querystring.searchParamsToUrlQuery)(finalUrl.searchParams);
++      const {
++        result,
++        params
++      } = interpolateAs(finalUrl.pathname, finalUrl.pathname, query);
++
++      if (result) {
++        interpolatedAs = (0, _utils.formatWithValidation)({
++          pathname: result,
++          hash: finalUrl.hash,
++          query: omitParmsFromQuery(query, params)
++        });
++      }
++    } // if the origin didn't change, it means we received a relative href
++
++
++    const resolvedHref = finalUrl.origin === base.origin ? finalUrl.href.slice(finalUrl.origin.length) : finalUrl.href;
++    return resolveAs ? [resolvedHref, interpolatedAs || resolvedHref] : resolvedHref;
++  } catch (_) {
++    return resolveAs ? [urlAsString] : urlAsString;
++  }
++}
++
++function stripOrigin(url) {
++  const origin = (0, _utils.getLocationOrigin)();
++  return url.startsWith(origin) ? url.substring(origin.length) : url;
++}
++
++function prepareUrlAs(router, url, as) {
++  // If url and as provided as an object representation,
++  // we'll format them into the string version here.
++  let [resolvedHref, resolvedAs] = resolveHref(router, url, true);
++  const origin = (0, _utils.getLocationOrigin)();
++  const hrefHadOrigin = resolvedHref.startsWith(origin);
++  const asHadOrigin = resolvedAs && resolvedAs.startsWith(origin);
++  resolvedHref = stripOrigin(resolvedHref);
++  resolvedAs = resolvedAs ? stripOrigin(resolvedAs) : resolvedAs;
++  const preparedUrl = hrefHadOrigin ? resolvedHref : addBasePath(resolvedHref);
++  const preparedAs = as ? stripOrigin(resolveHref(router, as)) : resolvedAs || resolvedHref;
++  return {
++    url: preparedUrl,
++    as: asHadOrigin ? preparedAs : addBasePath(preparedAs)
++  };
++}
++
++function resolveDynamicRoute(pathname, pages) {
++  const cleanPathname = (0, _normalizeTrailingSlash.removePathTrailingSlash)((0, _denormalizePagePath.denormalizePagePath)(pathname));
++
++  if (cleanPathname === '/404' || cleanPathname === '/_error') {
++    return pathname;
++  } // handle resolving href for dynamic routes
++
++
++  if (!pages.includes(cleanPathname)) {
++    // eslint-disable-next-line array-callback-return
++    pages.some(page => {
++      if ((0, _isDynamic.isDynamicRoute)(page) && (0, _routeRegex.getRouteRegex)(page).re.test(cleanPathname)) {
++        pathname = page;
++        return true;
++      }
++    });
++  }
++
++  return (0, _normalizeTrailingSlash.removePathTrailingSlash)(pathname);
++}
++
++const manualScrollRestoration = process.env.__NEXT_SCROLL_RESTORATION && typeof window !== 'undefined' && 'scrollRestoration' in window.history && !!function () {
++  try {
++    let v = '__next'; // eslint-disable-next-line no-sequences
++
++    return sessionStorage.setItem(v, v), sessionStorage.removeItem(v), true;
++  } catch (n) {}
++}();
++const SSG_DATA_NOT_FOUND = Symbol('SSG_DATA_NOT_FOUND');
++
++function fetchRetry(url, attempts) {
++  return fetch(url, {
++    // Cookies are required to be present for Next.js' SSG "Preview Mode".
++    // Cookies may also be required for `getServerSideProps`.
++    //
++    // > `fetch` won’t send cookies, unless you set the credentials init
++    // > option.
++    // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
++    //
++    // > For maximum browser compatibility when it comes to sending &
++    // > receiving cookies, always supply the `credentials: 'same-origin'`
++    // > option instead of relying on the default.
++    // https://github.com/github/fetch#caveats
++    credentials: 'same-origin'
++  }).then(res => {
++    if (!res.ok) {
++      if (attempts > 1 && res.status >= 500) {
++        return fetchRetry(url, attempts - 1);
++      }
++
++      if (res.status === 404) {
++        return res.json().then(data => {
++          if (data.notFound) {
++            return {
++              notFound: SSG_DATA_NOT_FOUND
++            };
++          }
++
++          throw new Error(`Failed to load static props`);
++        });
++      }
++
++      throw new Error(`Failed to load static props`);
++    }
++
++    return res.json();
++  });
++}
++
++function fetchNextData(dataHref, isServerRender) {
++  return fetchRetry(dataHref, isServerRender ? 3 : 1).catch(err => {
++    // We should only trigger a server-side transition if this was caused
++    // on a client-side transition. Otherwise, we'd get into an infinite
++    // loop.
++    if (!isServerRender) {
++      (0, _routeLoader.markAssetError)(err);
++    }
++
++    throw err;
++  });
++}
++
++class Router {
++  /**
+    * Map of all components loaded in `Router`
+-   */ // Static Data Cache
+-// In-flight Server Data Requests, for deduping
+-constructor(_pathname,_query,_as,{initialProps,pageLoader,App,wrapApp,Component,err,subscription,isFallback,locale,locales,defaultLocale,domainLocales,isPreview}){this.route=void 0;this.pathname=void 0;this.query=void 0;this.asPath=void 0;this.basePath=void 0;this.components=void 0;this.sdc={};this.sdr={};this.sub=void 0;this.clc=void 0;this.pageLoader=void 0;this._bps=void 0;this.events=void 0;this._wrapApp=void 0;this.isSsr=void 0;this.isFallback=void 0;this._inFlightRoute=void 0;this._shallow=void 0;this.locale=void 0;this.locales=void 0;this.defaultLocale=void 0;this.domainLocales=void 0;this.isReady=void 0;this.isPreview=void 0;this.isLocaleDomain=void 0;this._idx=0;this.onPopState=e=>{const state=e.state;if(!state){// We get state as undefined for two reasons.
+-//  1. With older safari (< 8) and older chrome (< 34)
+-//  2. When the URL changed with #
+-//
+-// In the both cases, we don't need to proceed and change the route.
+-// (as it's already changed)
+-// But we can simply replace the state with the new changes.
+-// Actually, for (1) we don't need to nothing. But it's hard to detect that event.
+-// So, doing the following for (1) does no harm.
+-const{pathname,query}=this;this.changeState('replaceState',(0,_utils.formatWithValidation)({pathname:addBasePath(pathname),query}),(0,_utils.getURL)());return;}if(!state.__N){return;}let forcedScroll;const{url,as,options,idx}=state;if(process.env.__NEXT_SCROLL_RESTORATION){if(manualScrollRestoration){if(this._idx!==idx){// Snapshot current scroll position:
+-try{sessionStorage.setItem('__next_scroll_'+this._idx,JSON.stringify({x:self.pageXOffset,y:self.pageYOffset}));}catch(_unused){}// Restore old scroll position:
+-try{const v=sessionStorage.getItem('__next_scroll_'+idx);forcedScroll=JSON.parse(v);}catch(_unused2){forcedScroll={x:0,y:0};}}}}this._idx=idx;const{pathname}=(0,_parseRelativeUrl.parseRelativeUrl)(url);// Make sure we don't re-render on initial load,
+-// can be caused by navigating back from an external site
+-if(this.isSsr&&as===this.asPath&&pathname===this.pathname){return;}// If the downstream application returns falsy, return.
+-// They will then be responsible for handling the event.
+-if(this._bps&&!this._bps(state)){return;}this.change('replaceState',url,as,Object.assign({},options,{shallow:options.shallow&&this._shallow,locale:options.locale||this.defaultLocale}),forcedScroll);};// represents the current component key
+-this.route=(0,_normalizeTrailingSlash.removePathTrailingSlash)(_pathname);// set up the component cache (by route keys)
+-this.components={};// We should not keep the cache, if there's an error
+-// Otherwise, this cause issues when when going back and
+-// come again to the errored page.
+-if(_pathname!=='/_error'){this.components[this.route]={Component,initial:true,props:initialProps,err,__N_SSG:initialProps&&initialProps.__N_SSG,__N_SSP:initialProps&&initialProps.__N_SSP};}this.components['/_app']={Component:App,styleSheets:[/* /_app does not need its stylesheets managed */]};// Backwards compat for Router.router.events
+-// TODO: Should be remove the following major version as it was never documented
+-this.events=Router.events;this.pageLoader=pageLoader;this.pathname=_pathname;this.query=_query;// if auto prerendered and dynamic route wait to update asPath
+-// until after mount to prevent hydration mismatch
+-const autoExportDynamic=(0,_isDynamic.isDynamicRoute)(_pathname)&&self.__NEXT_DATA__.autoExport;this.asPath=autoExportDynamic?_pathname:_as;this.basePath=basePath;this.sub=subscription;this.clc=null;this._wrapApp=wrapApp;// make sure to ignore extra popState in safari on navigating
+-// back from external site
+-this.isSsr=true;this.isFallback=isFallback;this.isReady=!!(self.__NEXT_DATA__.gssp||self.__NEXT_DATA__.gip||!autoExportDynamic&&!self.location.search&&!process.env.__NEXT_HAS_REWRITES);this.isPreview=!!isPreview;this.isLocaleDomain=false;if(process.env.__NEXT_I18N_SUPPORT){this.locale=locale;this.locales=locales;this.defaultLocale=defaultLocale;this.domainLocales=domainLocales;this.isLocaleDomain=!!detectDomainLocale(domainLocales,self.location.hostname);}if(typeof window!=='undefined'){// make sure "as" doesn't start with double slashes or else it can
+-// throw an error as it's considered invalid
+-if(_as.substr(0,2)!=='//'){// in order for `e.state` to work on the `onpopstate` event
+-// we have to register the initial route upon initialization
+-const options={locale};options._shouldResolveHref=_as!==_pathname;this.changeState('replaceState',(0,_utils.formatWithValidation)({pathname:addBasePath(_pathname),query:_query}),(0,_utils.getURL)(),options);}window.addEventListener('popstate',this.onPopState);// enable custom scroll restoration handling when available
+-// otherwise fallback to browser's default handling
+-if(process.env.__NEXT_SCROLL_RESTORATION){if(manualScrollRestoration){window.history.scrollRestoration='manual';}}}}reload(){window.location.reload();}/**
++   */
++  // Static Data Cache
++  // In-flight Server Data Requests, for deduping
++  constructor(_pathname, _query, _as, {
++    initialProps,
++    pageLoader,
++    App,
++    wrapApp,
++    Component,
++    err,
++    subscription,
++    isFallback,
++    locale,
++    locales,
++    defaultLocale,
++    domainLocales,
++    isPreview
++  }) {
++    this.route = void 0;
++    this.pathname = void 0;
++    this.query = void 0;
++    this.asPath = void 0;
++    this.basePath = void 0;
++    this.components = void 0;
++    this.sdc = {};
++    this.sdr = {};
++    this.sub = void 0;
++    this.clc = void 0;
++    this.pageLoader = void 0;
++    this._bps = void 0;
++    this.events = void 0;
++    this._wrapApp = void 0;
++    this.isSsr = void 0;
++    this.isFallback = void 0;
++    this._inFlightRoute = void 0;
++    this._shallow = void 0;
++    this.locale = void 0;
++    this.locales = void 0;
++    this.defaultLocale = void 0;
++    this.domainLocales = void 0;
++    this.isReady = void 0;
++    this.isPreview = void 0;
++    this.isLocaleDomain = void 0;
++    this._idx = 0;
++
++    this.onPopState = e => {
++      const state = e.state;
++
++      if (!state) {
++        // We get state as undefined for two reasons.
++        //  1. With older safari (< 8) and older chrome (< 34)
++        //  2. When the URL changed with #
++        //
++        // In the both cases, we don't need to proceed and change the route.
++        // (as it's already changed)
++        // But we can simply replace the state with the new changes.
++        // Actually, for (1) we don't need to nothing. But it's hard to detect that event.
++        // So, doing the following for (1) does no harm.
++        const {
++          pathname,
++          query
++        } = this;
++        this.changeState('replaceState', (0, _utils.formatWithValidation)({
++          pathname: addBasePath(pathname),
++          query
++        }), (0, _utils.getURL)());
++        return;
++      }
++
++      if (!state.__N) {
++        return;
++      }
++
++      let forcedScroll;
++      const {
++        url,
++        as,
++        options,
++        idx
++      } = state;
++
++      if (process.env.__NEXT_SCROLL_RESTORATION) {
++        if (manualScrollRestoration) {
++          if (this._idx !== idx) {
++            // Snapshot current scroll position:
++            try {
++              sessionStorage.setItem('__next_scroll_' + this._idx, JSON.stringify({
++                x: self.pageXOffset,
++                y: self.pageYOffset
++              }));
++            } catch (_unused) {} // Restore old scroll position:
++
++
++            try {
++              const v = sessionStorage.getItem('__next_scroll_' + idx);
++              forcedScroll = JSON.parse(v);
++            } catch (_unused2) {
++              forcedScroll = {
++                x: 0,
++                y: 0
++              };
++            }
++          }
++        }
++      }
++
++      this._idx = idx;
++      const {
++        pathname
++      } = (0, _parseRelativeUrl.parseRelativeUrl)(url); // Make sure we don't re-render on initial load,
++      // can be caused by navigating back from an external site
++
++      if (this.isSsr && as === this.asPath && pathname === this.pathname) {
++        return;
++      } // If the downstream application returns falsy, return.
++      // They will then be responsible for handling the event.
++
++
++      if (this._bps && !this._bps(state)) {
++        return;
++      }
++
++      this.change('replaceState', url, as, Object.assign({}, options, {
++        shallow: options.shallow && this._shallow,
++        locale: options.locale || this.defaultLocale
++      }), forcedScroll);
++    };
++
++    // represents the current component key
++    this.route = (0, _normalizeTrailingSlash.removePathTrailingSlash)(_pathname); // set up the component cache (by route keys)
++
++    this.components = {}; // We should not keep the cache, if there's an error
++    // Otherwise, this cause issues when when going back and
++    // come again to the errored page.
++
++    if (_pathname !== '/_error') {
++      this.components[this.route] = {
++        Component,
++        initial: true,
++        props: initialProps,
++        err,
++        __N_SSG: initialProps && initialProps.__N_SSG,
++        __N_SSP: initialProps && initialProps.__N_SSP
++      };
++    }
++
++    this.components['/_app'] = {
++      Component: App,
++      styleSheets: [
++        /* /_app does not need its stylesheets managed */
++      ]
++    }; // Backwards compat for Router.router.events
++    // TODO: Should be remove the following major version as it was never documented
++
++    this.events = Router.events;
++    this.pageLoader = pageLoader;
++    this.pathname = _pathname;
++    this.query = _query; // if auto prerendered and dynamic route wait to update asPath
++    // until after mount to prevent hydration mismatch
++
++    const autoExportDynamic = (0, _isDynamic.isDynamicRoute)(_pathname) && self.__NEXT_DATA__.autoExport;
++
++    this.asPath = autoExportDynamic ? _pathname : _as;
++    this.basePath = basePath;
++    this.sub = subscription;
++    this.clc = null;
++    this._wrapApp = wrapApp; // make sure to ignore extra popState in safari on navigating
++    // back from external site
++
++    this.isSsr = true;
++    this.isFallback = isFallback;
++    this.isReady = !!(self.__NEXT_DATA__.gssp || self.__NEXT_DATA__.gip || !autoExportDynamic && !self.location.search && !process.env.__NEXT_HAS_REWRITES);
++    this.isPreview = !!isPreview;
++    this.isLocaleDomain = false;
++
++    if (process.env.__NEXT_I18N_SUPPORT) {
++      this.locale = locale;
++      this.locales = locales;
++      this.defaultLocale = defaultLocale;
++      this.domainLocales = domainLocales;
++      this.isLocaleDomain = !!detectDomainLocale(domainLocales, self.location.hostname);
++    }
++
++    if (typeof window !== 'undefined') {
++      // make sure "as" doesn't start with double slashes or else it can
++      // throw an error as it's considered invalid
++      if (_as.substr(0, 2) !== '//') {
++        // in order for `e.state` to work on the `onpopstate` event
++        // we have to register the initial route upon initialization
++        const options = {
++          locale
++        };
++        options._shouldResolveHref = _as !== _pathname;
++        this.changeState('replaceState', (0, _utils.formatWithValidation)({
++          pathname: addBasePath(_pathname),
++          query: _query
++        }), (0, _utils.getURL)(), options);
++      }
++
++      window.addEventListener('popstate', this.onPopState); // enable custom scroll restoration handling when available
++      // otherwise fallback to browser's default handling
++
++      if (process.env.__NEXT_SCROLL_RESTORATION) {
++        if (manualScrollRestoration) {
++          window.history.scrollRestoration = 'manual';
++        }
++      }
++    }
++  }
++
++  reload() {
++    window.location.reload();
++  }
++  /**
+    * Go back in history
+-   */back(){window.history.back();}/**
++   */
++
++
++  back() {
++    window.history.back();
++  }
++  /**
+    * Performs a `pushState` with arguments
+    * @param url of the route
+    * @param as masks `url` for the browser
+    * @param options object you can define `shallow` and other options
+-   */push(url,as,options={}){if(process.env.__NEXT_SCROLL_RESTORATION){// TODO: remove in the future when we update history before route change
+-// is complete, as the popstate event should handle this capture.
+-if(manualScrollRestoration){try{// Snapshot scroll position right before navigating to a new page:
+-sessionStorage.setItem('__next_scroll_'+this._idx,JSON.stringify({x:self.pageXOffset,y:self.pageYOffset}));}catch(_unused3){}}};({url,as}=prepareUrlAs(this,url,as));return this.change('pushState',url,as,options);}/**
++   */
++
++
++  push(url, as, options = {}) {
++    if (process.env.__NEXT_SCROLL_RESTORATION) {
++      // TODO: remove in the future when we update history before route change
++      // is complete, as the popstate event should handle this capture.
++      if (manualScrollRestoration) {
++        try {
++          // Snapshot scroll position right before navigating to a new page:
++          sessionStorage.setItem('__next_scroll_' + this._idx, JSON.stringify({
++            x: self.pageXOffset,
++            y: self.pageYOffset
++          }));
++        } catch (_unused3) {}
++      }
++    }
++
++    ;
++    ({
++      url,
++      as
++    } = prepareUrlAs(this, url, as));
++    return this.change('pushState', url, as, options);
++  }
++  /**
+    * Performs a `replaceState` with arguments
+    * @param url of the route
+    * @param as masks `url` for the browser
+    * @param options object you can define `shallow` and other options
+-   */replace(url,as,options={}){;({url,as}=prepareUrlAs(this,url,as));return this.change('replaceState',url,as,options);}async change(method,url,as,options,forcedScroll){if(!isLocalURL(url)){window.location.href=url;return false;}const shouldResolveHref=url===as||options._h||options._shouldResolveHref;// for static pages with query params in the URL we delay
+-// marking the router ready until after the query is updated
+-if(options._h){this.isReady=true;}let localeChange=options.locale!==this.locale;if(process.env.__NEXT_I18N_SUPPORT){this.locale=options.locale===false?this.defaultLocale:options.locale||this.locale;if(typeof options.locale==='undefined'){options.locale=this.locale;}const parsedAs=(0,_parseRelativeUrl.parseRelativeUrl)(hasBasePath(as)?delBasePath(as):as);const localePathResult=(0,_normalizeLocalePath.normalizeLocalePath)(parsedAs.pathname,this.locales);if(localePathResult.detectedLocale){this.locale=localePathResult.detectedLocale;parsedAs.pathname=addBasePath(parsedAs.pathname);as=(0,_utils.formatWithValidation)(parsedAs);url=addBasePath((0,_normalizeLocalePath.normalizeLocalePath)(hasBasePath(url)?delBasePath(url):url,this.locales).pathname);}let didNavigate=false;// we need to wrap this in the env check again since regenerator runtime
+-// moves this on its own due to the return
+-if(process.env.__NEXT_I18N_SUPPORT){var _this$locales;// if the locale isn't configured hard navigate to show 404 page
+-if(!((_this$locales=this.locales)!=null&&_this$locales.includes(this.locale))){parsedAs.pathname=addLocale(parsedAs.pathname,this.locale);window.location.href=(0,_utils.formatWithValidation)(parsedAs);// this was previously a return but was removed in favor
+-// of better dead code elimination with regenerator runtime
+-didNavigate=true;}}const detectedDomain=detectDomainLocale(this.domainLocales,undefined,this.locale);// we need to wrap this in the env check again since regenerator runtime
+-// moves this on its own due to the return
+-if(process.env.__NEXT_I18N_SUPPORT){// if we are navigating to a domain locale ensure we redirect to the
+-// correct domain
+-if(!didNavigate&&detectedDomain&&this.isLocaleDomain&&self.location.hostname!==detectedDomain.domain){const asNoBasePath=delBasePath(as);window.location.href=`http${detectedDomain.http?'':'s'}://${detectedDomain.domain}${addBasePath(`${this.locale===detectedDomain.defaultLocale?'':`/${this.locale}`}${asNoBasePath==='/'?'':asNoBasePath}`||'/')}`;// this was previously a return but was removed in favor
+-// of better dead code elimination with regenerator runtime
+-didNavigate=true;}}if(didNavigate){return new Promise(()=>{});}}if(!options._h){this.isSsr=false;}// marking route changes as a navigation start entry
+-if(_utils.ST){performance.mark('routeChange');}const{shallow=false}=options;const routeProps={shallow};if(this._inFlightRoute){this.abortComponentLoad(this._inFlightRoute,routeProps);}as=addBasePath(addLocale(hasBasePath(as)?delBasePath(as):as,options.locale,this.defaultLocale));const cleanedAs=delLocale(hasBasePath(as)?delBasePath(as):as,this.locale);this._inFlightRoute=as;// If the url change is only related to a hash change
+-// We should not proceed. We should only change the state.
+-// WARNING: `_h` is an internal option for handing Next.js client-side
+-// hydration. Your app should _never_ use this property. It may change at
+-// any time without notice.
+-if(!options._h&&this.onlyAHashChange(cleanedAs)){this.asPath=cleanedAs;Router.events.emit('hashChangeStart',as,routeProps);// TODO: do we need the resolved href when only a hash change?
+-this.changeState(method,url,as,options);this.scrollToHash(cleanedAs);this.notify(this.components[this.route],null);Router.events.emit('hashChangeComplete',as,routeProps);return true;}let parsed=(0,_parseRelativeUrl.parseRelativeUrl)(url);let{pathname,query}=parsed;// The build manifest needs to be loaded before auto-static dynamic pages
+-// get their query parameters to allow ensuring they can be parsed properly
+-// when rewritten to
+-let pages,rewrites;try{pages=await this.pageLoader.getPageList();({__rewrites:rewrites}=await(0,_routeLoader.getClientBuildManifest)());}catch(err){// If we fail to resolve the page list or client-build manifest, we must
+-// do a server-side transition:
+-window.location.href=as;return false;}// If asked to change the current URL we should reload the current page
+-// (not location.reload() but reload getInitialProps and other Next.js stuffs)
+-// We also need to set the method = replaceState always
+-// as this should not go into the history (That's how browsers work)
+-// We should compare the new asPath to the current asPath, not the url
+-if(!this.urlIsNew(cleanedAs)&&!localeChange){method='replaceState';}// we need to resolve the as value using rewrites for dynamic SSG
+-// pages to allow building the data URL correctly
+-let resolvedAs=as;// url and as should always be prefixed with basePath by this
+-// point by either next/link or router.push/replace so strip the
+-// basePath from the pathname to match the pages dir 1-to-1
+-pathname=pathname?(0,_normalizeTrailingSlash.removePathTrailingSlash)(delBasePath(pathname)):pathname;if(shouldResolveHref&&pathname!=='/_error'){;options._shouldResolveHref=true;if(process.env.__NEXT_HAS_REWRITES&&as.startsWith('/')){const rewritesResult=(0,_resolveRewrites.default)(addBasePath(addLocale(cleanedAs,this.locale)),pages,rewrites,query,p=>resolveDynamicRoute(p,pages),this.locales);resolvedAs=rewritesResult.asPath;if(rewritesResult.matchedPage&&rewritesResult.resolvedHref){// if this directly matches a page we need to update the href to
+-// allow the correct page chunk to be loaded
+-pathname=rewritesResult.resolvedHref;parsed.pathname=addBasePath(pathname);url=(0,_utils.formatWithValidation)(parsed);}}else{parsed.pathname=resolveDynamicRoute(pathname,pages);if(parsed.pathname!==pathname){pathname=parsed.pathname;parsed.pathname=addBasePath(pathname);url=(0,_utils.formatWithValidation)(parsed);}}}const route=(0,_normalizeTrailingSlash.removePathTrailingSlash)(pathname);if(!isLocalURL(as)){if(process.env.NODE_ENV!=='production'){throw new Error(`Invalid href: "${url}" and as: "${as}", received relative href and external as`+`\nSee more info: https://nextjs.org/docs/messages/invalid-relative-url-external-as`);}window.location.href=as;return false;}resolvedAs=delLocale(delBasePath(resolvedAs),this.locale);if((0,_isDynamic.isDynamicRoute)(route)){const parsedAs=(0,_parseRelativeUrl.parseRelativeUrl)(resolvedAs);const asPathname=parsedAs.pathname;const routeRegex=(0,_routeRegex.getRouteRegex)(route);const routeMatch=(0,_routeMatcher.getRouteMatcher)(routeRegex)(asPathname);const shouldInterpolate=route===asPathname;const interpolatedAs=shouldInterpolate?interpolateAs(route,asPathname,query):{};if(!routeMatch||shouldInterpolate&&!interpolatedAs.result){const missingParams=Object.keys(routeRegex.groups).filter(param=>!query[param]);if(missingParams.length>0){if(process.env.NODE_ENV!=='production'){console.warn(`${shouldInterpolate?`Interpolating href`:`Mismatching \`as\` and \`href\``} failed to manually provide `+`the params: ${missingParams.join(', ')} in the \`href\`'s \`query\``);}throw new Error((shouldInterpolate?`The provided \`href\` (${url}) value is missing query values (${missingParams.join(', ')}) to be interpolated properly. `:`The provided \`as\` value (${asPathname}) is incompatible with the \`href\` value (${route}). `)+`Read more: https://nextjs.org/docs/messages/${shouldInterpolate?'href-interpolation-failed':'incompatible-href-as'}`);}}else if(shouldInterpolate){as=(0,_utils.formatWithValidation)(Object.assign({},parsedAs,{pathname:interpolatedAs.result,query:omitParmsFromQuery(query,interpolatedAs.params)}));}else{// Merge params into `query`, overwriting any specified in search
+-Object.assign(query,routeMatch);}}Router.events.emit('routeChangeStart',as,routeProps);try{var _self$__NEXT_DATA__$p,_self$__NEXT_DATA__$p2,_options$scroll;let routeInfo=await this.getRouteInfo(route,pathname,query,as,resolvedAs,routeProps);let{error,props,__N_SSG,__N_SSP}=routeInfo;// handle redirect on client-transition
+-if((__N_SSG||__N_SSP)&&props){if(props.pageProps&&props.pageProps.__N_REDIRECT){const destination=props.pageProps.__N_REDIRECT;// check if destination is internal (resolves to a page) and attempt
+-// client-navigation if it is falling back to hard navigation if
+-// it's not
+-if(destination.startsWith('/')){const parsedHref=(0,_parseRelativeUrl.parseRelativeUrl)(destination);parsedHref.pathname=resolveDynamicRoute(parsedHref.pathname,pages);const{url:newUrl,as:newAs}=prepareUrlAs(this,destination,destination);return this.change(method,newUrl,newAs,options);}window.location.href=destination;return new Promise(()=>{});}this.isPreview=!!props.__N_PREVIEW;// handle SSG data 404
+-if(props.notFound===SSG_DATA_NOT_FOUND){let notFoundRoute;try{await this.fetchComponent('/404');notFoundRoute='/404';}catch(_){notFoundRoute='/_error';}routeInfo=await this.getRouteInfo(notFoundRoute,notFoundRoute,query,as,resolvedAs,{shallow:false});}}Router.events.emit('beforeHistoryChange',as,routeProps);this.changeState(method,url,as,options);if(process.env.NODE_ENV!=='production'){const appComp=this.components['/_app'].Component;window.next.isPrerendered=appComp.getInitialProps===appComp.origGetInitialProps&&!routeInfo.Component.getInitialProps;}if(options._h&&pathname==='/_error'&&((_self$__NEXT_DATA__$p=self.__NEXT_DATA__.props)==null?void 0:(_self$__NEXT_DATA__$p2=_self$__NEXT_DATA__$p.pageProps)==null?void 0:_self$__NEXT_DATA__$p2.statusCode)===500&&props!=null&&props.pageProps){// ensure statusCode is still correct for static 500 page
+-// when updating query information
+-props.pageProps.statusCode=500;}// shallow routing is only allowed for same page URL changes.
+-const isValidShallowRoute=options.shallow&&this.route===route;const shouldScroll=(_options$scroll=options.scroll)!=null?_options$scroll:!isValidShallowRoute;const resetScroll=shouldScroll?{x:0,y:0}:null;await this.set(route,pathname,query,cleanedAs,routeInfo,forcedScroll!=null?forcedScroll:resetScroll).catch(e=>{if(e.cancelled)error=error||e;else throw e;});if(error){Router.events.emit('routeChangeError',error,cleanedAs,routeProps);throw error;}if(process.env.__NEXT_I18N_SUPPORT){if(this.locale){document.documentElement.lang=this.locale;}}Router.events.emit('routeChangeComplete',as,routeProps);return true;}catch(err){if(err.cancelled){return false;}throw err;}}changeState(method,url,as,options={}){if(process.env.NODE_ENV!=='production'){if(typeof window.history==='undefined'){console.error(`Warning: window.history is not available.`);return;}if(typeof window.history[method]==='undefined'){console.error(`Warning: window.history.${method} is not available`);return;}}if(method!=='pushState'||(0,_utils.getURL)()!==as){this._shallow=options.shallow;window.history[method]({url,as,options,__N:true,idx:this._idx=method!=='pushState'?this._idx:this._idx+1},// Most browsers currently ignores this parameter, although they may use it in the future.
+-// Passing the empty string here should be safe against future changes to the method.
+-// https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
+-'',as);}}async handleRouteInfoError(err,pathname,query,as,routeProps,loadErrorFail){if(err.cancelled){// bubble up cancellation errors
+-throw err;}if((0,_routeLoader.isAssetError)(err)||loadErrorFail){Router.events.emit('routeChangeError',err,as,routeProps);// If we can't load the page it could be one of following reasons
+-//  1. Page doesn't exists
+-//  2. Page does exist in a different zone
+-//  3. Internal error while loading the page
+-// So, doing a hard reload is the proper way to deal with this.
+-window.location.href=as;// Changing the URL doesn't block executing the current code path.
+-// So let's throw a cancellation error stop the routing logic.
+-throw buildCancellationError();}try{let Component;let styleSheets;let props;if(typeof Component==='undefined'||typeof styleSheets==='undefined'){;({page:Component,styleSheets}=await this.fetchComponent('/_error'));}const routeInfo={props,Component,styleSheets,err,error:err};if(!routeInfo.props){try{routeInfo.props=await this.getInitialProps(Component,{err,pathname,query});}catch(gipErr){console.error('Error in error page `getInitialProps`: ',gipErr);routeInfo.props={};}}return routeInfo;}catch(routeInfoErr){return this.handleRouteInfoError(routeInfoErr,pathname,query,as,routeProps,true);}}async getRouteInfo(route,pathname,query,as,resolvedAs,routeProps){try{const existingRouteInfo=this.components[route];if(routeProps.shallow&&existingRouteInfo&&this.route===route){return existingRouteInfo;}const cachedRouteInfo=existingRouteInfo&&'initial'in existingRouteInfo?undefined:existingRouteInfo;const routeInfo=cachedRouteInfo?cachedRouteInfo:await this.fetchComponent(route).then(res=>({Component:res.page,styleSheets:res.styleSheets,__N_SSG:res.mod.__N_SSG,__N_SSP:res.mod.__N_SSP}));const{Component,__N_SSG,__N_SSP}=routeInfo;if(process.env.NODE_ENV!=='production'){const{isValidElementType}=require('react-is');if(!isValidElementType(Component)){throw new Error(`The default export is not a React Component in page: "${pathname}"`);}}let dataHref;if(__N_SSG||__N_SSP){dataHref=this.pageLoader.getDataHref((0,_utils.formatWithValidation)({pathname,query}),resolvedAs,__N_SSG,this.locale);}const props=await this._getData(()=>__N_SSG?this._getStaticData(dataHref):__N_SSP?this._getServerData(dataHref):this.getInitialProps(Component,// we provide AppTree later so this needs to be `any`
+-{pathname,query,asPath:as,locale:this.locale,locales:this.locales,defaultLocale:this.defaultLocale}));routeInfo.props=props;this.components[route]=routeInfo;return routeInfo;}catch(err){return this.handleRouteInfoError(err,pathname,query,as,routeProps);}}set(route,pathname,query,as,data,resetScroll){this.isFallback=false;this.route=route;this.pathname=pathname;this.query=query;this.asPath=as;return this.notify(data,resetScroll);}/**
++   */
++
++
++  replace(url, as, options = {}) {
++    ;
++    ({
++      url,
++      as
++    } = prepareUrlAs(this, url, as));
++    return this.change('replaceState', url, as, options);
++  }
++
++  async change(method, url, as, options, forcedScroll) {
++    if (!isLocalURL(url)) {
++      window.location.href = url;
++      return false;
++    }
++
++    const shouldResolveHref = url === as || options._h || options._shouldResolveHref; // for static pages with query params in the URL we delay
++    // marking the router ready until after the query is updated
++
++    if (options._h) {
++      this.isReady = true;
++    }
++
++    let localeChange = options.locale !== this.locale;
++
++    if (process.env.__NEXT_I18N_SUPPORT) {
++      this.locale = options.locale === false ? this.defaultLocale : options.locale || this.locale;
++
++      if (typeof options.locale === 'undefined') {
++        options.locale = this.locale;
++      }
++
++      const parsedAs = (0, _parseRelativeUrl.parseRelativeUrl)(hasBasePath(as) ? delBasePath(as) : as);
++      const localePathResult = (0, _normalizeLocalePath.normalizeLocalePath)(parsedAs.pathname, this.locales);
++
++      if (localePathResult.detectedLocale) {
++        this.locale = localePathResult.detectedLocale;
++        parsedAs.pathname = addBasePath(parsedAs.pathname);
++        as = (0, _utils.formatWithValidation)(parsedAs);
++        url = addBasePath((0, _normalizeLocalePath.normalizeLocalePath)(hasBasePath(url) ? delBasePath(url) : url, this.locales).pathname);
++      }
++
++      let didNavigate = false; // we need to wrap this in the env check again since regenerator runtime
++      // moves this on its own due to the return
++
++      if (process.env.__NEXT_I18N_SUPPORT) {
++        var _this$locales;
++
++        // if the locale isn't configured hard navigate to show 404 page
++        if (!((_this$locales = this.locales) != null && _this$locales.includes(this.locale))) {
++          parsedAs.pathname = addLocale(parsedAs.pathname, this.locale);
++          window.location.href = (0, _utils.formatWithValidation)(parsedAs); // this was previously a return but was removed in favor
++          // of better dead code elimination with regenerator runtime
++
++          didNavigate = true;
++        }
++      }
++
++      const detectedDomain = detectDomainLocale(this.domainLocales, self.location.hostname, this.locale); // we need to wrap this in the env check again since regenerator runtime
++      // moves this on its own due to the return
++
++      if (process.env.__NEXT_I18N_SUPPORT) {
++        // if we are navigating to a domain locale ensure we redirect to the
++        // correct domain
++        if (!didNavigate && detectedDomain && this.isLocaleDomain && self.location.hostname !== detectedDomain.domain) {
++          const asNoBasePath = delBasePath(as);
++          window.location.href = `http${detectedDomain.http ? '' : 's'}://${detectedDomain.domain}${addBasePath(`${this.locale === detectedDomain.defaultLocale ? '' : `/${this.locale}`}${asNoBasePath === '/' ? '' : asNoBasePath}` || '/')}`; // this was previously a return but was removed in favor
++          // of better dead code elimination with regenerator runtime
++
++          didNavigate = true;
++        }
++      }
++
++      if (didNavigate) {
++        return new Promise(() => {});
++      }
++    }
++
++    if (!options._h) {
++      this.isSsr = false;
++    } // marking route changes as a navigation start entry
++
++
++    if (_utils.ST) {
++      performance.mark('routeChange');
++    }
++
++    const {
++      shallow = false
++    } = options;
++    const routeProps = {
++      shallow
++    };
++
++    if (this._inFlightRoute) {
++      this.abortComponentLoad(this._inFlightRoute, routeProps);
++    }
++
++    as = addBasePath(addLocale(hasBasePath(as) ? delBasePath(as) : as, options.locale, this.defaultLocale));
++    const cleanedAs = delLocale(hasBasePath(as) ? delBasePath(as) : as, this.locale);
++    this._inFlightRoute = as; // If the url change is only related to a hash change
++    // We should not proceed. We should only change the state.
++    // WARNING: `_h` is an internal option for handing Next.js client-side
++    // hydration. Your app should _never_ use this property. It may change at
++    // any time without notice.
++
++    if (!options._h && this.onlyAHashChange(cleanedAs)) {
++      this.asPath = cleanedAs;
++      Router.events.emit('hashChangeStart', as, routeProps); // TODO: do we need the resolved href when only a hash change?
++
++      this.changeState(method, url, as, options);
++      this.scrollToHash(cleanedAs);
++      this.notify(this.components[this.route], null);
++      Router.events.emit('hashChangeComplete', as, routeProps);
++      return true;
++    }
++
++    let parsed = (0, _parseRelativeUrl.parseRelativeUrl)(url);
++    let {
++      pathname,
++      query
++    } = parsed; // The build manifest needs to be loaded before auto-static dynamic pages
++    // get their query parameters to allow ensuring they can be parsed properly
++    // when rewritten to
++
++    let pages, rewrites;
++
++    try {
++      pages = await this.pageLoader.getPageList();
++      ({
++        __rewrites: rewrites
++      } = await (0, _routeLoader.getClientBuildManifest)());
++    } catch (err) {
++      // If we fail to resolve the page list or client-build manifest, we must
++      // do a server-side transition:
++      window.location.href = as;
++      return false;
++    } // If asked to change the current URL we should reload the current page
++    // (not location.reload() but reload getInitialProps and other Next.js stuffs)
++    // We also need to set the method = replaceState always
++    // as this should not go into the history (That's how browsers work)
++    // We should compare the new asPath to the current asPath, not the url
++
++
++    if (!this.urlIsNew(cleanedAs) && !localeChange) {
++      method = 'replaceState';
++    } // we need to resolve the as value using rewrites for dynamic SSG
++    // pages to allow building the data URL correctly
++
++
++    let resolvedAs = as; // url and as should always be prefixed with basePath by this
++    // point by either next/link or router.push/replace so strip the
++    // basePath from the pathname to match the pages dir 1-to-1
++
++    pathname = pathname ? (0, _normalizeTrailingSlash.removePathTrailingSlash)(delBasePath(pathname)) : pathname;
++
++    if (shouldResolveHref && pathname !== '/_error') {
++      ;
++      options._shouldResolveHref = true;
++
++      if (process.env.__NEXT_HAS_REWRITES && as.startsWith('/')) {
++        const rewritesResult = (0, _resolveRewrites.default)(addBasePath(addLocale(cleanedAs, this.locale)), pages, rewrites, query, p => resolveDynamicRoute(p, pages), this.locales);
++        resolvedAs = rewritesResult.asPath;
++
++        if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
++          // if this directly matches a page we need to update the href to
++          // allow the correct page chunk to be loaded
++          pathname = rewritesResult.resolvedHref;
++          parsed.pathname = addBasePath(pathname);
++          url = (0, _utils.formatWithValidation)(parsed);
++        }
++      } else {
++        parsed.pathname = resolveDynamicRoute(pathname, pages);
++
++        if (parsed.pathname !== pathname) {
++          pathname = parsed.pathname;
++          parsed.pathname = addBasePath(pathname);
++          url = (0, _utils.formatWithValidation)(parsed);
++        }
++      }
++    }
++
++    const route = (0, _normalizeTrailingSlash.removePathTrailingSlash)(pathname);
++
++    if (!isLocalURL(as)) {
++      if (process.env.NODE_ENV !== 'production') {
++        throw new Error(`Invalid href: "${url}" and as: "${as}", received relative href and external as` + `\nSee more info: https://nextjs.org/docs/messages/invalid-relative-url-external-as`);
++      }
++
++      window.location.href = as;
++      return false;
++    }
++
++    resolvedAs = delLocale(delBasePath(resolvedAs), this.locale);
++
++    if ((0, _isDynamic.isDynamicRoute)(route)) {
++      const parsedAs = (0, _parseRelativeUrl.parseRelativeUrl)(resolvedAs);
++      const asPathname = parsedAs.pathname;
++      const routeRegex = (0, _routeRegex.getRouteRegex)(route);
++      const routeMatch = (0, _routeMatcher.getRouteMatcher)(routeRegex)(asPathname);
++      const shouldInterpolate = route === asPathname;
++      const interpolatedAs = shouldInterpolate ? interpolateAs(route, asPathname, query) : {};
++
++      if (!routeMatch || shouldInterpolate && !interpolatedAs.result) {
++        const missingParams = Object.keys(routeRegex.groups).filter(param => !query[param]);
++
++        if (missingParams.length > 0) {
++          if (process.env.NODE_ENV !== 'production') {
++            console.warn(`${shouldInterpolate ? `Interpolating href` : `Mismatching \`as\` and \`href\``} failed to manually provide ` + `the params: ${missingParams.join(', ')} in the \`href\`'s \`query\``);
++          }
++
++          throw new Error((shouldInterpolate ? `The provided \`href\` (${url}) value is missing query values (${missingParams.join(', ')}) to be interpolated properly. ` : `The provided \`as\` value (${asPathname}) is incompatible with the \`href\` value (${route}). `) + `Read more: https://nextjs.org/docs/messages/${shouldInterpolate ? 'href-interpolation-failed' : 'incompatible-href-as'}`);
++        }
++      } else if (shouldInterpolate) {
++        as = (0, _utils.formatWithValidation)(Object.assign({}, parsedAs, {
++          pathname: interpolatedAs.result,
++          query: omitParmsFromQuery(query, interpolatedAs.params)
++        }));
++      } else {
++        // Merge params into `query`, overwriting any specified in search
++        Object.assign(query, routeMatch);
++      }
++    }
++
++    Router.events.emit('routeChangeStart', as, routeProps);
++
++    try {
++      var _self$__NEXT_DATA__$p, _self$__NEXT_DATA__$p2, _options$scroll;
++
++      let routeInfo = await this.getRouteInfo(route, pathname, query, as, resolvedAs, routeProps);
++      let {
++        error,
++        props,
++        __N_SSG,
++        __N_SSP
++      } = routeInfo; // handle redirect on client-transition
++
++      if ((__N_SSG || __N_SSP) && props) {
++        if (props.pageProps && props.pageProps.__N_REDIRECT) {
++          const destination = props.pageProps.__N_REDIRECT; // check if destination is internal (resolves to a page) and attempt
++          // client-navigation if it is falling back to hard navigation if
++          // it's not
++
++          if (destination.startsWith('/')) {
++            const parsedHref = (0, _parseRelativeUrl.parseRelativeUrl)(destination);
++            parsedHref.pathname = resolveDynamicRoute(parsedHref.pathname, pages);
++            const {
++              url: newUrl,
++              as: newAs
++            } = prepareUrlAs(this, destination, destination);
++            return this.change(method, newUrl, newAs, options);
++          }
++
++          window.location.href = destination;
++          return new Promise(() => {});
++        }
++
++        this.isPreview = !!props.__N_PREVIEW; // handle SSG data 404
++
++        if (props.notFound === SSG_DATA_NOT_FOUND) {
++          let notFoundRoute;
++
++          try {
++            await this.fetchComponent('/404');
++            notFoundRoute = '/404';
++          } catch (_) {
++            notFoundRoute = '/_error';
++          }
++
++          routeInfo = await this.getRouteInfo(notFoundRoute, notFoundRoute, query, as, resolvedAs, {
++            shallow: false
++          });
++        }
++      }
++
++      Router.events.emit('beforeHistoryChange', as, routeProps);
++      this.changeState(method, url, as, options);
++
++      if (process.env.NODE_ENV !== 'production') {
++        const appComp = this.components['/_app'].Component;
++        window.next.isPrerendered = appComp.getInitialProps === appComp.origGetInitialProps && !routeInfo.Component.getInitialProps;
++      }
++
++      if (options._h && pathname === '/_error' && ((_self$__NEXT_DATA__$p = self.__NEXT_DATA__.props) == null ? void 0 : (_self$__NEXT_DATA__$p2 = _self$__NEXT_DATA__$p.pageProps) == null ? void 0 : _self$__NEXT_DATA__$p2.statusCode) === 500 && props != null && props.pageProps) {
++        // ensure statusCode is still correct for static 500 page
++        // when updating query information
++        props.pageProps.statusCode = 500;
++      } // shallow routing is only allowed for same page URL changes.
++
++
++      const isValidShallowRoute = options.shallow && this.route === route;
++      const shouldScroll = (_options$scroll = options.scroll) != null ? _options$scroll : !isValidShallowRoute;
++      const resetScroll = shouldScroll ? {
++        x: 0,
++        y: 0
++      } : null;
++      await this.set(route, pathname, query, cleanedAs, routeInfo, forcedScroll != null ? forcedScroll : resetScroll).catch(e => {
++        if (e.cancelled) error = error || e;else throw e;
++      });
++
++      if (error) {
++        Router.events.emit('routeChangeError', error, cleanedAs, routeProps);
++        throw error;
++      }
++
++      if (process.env.__NEXT_I18N_SUPPORT) {
++        if (this.locale) {
++          document.documentElement.lang = this.locale;
++        }
++      }
++
++      Router.events.emit('routeChangeComplete', as, routeProps);
++      return true;
++    } catch (err) {
++      if (err.cancelled) {
++        return false;
++      }
++
++      throw err;
++    }
++  }
++
++  changeState(method, url, as, options = {}) {
++    if (process.env.NODE_ENV !== 'production') {
++      if (typeof window.history === 'undefined') {
++        console.error(`Warning: window.history is not available.`);
++        return;
++      }
++
++      if (typeof window.history[method] === 'undefined') {
++        console.error(`Warning: window.history.${method} is not available`);
++        return;
++      }
++    }
++
++    if (method !== 'pushState' || (0, _utils.getURL)() !== as) {
++      this._shallow = options.shallow;
++      window.history[method]({
++        url,
++        as,
++        options,
++        __N: true,
++        idx: this._idx = method !== 'pushState' ? this._idx : this._idx + 1
++      }, // Most browsers currently ignores this parameter, although they may use it in the future.
++      // Passing the empty string here should be safe against future changes to the method.
++      // https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState
++      '', as);
++    }
++  }
++
++  async handleRouteInfoError(err, pathname, query, as, routeProps, loadErrorFail) {
++    if (err.cancelled) {
++      // bubble up cancellation errors
++      throw err;
++    }
++
++    if ((0, _routeLoader.isAssetError)(err) || loadErrorFail) {
++      Router.events.emit('routeChangeError', err, as, routeProps); // If we can't load the page it could be one of following reasons
++      //  1. Page doesn't exists
++      //  2. Page does exist in a different zone
++      //  3. Internal error while loading the page
++      // So, doing a hard reload is the proper way to deal with this.
++
++      window.location.href = as; // Changing the URL doesn't block executing the current code path.
++      // So let's throw a cancellation error stop the routing logic.
++
++      throw buildCancellationError();
++    }
++
++    try {
++      let Component;
++      let styleSheets;
++      let props;
++
++      if (typeof Component === 'undefined' || typeof styleSheets === 'undefined') {
++        ;
++        ({
++          page: Component,
++          styleSheets
++        } = await this.fetchComponent('/_error'));
++      }
++
++      const routeInfo = {
++        props,
++        Component,
++        styleSheets,
++        err,
++        error: err
++      };
++
++      if (!routeInfo.props) {
++        try {
++          routeInfo.props = await this.getInitialProps(Component, {
++            err,
++            pathname,
++            query
++          });
++        } catch (gipErr) {
++          console.error('Error in error page `getInitialProps`: ', gipErr);
++          routeInfo.props = {};
++        }
++      }
++
++      return routeInfo;
++    } catch (routeInfoErr) {
++      return this.handleRouteInfoError(routeInfoErr, pathname, query, as, routeProps, true);
++    }
++  }
++
++  async getRouteInfo(route, pathname, query, as, resolvedAs, routeProps) {
++    try {
++      const existingRouteInfo = this.components[route];
++
++      if (routeProps.shallow && existingRouteInfo && this.route === route) {
++        return existingRouteInfo;
++      }
++
++      const cachedRouteInfo = existingRouteInfo && 'initial' in existingRouteInfo ? undefined : existingRouteInfo;
++      const routeInfo = cachedRouteInfo ? cachedRouteInfo : await this.fetchComponent(route).then(res => ({
++        Component: res.page,
++        styleSheets: res.styleSheets,
++        __N_SSG: res.mod.__N_SSG,
++        __N_SSP: res.mod.__N_SSP
++      }));
++      const {
++        Component,
++        __N_SSG,
++        __N_SSP
++      } = routeInfo;
++
++      if (process.env.NODE_ENV !== 'production') {
++        const {
++          isValidElementType
++        } = require('react-is');
++
++        if (!isValidElementType(Component)) {
++          throw new Error(`The default export is not a React Component in page: "${pathname}"`);
++        }
++      }
++
++      let dataHref;
++
++      if (__N_SSG || __N_SSP) {
++        dataHref = this.pageLoader.getDataHref((0, _utils.formatWithValidation)({
++          pathname,
++          query
++        }), resolvedAs, __N_SSG, this.locale);
++      }
++
++      const props = await this._getData(() => __N_SSG ? this._getStaticData(dataHref) : __N_SSP ? this._getServerData(dataHref) : this.getInitialProps(Component, // we provide AppTree later so this needs to be `any`
++      {
++        pathname,
++        query,
++        asPath: as,
++        locale: this.locale,
++        locales: this.locales,
++        defaultLocale: this.defaultLocale
++      }));
++      routeInfo.props = props;
++      this.components[route] = routeInfo;
++      return routeInfo;
++    } catch (err) {
++      return this.handleRouteInfoError(err, pathname, query, as, routeProps);
++    }
++  }
++
++  set(route, pathname, query, as, data, resetScroll) {
++    this.isFallback = false;
++    this.route = route;
++    this.pathname = pathname;
++    this.query = query;
++    this.asPath = as;
++    return this.notify(data, resetScroll);
++  }
++  /**
+    * Callback to execute before replacing router state
+    * @param cb callback to be executed
+-   */beforePopState(cb){this._bps=cb;}onlyAHashChange(as){if(!this.asPath)return false;const[oldUrlNoHash,oldHash]=this.asPath.split('#');const[newUrlNoHash,newHash]=as.split('#');// Makes sure we scroll to the provided hash if the url/hash are the same
+-if(newHash&&oldUrlNoHash===newUrlNoHash&&oldHash===newHash){return true;}// If the urls are change, there's more than a hash change
+-if(oldUrlNoHash!==newUrlNoHash){return false;}// If the hash has changed, then it's a hash only change.
+-// This check is necessary to handle both the enter and
+-// leave hash === '' cases. The identity case falls through
+-// and is treated as a next reload.
+-return oldHash!==newHash;}scrollToHash(as){const[,hash]=as.split('#');// Scroll to top if the hash is just `#` with no value or `#top`
+-// To mirror browsers
+-if(hash===''||hash==='top'){window.scrollTo(0,0);return;}// First we check if the element by id is found
+-const idEl=document.getElementById(hash);if(idEl){idEl.scrollIntoView();return;}// If there's no element with the id, we check the `name` property
+-// To mirror browsers
+-const nameEl=document.getElementsByName(hash)[0];if(nameEl){nameEl.scrollIntoView();}}urlIsNew(asPath){return this.asPath!==asPath;}/**
++   */
++
++
++  beforePopState(cb) {
++    this._bps = cb;
++  }
++
++  onlyAHashChange(as) {
++    if (!this.asPath) return false;
++    const [oldUrlNoHash, oldHash] = this.asPath.split('#');
++    const [newUrlNoHash, newHash] = as.split('#'); // Makes sure we scroll to the provided hash if the url/hash are the same
++
++    if (newHash && oldUrlNoHash === newUrlNoHash && oldHash === newHash) {
++      return true;
++    } // If the urls are change, there's more than a hash change
++
++
++    if (oldUrlNoHash !== newUrlNoHash) {
++      return false;
++    } // If the hash has changed, then it's a hash only change.
++    // This check is necessary to handle both the enter and
++    // leave hash === '' cases. The identity case falls through
++    // and is treated as a next reload.
++
++
++    return oldHash !== newHash;
++  }
++
++  scrollToHash(as) {
++    const [, hash] = as.split('#'); // Scroll to top if the hash is just `#` with no value or `#top`
++    // To mirror browsers
++
++    if (hash === '' || hash === 'top') {
++      window.scrollTo(0, 0);
++      return;
++    } // First we check if the element by id is found
++
++
++    const idEl = document.getElementById(hash);
++
++    if (idEl) {
++      idEl.scrollIntoView();
++      return;
++    } // If there's no element with the id, we check the `name` property
++    // To mirror browsers
++
++
++    const nameEl = document.getElementsByName(hash)[0];
++
++    if (nameEl) {
++      nameEl.scrollIntoView();
++    }
++  }
++
++  urlIsNew(asPath) {
++    return this.asPath !== asPath;
++  }
++  /**
+    * Prefetch page code, you may wait for the data during page rendering.
+    * This feature only works in production!
+    * @param url the href of prefetched page
+    * @param asPath the as path of the prefetched page
+-   */async prefetch(url,asPath=url,options={}){let parsed=(0,_parseRelativeUrl.parseRelativeUrl)(url);let{pathname}=parsed;if(process.env.__NEXT_I18N_SUPPORT){if(options.locale===false){pathname=(0,_normalizeLocalePath.normalizeLocalePath)(pathname,this.locales).pathname;parsed.pathname=pathname;url=(0,_utils.formatWithValidation)(parsed);let parsedAs=(0,_parseRelativeUrl.parseRelativeUrl)(asPath);const localePathResult=(0,_normalizeLocalePath.normalizeLocalePath)(parsedAs.pathname,this.locales);parsedAs.pathname=localePathResult.pathname;options.locale=localePathResult.detectedLocale||this.defaultLocale;asPath=(0,_utils.formatWithValidation)(parsedAs);}}const pages=await this.pageLoader.getPageList();let resolvedAs=asPath;if(process.env.__NEXT_HAS_REWRITES&&asPath.startsWith('/')){let rewrites;({__rewrites:rewrites}=await(0,_routeLoader.getClientBuildManifest)());const rewritesResult=(0,_resolveRewrites.default)(addBasePath(addLocale(asPath,this.locale)),pages,rewrites,parsed.query,p=>resolveDynamicRoute(p,pages),this.locales);resolvedAs=delLocale(delBasePath(rewritesResult.asPath),this.locale);if(rewritesResult.matchedPage&&rewritesResult.resolvedHref){// if this directly matches a page we need to update the href to
+-// allow the correct page chunk to be loaded
+-pathname=rewritesResult.resolvedHref;parsed.pathname=pathname;url=(0,_utils.formatWithValidation)(parsed);}}else{parsed.pathname=resolveDynamicRoute(parsed.pathname,pages);if(parsed.pathname!==pathname){pathname=parsed.pathname;parsed.pathname=pathname;url=(0,_utils.formatWithValidation)(parsed);}}const route=(0,_normalizeTrailingSlash.removePathTrailingSlash)(pathname);// Prefetch is not supported in development mode because it would trigger on-demand-entries
+-if(process.env.NODE_ENV!=='production'){return;}await Promise.all([this.pageLoader._isSsg(route).then(isSsg=>{return isSsg?this._getStaticData(this.pageLoader.getDataHref(url,resolvedAs,true,typeof options.locale!=='undefined'?options.locale:this.locale)):false;}),this.pageLoader[options.priority?'loadPage':'prefetch'](route)]);}async fetchComponent(route){let cancelled=false;const cancel=this.clc=()=>{cancelled=true;};const componentResult=await this.pageLoader.loadPage(route);if(cancelled){const error=new Error(`Abort fetching component for route: "${route}"`);error.cancelled=true;throw error;}if(cancel===this.clc){this.clc=null;}return componentResult;}_getData(fn){let cancelled=false;const cancel=()=>{cancelled=true;};this.clc=cancel;return fn().then(data=>{if(cancel===this.clc){this.clc=null;}if(cancelled){const err=new Error('Loading initial props cancelled');err.cancelled=true;throw err;}return data;});}_getStaticData(dataHref){const{href:cacheKey}=new URL(dataHref,window.location.href);if(process.env.NODE_ENV==='production'&&!this.isPreview&&this.sdc[cacheKey]){return Promise.resolve(this.sdc[cacheKey]);}return fetchNextData(dataHref,this.isSsr).then(data=>{this.sdc[cacheKey]=data;return data;});}_getServerData(dataHref){const{href:resourceKey}=new URL(dataHref,window.location.href);if(this.sdr[resourceKey]){return this.sdr[resourceKey];}return this.sdr[resourceKey]=fetchNextData(dataHref,this.isSsr).then(data=>{delete this.sdr[resourceKey];return data;}).catch(err=>{delete this.sdr[resourceKey];throw err;});}getInitialProps(Component,ctx){const{Component:App}=this.components['/_app'];const AppTree=this._wrapApp(App);ctx.AppTree=AppTree;return(0,_utils.loadGetInitialProps)(App,{AppTree,Component,router:this,ctx});}abortComponentLoad(as,routeProps){if(this.clc){Router.events.emit('routeChangeError',buildCancellationError(),as,routeProps);this.clc();this.clc=null;}}notify(data,resetScroll){return this.sub(data,this.components['/_app'].Component,resetScroll);}}exports.default=Router;Router.events=(0,_mitt.default)();
++   */
++
++
++  async prefetch(url, asPath = url, options = {}) {
++    let parsed = (0, _parseRelativeUrl.parseRelativeUrl)(url);
++    let {
++      pathname
++    } = parsed;
++
++    if (process.env.__NEXT_I18N_SUPPORT) {
++      if (options.locale === false) {
++        pathname = (0, _normalizeLocalePath.normalizeLocalePath)(pathname, this.locales).pathname;
++        parsed.pathname = pathname;
++        url = (0, _utils.formatWithValidation)(parsed);
++        let parsedAs = (0, _parseRelativeUrl.parseRelativeUrl)(asPath);
++        const localePathResult = (0, _normalizeLocalePath.normalizeLocalePath)(parsedAs.pathname, this.locales);
++        parsedAs.pathname = localePathResult.pathname;
++        options.locale = localePathResult.detectedLocale || this.defaultLocale;
++        asPath = (0, _utils.formatWithValidation)(parsedAs);
++      }
++    }
++
++    const pages = await this.pageLoader.getPageList();
++    let resolvedAs = asPath;
++
++    if (process.env.__NEXT_HAS_REWRITES && asPath.startsWith('/')) {
++      let rewrites;
++      ({
++        __rewrites: rewrites
++      } = await (0, _routeLoader.getClientBuildManifest)());
++      const rewritesResult = (0, _resolveRewrites.default)(addBasePath(addLocale(asPath, this.locale)), pages, rewrites, parsed.query, p => resolveDynamicRoute(p, pages), this.locales);
++      resolvedAs = delLocale(delBasePath(rewritesResult.asPath), this.locale);
++
++      if (rewritesResult.matchedPage && rewritesResult.resolvedHref) {
++        // if this directly matches a page we need to update the href to
++        // allow the correct page chunk to be loaded
++        pathname = rewritesResult.resolvedHref;
++        parsed.pathname = pathname;
++        url = (0, _utils.formatWithValidation)(parsed);
++      }
++    } else {
++      parsed.pathname = resolveDynamicRoute(parsed.pathname, pages);
++
++      if (parsed.pathname !== pathname) {
++        pathname = parsed.pathname;
++        parsed.pathname = pathname;
++        url = (0, _utils.formatWithValidation)(parsed);
++      }
++    }
++
++    const route = (0, _normalizeTrailingSlash.removePathTrailingSlash)(pathname); // Prefetch is not supported in development mode because it would trigger on-demand-entries
++
++    if (process.env.NODE_ENV !== 'production') {
++      return;
++    }
++
++    await Promise.all([this.pageLoader._isSsg(route).then(isSsg => {
++      return isSsg ? this._getStaticData(this.pageLoader.getDataHref(url, resolvedAs, true, typeof options.locale !== 'undefined' ? options.locale : this.locale)) : false;
++    }), this.pageLoader[options.priority ? 'loadPage' : 'prefetch'](route)]);
++  }
++
++  async fetchComponent(route) {
++    let cancelled = false;
++
++    const cancel = this.clc = () => {
++      cancelled = true;
++    };
++
++    const componentResult = await this.pageLoader.loadPage(route);
++
++    if (cancelled) {
++      const error = new Error(`Abort fetching component for route: "${route}"`);
++      error.cancelled = true;
++      throw error;
++    }
++
++    if (cancel === this.clc) {
++      this.clc = null;
++    }
++
++    return componentResult;
++  }
++
++  _getData(fn) {
++    let cancelled = false;
++
++    const cancel = () => {
++      cancelled = true;
++    };
++
++    this.clc = cancel;
++    return fn().then(data => {
++      if (cancel === this.clc) {
++        this.clc = null;
++      }
++
++      if (cancelled) {
++        const err = new Error('Loading initial props cancelled');
++        err.cancelled = true;
++        throw err;
++      }
++
++      return data;
++    });
++  }
++
++  _getStaticData(dataHref) {
++    const {
++      href: cacheKey
++    } = new URL(dataHref, window.location.href);
++
++    if (process.env.NODE_ENV === 'production' && !this.isPreview && this.sdc[cacheKey]) {
++      return Promise.resolve(this.sdc[cacheKey]);
++    }
++
++    return fetchNextData(dataHref, this.isSsr).then(data => {
++      this.sdc[cacheKey] = data;
++      return data;
++    });
++  }
++
++  _getServerData(dataHref) {
++    const {
++      href: resourceKey
++    } = new URL(dataHref, window.location.href);
++
++    if (this.sdr[resourceKey]) {
++      return this.sdr[resourceKey];
++    }
++
++    return this.sdr[resourceKey] = fetchNextData(dataHref, this.isSsr).then(data => {
++      delete this.sdr[resourceKey];
++      return data;
++    }).catch(err => {
++      delete this.sdr[resourceKey];
++      throw err;
++    });
++  }
++
++  getInitialProps(Component, ctx) {
++    const {
++      Component: App
++    } = this.components['/_app'];
++
++    const AppTree = this._wrapApp(App);
++
++    ctx.AppTree = AppTree;
++    return (0, _utils.loadGetInitialProps)(App, {
++      AppTree,
++      Component,
++      router: this,
++      ctx
++    });
++  }
++
++  abortComponentLoad(as, routeProps) {
++    if (this.clc) {
++      Router.events.emit('routeChangeError', buildCancellationError(), as, routeProps);
++      this.clc();
++      this.clc = null;
++    }
++  }
++
++  notify(data, resetScroll) {
++    return this.sub(data, this.components['/_app'].Component, resetScroll);
++  }
++
++}
++
++exports.default = Router;
++Router.events = (0, _mitt.default)();
+ //# sourceMappingURL=router.js.map

--- a/yarn.lock
+++ b/yarn.lock
@@ -3833,6 +3833,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0, abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -5345,6 +5350,11 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 ci-info@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
@@ -5928,7 +5938,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -8222,6 +8232,13 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -8409,6 +8426,15 @@ fs-extra@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
   integrity sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -9531,6 +9557,13 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
 is-ci@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
@@ -9608,6 +9641,11 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -9877,6 +9915,13 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -10700,6 +10745,13 @@ klaw-sync@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-4.0.0.tgz#7785692ea1a320ac3dda7a6c0c22b33a30aa3b3f"
   integrity sha512-go/5tXbgLkgwxQ2c2ewaMen6TpQtI9fTzzmTdlSGK8XxKcFSsJvn/Sgn75Vg+mOJwkKVPrqLw2Xq7x/zP1v7PQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
   dependencies:
     graceful-fs "^4.1.11"
 
@@ -12200,6 +12252,14 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -12254,6 +12314,11 @@ os-locale@^2.0.0:
     execa "^0.7.0"
     lcid "^1.0.0"
     mem "^1.1.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 ospath@^1.2.2:
   version "1.2.2"
@@ -12544,6 +12609,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -13789,6 +13873,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
+  integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -15111,7 +15200,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.7.1:
+rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -16631,6 +16720,13 @@ tippy.js@^6.3.1:
   integrity sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==
   dependencies:
     "@popperjs/core" "^2.8.3"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 tmp@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Patch nextjs with a fix for the faulty domain lookup.
The patch is built on next@v11.0.1 (e969d2269) with the following changes which based on changes from https://github.com/vercel/next.js/pull/22337.

Note that we shouldn't want to patch a dependency, we can maybe use this for testing stuff but I have a very bad feeling about running this in production. An additional instance should absolutely have our preference.

```diff
diff --git a/packages/next/next-server/lib/i18n/detect-domain-locale.ts b/packages/next/next-server/lib/i18n/detect-domain-locale.ts
index 7ad9d9890..2fecb5a46 100644
--- a/packages/next/next-server/lib/i18n/detect-domain-locale.ts
+++ b/packages/next/next-server/lib/i18n/detect-domain-locale.ts
@@ -24,18 +24,19 @@ export function detectDomainLocale(
       detectedLocale = detectedLocale.toLowerCase()
     }
 
-    for (const item of domainItems) {
-      // remove port if present
-      const domainHostname = item.domain?.split(':')[0].toLowerCase()
-      if (
-        hostname === domainHostname ||
-        detectedLocale === item.defaultLocale.toLowerCase() ||
-        item.locales?.some((locale) => locale.toLowerCase() === detectedLocale)
-      ) {
-        domainItem = item
-        break
-      }
-    }
+    domainItem =
+      // Check whether current hostname is defined in domains and return it
+      domainItems.find(
+        (item) => hostname === item.domain?.split(':')[0].toLowerCase()
+      ) ??
+      // Check for domain item that uses the detected locale
+      domainItems.find(
+        (item) =>
+          detectedLocale === item.defaultLocale.toLowerCase() ||
+          item.locales?.some(
+            (locale) => locale.toLowerCase() === detectedLocale
+          )
+      )
   }
 
   return domainItem
diff --git a/packages/next/next-server/lib/router/router.ts b/packages/next/next-server/lib/router/router.ts
index c915f38c1..9b411ee52 100644
--- a/packages/next/next-server/lib/router/router.ts
+++ b/packages/next/next-server/lib/router/router.ts
@@ -863,7 +863,7 @@ export default class Router implements BaseRouter {
 
       const detectedDomain = detectDomainLocale(
         this.domainLocales,
-        undefined,
+        self.location.hostname,
         this.locale
       )
 
```