### PR TITLE
PoC: Lazy load the VrChoropleth on the homepage

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,7 @@
     "react-markdown": "^5",
     "styled-components": "^5.2.0",
     "styled-system": "^5.1.5",
+    "swr": "^0.5.6",
     "tippy.js": "^6.3.1",
     "topojson-client": "^3.1.0",
     "ts-is-present": "^1.1.5",

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -108,7 +108,6 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
   const { selectedNlData: data, choropleth, content, lastGenerated } = props;
 
   const { data: VRData, error } = useSWR('/json/VR_COLLECTION.json', fetcher);
-  console.log({ VRData, error });
 
   const dataInfectedTotal = data.tested_overall;
   const dataHospitalIntake = data.hospital_nice;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7853,6 +7853,11 @@ depd@^1.1.2, depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -17585,6 +17590,13 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+swr@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.5.6.tgz#70bfe9bc9d7ac49a064be4a0f4acf57982e55a31"
+  integrity sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Summary

In my neverending quest for performance optimizations I'm trying to see if lazy loading the choropleths on the homepage brings substantial performance improvements.

## Motivation

- The choropleths have a LOT of DOM elements which impacts lighthouse scores
- The GeoJSON files are very heavy on the HTML size. Loading and caching them client-side makes the pages much smaller.

## Detailed design

- Used SWR to load the GeoJSON files.
- Use next/dynamic to lazy load the choropleths and don't render them server-side (because we only have the data on the client)

## Drawbacks

Without JS execution the choropleths are missing. I'm not sure if that's a good enough reason not to hide the choropleths below the fold on the homepage.

## Still todo if we like this approach and the performance improvement is significant

- [ ] Fix some TypeScript issues
- [ ] Re-apply the filters to the GeoJSON to make it even smaller
- [ ] Maybe add loading/skeleton states? We want to prevent layout shifting at the very least :)