### PR TITLE
Sanity duplicate checks and tooling

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -12,6 +12,7 @@
     "compile": "tsc --pretty --noEmit",
     "lint": "echo '@TODO add eslint'",
     "lokalize:export": "ts-node src/lokalize/export.ts",
+    "lokalize:dedupe": "ts-node src/lokalize/clean-duplicates.ts",
     "lokalize:apply-json-edits": "ts-node src/lokalize/apply-json-edits.ts",
     "lokalize:generate-types": "ts-node src/lokalize/generate-types.ts",
     "lokalize:sync-after-release": "ts-node src/lokalize/sync-after-release.ts",

--- a/packages/cms/src/lokalize/apply-json-edits.ts
+++ b/packages/cms/src/lokalize/apply-json-edits.ts
@@ -94,7 +94,9 @@ import {
           documentId: document._id,
         });
       } else {
-        console.warn(`A lokalize document with key ${key} already exists.`);
+        console.warn(
+          `A lokalize document with key ${key} already exists. Skipped adding a new one.`
+        );
       }
     }
 

--- a/packages/cms/src/lokalize/apply-json-edits.ts
+++ b/packages/cms/src/lokalize/apply-json-edits.ts
@@ -79,14 +79,23 @@ import {
        * First create the document in Sanity, so that we can store the document
        * id in the mutations log. We need this id later to sync to production,
        * because both datasets share their document ids for lokalize texts.
+       *
+       * If a document with the given key already exists we log a warning.
        */
-      const document = await devClient.create(createTextDocument(key, text));
+      const count = await devClient.fetch(
+        `count(*[_type == 'lokalizeText' && key == '${key}'])`
+      );
+      if (count === 0) {
+        const document = await devClient.create(createTextDocument(key, text));
 
-      await appendTextMutation({
-        action: 'add',
-        key,
-        documentId: document._id,
-      });
+        await appendTextMutation({
+          action: 'add',
+          key,
+          documentId: document._id,
+        });
+      } else {
+        console.warn(`A lokalize document with key ${key} already exists.`);
+      }
     }
 
     if (choice.type === 'move') {

--- a/packages/cms/src/lokalize/clean-duplicates.ts
+++ b/packages/cms/src/lokalize/clean-duplicates.ts
@@ -19,11 +19,6 @@ type LokalizeText = {
     "*[_type == 'lokalizeText' && !(_id in path('drafts.**'))]{_id, key, text}"
   );
 
-  if (!texts) {
-    console.log('No duplicates found!');
-    process.exit(0);
-  }
-
   const duplicates = texts.reduce<Record<string, LokalizeText[]>>(
     (aggr: any, text: any) => {
       if (!aggr[text.key]) {
@@ -40,6 +35,11 @@ type LokalizeText = {
       delete duplicates[key];
     }
   });
+
+  if (Object.keys(duplicates).length === 0) {
+    console.log('No duplicate keys found...');
+    process.exit(0);
+  }
 
   const choices = Object.entries(duplicates)
     .map(([key, duplicates]) => {

--- a/packages/cms/src/lokalize/clean-duplicates.ts
+++ b/packages/cms/src/lokalize/clean-duplicates.ts
@@ -3,6 +3,15 @@ import meow from 'meow';
 import prompts from 'prompts';
 import { getClient } from '../client';
 
+/**
+ * This tool should ideally never needed to be used. It was written after some bugs were determined in the
+ * apply-json-edits script where sometimes duplicate keys ended up in the Sanity dataset, and this tool
+ * allowed for an easy way to fix those errors.
+ *
+ * After the apply-json-edits script was fixed, duplicates shouldn't occur anymore. But, if for some reason
+ * they happen again, this tool can assist in making fixes.
+ *
+ */
 type LokalizeText = {
   _id: string;
   key: string;

--- a/packages/cms/src/lokalize/clean-duplicates.ts
+++ b/packages/cms/src/lokalize/clean-duplicates.ts
@@ -1,0 +1,127 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { getClient } from '../client';
+
+type LokalizeText = {
+  _id: string;
+  key: string;
+  text: {
+    _type: string;
+    nl: string;
+    en: string;
+  };
+};
+
+(async function run() {
+  const sanityClient = getClient('development');
+
+  const texts = await sanityClient.fetch<LokalizeText[]>(
+    "*[_type == 'lokalizeText' && !(_id in path('drafts.**'))]{_id, key, text}"
+  );
+
+  if (!texts) {
+    console.log('No duplicates found!');
+    process.exit(0);
+  }
+
+  const duplicates = texts.reduce<Record<string, LokalizeText[]>>(
+    (aggr: any, text: any) => {
+      if (!aggr[text.key]) {
+        aggr[text.key] = [];
+      }
+      aggr[text.key].push(text);
+      return aggr;
+    },
+    {} as Record<string, LokalizeText[]>
+  );
+
+  Object.keys(duplicates).forEach((key) => {
+    if (duplicates[key].length < 2) {
+      delete duplicates[key];
+    }
+  });
+
+  const choices = Object.entries(duplicates)
+    .map(([key, duplicates]) => {
+      return duplicates.map(
+        (duplicate) =>
+          ({
+            title: chalk.green(`${key}\t\t${duplicate.text.nl}`),
+            value: duplicate,
+          } as const)
+      );
+    })
+    .flat();
+
+  const duplicateResponse = (await prompts({
+    type: 'multiselect',
+    name: 'keys',
+    message: 'Select the duplicate lokalize texts that will be deleted:',
+    choices,
+    onState,
+  })) as { keys: typeof choices[number]['value'][] };
+
+  const completeDeletions = findCompleteDeletions(
+    duplicateResponse.keys,
+    duplicates
+  );
+
+  if (completeDeletions.size > 0) {
+    const response = await prompts([
+      {
+        type: 'confirm',
+        name: 'isConfirmed',
+        message: `The following keys will be deleted completely (all documents were selected): ${Array.from(
+          completeDeletions
+        ).join(', ')}.\nAre you sure?`,
+        initial: false,
+      },
+    ]);
+
+    if (!response.isConfirmed) {
+      process.exit(0);
+    }
+  }
+
+  await Promise.all(
+    duplicateResponse.keys.map((x) => sanityClient.delete(x._id))
+  );
+})().catch((err) => {
+  console.error('An error occurred:', err.message);
+  process.exit(1);
+});
+
+/**
+ * There is currently no native way to exit prompts on ctrl-c. This is a
+ * workaround that needs to be added to every prompts instance. For more info
+ * see: https://github.com/terkelg/prompts/issues/252#issuecomment-778683666
+ */
+function onState(state: { aborted: boolean }) {
+  if (state.aborted) {
+    process.nextTick(() => {
+      process.exit(0);
+    });
+  }
+}
+
+function findCompleteDeletions(
+  responseTexts: LokalizeText[],
+  duplicates: Record<string, LokalizeText[]>
+) {
+  const responseDuplicates = responseTexts.reduce<
+    Record<string, LokalizeText[]>
+  >((aggr: any, text: any) => {
+    if (!aggr[text.key]) {
+      aggr[text.key] = [];
+    }
+    aggr[text.key].push(text);
+    return aggr;
+  }, {} as Record<string, LokalizeText[]>);
+
+  return Object.keys(responseDuplicates).reduce((aggr, key) => {
+    if (responseDuplicates[key].length === duplicates[key].length) {
+      aggr.add(key);
+    }
+    return aggr;
+  }, new Set<string>());
+}

--- a/packages/cms/src/lokalize/clean-duplicates.ts
+++ b/packages/cms/src/lokalize/clean-duplicates.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import meow from 'meow';
 import prompts from 'prompts';
 import { getClient } from '../client';
 
@@ -12,8 +13,34 @@ type LokalizeText = {
   };
 };
 
+const cli = meow(
+  `
+      Usage
+        $ lokalize:dedupe
+  
+      Options
+        --drafts Include draft documents
+        --dataset Define dataset to export, default is "development"
+  
+      Examples
+        $ lokalize:dedupe --dataset=production
+  `,
+  {
+    flags: {
+      dataset: {
+        type: 'string',
+        default: 'development',
+      },
+      cleanJson: {
+        type: 'boolean',
+      },
+    },
+  }
+);
+
 (async function run() {
-  const sanityClient = getClient('development');
+  const dataset = cli.flags.dataset;
+  const sanityClient = getClient(dataset);
 
   const texts = await sanityClient.fetch<LokalizeText[]>(
     "*[_type == 'lokalizeText' && !(_id in path('drafts.**'))]{_id, key, text}"


### PR DESCRIPTION
## Summary

`lokalize:apply-json-edits` sometimes added duplicate keys to Sanity. This PR adds a quick check to see whether a lokalize key already exists, in which case no new entry is saved and a warning is logged.
This PR also adds a new a small console app called `lokalize:dedupe`, this tool scans the specified sanity dataset for duplicate documents with the same key and offers a select option to delete specific lokalize documents.

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
