### PR TITLE
Hotfix: difference displayed as percentage (#3390)

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -78,7 +78,7 @@ export function TileDifference({
       </IconContainer>
       <InlineText>
         {text.gelijk}
-        {isPercentage ? '%' : ''} {timespanTextNode}
+        {timespanTextNode}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -82,13 +82,13 @@ export function KpiValue({
         (isMovingAverageDifference ? (
           <TileAverageDifference
             value={difference}
-            isPercentage={isDefined(percentage)}
+            isPercentage={isDefined(percentage) && !isDefined(absolute)}
           />
         ) : (
           <TileDifference
             value={difference}
             staticTimespan={differenceStaticTimespan}
-            isPercentage={isDefined(percentage)}
+            isPercentage={isDefined(percentage) && !isDefined(absolute)}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}


### PR DESCRIPTION
* Check if number is absolute for difference in %

* Do not show percentage after textual difference