### PR TITLE
Supply default language to get content method

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -14,7 +14,7 @@ import {
   ImageBlock,
   InlineAttachment,
   InlineLink,
-  RichContentImageBlock
+  RichContentImageBlock,
 } from '~/types/cms';
 import { assert } from '~/utils/assert';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
@@ -96,7 +96,7 @@ function InlineAttachmentMark(props: {
 function InlineLinkMark(props: { children: ReactNode; mark: InlineLink }) {
   const { mark, children } = props;
 
-  const { locale = 'nl' } = useIntl();
+  const { locale } = useIntl();
 
   if (!mark.href) return <>{children}</>;
 

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -17,8 +17,7 @@ import { IsTouchDeviceContextProvider } from '~/utils/use-is-touch-device';
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
   const router = useRouter();
-
-  const { locale } = router;
+  const { locale = 'nl' } = router;
 
   const [text, toggleHotReloadButton, dataset] = useLokalizeText(
     locale as LanguageKey

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -18,7 +18,7 @@ export default function App(props: AppProps) {
   const { Component, pageProps } = props;
   const router = useRouter();
 
-  const { locale = 'nl' } = useRouter();
+  const { locale } = router;
 
   const [text, toggleHotReloadButton, dataset] = useLokalizeText(
     locale as LanguageKey

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -40,7 +40,7 @@ export async function getStaticPaths() {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<Article>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     assert(context?.params?.slug, 'Slug required to retrieve article');
     return `*[_type == 'article' && slug.current == '${context.params.slug}']{

--- a/packages/app/src/pages/artikelen/index.tsx
+++ b/packages/app/src/pages/artikelen/index.tsx
@@ -28,7 +28,7 @@ import { useBreakpoints } from '~/utils/use-breakpoints';
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<ArticleSummary[]>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `*[_type == 'article'] | order(publicationDate desc) {
         "title":title.${locale},

--- a/packages/app/src/pages/contact.tsx
+++ b/packages/app/src/pages/contact.tsx
@@ -22,7 +22,7 @@ interface ContactData {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<ContactData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `*[_type == 'contact']{
       title,

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -63,7 +63,7 @@ export const getStaticProps = createGetStaticProps(
     page: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `{
       "page": ${createPageArticlesQuery('positiveTestsPage', locale)},
       "elements": ${createElementsQuery('gm', ['tested_overall'], locale)}

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -40,7 +40,7 @@ export const getStaticProps = createGetStaticProps(
     'code'
   ),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('sewerPage', locale);
   })
 );

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -32,7 +32,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectGmPageMetricData('deceased_rivm', 'difference', 'code'),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('deceasedPage', locale);
   })
 );

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -53,7 +53,7 @@ export const getStaticProps = createGetStaticProps(
     page: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `{
       "page": ${createPageArticlesQuery('hospitalPage', locale)},

--- a/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
@@ -56,7 +56,7 @@ export const getStaticProps = withFeatureNotFoundPage(
         articles?: ArticleSummary[];
       };
     }>((context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       return `{
       "page": ${getInPositiveTestsQuery(context)},
       "highlight": ${createPageArticlesQuery('in_positiveTestsPage', locale)}

--- a/packages/app/src/pages/internationaal/varianten.tsx
+++ b/packages/app/src/pages/internationaal/varianten.tsx
@@ -42,7 +42,7 @@ export const getStaticProps = withFeatureNotFoundPage(
   createGetStaticProps(
     getLastGeneratedDate,
     (context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       const countryNames = loadJsonFromDataFile<Record<string, string>>(
         `${locale}-country-names.json`,
         'static-json'
@@ -67,7 +67,7 @@ export const getStaticProps = withFeatureNotFoundPage(
       };
       highlight: PageArticlesQueryResult;
     }>((context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       return `{
         "page": *[_type=='in_variantsPage']{
           "usefulLinks": [...pageLinks[]{

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -28,7 +28,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectNlPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('infectiousPeoplePage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/brononderzoek.tsx
+++ b/packages/app/src/pages/landelijk/brononderzoek.tsx
@@ -32,7 +32,7 @@ export const getStaticProps = withFeatureNotFoundPage(
       }),
     }),
     createGetContent<PageArticlesQueryResult>((context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       return createPageArticlesQuery('situationsPage', locale);
     })
   )

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -40,7 +40,7 @@ export const getStaticProps = createGetStaticProps(
     vr: ({ behavior }) => ({ behavior }),
   }),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('behaviorPage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -46,7 +46,7 @@ export const getStaticProps = createGetStaticProps(
     vr: ({ disability_care }) => ({ disability_care }),
   }),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('disabilityCarePage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -43,7 +43,7 @@ export const getStaticProps = createGetStaticProps(
     page: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `{
       "page": ${createPageArticlesQuery('intensiveCarePage', locale)},
       "elements": ${createElementsQuery('nl', ['intensive_care_nice'], locale)}

--- a/packages/app/src/pages/landelijk/maatregelen.tsx
+++ b/packages/app/src/pages/landelijk/maatregelen.tsx
@@ -29,7 +29,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectNlPageMetricData(),
   createGetContent<MaatregelenData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `
     {
       'lockdown': *[_type == 'lockdown']{

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -67,7 +67,7 @@ export const getStaticProps = createGetStaticProps(
     ggd: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     const query = `{
       "main": ${createPageArticlesQuery('positiveTestsPage', locale)},

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -28,7 +28,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectNlPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('reproductionPage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -51,7 +51,7 @@ export const getStaticProps = createGetStaticProps(
     gm: ({ sewer }) => ({ sewer }),
   }),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('sewerPage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = createGetStaticProps(
     main: { articles: ArticleSummary[] };
     monitor: { articles: ArticleSummary[] };
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `{
       "main": ${createPageArticlesQuery('deceasedPage', locale)},
       "monitor": ${createPageArticlesQuery(

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -44,7 +44,7 @@ export const getStaticProps = createGetStaticProps(
     vr: ({ elderly_at_home }) => ({ elderly_at_home }),
   }),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('elderlyAtHomePage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -68,7 +68,7 @@ export const getStaticProps = createGetStaticProps(
     page: VaccinationPageQuery;
     highlight: PageArticlesQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `{
       "page": ${getVaccinePageQuery(locale)},
       "highlight": ${createPageArticlesQuery('vaccinationsPage', locale)}

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -46,7 +46,7 @@ export const getStaticProps = withFeatureNotFoundPage(
         articles?: ArticleSummary[];
       };
     }>((context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       return `{
         "page": ${getVariantsPageQuery(context)},
         "highlight": ${createPageArticlesQuery('variantsPage', locale)}

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -46,7 +46,7 @@ export const getStaticProps = createGetStaticProps(
     vr: ({ nursing_home }) => ({ nursing_home }),
   }),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('nursingHomePage', locale);
   })
 );

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -62,7 +62,7 @@ export const getStaticProps = createGetStaticProps(
     page: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `{
       "page": ${createPageArticlesQuery('hospitalPage', locale)},

--- a/packages/app/src/pages/over-risiconiveaus.tsx
+++ b/packages/app/src/pages/over-risiconiveaus.tsx
@@ -45,7 +45,7 @@ export const getStaticProps = createGetStaticProps(
     vr: ({ escalation_levels }) => ({ escalation_levels }),
   }),
   createGetContent<OverRisiconiveausData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `*[_type == 'overRisicoNiveaus']{
       "title": title.${locale},
       "description": {

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -22,7 +22,7 @@ interface OverData {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<OverData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `
     *[_type == 'overDitDashboard']{
       ...,

--- a/packages/app/src/pages/toegankelijkheid.tsx
+++ b/packages/app/src/pages/toegankelijkheid.tsx
@@ -22,7 +22,7 @@ interface AccessibilityPageData {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<AccessibilityPageData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `*[_type == 'toegankelijkheid']{
       ...,

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -27,7 +27,7 @@ interface VeelgesteldeVragenData {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<VeelgesteldeVragenData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `*[_type == 'veelgesteldeVragen']{
       ...,

--- a/packages/app/src/pages/veiligheidsregio/[code]/brononderzoek.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/brononderzoek.tsx
@@ -38,7 +38,7 @@ export const getStaticProps = withFeatureNotFoundPage(
     getLastGeneratedDate,
     selectVrPageMetricData('situations'),
     createGetContent<PageArticlesQueryResult>((context) => {
-      const { locale = 'nl' } = context;
+      const { locale } = context;
       return createPageArticlesQuery('situationsPage', locale);
     })
   )

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('behaviorPage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -34,7 +34,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('disabilityCarePage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/maatregelen.tsx
@@ -34,7 +34,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData(),
   createGetContent<MaatregelenData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `
     {

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -60,7 +60,7 @@ export const getStaticProps = createGetStaticProps(
     ggd: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `{
       "main": ${createPageArticlesQuery('positiveTestsPage', locale)},
       "ggd": ${createPageArticlesQuery(

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData('sewer_per_installation', 'sewer'),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('sewerPage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/risiconiveau.tsx
@@ -56,7 +56,7 @@ export const getStaticProps = createGetStaticProps(
     'tested_overall_sum'
   ),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('escalationLevelPage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData('deceased_cbs', 'deceased_rivm'),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('deceasedPage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -33,7 +33,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('elderlyAtHomePage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -35,7 +35,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectVrPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return createPageArticlesQuery('nursingHomePage', locale);
   })
 );

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -51,7 +51,7 @@ export const getStaticProps = createGetStaticProps(
     page: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     return `{
       "page": ${createPageArticlesQuery('hospitalPage', locale)},

--- a/packages/app/src/pages/verantwoording.tsx
+++ b/packages/app/src/pages/verantwoording.tsx
@@ -27,7 +27,7 @@ interface VerantwoordingData {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<VerantwoordingData>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
     return `*[_type == 'cijferVerantwoording']{
       ...,
       "description": {

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -40,7 +40,7 @@ export async function getStaticPaths() {
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<Editorial>((context) => {
-    const { locale = 'nl' } = context;
+    const { locale } = context;
 
     assert(context.params?.slug, 'Slug required to retrieve article');
     return `

--- a/packages/app/src/queries/in-positive-tests-query.ts
+++ b/packages/app/src/queries/in-positive-tests-query.ts
@@ -1,7 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 
 export function getInPositiveTestsQuery(context: GetStaticPropsContext) {
-  const { locale = 'nl' } = context;
+  const { locale } = context;
 
   return `
   *[_type=='in_positiveTestsPage']{

--- a/packages/app/src/queries/topical-page-query.ts
+++ b/packages/app/src/queries/topical-page-query.ts
@@ -1,7 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 
 export function getTopicalPageQuery(context: GetStaticPropsContext) {
-  const { locale = 'nl' } = context;
+  const { locale } = context;
 
   return /* groq */ `{
     // Retrieve the latest 3 articles with the highlighted article filtered out:

--- a/packages/app/src/queries/variants-page-query.ts
+++ b/packages/app/src/queries/variants-page-query.ts
@@ -1,7 +1,7 @@
 import { GetStaticPropsContext } from 'next';
 
 export function getVariantsPageQuery(context: GetStaticPropsContext) {
-  const { locale = 'nl' } = context;
+  const { locale } = context;
 
   return `
   *[_type=='variantsPage']{

--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -66,18 +66,19 @@ export function getLastGeneratedDate() {
 }
 
 export function createGetContent<T>(
-  queryOrQueryGetter: string | ((context: GetStaticPropsContext) => string)
+  queryOrQueryGetter:
+    | string
+    | ((context: GetStaticPropsContext & { locale: string }) => string)
 ) {
   return async (context: GetStaticPropsContext) => {
+    const { locale = 'nl' } = context;
     const client = await getClient();
     const query =
       typeof queryOrQueryGetter === 'function'
-        ? queryOrQueryGetter(context)
+        ? queryOrQueryGetter({ locale, ...context })
         : queryOrQueryGetter;
 
     const rawContent = (await client.fetch<T>(query)) ?? {};
-
-    const { locale = 'nl' } = context;
 
     // this function call will mutate `rawContent`
     await replaceReferencesInContent(rawContent, client);

--- a/packages/app/src/static-props/utils/get-country-names.ts
+++ b/packages/app/src/static-props/utils/get-country-names.ts
@@ -2,7 +2,7 @@ import { GetStaticPropsContext } from 'next';
 import { loadJsonFromDataFile } from './load-json-from-data-file';
 
 export function getCountryNames(context: GetStaticPropsContext) {
-  const { locale = 'nl' } = context;
+  const { locale } = context;
 
   const names = loadJsonFromDataFile<Record<string, string>>(
     `${locale}-country-names.json`,


### PR DESCRIPTION
## Summary

Supply default language to get content method

For some reason, the `GetStaticPropsContext` does not get that we always have a language, and so `locale` can be undefined. Since a lot of fallback `= 'nl'` are supplied in the getcontent method, I've ensured `locale` is never undefined there, cleaning up some code.