### PR TITLE
Remove locale resolving from SSR

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -11,9 +11,6 @@ const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack
 const path = require('path');
 
 const nextConfig = {
-  serverRuntimeConfig: {
-    PROJECT_ROOT: __dirname,
-  },
   /**
    * Enables react strict mode
    * https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode

--- a/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
@@ -78,20 +78,13 @@ function MobileVariantRow(props: MobileVariantRowProps) {
 
   const [, variantDescription] = useVariantNameAndDescription(
     row.variant,
-    text.anderen_tooltip,
-    row.countryOfOrigin
+    text.anderen_tooltip
   );
 
   return (
     <>
       <tr style={{ cursor: 'pointer' }} onClick={collapsible.toggle}>
-        <VariantNameCell
-          variant={row.variant}
-          text={text}
-          mobile
-          narrow
-          countryOfOrigin={row.countryOfOrigin}
-        />
+        <VariantNameCell variant={row.variant} text={text} mobile narrow />
         <Cell mobile>
           {isPresent(row.percentage) ? (
             <PercentageBarWithNumber

--- a/packages/app/src/domain/variants/variants-table-tile/components/variant-name-cell.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variant-name-cell.tsx
@@ -6,19 +6,17 @@ import { useVariantNameAndDescription } from '../logic/use-variant-name-and-desc
 
 type VariantNameCellProps = {
   variant: string;
-  countryOfOrigin: string;
   text: TableText;
   mobile?: boolean;
   narrow?: boolean;
 };
 
 export function VariantNameCell(props: VariantNameCellProps) {
-  const { variant, text, mobile, narrow, countryOfOrigin } = props;
+  const { variant, text, mobile, narrow } = props;
 
   const [variantName, variantDescription] = useVariantNameAndDescription(
     variant,
-    text.anderen_tooltip,
-    countryOfOrigin
+    text.anderen_tooltip
   );
 
   return (

--- a/packages/app/src/domain/variants/variants-table-tile/components/wide-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/wide-variants-table.tsx
@@ -50,11 +50,7 @@ export function WideVariantsTable(props: WideVariantsTableProps) {
       <tbody>
         {rows.map((row) => (
           <tr key={row.variant}>
-            <VariantNameCell
-              variant={row.variant}
-              text={text}
-              countryOfOrigin={row.countryOfOrigin}
-            />
+            <VariantNameCell variant={row.variant} text={text} />
             <Cell>
               {isPresent(row.percentage) ? (
                 <Box maxWidth="20em">

--- a/packages/app/src/domain/variants/variants-table-tile/logic/use-variant-name-and-description.ts
+++ b/packages/app/src/domain/variants/variants-table-tile/logic/use-variant-name-and-description.ts
@@ -4,8 +4,7 @@ import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
 export function useVariantNameAndDescription(
   variant: string,
-  otherDescription: string,
-  countryOfOrigin: string
+  otherDescription: string
 ) {
   const { siteText } = useIntl();
 
@@ -20,8 +19,13 @@ export function useVariantNameAndDescription(
           variant
         ];
 
+  const countryOfOrigin = (
+    siteText.covid_varianten.landen_van_herkomst as Dictionary<string>
+  )[variant];
+
   assert(variantName, `No translation found for variant ${variant}`);
   assert(variantDescription, `No tooltip found for variant ${variant}`);
+  assert(countryOfOrigin, `No country of origin found for variant ${variant}`);
 
   return [
     variantName,

--- a/packages/app/src/pages-disabled/internationaal/varianten.tsx
+++ b/packages/app/src/pages-disabled/internationaal/varianten.tsx
@@ -26,7 +26,6 @@ import {
   createGetContent,
   getInData,
   getLastGeneratedDate,
-  getLocaleFile,
 } from '~/static-props/get-data';
 import { loadJsonFromDataFile } from '~/static-props/utils/load-json-from-data-file';
 import {
@@ -43,7 +42,6 @@ export const getStaticProps = withFeatureNotFoundPage(
     getLastGeneratedDate,
     () => {
       const locale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
-      const siteText = getLocaleFile(locale);
       const countryNames = loadJsonFromDataFile<Record<string, string>>(
         `${locale}-country-names.json`,
         'static-json'
@@ -58,10 +56,7 @@ export const getStaticProps = withFeatureNotFoundPage(
 
       return {
         countryOptions,
-        ...getInternationalVariantTableData(
-          internationalData,
-          siteText.covid_varianten.landen_van_herkomst
-        ),
+        ...getInternationalVariantTableData(internationalData),
         ...getInternationalVariantChartData(internationalData),
       };
     },

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -18,7 +18,6 @@ import {
 import {
   createGetContent,
   getLastGeneratedDate,
-  getLocaleFile,
   selectNlPageMetricData,
 } from '~/static-props/get-data';
 import {
@@ -34,8 +33,6 @@ export const getStaticProps = withFeatureNotFoundPage(
   createGetStaticProps(
     getLastGeneratedDate,
     () => {
-      const locale = process.env.NEXT_PUBLIC_LOCALE || 'nl';
-      const siteText = getLocaleFile(locale);
       const data = selectNlPageMetricData('variants')();
       const variants = data.selectedNlData.variants;
       delete data.selectedNlData.variants;
@@ -44,17 +41,9 @@ export const getStaticProps = withFeatureNotFoundPage(
 
       return {
         selectedNlData: data.selectedNlData,
-        ...getVariantTableData(
-          variants,
-          data.selectedNlData.named_difference,
-          siteText.covid_varianten.landen_van_herkomst
-        ),
+        ...getVariantTableData(variants, data.selectedNlData.named_difference),
         ...chartData,
-        ...getSeriesConfig(
-          chartData?.variantChart?.[0],
-          siteText.covid_varianten.varianten,
-          colors.data.variants
-        ),
+        ...getSeriesConfig(chartData?.variantChart?.[0], colors.data.variants),
       };
     },
     createGetContent<{
@@ -95,6 +84,13 @@ export default function CovidVariantenPage(
     title: text.metadata.title,
     description: text.metadata.description,
   };
+
+  seriesConfig?.forEach((x) => {
+    const label = (text.varianten as Record<string, string>)[x.label];
+    if (label) {
+      x.label = label;
+    }
+  });
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -10,11 +10,9 @@ import {
   VrCollection,
 } from '@corona-dashboard/common';
 import { SanityClient } from '@sanity/client';
-import fs from 'fs';
 import set from 'lodash/set';
 import { GetStaticPropsContext } from 'next';
 import getConfig from 'next/config';
-import path from 'path';
 import { AsyncWalkBuilder } from 'walkjs';
 import { gmData } from '~/data/gm';
 import { vrData } from '~/data/vr';
@@ -29,7 +27,6 @@ import {
   VrRegionPageMetricNames,
 } from '~/domain/layout/vr-layout';
 import { getClient, localize } from '~/lib/sanity';
-import { cleanText } from '~/locale';
 import { loadJsonFromDataFile } from './utils/load-json-from-data-file';
 import {
   getVariantSidebarValue,
@@ -333,17 +330,4 @@ export function getInData(countryCodes: CountryCode[]) {
       internationalData: Record<CountryCode, In>;
     };
   };
-}
-
-export function getLocaleFile(locale: string) {
-  const content = fs.readFileSync(
-    path.join(
-      serverRuntimeConfig.PROJECT_ROOT,
-      `src/locale/${locale}_export.json`
-    ),
-    { encoding: 'utf-8' }
-  );
-
-  const rawLocaleFile = JSON.parse(content) as Record<string, unknown>;
-  return cleanText(rawLocaleFile);
 }

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -12,7 +12,6 @@ import {
 import { SanityClient } from '@sanity/client';
 import set from 'lodash/set';
 import { GetStaticPropsContext } from 'next';
-import getConfig from 'next/config';
 import { AsyncWalkBuilder } from 'walkjs';
 import { gmData } from '~/data/gm';
 import { vrData } from '~/data/vr';
@@ -32,7 +31,6 @@ import {
   getVariantSidebarValue,
   VariantSidebarValue,
 } from './variants/get-variant-sidebar-value';
-const { serverRuntimeConfig } = getConfig();
 
 /**
  * Usage:

--- a/packages/app/src/static-props/variants/get-international-variant-table-data.ts
+++ b/packages/app/src/static-props/variants/get-international-variant-table-data.ts
@@ -1,19 +1,11 @@
 import { In } from '@corona-dashboard/common';
-import { SiteText } from '~/locale';
 import { getVariantTableData } from './get-variant-table-data';
 
-export function getInternationalVariantTableData(
-  data: Record<string, In>,
-  variantTranslations: SiteText['covid_varianten']['varianten']
-) {
+export function getInternationalVariantTableData(data: Record<string, In>) {
   const variantTableData = Object.fromEntries(
     Object.entries(data).map(([key, value]) => [
       key,
-      getVariantTableData(
-        value.variants,
-        value.named_difference,
-        variantTranslations
-      ),
+      getVariantTableData(value.variants, value.named_difference),
     ])
   );
 

--- a/packages/app/src/static-props/variants/get-variant-chart-data.ts
+++ b/packages/app/src/static-props/variants/get-variant-chart-data.ts
@@ -60,7 +60,6 @@ export function getVariantChartData(variants: NlVariants | undefined) {
 
 export function getSeriesConfig(
   value: Record<string, string | number> | undefined,
-  variantTranslations: Dictionary<string>,
   colors: Dictionary<string>
 ) {
   if (!isDefined(value)) {
@@ -75,9 +74,8 @@ export function getSeriesConfig(
     LineSeriesDefinition<VariantChartValue>
   >((x) => {
     const color = colors[x];
-    const label = variantTranslations[x];
+    const label = x;
     assert(color, `No color specified for variant called "${x}"`);
-    assert(label, `No label specified for variant called "${x}"`);
 
     return {
       metricProperty: `${x}_percentage`,

--- a/packages/app/src/static-props/variants/get-variant-table-data.ts
+++ b/packages/app/src/static-props/variants/get-variant-table-data.ts
@@ -13,12 +13,10 @@ import {
 } from '@corona-dashboard/common';
 import { first } from 'lodash';
 import { isDefined, isPresent } from 'ts-is-present';
-import { SiteText } from '~/locale';
 import { colors } from '~/style/theme';
 
 export type VariantRow = {
   variant: string;
-  countryOfOrigin: string;
   percentage: number | null;
   difference?: OptionalNamedDifferenceDecimal;
   color: string;
@@ -28,8 +26,7 @@ export type VariantTableData = ReturnType<typeof getVariantTableData>;
 
 export function getVariantTableData(
   variants: NlVariants | InVariants | undefined,
-  namedDifference: NlNamedDifference | InNamedDifference,
-  countriesOfOrigin: SiteText['covid_varianten']['landen_van_herkomst']
+  namedDifference: NlNamedDifference | InNamedDifference
 ) {
   if (!isDefined(variants) || !isDefined(variants.values)) {
     return {
@@ -47,12 +44,6 @@ export function getVariantTableData(
       assert(difference, `No variants__percentage found for variant ${name}`);
       return difference;
     }
-  }
-
-  function findCountryOfOrigin(name: string) {
-    const countryOfOrigin = (countriesOfOrigin as Dictionary<string>)[name];
-    assert(countryOfOrigin, `No country of origin found for variant ${name}`);
-    return countryOfOrigin;
   }
 
   function findColor(name: string) {
@@ -86,7 +77,6 @@ export function getVariantTableData(
   const variantTable = variants.values
     .map<VariantRow>((variant) => ({
       variant: variant.name,
-      countryOfOrigin: findCountryOfOrigin(variant.name),
       percentage: variant.last_value.percentage,
       difference: findDifference(variant.name),
       color: findColor(variant.name),


### PR DESCRIPTION
## Summary

The variant data shaping was loading the locale files to resolve translation during the SSR phase.
It turned out to be a wrong assumption since this was interfering with some existing lokalize functionality.
Therefore all of the SSR locale bits have been reverted and all locale resolving happens on the client again. 

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
