### PR TITLE
Update international variant chart legend

### DIFF
--- a/packages/app/src/components/legend.tsx
+++ b/packages/app/src/components/legend.tsx
@@ -1,8 +1,14 @@
 import css, { SystemStyleObject } from '@styled-system/css';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
+import { colors } from '~/style/theme';
 
-type LegendShape = 'line' | 'square' | 'circle' | 'dotted-square';
+type LegendShape =
+  | 'line'
+  | 'square'
+  | 'circle'
+  | 'dotted-square'
+  | 'outlined-square';
 type LegendLineStyle = 'solid' | 'dashed';
 
 export type LegendItem = {
@@ -37,6 +43,9 @@ export function Legend({ items }: LegendProps) {
           <Item key={i}>
             {item.label}
             {item.shape === 'square' && <Square color={item.color} />}
+            {item.shape === 'outlined-square' && (
+              <OutlinedSquare color={item.color} />
+            )}
             {item.shape === 'dotted-square' && (
               <DottedSquare color={item.color} />
             )}
@@ -127,6 +136,18 @@ function DottedSquare({ color }: { color: string }) {
     </Shape>
   );
 }
+
+const OutlinedSquare = styled(Shape)(
+  css({
+    top: '3px',
+    width: '15px',
+    height: '15px',
+    borderColor: colors.labelGray,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderRadius: '2px',
+  })
+);
 
 const Square = styled(Shape)(
   css({

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -86,8 +86,8 @@ function VariantStackedAreaTileWithData({
   /* Static legend contains only the inaccurate item */
   const staticLegendItems: LegendItem[] = [
     {
-      shape: 'square',
-      color: colors.data.underReported,
+      shape: 'outlined-square',
+      color: colors.white,
       label: text.legend_niet_compleet_label,
     },
   ];


### PR DESCRIPTION
## Summary

Added and new legend-shape called `outlined-square` and used it to update the international variant chart's legend to show a white square as representation for no data

## Motivation

QA

