### PR TITLE
Add brononderzoek link to Actueel overview

### DIFF
--- a/packages/app/src/components/sitemap/use-data-sitemap.ts
+++ b/packages/app/src/components/sitemap/use-data-sitemap.ts
@@ -152,6 +152,10 @@ export function useDataSitemap(
           href: reverseRouter.nl.varianten(),
         },
         {
+          text: siteText.brononderzoek.titel_sidebar,
+          href: reverseRouter.nl.brononderzoek(),
+        },
+        {
           text: siteText.besmettelijke_personen.titel_sidebar,
           href: reverseRouter.nl.besmettelijkeMensen(),
         },


### PR DESCRIPTION
## Summary

Adds a link to the brononderzoek page on the Actueel overview.