### PR TITLE
Add VR and GM vaccination page

### DIFF
--- a/packages/app/schema/gm/__difference.json
+++ b/packages/app/schema/gm/__difference.json
@@ -17,17 +17,13 @@
     },
     "deceased_rivm__covid_daily": {
       "$ref": "#/definitions/diff_integer"
-    },
-    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus": {
-      "$ref": "#/definitions/diff_decimal"
     }
   },
   "required": [
     "tested_overall__infected_per_100k_moving_average",
     "tested_overall__infected_moving_average",
     "hospital_nice__admissions_on_date_of_reporting_moving_average",
-    "deceased_rivm__covid_daily",
-    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
+    "deceased_rivm__covid_daily"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/gm/__difference.json
+++ b/packages/app/schema/gm/__difference.json
@@ -17,13 +17,17 @@
     },
     "deceased_rivm__covid_daily": {
       "$ref": "#/definitions/diff_integer"
+    },
+    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus": {
+      "$ref": "#/definitions/diff_decimal"
     }
   },
   "required": [
     "tested_overall__infected_per_100k_moving_average",
     "tested_overall__infected_moving_average",
     "hospital_nice__admissions_on_date_of_reporting_moving_average",
-    "deceased_rivm__covid_daily"
+    "deceased_rivm__covid_daily",
+    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/gm/__index.json
+++ b/packages/app/schema/gm/__index.json
@@ -13,7 +13,8 @@
     "deceased_rivm",
     "difference",
     "static_values",
-    "sewer"
+    "sewer",
+    "vaccine_coverage_per_age_group"
   ],
   "properties": {
     "last_generated": {
@@ -54,6 +55,9 @@
     },
     "vaccine_coverage": {
       "$ref": "vaccine_coverage.json"
+    },
+    "vaccine_coverage_per_age_group": {
+      "$ref": "vaccine_coverage_per_age_group.json"
     }
   }
 }

--- a/packages/app/schema/gm/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm/vaccine_coverage_per_age_group.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "gm_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["last_value"],
+  "required": ["values", "last_value"],
   "additionalProperties": false,
   "properties": {
     "values": {
@@ -33,21 +33,17 @@
       "properties": {
         "age_group_range": {
           "type": "string",
-          "enum": [
-            "12+",
-            "12-17",
-            "18+"
-          ]
+          "enum": ["12+", "12-17", "18+"]
         },
         "fully_vaccinated_percentage": {
-          "type":[ "integer", "null"]
+          "type": ["integer", "null"]
         },
         "has_1_shot_percentage": {
-          "type":[ "integer", "null"]
+          "type": ["integer", "null"]
         },
         "birthyear_range": {
           "type": "string",
-          "pattern": "^[0-9]*-[0-9]*$"
+          "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
         },
         "fully_vaccinated_percentage_label": {
           "type": ["string", "null"],

--- a/packages/app/schema/gm/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm/vaccine_coverage_per_age_group.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gm_vaccine_coverage_per_age_group",
+  "type": "object",
+  "required": ["last_value"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "gm_vaccine_coverage_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "age_group_range",
+        "fully_vaccinated_percentage",
+        "has_1_shot_percentage",
+        "fully_vaccinated_percentage_label",
+        "has_1_shot_percentage_label",
+        "birthyear_range",
+        "date_of_insertion_unix",
+        "date_unix"
+      ],
+      "properties": {
+        "age_group_range": {
+          "type": "string",
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
+        },
+        "fully_vaccinated_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "has_1_shot_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "birthyear_range": {
+          "type": "string",
+          "pattern": "^[0-9]*-[0-9]*$"
+        },
+        "fully_vaccinated_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "has_1_shot_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/schema/gm_collection/__index.json
+++ b/packages/app/schema/gm_collection/__index.json
@@ -10,7 +10,8 @@
     "code",
     "hospital_nice",
     "tested_overall",
-    "sewer"
+    "sewer",
+    "vaccine_coverage_per_age_group"
   ],
   "properties": {
     "last_generated": {
@@ -47,6 +48,13 @@
       "maxItems": 355,
       "items": {
         "$ref": "sewer.json"
+      }
+    },
+    "vaccine_coverage_per_age_group": {
+      "type": "array",
+      "maxItems": 355,
+      "items": {
+        "$ref": "vaccine_coverage_per_age_group.json"
       }
     }
   }

--- a/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gm_collection_vaccine_coverage_per_age_group",
+  "type": "object",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "gm_collection_vaccine_coverage_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "gmcode",
+        "age_group_range",
+        "fully_vaccinated_percentage",
+        "birthyear_range",
+        "fully_vaccinated_percentage_label",
+        "date_of_insertion_unix",
+        "date_unix"
+      ],
+      "properties": {
+        "gmcode": {
+          "type": "string",
+          "pattern": "^GM[0-9]+$"
+        },
+        "age_group_range": {
+          "type": "string",
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
+        },
+        "fully_vaccinated_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "birthyear_range": {
+          "type": "string",
+          "pattern": "^[0-9]*-[0-9]*$"
+        },
+        "fully_vaccinated_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
@@ -2,61 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "gm_collection_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["values"],
   "additionalProperties": false,
+  "required": [
+    "gmcode",
+    "age_group_range",
+    "fully_vaccinated_percentage",
+    "birthyear_range",
+    "fully_vaccinated_percentage_label",
+    "date_of_insertion_unix",
+    "date_unix"
+  ],
   "properties": {
-    "values": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/value"
-      }
-    }
-  },
-  "definitions": {
-    "value": {
-      "title": "gm_collection_vaccine_coverage_per_age_group_value",
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "gmcode",
-        "age_group_range",
-        "fully_vaccinated_percentage",
-        "birthyear_range",
-        "fully_vaccinated_percentage_label",
-        "date_of_insertion_unix",
-        "date_unix"
-      ],
-      "properties": {
-        "gmcode": {
-          "type": "string",
-          "pattern": "^GM[0-9]+$"
-        },
-        "age_group_range": {
-          "type": "string",
-          "enum": [
-            "12+",
-            "12-17",
-            "18+"
-          ]
-        },
-        "fully_vaccinated_percentage": {
-          "type":[ "integer", "null"]
-        },
-        "birthyear_range": {
-          "type": "string",
-          "pattern": "^[0-9]*-[0-9]*$"
-        },
-        "fully_vaccinated_percentage_label": {
-          "type": ["string", "null"],
-          "pattern": "^([0-9]+-)*[0-9]+$"
-        },
-        "date_unix": {
-          "type": "integer"
-        },
-        "date_of_insertion_unix": {
-          "type": "integer"
-        }
-      }
+    "gmcode": {
+      "type": "string",
+      "pattern": "^GM[0-9]+$"
+    },
+    "age_group_range": {
+      "type": "string",
+      "enum": ["12+", "12-17", "18+"]
+    },
+    "fully_vaccinated_percentage": {
+      "type": ["integer", "null"]
+    },
+    "birthyear_range": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
+    },
+    "fully_vaccinated_percentage_label": {
+      "type": ["string", "null"],
+      "pattern": "^([0-9]+-)*[0-9]+$"
+    },
+    "date_unix": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
     }
   }
 }

