### PR TITLE
Add python install to docker pre-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,21 @@ COPY packages/cli/package.json ./packages/cli/
 COPY packages/cms/package.json ./packages/cms/
 COPY packages/common/package.json ./packages/common/
 COPY packages/icons/package.json ./packages/icons/
-
-RUN yarn install --frozen-lockfile --production=false
+RUN apk --no-cache --virtual build-dependencies --update add \
+    sudo \
+    curl \
+    build-base \
+    g++ \
+    libpng \
+    libpng-dev \
+    jpeg-dev \
+    pango-dev \
+    cairo-dev \
+    giflib-dev \
+    python3 \
+    && yarn install --frozen-lockfile --production=false \
+    && apk del build-dependencies \
+    ;
 
 # Layer cache for rebuilds without sourcecode changes.
 # This relies on the JSONS being downloaded by the builder.


### PR DESCRIPTION
## Summary

As the title states, hopefully this will fix the node-canvas compilation on the buildserver

### Governance

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [ ] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [ ] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
