### PR TITLE
Fix sewer location tooltip

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -140,7 +140,14 @@ export function SewerChart({
                     isNonInteractive: true,
                   },
                 ]}
-                formatTooltip={(data) => <LocationTooltip data={data} />}
+                formatTooltip={(data) => {
+                  /**
+                   * Silently fail when unable to find line configuration in location tooltip
+                   */
+                  if (data.config.find((x) => x.type === 'line')) {
+                    return <LocationTooltip data={data} />;
+                  }
+                }}
                 dataOptions={{ valueAnnotation: text.valueAnnotation }}
               />
             ) : (


### PR DESCRIPTION
## Summary

Fix sewer location tooltip

My hunch is that this only fails on some machines when trying to render/handle the dropdown while still displaying the tooltip. Not all data might be there during the switch, resulting in the error. This prevents the tooltip from rendering at all when there is no config, instead of giving an error.

I kept the assert within the `LocationTooltip`, but it should never get that far in this new situation.