--- a/packages/app/schema/vr/__difference.json
+++ b/packages/app/schema/vr/__difference.json
@@ -41,9 +41,6 @@
     },
     "deceased_rivm__covid_daily": {
       "$ref": "#/definitions/diff_integer"
-    },
-    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus": {
-      "$ref": "#/definitions/diff_decimal"
     }
   },
   "required": [
@@ -59,8 +56,7 @@
     "disability_care__newly_infected_people",
     "disability_care__infected_locations_total",
     "elderly_at_home__positive_tested_daily",
-    "deceased_rivm__covid_daily",
-    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
+    "deceased_rivm__covid_daily"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/vr/__difference.json
+++ b/packages/app/schema/vr/__difference.json
@@ -41,6 +41,9 @@
     },
     "deceased_rivm__covid_daily": {
       "$ref": "#/definitions/diff_integer"
+    },
+    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus": {
+      "$ref": "#/definitions/diff_decimal"
     }
   },
   "required": [
@@ -56,7 +59,8 @@
     "disability_care__newly_infected_people",
     "disability_care__infected_locations_total",
     "elderly_at_home__positive_tested_daily",
-    "deceased_rivm__covid_daily"
+    "deceased_rivm__covid_daily",
+    "vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/vr/__index.json
+++ b/packages/app/schema/vr/__index.json
@@ -98,6 +98,9 @@
     },
     "situations": {
       "$ref": "situations.json"
+    },
+    "vaccine_coverage_per_age_group": {
+      "$ref": "vaccine_coverage_per_age_group.json"
     }
   }
 }

--- a/packages/app/schema/vr/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr/vaccine_coverage_per_age_group.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "vr_vaccine_coverage_per_age_group",
+  "type": "object",
+  "required": ["last_value"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "vr_vaccine_coverage_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "age_group_range",
+        "fully_vaccinated_percentage",
+        "has_1_shot_percentage",
+        "fully_vaccinated_percentage_label",
+        "has_1_shot_percentage_label",
+        "birthyear_range",
+        "date_of_insertion_unix",
+        "date_unix"
+      ],
+      "properties": {
+        "age_group_range": {
+          "type": "string",
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
+        },
+        "fully_vaccinated_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "has_1_shot_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "birthyear_range": {
+          "type": "string",
+          "pattern": "^[0-9]*-[0-9]*$"
+        },
+        "fully_vaccinated_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "has_1_shot_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/schema/vr/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr/vaccine_coverage_per_age_group.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "vr_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["last_value"],
+  "required": ["values", "last_value"],
   "additionalProperties": false,
   "properties": {
     "values": {
@@ -33,21 +33,17 @@
       "properties": {
         "age_group_range": {
           "type": "string",
-          "enum": [
-            "12+",
-            "12-17",
-            "18+"
-          ]
+          "enum": ["12+", "12-17", "18+"]
         },
         "fully_vaccinated_percentage": {
-          "type":[ "integer", "null"]
+          "type": ["integer", "null"]
         },
         "has_1_shot_percentage": {
-          "type":[ "integer", "null"]
+          "type": ["integer", "null"]
         },
         "birthyear_range": {
           "type": "string",
-          "pattern": "^[0-9]*-[0-9]*$"
+          "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
         },
         "fully_vaccinated_percentage_label": {
           "type": ["string", "null"],

--- a/packages/app/schema/vr_collection/__index.json
+++ b/packages/app/schema/vr_collection/__index.json
@@ -16,7 +16,8 @@
     "elderly_at_home",
     "disability_care",
     "sewer",
-    "situations"
+    "situations",
+    "vaccine_coverage_per_age_group"
   ],
   "properties": {
     "last_generated": {
@@ -103,6 +104,14 @@
       "maxItems": 25,
       "items": {
         "$ref": "situations.json"
+      }
+    },
+    "vaccine_coverage_per_age_group": {
+      "type": "array",
+      "minItems": 25,
+      "maxItems": 25,
+      "items": {
+        "$ref": "vaccine_coverage_per_age_group.json"
       }
     }
   }

--- a/packages/app/schema/vr_collection/disability_care.json
+++ b/packages/app/schema/vr_collection/disability_care.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "title": "vr_collection_disability_care",
   "type": "object",
   "properties": {

--- a/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
@@ -2,61 +2,41 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "vr_collection_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["values"],
   "additionalProperties": false,
+  "required": [
+    "vrcode",
+    "age_group_range",
+    "fully_vaccinated_percentage",
+    "birthyear_range",
+    "fully_vaccinated_percentage_label",
+    "date_of_insertion_unix",
+    "date_unix"
+  ],
   "properties": {
-    "values": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/value"
-      }
-    }
-  },
-  "definitions": {
-    "value": {
-      "title": "vr_collection_vaccine_coverage_per_age_group_value",
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "vrcode",
-        "age_group_range",
-        "fully_vaccinated_percentage",
-        "birthyear_range",
-        "fully_vaccinated_percentage_label",
-        "date_of_insertion_unix",
-        "date_unix"
-      ],
-      "properties": {
-        "vrcode": {
-          "type": "string",
-          "pattern": "^VR[0-9]+$"
-        },
-        "age_group_range": {
-          "type": "string",
-          "enum": [
-            "12+",
-            "12-17",
-            "18+"
-          ]
-        },
-        "fully_vaccinated_percentage": {
-          "type":[ "integer", "null"]
-        },
-        "birthyear_range": {
-          "type": "string",
-          "pattern": "^[0-9]*-[0-9]*$"
-        },
-        "fully_vaccinated_percentage_label": {
-          "type": ["string", "null"],
-          "pattern": "^([0-9]+-)*[0-9]+$"
-        },
-        "date_unix": {
-          "type": "integer"
-        },
-        "date_of_insertion_unix": {
-          "type": "integer"
-        }
-      }
+    "vrcode": {
+      "type": "string",
+      "pattern": "^VR[0-9]+$"
+    },
+    "age_group_range": {
+      "type": "string",
+      "enum": ["12+", "12-17", "18+"]
+    },
+    "fully_vaccinated_percentage": {
+      "type": ["integer", "null"]
+    },
+    "birthyear_range": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
+    },
+    "fully_vaccinated_percentage_label": {
+      "type": ["string", "null"],
+      "pattern": "^([0-9]+-)*[0-9]+$"
+    },
+    "date_unix": {
+      "type": "integer"
+    },
+    "date_of_insertion_unix": {
+      "type": "integer"
     }
   }
 }

--- a/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "vr_collection_vaccine_coverage_per_age_group",
+  "type": "object",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "vr_collection_vaccine_coverage_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "vrcode",
+        "age_group_range",
+        "fully_vaccinated_percentage",
+        "birthyear_range",
+        "fully_vaccinated_percentage_label",
+        "date_of_insertion_unix",
+        "date_unix"
+      ],
+      "properties": {
+        "vrcode": {
+          "type": "string",
+          "pattern": "^VR[0-9]+$"
+        },
+        "age_group_range": {
+          "type": "string",
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
+        },
+        "fully_vaccinated_percentage": {
+          "type":[ "integer", "null"]
+        },
+        "birthyear_range": {
+          "type": "string",
+          "pattern": "^[0-9]*-[0-9]*$"
+        },
+        "fully_vaccinated_percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([0-9]+-)*[0-9]+$"
+        },
+        "date_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/src/components/choropleth/tooltips/choropleth-tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/choropleth-tooltip.tsx
@@ -32,7 +32,7 @@ export function ChoroplethTooltip<T extends ChoroplethDataItem>(
     text as unknown as Record<string, Record<string, Record<string, string>>>
   )[data.map]?.[data.dataConfig.metricProperty as string]?.content;
   assert(
-    isDefined(subject),
+    isDefined(tooltipContent),
     `No tooltip content found in siteText.choropleth_tooltip.${data.map}.${data.dataConfig.metricProperty}`
   );
 

