### PR TITLE
Fix alignment of the hovering date on time series chart. 

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -192,6 +192,7 @@ export const Axes = memo(function Axes({
         tickLabelProps={(x) => ({
           fill: colors.data.axisLabels,
           fontSize: 12,
+          dy: '-0.5px',
           /**
            * Using anchor middle the line marker label will fall nicely on top
            * of the axis label.

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -1,8 +1,7 @@
 import { TimeframeOption, TimestampedValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { useTooltip } from '@visx/tooltip';
-import { first } from 'lodash';
-import { last } from 'lodash';
+import { first, last } from 'lodash';
 import { useCallback, useEffect, useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components/base';


### PR DESCRIPTION
Well, apparently the alignment of the date when hovering was not totally aligned with the axes dates. It's now perfect ⭐ 

<img width="238" alt="Screenshot 2021-07-29 at 14 33 46" src="https://user-images.githubusercontent.com/76471292/127493318-c2900d73-bda8-4ece-8ea1-8e8ff7f4e730.png">