### PR TITLE
Fix locale sanity issues

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -34,9 +34,12 @@ const nextConfig = {
     /**
      * Configure english domain when it's available on the environment variables
      */
-    ...(process.env.DOMAIN_EN
-      ? { domains: [{ domain: process.env.DOMAIN_EN, defaultLocale: 'en' }] }
-      : {}),
+    domains: [
+      {
+        domain: process.env.DOMAIN_EN ?? 'coronadashboard.government.nl',
+        defaultLocale: 'en',
+      },
+    ],
   },
 
   /**

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -16,6 +16,7 @@ import { ContentImage } from './content-image';
 import { ExternalLink } from '~/components/external-link';
 import { Link } from '~/utils/link';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
+import { useIntl } from '~/intl';
 
 interface RichContentProps {
   blocks: PortableTextEntry[];
@@ -92,12 +93,14 @@ function InlineAttachmentMark(props: {
 function InlineLinkMark(props: { children: ReactNode; mark: InlineLink }) {
   const { mark, children } = props;
 
+  const { locale = 'nl' } = useIntl();
+
   if (!mark.href) return <>{children}</>;
 
   return isAbsoluteUrl(mark.href) ? (
     <ExternalLink href={mark.href}>{children}</ExternalLink>
   ) : (
-    <Link href={mark.href} passHref>
+    <Link href={mark.href} passHref locale={locale}>
       <a>{children}</a>
     </Link>
   );

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -16,6 +16,7 @@ import { ContentImage } from './content-image';
 import { ExternalLink } from '~/components/external-link';
 import { Link } from '~/utils/link';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
+
 interface RichContentProps {
   blocks: PortableTextEntry[];
   contentWrapper?: FunctionComponent;

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -19,9 +19,23 @@ const articlesQuery = `*[_type == 'article'] {"slug":slug.current}`;
 export async function getStaticPaths() {
   const articlesData = await (await getClient()).fetch(articlesQuery);
 
-  const paths = articlesData.map((article: { slug: string }) => ({
-    params: { slug: article.slug },
-  }));
+  /**
+   * getStaticPaths needs explicit locale routes to function properly...
+   */
+  const paths = articlesData.reduce(
+    (paths: { params: any; locale: string }[], article: { slug: string }) => {
+      return paths.concat([
+        {
+          params: { slug: article.slug },
+          locale: 'en',
+        },
+        {
+          params: { slug: article.slug },
+          locale: 'nl',
+        },
+      ]);
+    }
+  );
 
   // { fallback: false } means other routes should 404.
   return { paths, fallback: false };

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -22,20 +22,16 @@ export async function getStaticPaths() {
   /**
    * getStaticPaths needs explicit locale routes to function properly...
    */
-  const paths = articlesData.reduce(
-    (paths: { params: any; locale: string }[], article: { slug: string }) => {
-      return paths.concat([
-        {
-          params: { slug: article.slug },
-          locale: 'en',
-        },
-        {
-          params: { slug: article.slug },
-          locale: 'nl',
-        },
-      ]);
-    }
-  );
+  const paths = articlesData.flatMap((article: { slug: string }) => [
+    {
+      params: { slug: article.slug },
+      locale: 'en',
+    },
+    {
+      params: { slug: article.slug },
+      locale: 'nl',
+    },
+  ]);
 
   // { fallback: false } means other routes should 404.
   return { paths, fallback: false };

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -19,9 +19,19 @@ const editorialsQuery = `*[_type == 'editorial'] {"slug":slug.current}`;
 export async function getStaticPaths() {
   const editorialData = await (await getClient()).fetch(editorialsQuery);
 
-  const paths = editorialData.map((editorial: { slug: string }) => ({
-    params: { slug: editorial.slug },
-  }));
+  /**
+   * getStaticPaths needs explicit locale routes to function properly...
+   */
+  const paths = editorialData.flatMap((editorial: { slug: string }) => [
+    {
+      params: { slug: editorial.slug },
+      locale: 'en',
+    },
+    {
+      params: { slug: editorial.slug },
+      locale: 'nl',
+    },
+  ]);
 
   // { fallback: false } means other routes should 404.
   return { paths, fallback: false };

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -78,7 +78,7 @@ export function createGetContent<T>(
     // this function call will mutate `rawContent`
     await replaceReferencesInContent(rawContent, client);
 
-    const content = localize(rawContent, [locale, 'nl']) as T;
+    const content = localize(rawContent, [locale]) as T;
     return { content };
   };
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -1,11 +1,13 @@
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps } from 'next/link';
+import { useIntl } from '~/intl';
 
 /**
  * Link component which disables the default Next/Link scroll behavior
  */
 
 export function Link(props: LinkProps & { children?: React.ReactNode }) {
-  const { locale = false } = props;
+  const defaultLocale = useIntl().locale ?? 'nl';
+  const { locale = defaultLocale } = props;
   return <NextLink {...props} scroll={props.scroll ?? false} locale={locale} />;
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -1,13 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import NextLink, { LinkProps } from 'next/link';
-import { useIntl } from '~/intl';
 
 /**
  * Link component which disables the default Next/Link scroll behavior
  */
 
 export function Link(props: LinkProps & { children?: React.ReactNode }) {
-  const defaultLocale = useIntl().locale ?? 'nl';
-  const { locale = defaultLocale } = props;
+  const { locale = false } = props;
   return <NextLink {...props} scroll={props.scroll ?? false} locale={locale} />;
 }


### PR DESCRIPTION
## Summary

Fix locale sanity issues

* Always specify a domains list, by adding an explicit fallback when no `DOMAIN_EN` is set.
* `getStaticPaths` is behaving odd. We don't use localized routes, but the returned array needs both locales.
* Some pages using our `<Link>` component were broken, especially ones using Rich Content from Sanity. Fixed by always explicitly providing a default locale to `Link`.