### PR TITLE
Remove "waarde van" on most vaccination page tiles

### DIFF
--- a/packages/app/src/domain/vaccine/vaccine-administrations-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-administrations-kpi-section.tsx
@@ -36,8 +36,6 @@ export function VaccineAdministrationsKpiSection({
       <KpiTile
         title={text.gezette_prikken.title}
         metadata={{
-          date: data.vaccine_administered_total.last_value
-            .date_of_insertion_unix,
           source: text.bronnen.all_left,
         }}
       >

--- a/packages/app/src/domain/vaccine/vaccine-delivery-and-administrations-area-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-delivery-and-administrations-area-chart.tsx
@@ -42,7 +42,6 @@ export function VaccineDeliveryAndAdministrationsAreaChart({
       title={siteText.vaccinaties.grafiek.titel}
       description={siteText.vaccinaties.grafiek.omschrijving}
       metadata={{
-        date: firstValue?.date_of_report_unix,
         source: siteText.vaccinaties.bronnen.rivm,
       }}
     >

--- a/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
@@ -47,7 +47,6 @@ export function VaccineDeliveryBarChart({
     <ChartTile
       title={text.titel}
       metadata={{
-        date: data.last_value.date_of_report_unix,
         source: intl.siteText.vaccinaties.bronnen.rivm,
       }}
     >

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -133,7 +133,6 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                 text.grafiek_gevaccineerd_door_de_tijd_heen.omschrijving
               }
               metadata={{
-                date: data.vaccine_coverage.last_value.date_of_insertion_unix,
                 source: text.bronnen.rivm,
               }}
             >


### PR DESCRIPTION
## Summary

Removing the date from the following tiles on the vaccination page
- Aantal gevaccineerde mensen door de tijd heen
- Geleverde en gecontroleerde vaccins & gezette prikken in totaal
- Leveringen
- Aantal gezette prikken