--- a/packages/app/src/config/features.ts
+++ b/packages/app/src/config/features.ts
@@ -35,4 +35,14 @@ export const features: Feature[] = [
     dataScopes: ['in'],
     metricName: 'variants',
   },
+  {
+    name: 'vrVaccinationPage',
+    isEnabled: true,
+    dataScopes: ['vr_collection'],
+  },
+  {
+    name: 'gmVaccinationPage',
+    isEnabled: true,
+    dataScopes: ['gm_collection'],
+  },
 ];

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -152,7 +152,11 @@ export function GmLayout(props: GmLayoutProps) {
                             href={reverseRouter.gm.vaccinaties(code)}
                             icon={<VaccinatieIcon />}
                             title={siteText.gemeente_vaccinaties.titel_sidebar}
-                          ></MetricMenuItemLink>
+                          >
+                            {
+                              // @TODO add vaccine sidebar metric once the data is avaliable
+                            }
+                          </MetricMenuItemLink>
                         </CategoryMenu>
                       )}
 

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -152,16 +152,7 @@ export function GmLayout(props: GmLayoutProps) {
                             href={reverseRouter.gm.vaccinaties(code)}
                             icon={<VaccinatieIcon />}
                             title={siteText.gemeente_vaccinaties.titel_sidebar}
-                          >
-                            {/* <SidebarMetric
-                              data={sidebarData}
-                              scope="gm"
-                              metricName="hospital_nice"
-                              metricProperty="admissions_on_date_of_reporting"
-                              localeTextKey="gemeente_vaccinaties"
-                              differenceKey="hospital_nice__admissions_on_date_of_reporting_moving_average"
-                            /> */}
-                          </MetricMenuItemLink>
+                          ></MetricMenuItemLink>
                         </CategoryMenu>
                       )}
 

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react';
 import { ReactComponent as CoronavirusIcon } from '~/assets/coronavirus.svg';
 import { ReactComponent as RioolwaterMonitoring } from '~/assets/rioolwater-monitoring.svg';
 import { ReactComponent as GetestIcon } from '~/assets/test.svg';
