### PR TITLE
Fix alignment vaccine chart and header block component

### DIFF
--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -78,6 +78,10 @@ export function PageInformationBlock({
               display={{ md: 'grid' }}
               gridTemplateColumns="repeat(2, 1fr)"
               width="100%"
+              spacing={{
+                _: usefulLinks && usefulLinks.length > 0 ? 0 : 3,
+                md: 0,
+              }}
               css={css({
                 columnGap: 4,
               })}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,7 +1,7 @@
 import { NlVaccineCoverageValue } from '@corona-dashboard/common';
 import { isEmpty } from 'lodash';
 import { ReactComponent as VaccinatiesIcon } from '~/assets/vaccinaties.svg';
-import { Spacer } from '~/components/base';
+import { Box, Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -23,18 +23,18 @@ import { useIntl } from '~/intl';
 import { useFeature } from '~/lib/features';
 import {
   createPageArticlesQuery,
-  PageArticlesQueryResult
+  PageArticlesQueryResult,
 } from '~/queries/create-page-articles-query';
 import { getVaccinePageQuery } from '~/queries/vaccine-page-query';
 import {
   createGetStaticProps,
-  StaticProps
+  StaticProps,
 } from '~/static-props/create-get-static-props';
 import {
   createGetContent,
   getLastGeneratedDate,
   getNlData,
-  selectNlPageMetricData
+  selectNlPageMetricData,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
 import { VaccinationPageQuery } from '~/types/cms';
@@ -102,7 +102,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             />
           )}
           <VaccinePageIntroduction data={data} />
-          
+
           <PageInformationBlock
             description={content.page.pageDescription}
             metadata={{
@@ -241,82 +241,83 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               ],
             }}
           >
-            <section>
-              <KpiValue
-                percentage={
-                  data.vaccine_vaccinated_or_support.last_value
-                    .percentage_average
-                }
-              />
-              <Text>{text.grafiek_draagvlak.kpi_omschrijving}</Text>
-            </section>
-
-            <TimeSeriesChart
-              accessibility={{
-                key: 'vaccines_support_over_time_chart',
-              }}
-              tooltipTitle={text.grafiek_draagvlak.titel}
-              values={data.vaccine_vaccinated_or_support.values}
-              numGridLines={20}
-              tickValues={[0, 25, 50, 75, 100]}
-              dataOptions={{
-                isPercentage: true,
-                forcedMaximumValue: 100,
-              }}
-              seriesConfig={[
-                {
-                  type: 'line',
-                  metricProperty: 'percentage_70_plus',
-                  label: replaceVariablesInText(
-                    text.grafiek_draagvlak.leeftijd_jaar,
-                    { ageGroup: '70+' }
-                  ),
-                  color: colors.data.multiseries.magenta,
-                },
-                {
-                  type: 'line',
-                  metricProperty: 'percentage_55_69',
-                  label: replaceVariablesInText(
-                    text.grafiek_draagvlak.leeftijd_jaar,
-                    { ageGroup: '55 - 69' }
-                  ),
-                  color: colors.data.multiseries.orange,
-                },
-                {
-                  type: 'line',
-                  metricProperty: 'percentage_40_54',
-                  label: replaceVariablesInText(
-                    text.grafiek_draagvlak.leeftijd_jaar,
-                    { ageGroup: '40 - 54' }
-                  ),
-                  color: colors.data.multiseries.turquoise,
-                },
-                {
-                  type: 'line',
-                  metricProperty: 'percentage_25_39',
-                  label: replaceVariablesInText(
-                    text.grafiek_draagvlak.leeftijd_jaar,
-                    { ageGroup: '25 - 39' }
-                  ),
-                  color: colors.data.multiseries.yellow,
-                },
-                {
-                  type: 'line',
-                  metricProperty: 'percentage_16_24',
-                  label: replaceVariablesInText(
-                    text.grafiek_draagvlak.leeftijd_jaar,
-                    { ageGroup: '16 - 24' }
-                  ),
-                  color: colors.data.multiseries.cyan,
-                },
-                {
-                  type: 'invisible',
-                  metricProperty: 'percentage_average',
-                  label: siteText.common.totaal,
+            <Box spacing={3}>
+              <section>
+                <KpiValue
+                  percentage={
+                    data.vaccine_vaccinated_or_support.last_value
+                      .percentage_average
+                  }
+                />
+                <Text>{text.grafiek_draagvlak.kpi_omschrijving}</Text>
+              </section>
+              <TimeSeriesChart
+                accessibility={{
+                  key: 'vaccines_support_over_time_chart',
+                }}
+                tooltipTitle={text.grafiek_draagvlak.titel}
+                values={data.vaccine_vaccinated_or_support.values}
+                numGridLines={20}
+                tickValues={[0, 25, 50, 75, 100]}
+                dataOptions={{
                   isPercentage: true,
-                },
-              ]}
-            />
+                  forcedMaximumValue: 100,
+                }}
+                seriesConfig={[
+                  {
+                    type: 'line',
+                    metricProperty: 'percentage_70_plus',
+                    label: replaceVariablesInText(
+                      text.grafiek_draagvlak.leeftijd_jaar,
+                      { ageGroup: '70+' }
+                    ),
+                    color: colors.data.multiseries.magenta,
+                  },
+                  {
+                    type: 'line',
+                    metricProperty: 'percentage_55_69',
+                    label: replaceVariablesInText(
+                      text.grafiek_draagvlak.leeftijd_jaar,
+                      { ageGroup: '55 - 69' }
+                    ),
+                    color: colors.data.multiseries.orange,
+                  },
+                  {
+                    type: 'line',
+                    metricProperty: 'percentage_40_54',
+                    label: replaceVariablesInText(
+                      text.grafiek_draagvlak.leeftijd_jaar,
+                      { ageGroup: '40 - 54' }
+                    ),
+                    color: colors.data.multiseries.turquoise,
+                  },
+                  {
+                    type: 'line',
+                    metricProperty: 'percentage_25_39',
+                    label: replaceVariablesInText(
+                      text.grafiek_draagvlak.leeftijd_jaar,
+                      { ageGroup: '25 - 39' }
+                    ),
+                    color: colors.data.multiseries.yellow,
+                  },
+                  {
+                    type: 'line',
+                    metricProperty: 'percentage_16_24',
+                    label: replaceVariablesInText(
+                      text.grafiek_draagvlak.leeftijd_jaar,
+                      { ageGroup: '16 - 24' }
+                    ),
+                    color: colors.data.multiseries.cyan,
+                  },
+                  {
+                    type: 'invisible',
+                    metricProperty: 'percentage_average',
+                    label: siteText.common.totaal,
+                    isPercentage: true,
+                  },
+                ]}
+              />
+            </Box>
           </ChartTile>
 
           <Spacer pb={3} />


### PR DESCRIPTION
Due to the annotations paddings that got changed the margin was removed. Also found a subtle bug with margins in the header block component when there are no links but it needs some spacing on mobile.