### PR TITLE
Remove margin page information block

### DIFF
--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -78,7 +78,6 @@ export function PageInformationBlock({
               display={{ md: 'grid' }}
               gridTemplateColumns="repeat(2, 1fr)"
               width="100%"
-              spacing={3}
               css={css({
                 columnGap: 4,
               })}


### PR DESCRIPTION
There was one spacing too much that would result in a weird bottom margin on desktop.  This has no impact visually on mobile.

Old:
<img width="948" alt="Screenshot 2021-08-19 at 10 47 02" src="https://user-images.githubusercontent.com/76471292/130038547-158b5e0d-137a-4d48-a949-d1a29cc28b0f.png">

New:
<img width="932" alt="Screenshot 2021-08-19 at 10 47 56" src="https://user-images.githubusercontent.com/76471292/130038572-93279790-a5d7-4781-bcf5-c01fc471fc18.png">
