### PR TITLE
Fix server side console error

### DIFF
--- a/packages/app/src/components/layout/components/language-switcher.tsx
+++ b/packages/app/src/components/layout/components/language-switcher.tsx
@@ -19,7 +19,7 @@ export function LanguageSwitcher() {
         NL
       </LanguageLink>
 
-      <Separator />
+      <Separator aria-hidden="true" />
 
       <LanguageLink
         href={`https://coronadashboard.government.nl${router.asPath}`}
@@ -33,10 +33,14 @@ export function LanguageSwitcher() {
     </Box>
   );
 }
-const Separator = styled.span.attrs({ 'aria-hidden': 'true', children: '|' })(
+const Separator = styled.span(
   css({
     mx: 2,
     display: 'inline-block',
+
+    '&:after': {
+      content: '"|"',
+    },
   })
 );
 


### PR DESCRIPTION
Fixing the console error: `react-dom.development.js?a814:67 Warning: Prop `aria-controls` did not match. `. This fix has the same visually result just in a slightly different way.