### PR TITLE
Create copy lokalize key feature

### DIFF
--- a/packages/app/src/locale/use-copy-lokalize-key.ts
+++ b/packages/app/src/locale/use-copy-lokalize-key.ts
@@ -1,0 +1,161 @@
+import { assert } from '@corona-dashboard/common';
+import '@reach/combobox/styles.css';
+import { isEqual } from 'lodash';
+import { useEffect, useState } from 'react';
+import { isDefined, isPresent } from 'ts-is-present';
+
+export const TAG_OPEN = ''; // unicode START OF TEXT (U+0002)
+export const TAG_CLOSE = ''; // unicode END OF TEXT (U+0003)
+
+/**
+ * This hook will select lokalize keys if you hover them with the mouse, a
+ * mouse-click will copy the key to the clipboard.
+ * This mode is only enabled when you hold shift, command or control.
+ */
+export function useCopyLokalizeKey({ isEnabled }: { isEnabled: boolean }) {
+  const [isActive, setIsActive] = useState(false);
+
+  useEffect(() => {
+    if (isEnabled) {
+      document.body.addEventListener('keydown', handleEvent);
+      document.body.addEventListener('keyup', handleEvent);
+      document.body.addEventListener('mousemove', handleEvent);
+
+      return () => {
+        document.body.removeEventListener('keydown', handleEvent);
+        document.body.removeEventListener('keyup', handleEvent);
+        document.body.addEventListener('mousemove', handleEvent);
+      };
+    }
+
+    function handleEvent(evt: KeyboardEvent | MouseEvent) {
+      setIsActive(isValidEvent(evt));
+    }
+  }, [isEnabled]);
+
+  useEffect(() => {
+    if (isActive) {
+      window.addEventListener('mousemove', handleMouse);
+      return () => {
+        window.removeEventListener('mousemove', handleMouse);
+        removeLokalizeListener();
+      };
+    }
+  }, [isActive]);
+
+  return isActive;
+}
+
+function isValidEvent(evt: MouseEvent | KeyboardEvent) {
+  return evt.metaKey || evt.ctrlKey;
+}
+
+let prevTextContent: string | undefined;
+
+function handleMouse(evt: MouseEvent) {
+  let range: Range | undefined | CaretPosition;
+  let textNode: Node | undefined;
+  let offset: number | undefined;
+
+  /**
+   * Firefox
+   */
+  if (document.caretPositionFromPoint) {
+    range =
+      document.caretPositionFromPoint(evt.clientX, evt.clientY) || undefined;
+    textNode = range?.offsetNode;
+    offset = range?.offset;
+  }
+
+  /**
+   * Chrome
+   */
+  if (document.caretRangeFromPoint) {
+    range = document.caretRangeFromPoint(evt.clientX, evt.clientY);
+    textNode = range?.startContainer;
+    offset = range?.startOffset;
+  }
+
+  if (!isDefined(textNode)) return;
+  if (!isDefined(offset)) return;
+  if (textNode.nodeType !== Node.TEXT_NODE) return;
+
+  const text = textNode.textContent;
+
+  if (!isPresent(text)) return;
+
+  /**
+   * Sometimes the offset can be at the 'length' of the data.
+   * It might be a bug with this 'experimental' feature
+   * Compensate for this below
+   */
+  if (offset >= text.length) {
+    offset = text.length - 1;
+  }
+
+  if (text && prevTextContent !== text) {
+    prevTextContent = textNode.textContent || undefined;
+  }
+
+  if (text && isDefined(offset) && range) {
+    const selectionOffset = findStartEndOffset(text, offset);
+    if (selectionOffset) {
+      selectRange(textNode, selectionOffset);
+    }
+  }
+}
+
+function findStartEndOffset(text: string, offset: number) {
+  const chars = text.split('');
+  const open = chars.slice(0, offset).reverse().indexOf(TAG_OPEN);
+  const close = chars.slice(offset, chars.length).indexOf(TAG_CLOSE);
+
+  if (open > -1 && close > -1) {
+    return [offset - open, offset + close] as [number, number];
+  }
+}
+
+let currentNode: LokalizeTextNode | undefined;
+let currentSelection: [number, number] | undefined;
+
+function selectRange(node: Node, selection: [number, number]) {
+  if (currentNode === node && isEqual(currentSelection, selection)) return;
+  removeLokalizeListener();
+
+  currentNode = node;
+  currentSelection = selection;
+
+  assert(node.textContent, 'could not find textContent on node');
+  const key = node.textContent.slice(selection[0], selection[1]);
+
+  document
+    .getSelection()
+    ?.setBaseAndExtent(node, selection[0], node, selection[1]);
+
+  addLokalizeListener(node, key);
+}
+
+function addLokalizeListener(node: LokalizeTextNode, key: string) {
+  function handleClick(evt: Event) {
+    if (isValidEvent(evt as MouseEvent)) {
+      evt.preventDefault();
+      document.execCommand('copy');
+      alert(`De lokalize key "${key}" is gekopieerd naar het klembord`);
+    }
+  }
+
+  node.__lokalizeHandler = handleClick;
+  node.parentNode?.addEventListener('click', handleClick);
+}
+
+function removeLokalizeListener() {
+  if (currentNode?.__lokalizeHandler) {
+    currentNode.parentNode?.removeEventListener(
+      'click',
+      currentNode.__lokalizeHandler
+    );
+    delete currentNode.__lokalizeHandler;
+  }
+}
+
+type LokalizeTextNode = Node & { __lokalizeHandler?: EventListener };

--- a/packages/app/src/locale/use-lokalize-text.tsx
+++ b/packages/app/src/locale/use-lokalize-text.tsx
@@ -14,12 +14,17 @@ import { VisuallyHidden } from '~/components/visually-hidden';
 import { getClient } from '~/lib/sanity';
 import { LanguageKey, languages, SiteText } from '~/locale';
 import { LokalizeText } from '~/types/cms';
+import {
+  TAG_CLOSE,
+  TAG_OPEN,
+  useCopyLokalizeKey,
+} from './use-copy-lokalize-key';
 
 const datasets = ['development', 'production', 'keys'] as const;
 export type Dataset = typeof datasets[number];
 
 const query = `*[_type == 'lokalizeText']`;
-const enableHotReload = process.env.NEXT_PUBLIC_PHASE === 'develop';
+const enableHotReload = process.env.NEXT_PUBLIC_PHASE === 'development';
 
 /**
  * This hook will return an object which contains all lokalize translations.
@@ -39,6 +44,8 @@ export function useLokalizeText(initialLocale: LanguageKey) {
   const [dataset, setDataset] = useState<typeof datasets[number]>(
     process.env.NEXT_PUBLIC_SANITY_DATASET as 'development'
   );
+
+  useCopyLokalizeKey({ isEnabled: enableHotReload && dataset === 'keys' });
 
   const toggleButton = enableHotReload ? (
     <ToggleButton isActive={isActive} onClick={() => setIsActive((x) => !x)}>
@@ -143,7 +150,7 @@ function mapSiteTextValuesToKeys(siteText: SiteText) {
   const keys = Object.keys(flatten(siteText));
 
   const obj = keys.reduce(
-    (result, key) => set(result, key, key),
+    (result, key) => set(result, key, `${TAG_OPEN}${key}${TAG_CLOSE}`),
     {} as Record<string, string>
   );
 


### PR DESCRIPTION
I still had this functionality somewhere on the shelf. It allows COMM to easily copy/paste lokalize keys to their clipboard by pressing command/control and hover + click lokalize keys.

Not sure we want this, but well .. it was already written so here it is in a PR. It's also not the cleanest code, bit hacky but it works.
