### PR TITLE
Reduce number of ticks on narrow time series

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -16,8 +16,8 @@ import { memo, Ref, useCallback } from 'react';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/create-date';
-import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useIsMounted } from '~/utils/use-is-mounted';
+import { useResizeObserver } from '~/utils/use-resize-observer';
 import { Bounds } from '../logic';
 import { WeekNumbers } from './week-numbers';
 
@@ -101,7 +101,7 @@ export const Axes = memo(function Axes({
 }: AxesProps) {
   const [startUnix, endUnix] = timeDomain;
   const isMounted = useIsMounted();
-  const breakpoints = useBreakpoints();
+  const [axesRef, axesSize] = useResizeObserver<SVGGElement>();
 
   const {
     formatDateFromSeconds,
@@ -124,7 +124,8 @@ export const Axes = memo(function Axes({
     [formatPercentage]
   );
 
-  const xTickNumber = breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3;
+  // Make sure each tick has 130px of space so it does not get too crowded
+  const xTickNumber = Math.floor((axesSize.width ?? 600) / 130);
   const xTicks = createTimeTicks(startUnix, endUnix, xTickNumber);
 
   const formatXAxis = useCallback(
@@ -193,7 +194,7 @@ export const Axes = memo(function Axes({
   const numDarkGridLines = allZeroValues ? 1 : numGridLines;
 
   return (
-    <g css={css({ pointerEvents: 'none' })}>
+    <g ref={axesRef} css={css({ pointerEvents: 'none' })}>
       <GridRows
         /**
          * Lighter gray grid lines are used for the lines that have no label on

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -90,7 +90,6 @@ export const Axes = memo(function Axes({
   isPercentage,
   xScale,
   yScale,
-  timeframe,
   yTickValues,
   timeDomain,
   formatYTickValue,

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -16,8 +16,8 @@ import { memo, Ref, useCallback } from 'react';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/create-date';
+import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useIsMounted } from '~/utils/use-is-mounted';
-import { useResizeObserver } from '~/utils/use-resize-observer';
 import { Bounds } from '../logic';
 import { WeekNumbers } from './week-numbers';
 
@@ -101,7 +101,7 @@ export const Axes = memo(function Axes({
 }: AxesProps) {
   const [startUnix, endUnix] = timeDomain;
   const isMounted = useIsMounted();
-  const [axesRef, axesSize] = useResizeObserver<SVGGElement>();
+  const breakpoints = useBreakpoints();
 
   const {
     formatDateFromSeconds,
@@ -124,8 +124,7 @@ export const Axes = memo(function Axes({
     [formatPercentage]
   );
 
-  // Make sure each tick has 130px of space so it does not get too crowded
-  const xTickNumber = Math.floor((axesSize.width ?? 600) / 130);
+  const xTickNumber = breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3;
   const xTicks = createTimeTicks(startUnix, endUnix, xTickNumber);
 
   const formatXAxis = useCallback(
@@ -194,7 +193,7 @@ export const Axes = memo(function Axes({
   const numDarkGridLines = allZeroValues ? 1 : numGridLines;
 
   return (
-    <g ref={axesRef} css={css({ pointerEvents: 'none' })}>
+    <g css={css({ pointerEvents: 'none' })}>
       <GridRows
         /**
          * Lighter gray grid lines are used for the lines that have no label on

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -43,6 +43,7 @@ type AxesProps = {
   yAxisRef?: Ref<SVGGElement>;
   yTickValues?: number[];
   timeDomain: [number, number];
+  xTickNumber?: number;
   formatYTickValue?: (value: number) => string;
 
   /**
@@ -93,6 +94,7 @@ export const Axes = memo(function Axes({
   timeframe,
   yTickValues,
   timeDomain,
+  xTickNumber,
   formatYTickValue,
   yAxisRef,
   isYAxisCollapsed,
@@ -124,7 +126,8 @@ export const Axes = memo(function Axes({
     [formatPercentage]
   );
 
-  const xTickNumber = breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3;
+  xTickNumber =
+    xTickNumber ?? (breakpoints.sm ? (timeframe === 'all' ? 6 : 5) : 3);
   const xTicks = createTimeTicks(startUnix, endUnix, xTickNumber);
 
   const formatXAxis = useCallback(

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -13,6 +13,7 @@ import { scaleLinear } from '@visx/scale';
 import { ScaleBand, ScaleLinear } from 'd3-scale';
 import { differenceInDays } from 'date-fns';
 import { memo, Ref, useCallback } from 'react';
+import { isPresent } from 'ts-is-present';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
 import { createDate } from '~/utils/create-date';
@@ -126,7 +127,7 @@ export const Axes = memo(function Axes({
     [formatPercentage]
   );
 
-  if (!xTickNumber) {
+  if (!isPresent(xTickNumber)) {
     const preferredDateTicks = breakpoints.sm
       ? timeframe === 'all'
         ? 6

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -90,6 +90,7 @@ export const Axes = memo(function Axes({
   isPercentage,
   xScale,
   yScale,
+  timeframe,
   yTickValues,
   timeDomain,
   formatYTickValue,

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -114,6 +114,7 @@ type TimeSeriesChartProps<
   numGridLines?: number;
   showWeekNumbers?: boolean;
   tickValues?: number[];
+  xTickNumber?: number;
   formatTickValue?: (value: number) => string;
   paddingLeft?: number;
   /**
@@ -154,6 +155,7 @@ export function TimeSeriesChart<
   showWeekNumbers,
   numGridLines = 4,
   tickValues: yTickValues,
+  xTickNumber,
   formatTickValue: formatYTickValue,
   paddingLeft,
   tooltipTitle,
@@ -399,6 +401,7 @@ export function TimeSeriesChart<
               timeframe={timeframe}
               yTickValues={yTickValues}
               timeDomain={timeDomain}
+              xTickNumber={xTickNumber}
               formatYTickValue={formatYTickValue}
               xScale={xScale}
               yScale={yScale}

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -396,6 +396,7 @@ export function TimeSeriesChart<
             <Axes
               bounds={bounds}
               numGridLines={numGridLines}
+              timeframe={timeframe}
               yTickValues={yTickValues}
               timeDomain={timeDomain}
               formatYTickValue={formatYTickValue}

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -396,7 +396,6 @@ export function TimeSeriesChart<
             <Axes
               bounds={bounds}
               numGridLines={numGridLines}
-              timeframe={timeframe}
               yTickValues={yTickValues}
               timeDomain={timeDomain}
               formatYTickValue={formatYTickValue}

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -78,6 +78,7 @@ export function MiniTrendTile<T extends TimestampedValue>(
               initialWidth={400}
               minHeight={sm ? 180 : 140}
               timeframe="5weeks"
+              xTickNumber={2}
               values={trendData}
               displayTooltipValueOnly
               numGridLines={3}

--- a/packages/app/src/domain/vaccine/vaccine-administrations-over-time-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-administrations-over-time-chart.tsx
@@ -28,6 +28,7 @@ export function VaccineAdministrationsOverTimeChart({
         minHeight={sm ? 180 : 140}
         timeframe="all"
         values={values}
+        xTickNumber={2}
         displayTooltipValueOnly
         numGridLines={3}
         seriesConfig={[


### PR DESCRIPTION
## Summary

The number of date ticks in a time series was determined based on the screen width. However, sometimes time series are displayed narrow on desktop screens as well, and you get the same spacing issues. This PR makes it possible to force a certain number of ticks in those cases, and applies it to the narrow time series we currently have.