### PR TITLE
Add inline tooltip when there are gaps in the line chart behavior page

### DIFF
--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -2,7 +2,7 @@ import { NlBehaviorValue, VrBehaviorValue } from '@corona-dashboard/common';
 import { dropRightWhile, dropWhile } from 'lodash';
 import { useMemo } from 'react';
 import { isDefined, isPresent } from 'ts-is-present';
-import { Box, Spacer } from '~/components/base';
+import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { InlineTooltip } from '~/components/inline-tooltip';
 import { MetadataProps } from '~/components/metadata';

--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -1,8 +1,8 @@
 import { NlBehaviorValue, VrBehaviorValue } from '@corona-dashboard/common';
 import { dropRightWhile, dropWhile } from 'lodash';
 import { useMemo } from 'react';
-import { isDefined } from 'ts-is-present';
-import { Box } from '~/components/base';
+import { isDefined, isPresent } from 'ts-is-present';
+import { Box, Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { InlineTooltip } from '~/components/inline-tooltip';
 import { MetadataProps } from '~/components/metadata';
@@ -38,14 +38,11 @@ export function BehaviorLineChartTile({
   const selectedSupportValueKey =
     `${currentId}_support` as keyof NlBehaviorValue;
 
-  const complianceValuesHasGap = useTrimValuesAndFindGap(
+  const complianceValuesHasGap = useDataHasGaps(
     values,
     selectedComplianceValueKey
   );
-  const supportValuesHasGap = useTrimValuesAndFindGap(
-    values,
-    selectedSupportValueKey
-  );
+  const supportValuesHasGap = useDataHasGaps(values, selectedSupportValueKey);
 
   return (
     <ChartTile
@@ -54,7 +51,12 @@ export function BehaviorLineChartTile({
       description={chartText.description}
     >
       <Box spacing={4}>
-        <Box display="flex" alignItems="center" flexWrap="wrap">
+        <Box
+          display="flex"
+          alignItems={{ lg: 'center' }}
+          spacing={{ _: 3, lg: 0 }}
+          flexDirection={{ _: 'column', lg: 'row' }}
+        >
           <Box pr={3}>
             <SelectBehavior
               value={currentId}
@@ -64,15 +66,11 @@ export function BehaviorLineChartTile({
           </Box>
 
           {(complianceValuesHasGap || supportValuesHasGap) && (
-            <Box py={2}>
-              <InlineTooltip
-                content={chartText.tooltip_witte_gaten_beschrijving}
-              >
-                <InlineText fontWeight="bold">
-                  {chartText.tooltip_witte_gaten_label}
-                </InlineText>
-              </InlineTooltip>
-            </Box>
+            <InlineTooltip content={chartText.tooltip_witte_gaten_beschrijving}>
+              <InlineText fontWeight="bold">
+                {chartText.tooltip_witte_gaten_label}
+              </InlineText>
+            </InlineTooltip>
           )}
         </Box>
 
@@ -124,17 +122,17 @@ export function getBehaviorChartOptions<T>(value: T) {
  * Trimm all the null values on the left and the right side of the array.
  * If there are still null values left we can assume there is a gap in the data.
  */
-export function useTrimValuesAndFindGap(
+export function useDataHasGaps(
   values: NlBehaviorValue[] | VrBehaviorValue[],
   key: keyof NlBehaviorValue
 ) {
   return useMemo(() => {
-    const trimmedLeftValues = dropWhile(values, (i) => i[key] === null);
+    const trimmedLeftValues = dropWhile(values, (i) => !isPresent(i[key]));
     const trimmedLeftAndRightValues = dropRightWhile(
       trimmedLeftValues,
-      (i) => i[key] === null
+      (i) => !isPresent(i[key])
     );
 
-    return trimmedLeftAndRightValues.some((i) => i[key] === null);
+    return trimmedLeftAndRightValues.some((i) => !isPresent(i[key]));
   }, [key, values]);
 }

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -80,3 +80,5 @@ timestamp,action,key,document_id,move_to
 2021-08-12T09:46:57.628Z,move,choropleth_tooltip.infected_locations,jF33EuwumlGuwav2FD4IGq,choropleth_tooltip.vr.infected_locations_percentage.subject
 2021-08-12T09:46:57.628Z,move,choropleth_tooltip.elderly_at_home,jF33EuwumlGuwav2FD4IIW,choropleth_tooltip.vr.positive_tested_daily_per_100k.subject
 2021-08-12T09:46:57.629Z,move,choropleth_tooltip.sewer_regional,jF33EuwumlGuwav2FD4IKC,choropleth_tooltip.vr.average.subject
+2021-08-16T10:44:00.282Z,add,gedrag_common.line_chart.tooltip_witte_gaten_beschrijving,4wy7f8NuwuLne309tI5xhE,__
+2021-08-16T10:44:01.287Z,add,gedrag_common.line_chart.tooltip_witte_gaten_label,DWLUotrm23arH2ViSFggy4,__


### PR DESCRIPTION
Add a function that trims the left and right `null` values and then checks if there are still `null` values. Based on that render a `InlineTooltip`. 

<img width="946" alt="Screenshot 2021-08-16 at 12 47 40" src="https://user-images.githubusercontent.com/76471292/129552326-a5960b9f-ca09-44ad-b369-cff221b5faf7.png">
