### PR TITLE
Add command line script to add an element

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -19,6 +19,7 @@
     "lokalize:sync-after-feature": "ts-node src/lokalize/sync-after-feature.ts",
     "lokalize:sync-prd-to-dev": "ts-node src/lokalize/sync-prd-to-dev.ts",
     "lokalize:strip-unused-keys": "yarn lokalize:export --clean-json && ts-node src/lokalize/strip-unused-keys.ts && yarn lokalize:export --clean-json && yarn workspace @corona-dashboard/app compile",
+    "elements:add": "ts-node src/elements/add.ts",
     "format": "prettier --write \"src/**/*.{js,ts,tsx}\" \"*.{js,json,md,yml}\""
   },
   "dependencies": {

--- a/packages/cms/src/elements/add.ts
+++ b/packages/cms/src/elements/add.ts
@@ -1,0 +1,180 @@
+import prompts from 'prompts';
+import { isDefined } from 'ts-is-present';
+import { getClient } from '../client';
+import {
+  loadSchemaMetricProperties,
+  loadSchemaMetrics,
+  Scope,
+} from './logic/load-schema';
+
+type Element = {
+  scope: Scope;
+  metricName: string;
+  metricProperty: string | undefined;
+  _type: ElementType;
+};
+
+type ElementType = 'choropleth' | 'timeSeries' | 'kpi';
+
+const devClient = getClient('development');
+const prodClient = getClient('production');
+
+(async function run() {
+  const element = await promptForElement();
+
+  if (isDefined(element)) {
+    await saveElement(element);
+  }
+
+  console.log('Have a nice day...');
+})();
+
+async function saveElement(element: Element) {
+  return Promise.all([devClient.create(element), prodClient.create(element)]);
+}
+
+async function promptForElement(): Promise<Element | undefined> {
+  const element: Element = {
+    scope: 'nl',
+    metricName: '',
+    metricProperty: undefined,
+    _type: 'choropleth',
+  };
+
+  const choices = [
+    { title: 'Municipal', value: 'gm' },
+    { title: 'Safety region', value: 'vr' },
+    { title: 'National', value: 'nl' },
+    { title: 'International', value: 'in' },
+  ];
+
+  const scopeResponse = (await prompts({
+    type: 'select',
+    name: 'scope',
+    message: 'Select the scope for this element:',
+    choices,
+    onState,
+  })) as { scope: Scope };
+
+  element.scope = scopeResponse.scope;
+
+  const metricNameResponse = (await prompts({
+    type: 'select',
+    name: 'metricName',
+    message: 'Select the metric name for this element:',
+    choices: loadSchemaMetrics(scopeResponse.scope).map((x) => ({
+      title: x,
+      value: x,
+    })),
+    onState,
+  })) as { metricName: string };
+
+  element.metricName = metricNameResponse.metricName;
+
+  const metricPropertyConfirmationresponse = await prompts([
+    {
+      type: 'confirm',
+      name: 'isConfirmed',
+      message: 'Do you need to select a metric property?',
+      initial: false,
+    },
+  ]);
+
+  if (metricPropertyConfirmationresponse.isConfirmed) {
+    const metricPropertyResponse = (await prompts({
+      type: 'select',
+      name: 'metricProperty',
+      message: 'Select a metric property for this element:',
+      choices: loadSchemaMetricProperties(
+        scopeResponse.scope,
+        metricNameResponse.metricName
+      ).map((x) => ({
+        title: x,
+        value: x,
+      })),
+      onState,
+    })) as { metricProperty: string };
+
+    element.metricProperty = metricPropertyResponse.metricProperty;
+  }
+
+  const elemenTypeChoices = [
+    { title: 'Time series', value: 'timeSeries' },
+    { title: 'Choropleth', value: 'choropleth' },
+    { title: 'KPI', value: 'kpi' },
+  ];
+
+  const typeResponse = (await prompts({
+    type: 'select',
+    name: '_type',
+    message: 'Select the element type:',
+    choices: elemenTypeChoices,
+    onState,
+  })) as { _type: ElementType };
+
+  element._type = typeResponse._type;
+
+  const isNew = await isNewElement(element);
+
+  if (!isNew) {
+    const startOverResponse = await prompts([
+      {
+        type: 'confirm',
+        name: 'isConfirmed',
+        message: `The element ${serializeElement(
+          element
+        )} already exists, do you want to start over?\nChoosing no will exit this prompt.`,
+        initial: false,
+      },
+    ]);
+    if (startOverResponse.isConfirmed) {
+      process.stdout.write('\x1Bc');
+      return promptForElement();
+    } else {
+      console.log('Aborting...');
+      process.exit(0);
+    }
+  }
+
+  const isCorrectResponse = await prompts([
+    {
+      type: 'confirm',
+      name: 'isConfirmed',
+      message: `Is this correct?\n${serializeElement(
+        element
+      )}\nWhen choosing 'yes' this element will be saved to both development and production.`,
+      initial: false,
+    },
+  ]);
+
+  if (isCorrectResponse.isConfirmed) {
+    return element;
+  }
+}
+
+async function isNewElement(element: Element) {
+  const { _type, scope, metricName, metricProperty } = element;
+  const query = !isDefined(metricProperty)
+    ? `*[_type == '${_type}' && scope == '${scope}' && metricName == '${metricName}'][0]`
+    : `*[_type == '${_type}' && scope == '${scope}' && metricName == '${metricName}' && metricProperty == '${metricProperty}'][0]`;
+
+  const devDocument = await devClient.fetch(query);
+  const prodDocument = await prodClient.fetch(query);
+
+  return devDocument === null && prodDocument === null;
+}
+
+function serializeElement(element: Element) {
+  if (!isDefined(element.metricProperty)) {
+    return `${element.scope}.${element.metricName}.${element._type}`;
+  }
+  return `${element.scope}.${element.metricName}.${element.metricProperty}.${element._type}`;
+}
+
+function onState(state: { aborted: boolean }) {
+  if (state.aborted) {
+    process.nextTick(() => {
+      process.exit(0);
+    });
+  }
+}

--- a/packages/cms/src/elements/add.ts
+++ b/packages/cms/src/elements/add.ts
@@ -1,3 +1,4 @@
+import { snakeCase } from 'change-case';
 import prompts from 'prompts';
 import { isDefined } from 'ts-is-present';
 import { getClient } from '../client';
@@ -162,20 +163,13 @@ async function isNewElement(element: Element) {
   return devDocument === null && prodDocument === null;
 }
 
-function camelToSnakeCase(camelCased: string) {
-  return camelCased.replace(
-    /[A-Z]/g,
-    (letter: string) => `_${letter.toLowerCase()}`
-  );
-}
-
 function elementToId(element: Element) {
   if (!isDefined(element.metricProperty)) {
-    return `${element.scope}__${element.metricName}__${camelToSnakeCase(
+    return `${element.scope}__${element.metricName}__${snakeCase(
       element._type
     )}`;
   }
-  return `${element.scope}__${element.metricName}__${camelToSnakeCase(
+  return `${element.scope}__${element.metricName}__${snakeCase(
     element._type
   )}__${element.metricProperty}`;
 }

--- a/packages/cms/src/elements/add.ts
+++ b/packages/cms/src/elements/add.ts
@@ -29,10 +29,6 @@ const prodClient = getClient('production');
   console.log('Have a nice day...');
 })();
 
-async function saveElement(element: Element) {
-  return Promise.all([devClient.create(element), prodClient.create(element)]);
-}
-
 async function promptForElement(): Promise<Element | undefined> {
   const element: Element = {
     scope: 'nl',
@@ -121,7 +117,7 @@ async function promptForElement(): Promise<Element | undefined> {
       {
         type: 'confirm',
         name: 'isConfirmed',
-        message: `The element ${serializeElement(
+        message: `The element ${elementToString(
           element
         )} already exists, do you want to start over?\nChoosing no will exit this prompt.`,
         initial: false,
@@ -140,7 +136,7 @@ async function promptForElement(): Promise<Element | undefined> {
     {
       type: 'confirm',
       name: 'isConfirmed',
-      message: `Is this correct?\n${serializeElement(
+      message: `Is this correct?\n${elementToString(
         element
       )}\nWhen choosing 'yes' this element will be saved to both development and production.`,
       initial: false,
@@ -164,11 +160,15 @@ async function isNewElement(element: Element) {
   return devDocument === null && prodDocument === null;
 }
 
-function serializeElement(element: Element) {
+function elementToString(element: Element) {
   if (!isDefined(element.metricProperty)) {
     return `${element.scope}.${element.metricName}.${element._type}`;
   }
   return `${element.scope}.${element.metricName}.${element.metricProperty}.${element._type}`;
+}
+
+async function saveElement(element: Element) {
+  return Promise.all([devClient.create(element), prodClient.create(element)]);
 }
 
 function onState(state: { aborted: boolean }) {

--- a/packages/cms/src/elements/logic/get-schema.ts
+++ b/packages/cms/src/elements/logic/get-schema.ts
@@ -5,16 +5,16 @@ export type Scope = 'nl' | 'gm' | 'vr' | 'in';
 
 const schemaPath = path.join(__dirname, '..\\..\\..\\..\\app\\schema');
 
-export function loadSchemaMetrics(scope: Scope) {
-  const schema = loadJSONFromFile(path.join(schemaPath, scope, '__index.json'));
+export function getSchemaMetrics(scope: Scope) {
+  const schema = loadJsonFromFile(path.join(schemaPath, scope, '__index.json'));
 
   return Object.entries<{ type: string } | { $ref: string }>(schema.properties)
     .filter(pickMetricNames)
     .map(([key]) => key);
 }
 
-export function loadSchemaMetricProperties(scope: Scope, metricName: string) {
-  const schema = loadJSONFromFile(
+export function getSchemaMetricProperties(scope: Scope, metricName: string) {
+  const schema = loadJsonFromFile(
     path.join(schemaPath, scope, `${metricName}.json`)
   );
 
@@ -38,7 +38,7 @@ function pickMetricNames([, value]: [
   }
 }
 
-function loadJSONFromFile(filePath: string) {
+function loadJsonFromFile(filePath: string) {
   const content = fs.readFileSync(filePath, { encoding: 'utf-8' });
   return JSON.parse(content);
 }

--- a/packages/cms/src/elements/logic/load-schema.ts
+++ b/packages/cms/src/elements/logic/load-schema.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+export type Scope = 'nl' | 'gm' | 'vr' | 'in';
+
+const schemaPath = path.join(__dirname, '..\\..\\..\\..\\app\\schema');
+
+export function loadSchemaMetrics(scope: Scope) {
+  const schema = loadJSONFromFile(path.join(schemaPath, scope, '__index.json'));
+
+  return Object.entries<{ type: string } | { $ref: string }>(schema.properties)
+    .filter(pickMetricNames)
+    .map(([key]) => key);
+}
+
+export function loadSchemaMetricProperties(scope: Scope, metricName: string) {
+  const schema = loadJSONFromFile(
+    path.join(schemaPath, scope, `${metricName}.json`)
+  );
+
+  return Object.keys(schema.definitions.value.properties).filter(
+    pickMetricProperties
+  );
+}
+
+function pickMetricProperties(key: string) {
+  return !key.startsWith('date_');
+}
+
+function pickMetricNames([, value]: [
+  string,
+  { type: string } | { $ref: string }
+]) {
+  if ('type' in value) {
+    return value.type !== 'string';
+  } else {
+    return !value.$ref.startsWith('__');
+  }
+}
+
+function loadJSONFromFile(filePath: string) {
+  const content = fs.readFileSync(filePath, { encoding: 'utf-8' });
+  return JSON.parse(content);
+}

--- a/packages/cms/src/elements/logic/load-schema.ts
+++ b/packages/cms/src/elements/logic/load-schema.ts
@@ -32,7 +32,7 @@ function pickMetricNames([, value]: [
   { type: string } | { $ref: string }
 ]) {
   if ('type' in value) {
-    return value.type !== 'string';
+    return false;
   } else {
     return !value.$ref.startsWith('__');
   }


### PR DESCRIPTION
## Summary

Kind of what the title states.
The prompt lets you choose from a list of generated types and metric names (pulled from the schema's).
When finished successfully it checks if an element with the given ID already exists
and if not, it creates it on both development and production.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
