### PR TITLE
Choropleth tweaks

### DIFF
--- a/packages/app/public/icons/chevron-black.svg
+++ b/packages/app/public/icons/chevron-black.svg
@@ -1,0 +1,4 @@
+
+<svg focusable="false" role="img" width="11" height="18" viewBox="0 0 11 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 17L9 9L1 1" stroke="#000000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/packages/app/public/icons/chevron-black.svg
+++ b/packages/app/public/icons/chevron-black.svg
@@ -1,4 +1,3 @@
-
 <svg focusable="false" role="img" width="11" height="18" viewBox="0 0 11 18" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M1 17L9 9L1 1" stroke="#000000" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/packages/app/src/components/choropleth/index.tsx
+++ b/packages/app/src/components/choropleth/index.tsx
@@ -317,6 +317,7 @@ const ChoroplethMap: <T extends MapType, K extends UnpackedDataItem<T>>(
         }}
       >
         <svg
+          aria-labelledby={annotations.props.ariaDescribedby}
           role="img"
           width={width}
           viewBox={`0 0 ${width} ${mapHeight}`}

--- a/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
@@ -96,7 +96,7 @@ const StyledTooltipHeader = styled.div(
 const Chevron = styled.div(
   css({
     ml: 3,
-    backgroundImage: 'url("/images/chevron-black.svg")',
+    backgroundImage: 'url("/icons/chevron-black.svg")',
     backgroundSize: '0.5em 0.9em',
     backgroundPosition: '0 50%',
     backgroundRepeat: 'no-repeat',


### PR DESCRIPTION
## Summary

- Add aria-describedby attribute because ARC toolkit was yelling about it
- Re-add chevron-black.svg because it is required by the choropleth tooltip

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
