### PR TITLE
Determine CMS dataset to use for the compile step based on target branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: init
     steps:
+      - name: Get target branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Lookup cached node_modules
@@ -41,11 +45,14 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Install packages
         run: yarn install
-
       - name: Build common module
         run: yarn workspace @corona-dashboard/common build
-      - name: Export texts
+      - name: Export texts (develop)
+        if: ${{ env.BRANCH_NAME != 'master' }}
         run: yarn workspace @corona-dashboard/cms lokalize:export --clean-json
+      - name: Export texts (production)
+        if: ${{ env.BRANCH_NAME == 'master' }}
+        run: yarn workspace @corona-dashboard/cms lokalize:export --dataset="production" --clean-json
       - name: Compile all code
         run: yarn compile
 


### PR DESCRIPTION
## Summary
Pull requests towards master should use the production dataset. Currently this is not the case, sometimes causing crashes in the pre-merge checks if there's a mismatch between the develop and master CMS definition.

This PR updates the workflow file, if the intended branch target is to merge in master the compile step will use the production dataset for validation. In all other cases, the default (develop). 

## Drawbacks
Can't really test if it works without opening a branche to master after this has been merged.

## Alternatives
It would be more elegant if we didn't duplicate the step with an "if" statement but used an environmental or a conditional to produce the desired value.