### PR TITLE
Add use-unreliable-data-annotations hook to merge adjacent time spans with unreliable data

### DIFF
--- a/packages/app/src/domain/international/variants-stacked-area-tile/logic/use-unreliable-data-annotations.ts
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/logic/use-unreliable-data-annotations.ts
@@ -1,0 +1,45 @@
+import { DateSpanValue } from '@corona-dashboard/common';
+import { last } from 'lodash';
+import { useMemo } from 'react';
+import { isDefined } from 'ts-is-present';
+import { TimespanAnnotationConfig } from '~/components/time-series-chart/logic';
+
+export function useUnreliableDataAnnotations(
+  values: (DateSpanValue & { is_reliable: boolean })[],
+  label: string
+) {
+  return useMemo(
+    () =>
+      values
+        .reduce<TimespanAnnotationConfig[]>(
+          (acc, x) => {
+            if (!x.is_reliable) {
+              const annotation =
+                last(acc) ??
+                ({ label, fill: 'dotted' } as TimespanAnnotationConfig);
+              if (!isDefined(annotation.start)) {
+                annotation.start = x.date_start_unix;
+                annotation.end = x.date_end_unix;
+              } else {
+                annotation.end = x.date_end_unix;
+              }
+            } else {
+              acc.push({ label, fill: 'dotted' } as TimespanAnnotationConfig);
+            }
+            return acc;
+          },
+          [{ label, fill: 'dotted' }] as TimespanAnnotationConfig[]
+        )
+        .filter((x) => isDefined(x.start) && isDefined(x.end)),
+    [values, label]
+  );
+}
+
+/*
+            {
+              start: x.date_start_unix,
+              end: x.date_end_unix,
+              label: label,
+              fill: 'dotted',
+            }
+*/

--- a/packages/app/src/domain/international/variants-stacked-area-tile/logic/use-unreliable-data-annotations.ts
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/logic/use-unreliable-data-annotations.ts
@@ -34,12 +34,3 @@ export function useUnreliableDataAnnotations(
     [values, label]
   );
 }
-
-/*
-            {
-              start: x.date_start_unix,
-              end: x.date_end_unix,
-              label: label,
-              fill: 'dotted',
-            }
-*/

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -3,23 +3,21 @@ import css from '@styled-system/css';
 import { ReactNode, useMemo } from 'react';
 import styled from 'styled-components';
 import { isDefined, isPresent } from 'ts-is-present';
+import { Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { InteractiveLegend } from '~/components/interactive-legend';
 import { Legend, LegendItem } from '~/components/legend';
 import { MetadataProps } from '~/components/metadata';
-import { Spacer } from '~/components/base';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
-import {
-  GappedStackedAreaSeriesDefinition,
-  TimespanAnnotationConfig,
-} from '~/components/time-series-chart/logic';
+import { GappedStackedAreaSeriesDefinition } from '~/components/time-series-chart/logic';
 import { VariantChartValue } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
 import { colors } from '~/style/theme';
 import { assert } from '~/utils/assert';
 import { useList } from '~/utils/use-list';
+import { useUnreliableDataAnnotations } from './logic/use-unreliable-data-annotations';
 
 type VariantsStackedAreaTileProps = {
   values?: VariantChartValue[] | null;
@@ -92,25 +90,20 @@ function VariantStackedAreaTileWithData({
       color: colors.data.underReported,
       label: text.legend_niet_compleet_label,
     },
-    {
+  ];
+
+  const timespanAnnotations = useUnreliableDataAnnotations(
+    values,
+    text.lagere_betrouwbaarheid
+  );
+
+  if (timespanAnnotations.length) {
+    staticLegendItems.push({
       shape: 'dotted-square',
       color: 'white',
       label: text.lagere_betrouwbaarheid,
-    },
-  ];
-
-  const timespanAnnotations = useMemo(
-    () =>
-      values
-        .filter((x) => !x.is_reliable)
-        .map<TimespanAnnotationConfig>((x) => ({
-          start: x.date_start_unix,
-          end: x.date_end_unix,
-          label: text.lagere_betrouwbaarheid,
-          fill: 'dotted',
-        })),
-    [values, text]
-  );
+    });
+  }
 
   return (
     <ChartTile


### PR DESCRIPTION
## Summary

Exactly as the title states again.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
