### PR TITLE
Add a dev script for @corona-dashboard/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typecheck": "yarn workspaces run typecheck",
     "lint": "yarn workspaces run lint",
     "format": "yarn workspaces run format",
-    "dev": "yarn workspace @corona-dashboard/app dev & yarn workspace @corona-dashboard/cms dev",
+    "dev": "yarn workspace @corona-dashboard/app dev & yarn workspace @corona-dashboard/cms dev & yarn workspace @corona-dashboard/common dev",
     "download": "yarn workspace @corona-dashboard/app download",
     "start": "yarn workspace @corona-dashboard/app start",
     "validate-json-all": "yarn workspace @corona-dashboard/cli validate-json-all",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,6 +12,7 @@
     "bootstrap": "yarn build",
     "test": "jest --watch",
     "test:ci": "jest --ci",
+    "dev": "tsc -w",
     "build": "tsc && tscpaths -p tsconfig.json -s ./src -o ./dist",
     "clean": "del-cli dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --pretty --noEmit",


### PR DESCRIPTION
## Summary

Changes in `@corona-dasboard/common` are fairly frequent and I had the need for a `dev` script in the package. This adds the script and the execution of said script to the workspace `package.json` `dev` script.