### PR TITLE
Add historical feature flag for GP suspicions

### DIFF
--- a/packages/app/src/config/features.ts
+++ b/packages/app/src/config/features.ts
@@ -1,4 +1,4 @@
-import { Feature } from '@corona-dashboard/common';
+import type { Feature } from '@corona-dashboard/common';
 
 export const features: Feature[] = [
   {
@@ -34,5 +34,9 @@ export const features: Feature[] = [
     isEnabled: true,
     dataScopes: ['in'],
     metricName: 'variants',
+  },
+  {
+    name: 'nlGpSuspicionsIsHistorical',
+    isEnabled: true,
   },
 ];

--- a/packages/app/src/domain/layout/nl-layout.tsx
+++ b/packages/app/src/domain/layout/nl-layout.tsx
@@ -28,6 +28,7 @@ import { SidebarMetric } from '~/components/sidebar-metric';
 import { SidebarKpiValue } from '~/components/sidebar-metric/sidebar-kpi-value';
 import { VariantSidebarValue } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import { SituationsSidebarValue } from '~/static-props/situations/get-situations-sidebar-value';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 import { SituationsSidebarMetric } from '../situations/situations-sidebar-metric';
@@ -89,6 +90,10 @@ export function NlLayout(props: NlLayoutProps) {
   const router = useRouter();
   const reverseRouter = useReverseRouter();
   const { siteText } = useIntl();
+
+  const { isEnabled: isGpSuspicionsHistorical } = useFeature(
+    'nlGpSuspicionsIsHistorical'
+  );
 
   return (
     <>
@@ -365,14 +370,20 @@ export function NlLayout(props: NlLayoutProps) {
                   icon={<Arts />}
                   title={siteText.verdenkingen_huisartsen.titel_sidebar}
                 >
-                  <SidebarMetric
-                    data={data}
-                    scope="nl"
-                    metricName="doctor"
-                    metricProperty="covid_symptoms"
-                    localeTextKey="verdenkingen_huisartsen"
-                    differenceKey="doctor__covid_symptoms"
-                  />
+                  {isGpSuspicionsHistorical ? (
+                    <SidebarKpiValue
+                      title={siteText.verdenkingen_huisartsen.kpi_titel}
+                    />
+                  ) : (
+                    <SidebarMetric
+                      data={data}
+                      scope="nl"
+                      metricName="doctor"
+                      metricProperty="covid_symptoms"
+                      localeTextKey="verdenkingen_huisartsen"
+                      differenceKey="doctor__covid_symptoms"
+                    />
+                  )}
                 </MetricMenuItemLink>
               </CategoryMenu>
 

--- a/packages/app/src/lib/features.ts
+++ b/packages/app/src/lib/features.ts
@@ -1,4 +1,5 @@
-import { assert } from '@corona-dashboard/common';
+import { assert, Feature } from '@corona-dashboard/common';
+import { hasValueAtKey } from 'ts-is-present';
 /**
  * We could provide features via the Context API, but since this doesn't change
  * at runtime I don't see any advantage doing so. An import is the most basic
@@ -6,8 +7,8 @@ import { assert } from '@corona-dashboard/common';
  */
 import { features } from '~/config';
 
-export function useFeature(name: string) {
-  const feature = features.find((x) => x.name === name);
+export function useFeature(name: string): Feature {
+  const feature = features.find(hasValueAtKey('name', name));
 
   assert(feature, `Failed using an unknown feature: ${name}`);
 

--- a/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import { ReactComponent as Arts } from '~/assets/arts.svg';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
@@ -7,9 +8,11 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Text } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import {
   createGetStaticProps,
   StaticProps,
@@ -38,6 +41,10 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
     description: text.metadata.description,
   };
 
+  const { isEnabled: isGpSuspicionsHistorical } = useFeature(
+    'nlGpSuspicionsIsHistorical'
+  );
+
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NlLayout data={data} lastGenerated={lastGenerated}>
@@ -58,6 +65,16 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
             }}
             referenceLink={text.reference.href}
           />
+
+          {isGpSuspicionsHistorical &&
+            text.belangrijk_bericht &&
+            !isEmpty(text.belangrijk_bericht) && (
+              <WarningTile
+                isFullWidth
+                message={text.belangrijk_bericht}
+                variant="emphasis"
+              />
+            )}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -98,3 +98,6 @@ timestamp,action,key,document_id,move_to
 2021-08-19T11:48:44.909Z,delete,common_actueel.secties.artikelen.categorie_filters.__alles,kZYjqFJyrN0fPPHPQq27cU,__
 2021-08-19T11:48:44.911Z,delete,common_actueel.secties.artikelen.categorie_filters.__alles,DWLUotrm23arH2ViSHQRMk,__
 2021-08-19T11:55:29.087Z,add,common_actueel.secties.artikelen.categorie_filters.__alles,DWLUotrm23arH2ViSJpokU,__
+2021-08-23T10:13:46.352Z,add,verdenkingen_huisartsen.belangrijke_text,m5cl7ciD7CmTUWm5dFOySe,__
+2021-08-23T10:40:23.238Z,add,verdenkingen_huisartsen.belangrijk_bericht,4wy7f8NuwuLne309uEanl2,__
+2021-08-23T10:40:23.240Z,delete,verdenkingen_huisartsen.belangrijke_text,m5cl7ciD7CmTUWm5dFOySe,__


### PR DESCRIPTION
## Summary

This PR adds a feature flag for displaying suspicions of COVID-19 infections by GP's as historical data.

## Motivation

Nivel will soon stop with supplying this data and it will become historical.

## Detailed design

- Added a feature flag `nlGpSuspicionsIsHistorical` in `app/src/config/features.ts`
- Added a ternary to the national sidebar that will only display a paragraph of text if the flag is enabled
- Added a `WarningTile` to the `verdenkingen-huisartsen` page, also behind a feature flag.
- A small improvement in the `useFeature` hook.

## Unresolved questions

- Would it make sense to statically type the `name` input of the `useFeature` hook to only except actual feature names? The accepted input is now `string`.
  - To do so we can `export const features = [ ... ] as const;` and in `useFeature(name: typeof features[number]["name"])`. 

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