+import { ReactComponent as VaccinatieIcon } from '~/assets/vaccinaties.svg';
 import { ReactComponent as Ziekenhuis } from '~/assets/ziekenhuis.svg';
 import {
   CategoryMenu,
@@ -17,6 +18,7 @@ import { AppContent } from '~/components/layout/app-content';
 import { SidebarMetric } from '~/components/sidebar-metric';
 import { Text } from '~/components/typography';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import { getVrForMunicipalityCode } from '~/utils/get-vr-for-municipality-code';
 import { Link } from '~/utils/link';
 import { useReverseRouter } from '~/utils/use-reverse-router';
@@ -77,6 +79,7 @@ export function GmLayout(props: GmLayoutProps) {
   const { siteText } = useIntl();
   const router = useRouter();
   const reverseRouter = useReverseRouter();
+  const vaccinationFeature = useFeature('gmVaccinationPage');
 
   const showMetricLinks = router.route !== '/gemeente';
 
@@ -141,6 +144,27 @@ export function GmLayout(props: GmLayoutProps) {
                 <Menu spacing={4}>
                   {sidebarData && (
                     <>
+                      {vaccinationFeature.isEnabled && (
+                        <CategoryMenu
+                          title={siteText.gemeente_layout.headings.vaccinaties}
+                        >
+                          <MetricMenuItemLink
+                            href={reverseRouter.gm.vaccinaties(code)}
+                            icon={<VaccinatieIcon />}
+                            title={siteText.gemeente_vaccinaties.titel_sidebar}
+                          >
+                            {/* <SidebarMetric
+                              data={sidebarData}
+                              scope="gm"
+                              metricName="hospital_nice"
+                              metricProperty="admissions_on_date_of_reporting"
+                              localeTextKey="gemeente_vaccinaties"
+                              differenceKey="hospital_nice__admissions_on_date_of_reporting_moving_average"
+                            /> */}
+                          </MetricMenuItemLink>
+                        </CategoryMenu>
+                      )}
+
                       <CategoryMenu
                         title={siteText.gemeente_layout.headings.ziekenhuizen}
                       >

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -1,13 +1,14 @@
 import { Vr } from '@corona-dashboard/common';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { ReactComponent as CoronavirusIcon } from '~/assets/coronavirus.svg';
 import { ReactComponent as ElderlyIcon } from '~/assets/elderly.svg';
 import { ReactComponent as Gedrag } from '~/assets/gedrag.svg';
 import { ReactComponent as Gehandicaptenzorg } from '~/assets/gehandicapte-zorg.svg';
 import { ReactComponent as RioolwaterMonitoring } from '~/assets/rioolwater-monitoring.svg';
 import { ReactComponent as GetestIcon } from '~/assets/test.svg';
+import { ReactComponent as VaccinatieIcon } from '~/assets/vaccinaties.svg';
 import { ReactComponent as Verpleeghuiszorg } from '~/assets/verpleeghuiszorg.svg';
-import { ReactComponent as CoronavirusIcon } from '~/assets/coronavirus.svg';
 import { ReactComponent as Ziekenhuis } from '~/assets/ziekenhuis.svg';
 import {
   CategoryMenu,
@@ -22,6 +23,7 @@ import { AppContent } from '~/components/layout/app-content';
 import { SidebarMetric } from '~/components/sidebar-metric';
 import { Text } from '~/components/typography';
 import { useIntl } from '~/intl';
+import { useFeature } from '~/lib/features';
 import { SituationsSidebarValue } from '~/static-props/situations/get-situations-sidebar-value';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 import { EscalationLevel } from '../restrictions/types';
@@ -88,6 +90,7 @@ export function VrLayout(props: VrLayoutProps) {
   const router = useRouter();
   const reverseRouter = useReverseRouter();
   const { siteText } = useIntl();
+  const vaccinationFeature = useFeature('vrVaccinationPage');
 
   const code = router.query.code as string;
 
@@ -177,6 +180,31 @@ export function VrLayout(props: VrLayoutProps) {
                       </Box>
                     </MetricMenuButtonLink>
                   </Box>
+
+                  {vaccinationFeature.isEnabled && (
+                    <CategoryMenu
+                      title={
+                        siteText.veiligheidsregio_layout.headings.vaccinaties
+                      }
+                    >
+                      <MetricMenuItemLink
+                        href={reverseRouter.vr.vaccinaties(code)}
+                        icon={<VaccinatieIcon />}
+                        title={
+                          siteText.veiligheidsregio_vaccinaties.titel_sidebar
+                        }
+                      >
+                        {/* <SidebarMetric
+                          data={data}
+                          scope="vr"
+                          metricName="vaccine_coverage_per_age_group"
+                          metricProperty="fully_vaccinated_percentage"
+                          localeTextKey="veiligheidsregio_vaccinaties"
+                          differenceKey="vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
+                        /> */}
+                      </MetricMenuItemLink>
+                    </CategoryMenu>
+                  )}
 
                   <CategoryMenu
                     title={

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -193,7 +193,11 @@ export function VrLayout(props: VrLayoutProps) {
                         title={
                           siteText.veiligheidsregio_vaccinaties.titel_sidebar
                         }
-                      ></MetricMenuItemLink>
+                      >
+                        {
+                          // @TODO add vaccine sidebar metric once the data is avaliable
+                        }
+                      </MetricMenuItemLink>
                     </CategoryMenu>
                   )}
 

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -193,16 +193,7 @@ export function VrLayout(props: VrLayoutProps) {
                         title={
                           siteText.veiligheidsregio_vaccinaties.titel_sidebar
                         }
-                      >
-                        {/* <SidebarMetric
-                          data={data}
-                          scope="vr"
-                          metricName="vaccine_coverage_per_age_group"
-                          metricProperty="fully_vaccinated_percentage"
-                          localeTextKey="veiligheidsregio_vaccinaties"
-                          differenceKey="vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus"
-                        /> */}
-                      </MetricMenuItemLink>
+                      ></MetricMenuItemLink>
                     </CategoryMenu>
                   )}
 

--- a/packages/app/src/domain/vaccine/components/vaccine-header-with-icon.tsx
+++ b/packages/app/src/domain/vaccine/components/vaccine-header-with-icon.tsx
@@ -1,0 +1,38 @@
+import css from '@styled-system/css';
+import { ReactComponent as VaccinatieIcon } from '~/assets/vaccinaties.svg';
+import { Box } from '~/components/base';
+import { Heading } from '~/components/typography';
+
+interface VaccineHeaderWithIcon {
+  title: string;
+}
+
+export function VaccineHeaderWithIcon({ title }: VaccineHeaderWithIcon) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      flexWrap="nowrap"
+      alignItems="center"
+    >
+      <Box
+        flex="0 0 4rem"
+        display="flex"
+        justifyContent="center"
+        padding={0}
+        margin={0}
+        mt="-0.6rem"
+        css={css({
+          svg: {
+            height: '3.5rem',
+          },
+        })}
+      >
+        <VaccinatieIcon />
+      </Box>
+      <Heading level={1} hyphens="auto">
+        {title}
+      </Heading>
+    </Box>
+  );
+}

--- a/packages/app/src/domain/vaccine/components/vaccine-header-with-icon.tsx
+++ b/packages/app/src/domain/vaccine/components/vaccine-header-with-icon.tsx
@@ -11,9 +11,9 @@ export function VaccineHeaderWithIcon({ title }: VaccineHeaderWithIcon) {
   return (
     <Box
       display="flex"
-      flexDirection="row"
+      flexDirection={{ _: 'column', md: 'row' }}
       flexWrap="nowrap"
-      alignItems="center"
+      alignItems={{ _: 'flex-start', md: 'center' }}
     >
       <Box
         flex="0 0 4rem"

--- a/packages/app/src/domain/vaccine/vaccine-page-introduction-nl.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-page-introduction-nl.tsx
@@ -1,6 +1,5 @@
 import { Nl } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { ReactComponent as VaccinatieIcon } from '~/assets/vaccinaties.svg';
 import { Box } from '~/components/base';
 import { KpiValue } from '~/components/kpi-value';
 import { Tile } from '~/components/tile';
@@ -9,10 +8,10 @@ import { Heading, InlineText, Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { createDate } from '~/utils/create-date';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
+import { VaccineHeaderWithIcon } from './components/vaccine-header-with-icon';
 import { VaccineTicker } from './components/vaccine-ticker';
 import { VaccineAdministrationsOverTimeChart } from './vaccine-administrations-over-time-chart';
-
-interface VaccinePageIntroductionProps {
+interface VaccinePageIntroductionNlProps {
   data: Pick<
     Nl,
     | 'vaccine_administered_planned'
@@ -21,9 +20,9 @@ interface VaccinePageIntroductionProps {
   >;
 }
 
-export function VaccinePageIntroduction({
+export function VaccinePageIntroductionNl({
   data,
-}: VaccinePageIntroductionProps) {
+}: VaccinePageIntroductionNlProps) {
   const { siteText, formatPercentage, formatDate } = useIntl();
   const text = siteText.vaccinaties;
 
@@ -35,32 +34,9 @@ export function VaccinePageIntroduction({
   return (
     <Box spacing={4}>
       <Tile>
+        <VaccineHeaderWithIcon title={text.title} />
+
         <Box spacing={3}>
-          <Box
-            display="flex"
-            flexDirection="row"
-            flexWrap="nowrap"
-            alignItems="center"
-          >
-            <Box
-              flex="0 0 4rem"
-              display="flex"
-              justifyContent="center"
-              padding={0}
-              margin={0}
-              mt="-0.6rem"
-              css={css({
-                svg: {
-                  height: '3.5rem',
-                },
-              })}
-            >
-              <VaccinatieIcon />
-            </Box>
-            <Heading level={1} hyphens="auto">
-              {text.title}
-            </Heading>
-          </Box>
           <Box spacing={4} px={{ md: 5 }}>
             <Text variant="h2" fontWeight="normal">
               {replaceComponentsInText(

--- a/packages/app/src/domain/vaccine/vaccine-page-introduction-vr-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-page-introduction-vr-gm.tsx
@@ -1,0 +1,39 @@
+import { Box } from '~/components/base';
+import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
+import { Tile } from '~/components/tile';
+import { TwoKpiSection } from '~/components/two-kpi-section';
+import { Heading } from '~/components/typography';
+import { VaccineHeaderWithIcon } from './components/vaccine-header-with-icon';
+
+interface VaccinePageIntroductionVrGm {
+  title: string;
+  description: string;
+  kpiTitle: string;
+  kpiValue: number;
+}
+
+export function VaccinePageIntroductionVrGm({
+  title,
+  description,
+  kpiTitle,
+  kpiValue,
+}: VaccinePageIntroductionVrGm) {
+  return (
+    <Tile>
+      <Box spacing={3}>
+        <VaccineHeaderWithIcon title={title} />
+
+        <TwoKpiSection>
+          <Box as="article" spacing={2} px={{ md: 5 }}>
+            <Heading level={3}>{kpiTitle}</Heading>
+            <KpiValue percentage={kpiValue} />
+            <Markdown content={description} />
+          </Box>
+
+          <div />
+        </TwoKpiSection>
+      </Box>
+    </Tile>
+  );
+}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -27,7 +27,7 @@ export const getStaticProps = withFeatureNotFoundPage(
   'gmVaccinationPage',
   createGetStaticProps(
     getLastGeneratedDate,
-    selectGmPageMetricData('deceased_rivm', 'difference', 'code'),
+    selectGmPageMetricData('difference', 'code'),
     createGetContent<{
       page: VaccinationPageQuery;
       highlight: PageArticlesQueryResult;

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -1,0 +1,105 @@
+import { PageInformationBlock } from '~/components/page-information-block';
+import { TileList } from '~/components/tile-list';
+import { GmLayout } from '~/domain/layout/gm-layout';
+import { Layout } from '~/domain/layout/layout';
+import { VaccinePageIntroductionVrGm } from '~/domain/vaccine/vaccine-page-introduction-vr-gm';
+import { useIntl } from '~/intl';
+import { withFeatureNotFoundPage } from '~/lib/features';
+import {
+  createPageArticlesQuery,
+  PageArticlesQueryResult,
+} from '~/queries/create-page-articles-query';
+import { getVaccinePageQuery } from '~/queries/vaccine-page-query';
+import {
+  createGetStaticProps,
+  StaticProps,
+} from '~/static-props/create-get-static-props';
+import {
+  createGetContent,
+  getLastGeneratedDate,
+  selectGmPageMetricData,
+} from '~/static-props/get-data';
+import { VaccinationPageQuery } from '~/types/cms';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+export { getStaticPaths } from '~/static-paths/vr';
+
+export const getStaticProps = withFeatureNotFoundPage(
+  'gmVaccinationPage',
+  createGetStaticProps(
+    getLastGeneratedDate,
+    selectGmPageMetricData('deceased_rivm', 'difference', 'code'),
+    createGetContent<{
+      page: VaccinationPageQuery;
+      highlight: PageArticlesQueryResult;
+    }>((context) => {
+      const { locale } = context;
+      return `{
+      "page": ${getVaccinePageQuery(locale)},
+      "highlight": ${createPageArticlesQuery('vaccinationsPage', locale)}
+    }`;
+    })
+  )
+);
+
+export const VaccinationsGmPage = (
+  props: StaticProps<typeof getStaticProps>
+) => {
+  const {
+    sideBarData,
+    municipalityName,
+    selectedGmData: { difference, code },
+    content,
+    lastGenerated,
+  } = props;
+  const { siteText } = useIntl();
+
+  const text = siteText.gemeente_vaccinaties;
+
+  const metadata = {
+    ...siteText.gemeente_vaccinaties.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      gemeenteNaam: municipalityName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      gemeenteNaam: municipalityName,
+    }),
+  };
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <GmLayout
+        data={sideBarData}
+        code={code}
+        difference={difference}
+        municipalityName={municipalityName}
+        lastGenerated={lastGenerated}
+      >
+        <TileList>
+          <VaccinePageIntroductionVrGm
+            title={replaceVariablesInText(text.introductie_sectie.titel, {
+              gemeenteNaam: municipalityName,
+            })}
+            description={text.introductie_sectie.beschrijving}
+            kpiTitle={text.introductie_sectie.kpi_titel}
+            kpiValue={9999999}
+          />
+
+          <PageInformationBlock
+            description={text.informatie_blok.beschrijving}
+            metadata={{
+              datumsText: text.informatie_blok.datums,
+              dateOrRange: 1629798465,
+              dateOfInsertionUnix: 1629798465,
+              dataSources: [],
+            }}
+            usefulLinks={content.page.usefulLinks}
+            referenceLink={text.informatie_blok.reference.href}
+            articles={content.highlight.articles}
+          />
+        </TileList>
+      </GmLayout>
+    </Layout>
+  );
+};
+
+export default VaccinationsGmPage;

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -17,7 +17,7 @@ import { VaccineAdministrationsKpiSection } from '~/domain/vaccine/vaccine-admin
 import { VaccineCoveragePerAgeGroup } from '~/domain/vaccine/vaccine-coverage-per-age-group';
 import { VaccineDeliveryAndAdministrationsAreaChart } from '~/domain/vaccine/vaccine-delivery-and-administrations-area-chart';
 import { VaccineDeliveryBarChart } from '~/domain/vaccine/vaccine-delivery-bar-chart';
-import { VaccinePageIntroduction } from '~/domain/vaccine/vaccine-page-introduction';
+import { VaccinePageIntroductionNl } from '~/domain/vaccine/vaccine-page-introduction-nl';
 import { VaccineStockPerSupplierChart } from '~/domain/vaccine/vaccine-stock-per-supplier-chart';
 import { useIntl } from '~/intl';
 import { useFeature } from '~/lib/features';
@@ -101,7 +101,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               variant="emphasis"
             />
           )}
-          <VaccinePageIntroduction data={data} />
+          <VaccinePageIntroductionNl data={data} />
 
           <PageInformationBlock
             description={content.page.pageDescription}

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -1,0 +1,59 @@
+import { TileList } from '~/components/tile-list';
+import { Layout } from '~/domain/layout/layout';
+import { VrLayout } from '~/domain/layout/vr-layout';
+import { useIntl } from '~/intl';
+import {
+  createPageArticlesQuery,
+  PageArticlesQueryResult,
+} from '~/queries/create-page-articles-query';
+import {
+  createGetStaticProps,
+  StaticProps,
+} from '~/static-props/create-get-static-props';
+import {
+  createGetContent,
+  getLastGeneratedDate,
+  selectVrPageMetricData,
+} from '~/static-props/get-data';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+export { getStaticPaths } from '~/static-paths/vr';
+
+export const getStaticProps = createGetStaticProps(
+  getLastGeneratedDate,
+  selectVrPageMetricData(),
+  createGetContent<PageArticlesQueryResult>((context) => {
+    const { locale } = context;
+    return createPageArticlesQuery('elderlyAtHomePage', locale);
+  })
+);
+
+const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) => {
+  const { vrName, selectedVrData: data, lastGenerated } = props;
+
+  // const { difference } = data;
+  const { siteText } = useIntl();
+
+  const text = siteText.veiligheidsregio_vaccinaties;
+
+  const metadata = {
+    ...siteText.veiligheidsregio_vaccinaties.metadata,
+    title: replaceVariablesInText(text.metadata.title, {
+      safetyRegion: vrName,
+    }),
+    description: replaceVariablesInText(text.metadata.description, {
+      safetyRegion: vrName,
+    }),
+  };
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <VrLayout data={data} vrName={vrName} lastGenerated={lastGenerated}>
+        <TileList>
+          <h1>Hoi</h1>
+        </TileList>
+      </VrLayout>
+    </Layout>
+  );
+};
+
+export default VaccinationsVrPage;

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -1,11 +1,15 @@
+import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { Layout } from '~/domain/layout/layout';
 import { VrLayout } from '~/domain/layout/vr-layout';
+import { VaccinePageIntroductionVrGm } from '~/domain/vaccine/vaccine-page-introduction-vr-gm';
 import { useIntl } from '~/intl';
+import { withFeatureNotFoundPage } from '~/lib/features';
 import {
   createPageArticlesQuery,
   PageArticlesQueryResult,
 } from '~/queries/create-page-articles-query';
+import { getVaccinePageQuery } from '~/queries/vaccine-page-query';
 import {
   createGetStaticProps,
   StaticProps,
@@ -15,22 +19,32 @@ import {
   getLastGeneratedDate,
   selectVrPageMetricData,
 } from '~/static-props/get-data';
+import { VaccinationPageQuery } from '~/types/cms';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 export { getStaticPaths } from '~/static-paths/vr';
 
-export const getStaticProps = createGetStaticProps(
-  getLastGeneratedDate,
-  selectVrPageMetricData(),
-  createGetContent<PageArticlesQueryResult>((context) => {
-    const { locale } = context;
-    return createPageArticlesQuery('elderlyAtHomePage', locale);
-  })
+export const getStaticProps = withFeatureNotFoundPage(
+  'vrVaccinationPage',
+  createGetStaticProps(
+    getLastGeneratedDate,
+    selectVrPageMetricData(),
+    createGetContent<{
+      page: VaccinationPageQuery;
+      highlight: PageArticlesQueryResult;
+    }>((context) => {
+      const { locale } = context;
+      return `{
+      "page": ${getVaccinePageQuery(locale)},
+      "highlight": ${createPageArticlesQuery('vaccinationsPage', locale)}
+    }`;
+    })
+  )
 );
 
-const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) => {
-  const { vrName, selectedVrData: data, lastGenerated } = props;
-
-  // const { difference } = data;
+export const VaccinationsVrPage = (
+  props: StaticProps<typeof getStaticProps>
+) => {
+  const { vrName, selectedVrData: data, lastGenerated, content } = props;
   const { siteText } = useIntl();
 
   const text = siteText.veiligheidsregio_vaccinaties;
@@ -38,10 +52,10 @@ const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) => {
   const metadata = {
     ...siteText.veiligheidsregio_vaccinaties.metadata,
     title: replaceVariablesInText(text.metadata.title, {
-      safetyRegion: vrName,
+      veiligheidsRegioNaam: vrName,
     }),
     description: replaceVariablesInText(text.metadata.description, {
-      safetyRegion: vrName,
+      veiligheidsRegioNaam: vrName,
     }),
   };
 
@@ -49,7 +63,27 @@ const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <VrLayout data={data} vrName={vrName} lastGenerated={lastGenerated}>
         <TileList>
-          <h1>Hoi</h1>
+          <VaccinePageIntroductionVrGm
+            title={replaceVariablesInText(text.introductie_sectie.titel, {
+              veiligheidsRegioNaam: vrName,
+            })}
+            description={text.introductie_sectie.beschrijving}
+            kpiTitle={text.introductie_sectie.kpi_titel}
+            kpiValue={9999999}
+          />
+
+          <PageInformationBlock
+            description={text.informatie_blok.beschrijving}
+            metadata={{
+              datumsText: text.informatie_blok.datums,
+              dateOrRange: 1629798465,
+              dateOfInsertionUnix: 1629798465,
+              dataSources: [],
+            }}
+            usefulLinks={content.page.usefulLinks}
+            referenceLink={text.informatie_blok.reference.href}
+            articles={content.highlight.articles}
+          />
         </TileList>
       </VrLayout>
     </Layout>

--- a/packages/app/src/utils/use-reverse-router.ts
+++ b/packages/app/src/utils/use-reverse-router.ts
@@ -54,6 +54,7 @@ export function useReverseRouter() {
             ? reverseRouter.vr.risiconiveau(code) + openMenuSuffix
             : '/veiligheidsregio',
         maatregelen: (code: string) => `/veiligheidsregio/${code}/maatregelen`,
+        vaccinaties: (code: string) => `/veiligheidsregio/${code}/vaccinaties`,
         risiconiveau: (code: string) =>
           `/veiligheidsregio/${code}/risiconiveau`,
         positiefGetesteMensen: (code: string) =>
@@ -84,6 +85,7 @@ export function useReverseRouter() {
         ziekenhuisopnames: (code: string) =>
           `/gemeente/${code}/ziekenhuis-opnames`,
         rioolwater: (code: string) => `/gemeente/${code}/rioolwater`,
+        vaccinaties: (code: string) => `/gemeente/${code}/vaccinaties`,
       },
     } as const;
 

--- a/packages/app/src/utils/use-reverse-router.ts
+++ b/packages/app/src/utils/use-reverse-router.ts
@@ -51,7 +51,7 @@ export function useReverseRouter() {
       vr: {
         index: (code?: string) =>
           code
-            ? reverseRouter.vr.risiconiveau(code) + openMenuSuffix
+            ? reverseRouter.vr.vaccinaties(code) + openMenuSuffix
             : '/veiligheidsregio',
         maatregelen: (code: string) => `/veiligheidsregio/${code}/maatregelen`,
         vaccinaties: (code: string) => `/veiligheidsregio/${code}/vaccinaties`,
@@ -77,7 +77,7 @@ export function useReverseRouter() {
       gm: {
         index: (code?: string) =>
           code
-            ? reverseRouter.gm.ziekenhuisopnames(code) + openMenuSuffix
+            ? reverseRouter.gm.vaccinaties(code) + openMenuSuffix
             : `/gemeente`,
         positiefGetesteMensen: (code: string) =>
           `/gemeente/${code}/positief-geteste-mensen`,

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -106,3 +106,17 @@ timestamp,action,key,document_id,move_to
 2021-08-24T06:58:37.421Z,add,gemeente_layout.headings.vaccinaties,DWLUotrm23arH2ViSP3cNG,__
 2021-08-24T07:08:04.024Z,add,veiligheidsregio_vaccinaties.metadata.description,m5cl7ciD7CmTUWm5dGlTxJ,__
 2021-08-24T07:08:05.039Z,add,veiligheidsregio_vaccinaties.metadata.title,4wy7f8NuwuLne309uM0FdM,__
+2021-08-24T09:44:54.091Z,add,veiligheidsregio_vaccinaties.introductie_sectie.titel,4wy7f8NuwuLne309uMwkHM,__
+2021-08-24T09:44:55.298Z,add,veiligheidsregio_vaccinaties.introductie_sectie.beschrijving,4wy7f8NuwuLne309uMwklc,__
+2021-08-24T09:44:56.120Z,add,veiligheidsregio_vaccinaties.introductie_sectie.kpi_titel,4wy7f8NuwuLne309uMwlsm,__
+2021-08-24T09:58:10.466Z,add,veiligheidsregio_vaccinaties.informatie_blok.beschrijving,4wy7f8NuwuLne309uN5voW,__
+2021-08-24T09:58:11.473Z,add,veiligheidsregio_vaccinaties.informatie_blok.datums,DWLUotrm23arH2ViSPEVme,__
+2021-08-24T09:58:12.671Z,add,veiligheidsregio_vaccinaties.informatie_blok.reference.href,DWLUotrm23arH2ViSPEVqK,__
+2021-08-24T10:08:13.768Z,add,gemeente_vaccinaties.informatie_blok.beschrijving,4wy7f8NuwuLne309uNBmLw,__
+2021-08-24T10:08:14.643Z,add,gemeente_vaccinaties.informatie_blok.datums,m5cl7ciD7CmTUWm5dGzNgh,__
+2021-08-24T10:08:15.764Z,add,gemeente_vaccinaties.informatie_blok.reference.href,DWLUotrm23arH2ViSPFMi8,__
+2021-08-24T10:08:16.833Z,add,gemeente_vaccinaties.introductie_sectie.beschrijving,4wy7f8NuwuLne309uNBnG8,__
+2021-08-24T10:08:17.698Z,add,gemeente_vaccinaties.introductie_sectie.kpi_titel,4wy7f8NuwuLne309uNBnXQ,__
+2021-08-24T10:08:18.710Z,add,gemeente_vaccinaties.introductie_sectie.titel,m5cl7ciD7CmTUWm5dGzNsY,__
+2021-08-24T10:08:19.721Z,add,gemeente_vaccinaties.metadata.description,DWLUotrm23arH2ViSPFMzI,__
+2021-08-24T10:08:20.928Z,add,gemeente_vaccinaties.metadata.title,DWLUotrm23arH2ViSPFN4o,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -98,3 +98,11 @@ timestamp,action,key,document_id,move_to
 2021-08-19T11:48:44.909Z,delete,common_actueel.secties.artikelen.categorie_filters.__alles,kZYjqFJyrN0fPPHPQq27cU,__
 2021-08-19T11:48:44.911Z,delete,common_actueel.secties.artikelen.categorie_filters.__alles,DWLUotrm23arH2ViSHQRMk,__
 2021-08-19T11:55:29.087Z,add,common_actueel.secties.artikelen.categorie_filters.__alles,DWLUotrm23arH2ViSJpokU,__
+2021-08-24T06:40:29.800Z,add,veiligheidsregio_layout.headings.vaccinaties,m5cl7ciD7CmTUWm5dGjo2b,__
+2021-08-24T06:40:30.814Z,add,veiligheidsregio_vaccinaties.titel_sidebar,m5cl7ciD7CmTUWm5dGjo4y,__
+2021-08-24T06:49:19.320Z,add,veiligheidsregio_vaccinaties.titel_kpi,m5cl7ciD7CmTUWm5dGkg7w,__
+2021-08-24T06:52:05.809Z,add,gemeente_vaccinaties.titel_kpi,DWLUotrm23arH2ViSP3OjS,__
+2021-08-24T06:52:06.866Z,add,gemeente_vaccinaties.titel_sidebar,m5cl7ciD7CmTUWm5dGknE9,__
+2021-08-24T06:58:37.421Z,add,gemeente_layout.headings.vaccinaties,DWLUotrm23arH2ViSP3cNG,__
+2021-08-24T07:08:04.024Z,add,veiligheidsregio_vaccinaties.metadata.description,m5cl7ciD7CmTUWm5dGlTxJ,__
+2021-08-24T07:08:05.039Z,add,veiligheidsregio_vaccinaties.metadata.title,4wy7f8NuwuLne309uM0FdM,__

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -114,7 +114,7 @@ export interface GmVaccineCoverageValue {
   date_of_insertion_unix: number;
 }
 export interface GmVaccineCoveragePerAgeGroup {
-  values?: GmVaccineCoveragePerAgeGroupValue[];
+  values: GmVaccineCoveragePerAgeGroupValue[];
   last_value: GmVaccineCoveragePerAgeGroupValue;
 }
 export interface GmVaccineCoveragePerAgeGroupValue {
@@ -161,10 +161,7 @@ export interface GmCollectionSewer {
   date_of_insertion_unix: number;
 }
 export interface GmCollectionVaccineCoveragePerAgeGroup {
-  values: GmCollectionVaccineCoveragePerAgeGroupValue[];
-}
-export interface GmCollectionVaccineCoveragePerAgeGroupValue {
-  vrcode: string;
+  gmcode: string;
   age_group_range: "12+" | "12-17" | "18+";
   fully_vaccinated_percentage: number | null;
   birthyear_range: string;
@@ -1234,7 +1231,7 @@ export interface VrSituationsValue {
   other: number | null;
 }
 export interface VrVaccineCoveragePerAgeGroup {
-  values?: VrVaccineCoveragePerAgeGroupValue[];
+  values: VrVaccineCoveragePerAgeGroupValue[];
   last_value: VrVaccineCoveragePerAgeGroupValue;
 }
 export interface VrVaccineCoveragePerAgeGroupValue {
@@ -1381,9 +1378,6 @@ export interface VrCollectionSituations {
   other: number | null;
 }
 export interface VrCollectionVaccineCoveragePerAgeGroup {
-  values: VrCollectionVaccineCoveragePerAgeGroupValue[];
-}
-export interface VrCollectionVaccineCoveragePerAgeGroupValue {
   vrcode: string;
   age_group_range: "12+" | "12-17" | "18+";
   fully_vaccinated_percentage: number | null;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -17,6 +17,7 @@ export interface Gm {
   sewer: GmSewer;
   sewer_per_installation?: GmSewerPerInstallation;
   vaccine_coverage?: GmVaccineCoverage;
+  vaccine_coverage_per_age_group: GmVaccineCoveragePerAgeGroup;
 }
 export interface GmStaticValues {
   population_count: number;
@@ -38,6 +39,7 @@ export interface GmDifference {
   hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   sewer__average?: DifferenceDecimal;
   deceased_rivm__covid_daily: DifferenceInteger;
+  vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus: DifferenceDecimal;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -111,6 +113,20 @@ export interface GmVaccineCoverageValue {
   date_end_unix: number;
   date_of_insertion_unix: number;
 }
+export interface GmVaccineCoveragePerAgeGroup {
+  values?: GmVaccineCoveragePerAgeGroupValue[];
+  last_value: GmVaccineCoveragePerAgeGroupValue;
+}
+export interface GmVaccineCoveragePerAgeGroupValue {
+  age_group_range: "12+" | "12-17" | "18+";
+  fully_vaccinated_percentage: number | null;
+  has_1_shot_percentage: number | null;
+  birthyear_range: string;
+  fully_vaccinated_percentage_label: string | null;
+  has_1_shot_percentage_label: string | null;
+  date_unix: number;
+  date_of_insertion_unix: number;
+}
 
 export interface GmCollection {
   last_generated: string;
@@ -120,6 +136,7 @@ export interface GmCollection {
   hospital_nice: GmCollectionHospitalNice[];
   tested_overall: GmCollectionTestedOverall[];
   sewer: GmCollectionSewer[];
+  vaccine_coverage_per_age_group: GmCollectionVaccineCoveragePerAgeGroup[];
 }
 export interface GmCollectionHospitalNice {
   date_unix: number;
@@ -141,6 +158,18 @@ export interface GmCollectionSewer {
   gmcode: string;
   average: number;
   total_installation_count: number;
+  date_of_insertion_unix: number;
+}
+export interface GmCollectionVaccineCoveragePerAgeGroup {
+  values: GmCollectionVaccineCoveragePerAgeGroupValue[];
+}
+export interface GmCollectionVaccineCoveragePerAgeGroupValue {
+  vrcode: string;
+  age_group_range: "12+" | "12-17" | "18+";
+  fully_vaccinated_percentage: number | null;
+  birthyear_range: string;
+  fully_vaccinated_percentage_label: string | null;
+  date_unix: number;
   date_of_insertion_unix: number;
 }
 
@@ -919,6 +948,7 @@ export interface Vr {
   hospital_nice_sum: VrHospitalNiceSum;
   vaccine_coverage?: VrVaccineCoverage;
   situations: VrSituations;
+  vaccine_coverage_per_age_group?: VrVaccineCoveragePerAgeGroup;
 }
 export interface VrStaticValues {
   population_count: number;
@@ -937,6 +967,7 @@ export interface VrDifference {
   disability_care__infected_locations_total: DifferenceInteger;
   elderly_at_home__positive_tested_daily: DifferenceInteger;
   deceased_rivm__covid_daily: DifferenceInteger;
+  vaccine_coverage_per_age_group_fully_vaccinated_percentage_18_plus: DifferenceDecimal;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -1202,6 +1233,20 @@ export interface VrSituationsValue {
   hospitality: number | null;
   other: number | null;
 }
+export interface VrVaccineCoveragePerAgeGroup {
+  values?: VrVaccineCoveragePerAgeGroupValue[];
+  last_value: VrVaccineCoveragePerAgeGroupValue;
+}
+export interface VrVaccineCoveragePerAgeGroupValue {
+  age_group_range: "12+" | "12-17" | "18+";
+  fully_vaccinated_percentage: number | null;
+  has_1_shot_percentage: number | null;
+  birthyear_range: string;
+  fully_vaccinated_percentage_label: string | null;
+  has_1_shot_percentage_label: string | null;
+  date_unix: number;
+  date_of_insertion_unix: number;
+}
 
 export interface VrCollection {
   last_generated: string;
@@ -1217,6 +1262,7 @@ export interface VrCollection {
   disability_care: VrCollectionDisabilityCare[];
   elderly_at_home: VrCollectionElderlyAtHome[];
   situations: VrCollectionSituations[];
+  vaccine_coverage_per_age_group: VrCollectionVaccineCoveragePerAgeGroup[];
 }
 export interface VrCollectionHospitalNice {
   date_unix: number;
@@ -1333,4 +1379,16 @@ export interface VrCollectionSituations {
   travel: number | null;
   hospitality: number | null;
   other: number | null;
+}
+export interface VrCollectionVaccineCoveragePerAgeGroup {
+  values: VrCollectionVaccineCoveragePerAgeGroupValue[];
+}
+export interface VrCollectionVaccineCoveragePerAgeGroupValue {
+  vrcode: string;
+  age_group_range: "12+" | "12-17" | "18+";
+  fully_vaccinated_percentage: number | null;
+  birthyear_range: string;
+  fully_vaccinated_percentage_label: string | null;
+  date_unix: number;
+  date_of_insertion_unix: number;
 }


### PR DESCRIPTION
Add the vaccination page on VR and GM, the sidebar + the page are hidden behind a feature plag.
The pages are in essential almost the same with a new header with KPI block and the page information block including the metadata, articles, and the handy links.

**Edit**, merged the schema for the vaccination stuff into this branch also.