### PR TITLE
Only use smooth scroll for sidebar links, use instant scroll for all others

### DIFF
--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -4,14 +4,13 @@ import { NextRouter, useRouter } from 'next/router';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 import { UrlObject } from 'url';
+import chevronUrl from '~/assets/chevron.svg';
 import { Box } from '~/components/base';
 import { Anchor, Text } from '~/components/typography';
 import { SpaceValue } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { Link } from '~/utils/link';
 import { AsideTitle } from './title';
-
-import chevronUrl from '~/assets/chevron.svg';
 
 type Url = UrlObject | string;
 
@@ -96,7 +95,7 @@ export function MetricMenuItemLink({
 
   return (
     <MetricMenuItem>
-      <Link href={href} passHref>
+      <Link href={href} scrollBehavior="smooth" passHref>
         <StyledAnchor isActive={isActive}>{content}</StyledAnchor>
       </Link>
     </MetricMenuItem>
@@ -123,7 +122,7 @@ export function MetricMenuButtonLink({
 
   return (
     <MetricMenuButton isActive={isActive} buttonVariant={buttonVariant}>
-      <Link href={href} passHref>
+      <Link href={href} scrollBehavior="smooth" passHref>
         <StyledAnchor isButton={true} isActive={isActive}>
           <AsideTitle title={title} subtitle={subtitle} />
           {children && <ChildrenWrapper>{children}</ChildrenWrapper>}

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -33,13 +33,7 @@ export default function App(props: AppProps) {
   );
 
   useEffect(() => {
-    const handleRouteChange = (pathname: string) => {
-      piwik.pageview();
-
-      if (!pathname.includes('#')) {
-        scrollToTop();
-      }
-    };
+    const handleRouteChange = () => piwik.pageview();
 
     router.events.on('routeChangeComplete', handleRouteChange);
     return () => {
@@ -69,13 +63,4 @@ export default function App(props: AppProps) {
       </ThemeProvider>
     </>
   );
-}
-
-function scrollToTop() {
-  const navigationBar = document.querySelector(
-    '#main-navigation'
-  ) as HTMLElement | null;
-  const offset = navigationBar?.offsetTop ?? 0;
-
-  window.scrollTo(0, window.scrollY >= offset ? offset : 0);
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -1,10 +1,50 @@
 // eslint-disable-next-line no-restricted-imports
-import NextLink, { LinkProps } from 'next/link';
+import NextLink, { LinkProps as NextLinkProps } from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useCallback } from 'react';
+
+type LinkProps = NextLinkProps & {
+  scrollBehavior?: ScrollBehavior;
+  children?: React.ReactNode;
+};
 
 /**
  * Link component which disables the default Next/Link scroll behavior
  */
 
-export function Link(props: LinkProps & { children?: React.ReactNode }) {
-  return <NextLink prefetch={false} scroll={false} locale={false} {...props} />;
+export function Link({ scrollBehavior = 'auto', ...props }: LinkProps) {
+  const router = useRouter();
+
+  const onClick = useCallback(() => {
+    const handleRouteChange = (pathname: string) => {
+      if (!pathname.includes('#')) {
+        scrollToTop();
+      }
+      document.documentElement.style.scrollBehavior = '';
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+
+    // Default is 'smooth' through CSS so anchor links have smooth scroll as
+    // well, so we have to temporarily overwrite it if it is 'auto' to get an
+    // instant scroll.
+    if (scrollBehavior === 'auto') {
+      document.documentElement.style.scrollBehavior = 'auto';
+    }
+    router.events.on('routeChangeComplete', handleRouteChange);
+  }, [router, scrollBehavior]);
+
+  return (
+    <span onClick={onClick}>
+      <NextLink prefetch={false} scroll={false} locale={false} {...props} />
+    </span>
+  );
+}
+
+function scrollToTop() {
+  const navigationBar = document.querySelector(
+    '#main-navigation'
+  ) as HTMLElement | null;
+  const offset = navigationBar?.offsetTop ?? 0;
+
+  window.scrollTo(0, window.scrollY >= offset ? offset : 0);
 }

--- a/packages/app/src/utils/link.tsx
+++ b/packages/app/src/utils/link.tsx
@@ -24,7 +24,7 @@ export function Link({ scrollBehavior = 'auto', ...props }: LinkProps) {
       router.events.off('routeChangeComplete', handleRouteChange);
     };
 
-    // Default is 'smooth' through CSS so anchor links have smooth scroll as
+    // Default is 'smooth' through CSS so hash links have smooth scroll as
     // well, so we have to temporarily overwrite it if it is 'auto' to get an
     // instant scroll.
     if (scrollBehavior === 'auto') {


### PR DESCRIPTION
## Summary

Only for sidebar links the smooth scroll actually makes sense, since the whole sidebar will stay visible. For all other page transitions the whole page will be replaced, which makes an instant scroll-to-top more logical. The only exception on this (I found while building this) are hash links: they will stay on the same page, or scroll to a specific position on a new page. In both cases a smooth scroll will help the user have some sense of where they are on the page.

## Design + Drawbacks

It took me a while to find the best way of doing it, because it seems like a really clean solution is not really possible. There are 3 main reasons for that:

1. We cannot detect through a route change event which link triggered the route change. Path is not reliable, since there are also links from non-sidebar pages to sidebar pages, and in those cases we don't want a smooth scroll. This makes that we have to fix this through some `onClick` behaviour on the links themselves.
2. Next links do not have something which lets you add your own `onClick` behaviour. I tried adjusting the `onClick` of the link's child (that's how the Next link itself makes it work without adding a wrapper element), but there's _a lot_ of edge cases you need to consider to do that properly, so I quickly abandoned that approach. Resolved to adding a wrapper element for our own `onClick` behaviour anyway. It seems like it does not impact styling of links on the site, but I don't know if there are links somewhere I didn't look at that are susceptible to this.
3. Because hash links still need a smooth scroll, we need to keep the smooth scroll on there through CSS. Since the options for `scrollTo()` behaviour are only 'smooth' or 'auto', we cannot use that to force an instant scroll once the smooth scroll is set through CSS. The only way of doing that is to temporarily overwrite that style. Not that nice, but it works.

If anyone sees another (cleaner) solution of the above points, please say so!
