### PR TITLE
Remove white gaps for a gapped-stacked-area chart

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -1,7 +1,8 @@
 import { TimelineEventConfig } from '../components/timeline';
 
 /**
- * The prop setNullToZero only make sense when rendering a gapped-stacked-area, hence why it only works there.
+ * The prop setNullToZero only make sense when rendering a gapped-stacked-area,
+ * hence why it only works in that particular config .
  */
 export interface DataOptions {
   valueAnnotation?: string;

--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -1,7 +1,7 @@
 import { TimelineEventConfig } from '../components/timeline';
 
 /**
- * The prop setNullToZero only make sense when rendering a gapped-stacked-area,
+ * The prop renderNullAsZero only make sense when rendering a gapped-stacked-area,
  * hence why it only works in that particular config .
  */
 export interface DataOptions {
@@ -12,7 +12,7 @@ export interface DataOptions {
   timespanAnnotations?: TimespanAnnotationConfig[];
   timeAnnotations?: TimeAnnotationConfig[];
   timelineEvents?: TimelineEventConfig[];
-  setNullToZero?: boolean;
+  renderNullAsZero?: boolean;
 }
 
 export interface BenchmarkConfig {

--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -1,5 +1,8 @@
 import { TimelineEventConfig } from '../components/timeline';
 
+/**
+ * The prop setNullToZero only make sense when rendering a gapped-stacked-area, hence why it only works there.
+ */
 export interface DataOptions {
   valueAnnotation?: string;
   forcedMaximumValue?: number | ((x: number) => number);
@@ -8,6 +11,7 @@ export interface DataOptions {
   timespanAnnotations?: TimespanAnnotationConfig[];
   timeAnnotations?: TimeAnnotationConfig[];
   timelineEvents?: TimelineEventConfig[];
+  setNullToZero?: boolean;
 }
 
 export interface BenchmarkConfig {

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -10,7 +10,7 @@ import { omit } from 'lodash';
 import { useMemo } from 'react';
 import { hasValueAtKey, isDefined, isPresent } from 'ts-is-present';
 import { useCurrentDate } from '~/utils/current-date-context';
-import { TimespanAnnotationConfig } from './common';
+import { DataOptions, TimespanAnnotationConfig } from './common';
 import { SplitPoint } from './split';
 
 export type SeriesConfig<T extends TimestampedValue> = (
@@ -209,11 +209,12 @@ export function isVisible<T extends TimestampedValue>(
 export function useSeriesList<T extends TimestampedValue>(
   values: T[],
   seriesConfig: SeriesConfig<T>,
-  cutValuesConfig?: CutValuesConfig[]
+  cutValuesConfig?: CutValuesConfig[],
+  dataOptions?: DataOptions
 ) {
   return useMemo(
-    () => getSeriesList(values, seriesConfig, cutValuesConfig),
-    [values, seriesConfig, cutValuesConfig]
+    () => getSeriesList(values, seriesConfig, cutValuesConfig, dataOptions),
+    [values, seriesConfig, cutValuesConfig, dataOptions]
   );
 }
 
@@ -323,7 +324,8 @@ export type SeriesList = SingleSeries[];
 function getSeriesList<T extends TimestampedValue>(
   values: T[],
   seriesConfig: SeriesConfig<T>,
-  cutValuesConfig?: CutValuesConfig[]
+  cutValuesConfig?: CutValuesConfig[],
+  dataOptions?: DataOptions
 ): SeriesList {
   return seriesConfig.filter(isVisible).map((config) =>
     config.type === 'stacked-area'
@@ -332,7 +334,8 @@ function getSeriesList<T extends TimestampedValue>(
       ? getGappedStackedAreaSeriesData(
           values,
           config.metricProperty,
-          seriesConfig
+          seriesConfig,
+          dataOptions
         )
       : config.type === 'range'
       ? getRangeSeriesData(
@@ -350,7 +353,8 @@ function getSeriesList<T extends TimestampedValue>(
 function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
   values: T[],
   metricProperty: keyof T,
-  seriesConfig: SeriesConfig<T>
+  seriesConfig: SeriesConfig<T>,
+  dataOptions?: DataOptions
 ) {
   /**
    * Stacked area series are rendered from top to bottom. The sum of a Y-value
@@ -361,8 +365,6 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
     hasValueAtKey('type', 'gapped-stacked-area' as const)
   );
 
-  // console.log(hasValueOffZeroWhatevre);
-
   const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(
     stackedAreaDefinitions,
     metricProperty
@@ -372,14 +374,7 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
   const seriesLow = getSeriesData(values, metricProperty);
 
   seriesLow.forEach((seriesSingleValue, index) => {
-    // console.log(seriesSingleValue);
-    // console.log(!('setNullToZero' in seriesConfig[index]));
-
-    // if (seriesConfig[index].hasOwnProperty('setNullToZero')) {
-    //   console.log(seriesConfig[index].setNullToZero);
-    // }
-
-    if (!isPresent(seriesSingleValue.__value)) {
+    if (!dataOptions?.setNullToZero && !isPresent(seriesSingleValue.__value)) {
       return;
     }
 
@@ -399,7 +394,9 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
     const valueLow = low.__value;
     const valueHigh = isDefined(valueLow)
       ? valueLow + (seriesHigh[index].__value ?? 0)
-      : 0;
+      : dataOptions?.setNullToZero
+      ? 0
+      : undefined;
 
     return {
       __date_unix: low.__date_unix,

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -142,6 +142,7 @@ export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
   strokeWidth?: number;
   isNonInteractive?: boolean;
   mixBlendMode?: Property.MixBlendMode;
+  setNullToZero?: boolean;
 }
 
 /**
@@ -360,6 +361,8 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
     hasValueAtKey('type', 'gapped-stacked-area' as const)
   );
 
+  // console.log(hasValueOffZeroWhatevre);
+
   const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(
     stackedAreaDefinitions,
     metricProperty
@@ -369,9 +372,17 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
   const seriesLow = getSeriesData(values, metricProperty);
 
   seriesLow.forEach((seriesSingleValue, index) => {
+    // console.log(seriesSingleValue);
+    // console.log(!('setNullToZero' in seriesConfig[index]));
+
+    // if (seriesConfig[index].hasOwnProperty('setNullToZero')) {
+    //   console.log(seriesConfig[index].setNullToZero);
+    // }
+
     if (!isPresent(seriesSingleValue.__value)) {
       return;
     }
+
     /**
      * The series are rendered from top to bottom. To get the low value of the
      * current series, we will sum up all values of the
@@ -388,7 +399,7 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
     const valueLow = low.__value;
     const valueHigh = isDefined(valueLow)
       ? valueLow + (seriesHigh[index].__value ?? 0)
-      : undefined;
+      : 0;
 
     return {
       __date_unix: low.__date_unix,

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -142,7 +142,6 @@ export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
   strokeWidth?: number;
   isNonInteractive?: boolean;
   mixBlendMode?: Property.MixBlendMode;
-  setNullToZero?: boolean;
 }
 
 /**
@@ -374,7 +373,10 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
   const seriesLow = getSeriesData(values, metricProperty);
 
   seriesLow.forEach((seriesSingleValue, index) => {
-    if (!dataOptions?.setNullToZero && !isPresent(seriesSingleValue.__value)) {
+    if (
+      !dataOptions?.renderNullAsZero &&
+      !isPresent(seriesSingleValue.__value)
+    ) {
       return;
     }
 
@@ -394,7 +396,7 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
     const valueLow = low.__value;
     const valueHigh = isDefined(valueLow)
       ? valueLow + (seriesHigh[index].__value ?? 0)
-      : dataOptions?.setNullToZero
+      : dataOptions?.renderNullAsZero
       ? 0
       : undefined;
 

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -205,7 +205,12 @@ export function TimeSeriesChart<
     [timespanAnnotations]
   );
 
-  const seriesList = useSeriesList(values, seriesConfig, cutValuesConfig);
+  const seriesList = useSeriesList(
+    values,
+    seriesConfig,
+    cutValuesConfig,
+    dataOptions
+  );
 
   /**
    * The maximum is calculated over all values, because you don't want the

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -217,6 +217,7 @@ function useSeriesConfig(
           strokeWidth: 0,
           fillOpacity: 1,
           mixBlendMode: 'multiply',
+          setNullToZero: true,
         };
       });
 

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -136,6 +136,7 @@ function VariantStackedAreaTileWithData({
               isPercentage: true,
               forcedMaximumValue: 100,
               timespanAnnotations,
+              setNullToZero: true,
             }}
             formatTooltip={(context) => {
               /**
@@ -217,7 +218,6 @@ function useSeriesConfig(
           strokeWidth: 0,
           fillOpacity: 1,
           mixBlendMode: 'multiply',
-          setNullToZero: true,
         };
       });
 

--- a/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/international/variants-stacked-area-tile/variants-stacked-area-tile.tsx
@@ -136,7 +136,7 @@ function VariantStackedAreaTileWithData({
               isPercentage: true,
               forcedMaximumValue: 100,
               timespanAnnotations,
-              setNullToZero: true,
+              renderNullAsZero: true,
             }}
             formatTooltip={(context) => {
               /**


### PR DESCRIPTION
When a value is null it can't draw an area and leaves a hole in the area graph. Maybe sometimes it has to be the behavior but for the international variants, it certainly didn't. 

Added a prop `renderNullAsZero ` on the `dataConfig` to enable this behavior.

Without `renderNullAsZero `.
<img width="904" alt="Screenshot 2021-08-11 at 10 57 36" src="https://user-images.githubusercontent.com/76471292/129000657-97c65472-86c2-469c-bea2-aa84b4b59691.png">

With `setNullToZero`
<img width="905" alt="Screenshot 2021-08-11 at 10 57 45" src="https://user-images.githubusercontent.com/76471292/129000645-7d3febe4-46e1-4ced-82d6-97d6b71bd422.png">


