### PR TITLE
Filtering Behavior Chart Select Options

### DIFF
--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -79,19 +79,17 @@ export function BehaviorLineChartTile({
   );
 }
 
-export function useBehaviorChartOptions(
-  values: NlBehaviorValue[] | VrBehaviorValue[]
-) {
+export function useBehaviorChartOptions<T>(values: T[]) {
   const behaviorLookupKeys = useBehaviorLookupKeys();
 
   return useMemo(() => {
     return behaviorLookupKeys
       .map((x) => {
         const complianceValues = values
-          .map((value) => value[x.complianceKey])
+          .map((value: any) => value[x.complianceKey])
           .filter(isPresent);
         const supportValues = values
-          .map((value) => value[x.supportKey])
+          .map((value: any) => value[x.supportKey])
           .filter(isPresent);
 
         if (complianceValues.length && supportValues.length) {

--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -1,6 +1,5 @@
 import { NlBehaviorValue, VrBehaviorValue } from '@corona-dashboard/common';
-import { useMemo } from 'react';
-import { isDefined, isPresent } from 'ts-is-present';
+import { isDefined } from 'ts-is-present';
 import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { MetadataProps } from '~/components/metadata';
@@ -8,8 +7,10 @@ import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { SelectBehavior } from './components/select-behavior';
-import { BehaviorIdentifier } from './logic/behavior-types';
-import { useBehaviorLookupKeys } from './logic/use-behavior-lookup-keys';
+import {
+  BehaviorIdentifier,
+  behaviorIdentifiers,
+} from './logic/behavior-types';
 
 interface BehaviorLineChartTileProps {
   values: NlBehaviorValue[] | VrBehaviorValue[];
@@ -79,23 +80,12 @@ export function BehaviorLineChartTile({
   );
 }
 
-export function useBehaviorChartOptions<T>(values: T[]) {
-  const behaviorLookupKeys = useBehaviorLookupKeys();
-
-  return useMemo(() => {
-    return behaviorLookupKeys
-      .map((x) => {
-        const complianceValues = values
-          .map((value: any) => value[x.complianceKey])
-          .filter(isPresent);
-        const supportValues = values
-          .map((value: any) => value[x.supportKey])
-          .filter(isPresent);
-
-        if (complianceValues.length && supportValues.length) {
-          return x.key;
-        }
-      })
-      .filter(isDefined);
-  }, [values, behaviorLookupKeys]);
+export function getBehaviorChartOptions<T>(value: T) {
+  return behaviorIdentifiers
+    .map((key) => {
+      if (`${key}_compliance` in value || `${key}_support` in value) {
+        return key;
+      }
+    })
+    .filter(isDefined);
 }

--- a/packages/app/src/domain/behavior/components/select-behavior.tsx
+++ b/packages/app/src/domain/behavior/components/select-behavior.tsx
@@ -9,21 +9,28 @@ import { BehaviorIcon } from './behavior-icon';
 interface SelectBehaviorProps {
   value: BehaviorIdentifier;
   onChange: (value: BehaviorIdentifier) => void;
+  options?: BehaviorIdentifier[];
 }
 
-export function SelectBehavior({ value, onChange }: SelectBehaviorProps) {
+export function SelectBehavior({
+  value,
+  onChange,
+  options = behaviorIdentifiers as unknown as BehaviorIdentifier[],
+}: SelectBehaviorProps) {
   const intl = useIntl();
-  const options = behaviorIdentifiers.map((id) => ({
-    value: id,
-    label: intl.siteText.gedrag_onderwerpen[id],
-  }));
+  const selectOptions = options
+    .map((id) => ({
+      value: id,
+      label: intl.siteText.gedrag_onderwerpen[id],
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   return (
     <Select
       value={value}
       onChange={onChange}
       icon={<BehaviorIcon name={value} size={25} />}
-      options={options}
+      options={selectOptions}
     />
   );
 }

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -8,7 +8,7 @@ import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Heading, InlineText, Text } from '~/components/typography';
 import {
   BehaviorLineChartTile,
-  useBehaviorChartOptions,
+  getBehaviorChartOptions,
 } from '~/domain/behavior/behavior-line-chart-tile';
 import { BehaviorTableTile } from '~/domain/behavior/behavior-table-tile';
 import { MoreInformation } from '~/domain/behavior/components/more-information';
@@ -35,17 +35,33 @@ export { getStaticPaths } from '~/static-paths/vr';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectVrPageMetricData(),
   createGetContent<PageArticlesQueryResult>((context) => {
     const { locale = 'nl' } = context;
     return createPageArticlesQuery('behaviorPage', locale);
-  })
+  }),
+  (context) => {
+    const data = selectVrPageMetricData()(context);
+    const chartBehaviorOptions = getBehaviorChartOptions<NlBehaviorValue>(
+      data.selectedVrData.behavior.values[0]
+    );
+
+    return {
+      ...data,
+      chartBehaviorOptions,
+    };
+  }
 );
 
 export default function BehaviorPageVr(
   props: StaticProps<typeof getStaticProps>
 ) {
-  const { lastGenerated, content, selectedVrData: data, vrName } = props;
+  const {
+    lastGenerated,
+    content,
+    selectedVrData: data,
+    vrName,
+    chartBehaviorOptions,
+  } = props;
 
   const { siteText, formatDateFromSeconds, formatNumber } = useIntl();
 
@@ -60,9 +76,6 @@ export default function BehaviorPageVr(
   const { regionaal_gedrag } = siteText;
   const behaviorLastValue = data.behavior.last_value;
 
-  const chartBehaviorOptions = useBehaviorChartOptions<NlBehaviorValue>(
-    data.behavior.values
-  );
   const [currentId, setCurrentId] = useState<BehaviorIdentifier>(
     chartBehaviorOptions[0]
   );

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -1,3 +1,4 @@
+import { NlBehaviorValue } from '@corona-dashboard/common';
 import { useRef, useState } from 'react';
 import { ReactComponent as Gedrag } from '~/assets/gedrag.svg';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -59,7 +60,9 @@ export default function BehaviorPageVr(
   const { regionaal_gedrag } = siteText;
   const behaviorLastValue = data.behavior.last_value;
 
-  const chartBehaviorOptions = useBehaviorChartOptions(data.behavior.values);
+  const chartBehaviorOptions = useBehaviorChartOptions<NlBehaviorValue>(
+    data.behavior.values
+  );
   const [currentId, setCurrentId] = useState<BehaviorIdentifier>(
     chartBehaviorOptions[0]
   );

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -5,7 +5,10 @@ import { Tile } from '~/components/tile';
 import { TileList } from '~/components/tile-list';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Heading, InlineText, Text } from '~/components/typography';
-import { BehaviorLineChartTile } from '~/domain/behavior/behavior-line-chart-tile';
+import {
+  BehaviorLineChartTile,
+  useBehaviorChartOptions,
+} from '~/domain/behavior/behavior-line-chart-tile';
 import { BehaviorTableTile } from '~/domain/behavior/behavior-table-tile';
 import { MoreInformation } from '~/domain/behavior/components/more-information';
 import { BehaviorIdentifier } from '~/domain/behavior/logic/behavior-types';
@@ -56,7 +59,10 @@ export default function BehaviorPageVr(
   const { regionaal_gedrag } = siteText;
   const behaviorLastValue = data.behavior.last_value;
 
-  const [currentId, setCurrentId] = useState<BehaviorIdentifier>('wash_hands');
+  const chartBehaviorOptions = useBehaviorChartOptions(data.behavior.values);
+  const [currentId, setCurrentId] = useState<BehaviorIdentifier>(
+    chartBehaviorOptions[0]
+  );
   const scrollToRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -144,6 +150,7 @@ export default function BehaviorPageVr(
             }}
             currentId={currentId}
             setCurrentId={setCurrentId}
+            behaviorOptions={chartBehaviorOptions}
           />
 
           <MoreInformation />


### PR DESCRIPTION
## Summary

Filtering VR behavior chart select to only show options that have data to display on the graph

## Motivation

Chart looks broken when there is no data

## Detailed design

Created a `useBehaviorChartOptions` hook in the `BehaviorLineChartTile` file which maps through each of the behavior identifiers to check if there are values for it to return the list of options that are conditionally passed to the `BehaviorLineChartTile` and then to the `SelectBehavior` component

The `SelectBehavior` component uses the defined list of behaviorIdentifiers as the default for it's options when the `options` prop is not provided 

## Alternatives

The options could be filtered within the BehaviorLineChartTile, but since this should only be necessary for VR, I thought it made more sense to pass it from the parent which also decides on the initial selected item

