### PR TITLE
Hotfix: difference displayed as percentage

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -78,7 +78,7 @@ export function TileDifference({
       </IconContainer>
       <InlineText>
         {text.gelijk}
-        {isPercentage ? '%' : ''} {timespanTextNode}
+        {timespanTextNode}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -82,13 +82,13 @@ export function KpiValue({
         (isMovingAverageDifference ? (
           <TileAverageDifference
             value={difference}
-            isPercentage={isDefined(percentage)}
+            isPercentage={isDefined(percentage) && !isDefined(absolute)}
           />
         ) : (
           <TileDifference
             value={difference}
             staticTimespan={differenceStaticTimespan}
-            isPercentage={isDefined(percentage)}
+            isPercentage={isDefined(percentage) && !isDefined(absolute)}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}


### PR DESCRIPTION
Fixes some cases where a percentage sign was shown in a KPI difference where it shouldn't.

2 bugs:
- If an absolute value was combined with a percentage in a KPI value, we showed a percentage sign in the difference even though the difference is for the absolute value.
- We showed a percentage sign after textual difference values