### PR TITLE
Set the minimum y scale  to 10 when there are no values

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -75,7 +75,7 @@ export function useScales<T extends TimestampedValue>(args: {
      * In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
      * A work-around turns out to be setting the max value to Infinity.
      */
-    const maximumDomainValue = maximumValue > 0 ? maximumValue : Infinity;
+    const maximumDomainValue = maximumValue > 0 ? maximumValue : 10;
     const yScale = scaleLinear({
       domain: [yMin, maximumValue > 0 ? maximumValue : maximumDomainValue],
       range: [bounds.height, 0],


### PR DESCRIPTION
Example where there are only 0 values in the series.
<img width="928" alt="Screenshot 2021-08-20 at 12 05 53" src="https://user-images.githubusercontent.com/76471292/130217526-f81dd995-daa4-46bf-83dc-11c8496e0c0e.png">
