### PR TITLE
Consistent naming for vaccination coverage choropleth Lokalize keys

### DIFF
--- a/packages/app/src/domain/vaccine/components/age-group-select.tsx
+++ b/packages/app/src/domain/vaccine/components/age-group-select.tsx
@@ -65,9 +65,7 @@ export function AgeGroupSelect(props: AgeGroupSelectProps) {
 
   return (
     <RichContentSelect
-      label={
-        siteText.vaccinaties.choropleth_vaccinatie_graad_per_gm.dropdown_label
-      }
+      label={siteText.vaccinaties.age_group_dropdown.label}
       visuallyHiddenLabel
       initialValue={initialValue}
       options={options}

--- a/packages/app/src/domain/vaccine/vaccine-coverage-per-municipality.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-per-municipality.tsx
@@ -39,21 +39,20 @@ export function VaccineCoveragePerMunicipality({
   const reverseRouter = useReverseRouter();
 
   const variables = {
-    regio: siteText.vaccinaties.choropleth_vaccinatie_graad_per_gm[selectedMap],
+    regio: siteText.vaccinaties.nl_choropleth_vaccinatie_graad[selectedMap],
   };
 
   return (
     <ChoroplethTile
       title={replaceVariablesInText(
-        siteText.vaccinaties.choropleth_vaccinatie_graad_per_gm.titel,
+        siteText.vaccinaties.nl_choropleth_vaccinatie_graad.titel,
         variables
       )}
       description={
         <>
           <Text>
             {replaceVariablesInText(
-              siteText.vaccinaties.choropleth_vaccinatie_graad_per_gm
-                .description,
+              siteText.vaccinaties.nl_choropleth_vaccinatie_graad.description,
               variables
             )}
           </Text>
@@ -64,7 +63,7 @@ export function VaccineCoveragePerMunicipality({
       legend={{
         thresholds: thresholds.gm.fully_vaccinated_percentage,
         title:
-          siteText.vaccinaties.choropleth_vaccinatie_graad_per_gm.legenda_titel,
+          siteText.vaccinaties.nl_choropleth_vaccinatie_graad.legenda_titel,
       }}
       metadata={{ source: siteText.brononderzoek.bronnen.rivm }}
       chartRegion={selectedMap}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -180,3 +180,6 @@ timestamp,action,key,document_id,move_to
 2021-08-30T10:20:33.399Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.legenda_titel,DWLUotrm23arH2ViSP7a9G,__
 2021-08-30T10:20:33.401Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.titel,m5cl7ciD7CmTUWm5dKee56,__
 2021-08-30T10:20:33.403Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.vr,DWLUotrm23arH2ViSS30TU,__
+2021-08-30T10:28:16.077Z,add,vaccinaties.age_group_dropdown.label,4wy7f8NuwuLne309vDxaRI,__
+2021-08-30T10:28:16.082Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.legenda_titel,DWLUotrm23arH2ViSP7a9G,__
+2021-08-30T10:28:16.085Z,delete,vaccinaties.nl_choropleth_vaccinatie_graad.dropdown_label,4wy7f8NuwuLne309vDtuo4,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -168,3 +168,15 @@ timestamp,action,key,document_id,move_to
 2021-08-30T07:22:54.232Z,add,vaccinaties.gm_choropleth_vaccinatie_graad.description,DWLUotrm23arH2ViSWTIzG,__
 2021-08-30T07:22:55.247Z,add,vaccinaties.gm_choropleth_vaccinatie_graad.legend_title,DWLUotrm23arH2ViSWTJ3Y,__
 2021-08-30T07:22:56.264Z,add,vaccinaties.gm_choropleth_vaccinatie_graad.title,4wy7f8NuwuLne309vCbZJM,__
+2021-08-30T10:20:24.822Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.description,4wy7f8NuwuLne309vDtuWm,__
+2021-08-30T10:20:25.845Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.dropdown_label,4wy7f8NuwuLne309vDtuo4,__
+2021-08-30T10:20:26.866Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.gm,DWLUotrm23arH2ViSWeZpq,__
+2021-08-30T10:20:28.913Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.legenda_titel,m5cl7ciD7CmTUWm5dQcS4w,__
+2021-08-30T10:20:32.195Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.titel,4wy7f8NuwuLne309vDtxWe,__
+2021-08-30T10:20:33.374Z,add,vaccinaties.nl_choropleth_vaccinatie_graad.vr,DWLUotrm23arH2ViSWeaNY,__
+2021-08-30T10:20:33.376Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.description,4wy7f8NuwuLne309uFgxmG,__
+2021-08-30T10:20:33.378Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.dropdown_label,m5cl7ciD7CmTUWm5dKct90,__
+2021-08-30T10:20:33.380Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.gm,m5cl7ciD7CmTUWm5dKcsiv,__
+2021-08-30T10:20:33.399Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.legenda_titel,DWLUotrm23arH2ViSP7a9G,__
+2021-08-30T10:20:33.401Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.titel,m5cl7ciD7CmTUWm5dKee56,__
+2021-08-30T10:20:33.403Z,delete,vaccinaties.choropleth_vaccinatie_graad_per_gm.vr,DWLUotrm23arH2ViSS30TU,__


### PR DESCRIPTION
## Summary

- Fixes the missing `description` key error in the current develop actions
- Consistent naming for vaccination coverage choropleth Lokalize keys, (eg. `<region>_choropleth_vaccinatie_graad`)