### PR TITLE
Fix grouping and ordering on cijferverantwoording

### DIFF
--- a/packages/app/src/pages/verantwoording.tsx
+++ b/packages/app/src/pages/verantwoording.tsx
@@ -86,33 +86,25 @@ const Verantwoording = (props: StaticProps<typeof getStaticProps>) => {
         <Box spacing={4}>
           {content.title && <Heading level={1}>{content.title}</Heading>}
           {content.description && <RichContent blocks={content.description} />}
-          {Object.entries(groups)
-            .sort((a, b) => a[0].localeCompare(b[0]))
-            .map(([group, collapsibleItems]) => (
-              <Box as="article" key={group} spacing={3}>
-                <Heading level={3} as="h2">
-                  {group}
-                </Heading>
-                <div>
-                  {collapsibleItems
-                    .sort((a, b) => a.title.localeCompare(b.title))
-                    .map((item) => {
-                      const id = getSkipLinkId(item.title);
-                      return item.content ? (
-                        <CollapsibleSection
-                          key={id}
-                          id={id}
-                          summary={item.title}
-                        >
-                          <Box pt={2} pb={4}>
-                            <RichContent blocks={item.content} />
-                          </Box>
-                        </CollapsibleSection>
-                      ) : null;
-                    })}
-                </div>
-              </Box>
-            ))}
+          {Object.entries(groups).map(([group, collapsibleItems]) => (
+            <Box as="article" key={group} spacing={3}>
+              <Heading level={3} as="h2">
+                {group}
+              </Heading>
+              <div>
+                {collapsibleItems.map((item) => {
+                  const id = getSkipLinkId(item.title);
+                  return item.content ? (
+                    <CollapsibleSection key={id} id={id} summary={item.title}>
+                      <Box pt={2} pb={4}>
+                        <RichContent blocks={item.content} />
+                      </Box>
+                    </CollapsibleSection>
+                  ) : null;
+                })}
+              </div>
+            </Box>
+          ))}
         </Box>
       </Content>
     </Layout>

--- a/packages/cms/src/schemas/documents/cijfer-verantwoording-item.ts
+++ b/packages/cms/src/schemas/documents/cijfer-verantwoording-item.ts
@@ -32,7 +32,7 @@ export const cijferVerantwoordingItem = {
   preview: {
     select: {
       title: 'title.nl',
-      subtitle: 'content.nl',
+      subtitle: 'group.group.nl',
     },
   },
 };


### PR DESCRIPTION
## Summary

- Remove custom sorting from the verantwoording page since we need to respect the incoming document order
- Set the group name as the subtitle for cijferverantwoording schema items, so that the order and grouping becomes readily apparent in Sanity studio

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
