### PR TITLE
Add higher lower and date in reproduction kpi tile

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -9,17 +9,18 @@ import { Container, IconContainer } from './containers';
 export function TileDifference({
   value,
   isDecimal,
-  staticTimespan,
   maximumFractionDigits,
   isPercentage,
+  showOldDateUnix,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
   isDecimal?: boolean;
   maximumFractionDigits?: number;
-  staticTimespan?: string;
   isPercentage?: boolean;
+  showOldDateUnix?: boolean;
 }) {
-  const { siteText, formatNumber, formatPercentage } = useIntl();
+  const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
+    useIntl();
   const text = siteText.toe_en_afname;
 
   const { difference } = value;
@@ -31,10 +32,14 @@ export function TileDifference({
       )
     : formatNumber(Math.abs(difference));
 
-  const timespanTextNode = staticTimespan ?? text.vorige_waarde;
+  const timespanTextNode = showOldDateUnix
+    ? formatDateFromSeconds(value.old_date_unix)
+    : text.vorige_waarde;
 
   if (difference > 0) {
-    const splitText = text.toename.split(' ');
+    const splitText = showOldDateUnix
+      ? text.hoger.split(' ')
+      : text.toename.split(' ');
 
     return (
       <Container>
@@ -53,7 +58,9 @@ export function TileDifference({
   }
 
   if (difference < 0) {
-    const splitText = text.afname.split(' ');
+    const splitText = showOldDateUnix
+      ? text.lager.split(' ')
+      : text.afname.split(' ');
 
     return (
       <Container>

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -15,7 +15,6 @@ interface KpiValueProps {
   percentage?: number;
   valueAnnotation?: string;
   difference?: DifferenceDecimal | DifferenceInteger;
-  differenceStaticTimespan?: string;
   text?: string;
   color?: string;
   isMovingAverageDifference?: boolean;
@@ -50,7 +49,6 @@ export function KpiValue({
   percentage,
   valueAnnotation,
   difference,
-  differenceStaticTimespan,
   text,
   color = 'data.primary',
   isMovingAverageDifference,
@@ -87,7 +85,6 @@ export function KpiValue({
         ) : (
           <TileDifference
             value={difference}
-            staticTimespan={differenceStaticTimespan}
             isPercentage={isDefined(percentage) && !isDefined(absolute)}
           />
         ))}

--- a/packages/app/src/components/page-barscale.tsx
+++ b/packages/app/src/components/page-barscale.tsx
@@ -30,10 +30,10 @@ interface PageBarScaleProps<T> {
   metricName: MetricKeys<T>;
   metricProperty: string;
   differenceKey?: string;
-  differenceStaticTimespan?: string;
   differenceFractionDigits?: number;
   currentValue?: number;
   isMovingAverageDifference?: boolean;
+  showOldDateUnix?: boolean;
 }
 
 export function PageBarScale<T>({
@@ -43,9 +43,9 @@ export function PageBarScale<T>({
   metricProperty,
   localeTextKey,
   differenceKey,
-  differenceStaticTimespan,
   differenceFractionDigits,
   isMovingAverageDifference,
+  showOldDateUnix,
 }: PageBarScaleProps<T>) {
   const { siteText } = useIntl();
 
@@ -141,8 +141,8 @@ export function PageBarScale<T>({
           <TileDifference
             value={differenceValue}
             isDecimal={config.isDecimal}
-            staticTimespan={differenceStaticTimespan}
             maximumFractionDigits={differenceFractionDigits}
+            showOldDateUnix={showOldDateUnix}
           />
         ))}
     </Box>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -89,6 +89,7 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
                 localeTextKey="reproductiegetal"
                 differenceKey="reproduction__index_average"
                 differenceFractionDigits={2}
+                showOldDateUnix
               />
               <Text>{text.barscale_toelichting}</Text>
             </KpiWithIllustrationTile>


### PR DESCRIPTION
Removed the `staticTimespan` since it doesn't get used in the app.
Added an option to show `the old_date_unix` in the text below the KPI bar chart.