### PR TITLE
Fix full width image article detail

### DIFF
--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -50,7 +50,6 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
       </ContentBlock>
       {!!article.content?.length && (
         <Box
-          fontSize="1.125rem"
           // Since you can't serialize unordered lists we have to position them here in the container
           css={css({
             ul: {

--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -49,14 +49,20 @@ export function ArticleDetail({ article }: ArticleDetailProps) {
         />
       </ContentBlock>
       {!!article.content?.length && (
-        <ContentBlock>
-          <Box textVariant="body1">
-            <RichContent
-              blocks={article.content}
-              contentWrapper={ContentBlock}
-            />
-          </Box>
-        </ContentBlock>
+        <Box
+          fontSize="1.125rem"
+          // Since you can't serialize unordered lists we have to position them here in the container
+          css={css({
+            ul: {
+              mx: 'auto',
+              maxWidth: 'contentWidth',
+              pr: 4,
+              pl: 5,
+            },
+          })}
+        >
+          <RichContent blocks={article.content} contentWrapper={ContentBlock} />
+        </Box>
       )}
 
       {article.categories && (


### PR DESCRIPTION
Apparently, by a merge conflict, this got accidentally overwritten, added back.

<img width="1770" alt="Screenshot 2021-08-19 at 11 17 42" src="https://user-images.githubusercontent.com/76471292/130043219-bf05e86f-7b9c-40c8-a82b-1d48a097a060.png">
