### PR TITLE
Set maximum number of date ticks to number of full days in time domain of 

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -124,7 +124,12 @@ export const Axes = memo(function Axes({
     [formatPercentage]
   );
 
-  const xTickNumber = breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3;
+  const preferredDateTicks = breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3;
+  const fullDaysInDomain = Math.floor((endUnix - startUnix) / 86400);
+  const xTickNumber = Math.max(
+    Math.min(fullDaysInDomain, preferredDateTicks),
+    2
+  );
   const xTicks = createTimeTicks(startUnix, endUnix, xTickNumber);
 
   const formatXAxis = useCallback(


### PR DESCRIPTION
## Summary

If a time series only spans 2-3 days, we still show 5 date ticks on desktop, which does not make sense. This PR sets the maximum to the number of full days in the time series, so we don't get double date ticks:

Old:
![image](https://user-images.githubusercontent.com/85888969/131667985-f34c194f-6e1b-4ee0-b766-3fbe171e024f.png)

New:
![image](https://user-images.githubusercontent.com/85888969/131668024-abd46f17-fc79-4c52-91a7-9aa567188cfd.png)
