### PR TITLE
Update vaccine coverage label pattern

### DIFF
--- a/packages/app/schema/gm/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm/vaccine_coverage_per_age_group.json
@@ -2,7 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "gm_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["values", "last_value"],
+  "required": [
+    "values",
+    "last_value"
+  ],
   "additionalProperties": false,
   "properties": {
     "values": {
@@ -33,24 +36,40 @@
       "properties": {
         "age_group_range": {
           "type": "string",
-          "enum": ["12+", "12-17", "18+"]
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
         },
         "fully_vaccinated_percentage": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "has_1_shot_percentage": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "birthyear_range": {
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
         },
         "fully_vaccinated_percentage_label": {
-          "type": ["string", "null"],
-          "pattern": "^([0-9]+-)*[0-9]+$"
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^([><][=][0-9]{1,2})$"
         },
         "has_1_shot_percentage_label": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^([0-9]+-)*[0-9]+$"
         },
         "date_unix": {

--- a/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
@@ -19,18 +19,28 @@
     },
     "age_group_range": {
       "type": "string",
-      "enum": ["12+", "12-17", "18+"]
+      "enum": [
+        "12+",
+        "12-17",
+        "18+"
+      ]
     },
     "fully_vaccinated_percentage": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "birthyear_range": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
     },
     "fully_vaccinated_percentage_label": {
-      "type": ["string", "null"],
-      "pattern": "^([0-9]+-)*[0-9]+$"
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^([><][=][0-9]{1,2})$"
     },
     "date_unix": {
       "type": "integer"

--- a/packages/app/schema/vr/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr/vaccine_coverage_per_age_group.json
@@ -2,7 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "vr_vaccine_coverage_per_age_group",
   "type": "object",
-  "required": ["values", "last_value"],
+  "required": [
+    "values",
+    "last_value"
+  ],
   "additionalProperties": false,
   "properties": {
     "values": {
@@ -33,24 +36,40 @@
       "properties": {
         "age_group_range": {
           "type": "string",
-          "enum": ["12+", "12-17", "18+"]
+          "enum": [
+            "12+",
+            "12-17",
+            "18+"
+          ]
         },
         "fully_vaccinated_percentage": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "has_1_shot_percentage": {
-          "type": ["integer", "null"]
+          "type": [
+            "integer",
+            "null"
+          ]
         },
         "birthyear_range": {
           "type": "string",
           "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
         },
         "fully_vaccinated_percentage_label": {
-          "type": ["string", "null"],
-          "pattern": "^([0-9]+-)*[0-9]+$"
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^([><][=][0-9]{1,2})$"
         },
         "has_1_shot_percentage_label": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^([0-9]+-)*[0-9]+$"
         },
         "date_unix": {

--- a/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
@@ -19,18 +19,28 @@
     },
     "age_group_range": {
       "type": "string",
-      "enum": ["12+", "12-17", "18+"]
+      "enum": [
+        "12+",
+        "12-17",
+        "18+"
+      ]
     },
     "fully_vaccinated_percentage": {
-      "type": ["integer", "null"]
+      "type": [
+        "integer",
+        "null"
+      ]
     },
     "birthyear_range": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
     },
     "fully_vaccinated_percentage_label": {
-      "type": ["string", "null"],
-      "pattern": "^([0-9]+-)*[0-9]+$"
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^([><][=][0-9]{1,2})$"
     },
     "date_unix": {
       "type": "integer"


### PR DESCRIPTION
## Summary

Update the pattern for the `fully_vaccinated_percentage_label` value for `vaccine_coverage_per_age_group` data. This iteration is somewhat easier to parse.

## Detailed design

We'll expect a lesser or greater than symbol, an equals sign, and a number of 1 or 2 digits. By parsing out the lesser/greater than symbol and the number we can more easily decide the logic to apply to labels and coloring when compared to the previous pattern of number ranges, (eg. `[low, high]`) as the new pattern signifies more definitively what the data means.