### PR TITLE
Disable Next Link prefetching

### DIFF
--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -7,5 +7,12 @@ import NextLink, { LinkProps } from 'next/link';
 
 export function Link(props: LinkProps & { children?: React.ReactNode }) {
   const { locale = false } = props;
-  return <NextLink {...props} scroll={props.scroll ?? false} locale={locale} />;
+  return (
+    <NextLink
+      {...props}
+      prefetch={false}
+      scroll={props.scroll ?? false}
+      locale={locale}
+    />
+  );
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -6,13 +6,5 @@ import NextLink, { LinkProps } from 'next/link';
  */
 
 export function Link(props: LinkProps & { children?: React.ReactNode }) {
-  const { locale = false } = props;
-  return (
-    <NextLink
-      {...props}
-      prefetch={false}
-      scroll={props.scroll ?? false}
-      locale={locale}
-    />
-  );
+  return <NextLink prefetch={false} scroll={false} locale={false} {...props} />;
 }


### PR DESCRIPTION
## Summary

Disable next link prefetching 

## Motivation

Reduce requests on initial page load

## Detailed design

Set prefetch="false" on Next links via `Links` component in utils

