### PR TITLE
Add last_value existence check

### DIFF
--- a/packages/cli/src/schema/custom-validations/choropleth.ts
+++ b/packages/cli/src/schema/custom-validations/choropleth.ts
@@ -73,6 +73,10 @@ export const validateChoroplethValues = (
 
       const lastValue = (input[propertyName] as { last_value: UnknownObject })
         .last_value;
+      if (!isDefined(lastValue)) {
+        return `No last_value property exists on ${propertyName}`;
+      }
+
       return validateCommonPropertyEquality(
         lastValue,
         collectionValue,


### PR DESCRIPTION
## Summary

Choropleth validator now makes sure last_value actually exists before examining the values...

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
