### PR TITLE
Add dates to vaccination coverage tiles

### DIFF
--- a/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
@@ -65,7 +65,10 @@ export function VaccineCoverageChoroplethPerGm({
         title:
           siteText.vaccinaties.nl_choropleth_vaccinatie_graad.legenda_titel,
       }}
-      metadata={{ source: siteText.brononderzoek.bronnen.rivm }}
+      metadata={{
+        source: siteText.brononderzoek.bronnen.rivm,
+        date: data[selectedMap][0].date_unix,
+      }}
       chartRegion={selectedMap}
       onChartRegionChange={setSelectedMap}
     >

--- a/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
@@ -66,7 +66,7 @@ export function VaccineCoverageChoroplethPerGm({
           siteText.vaccinaties.nl_choropleth_vaccinatie_graad.legenda_titel,
       }}
       metadata={{
-        source: siteText.brononderzoek.bronnen.rivm,
+        source: siteText.vaccinaties.vaccination_coverage.bronnen.rivm,
         date: data[selectedMap][0].date_unix,
       }}
       chartRegion={selectedMap}

--- a/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group-vr-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group-vr-gm.tsx
@@ -47,7 +47,14 @@ export function VaccineCoveragePerAgeGroupVrGm({
   );
 
   return (
-    <ChartTile title={title} description={description}>
+    <ChartTile
+      title={title}
+      description={description}
+      metadata={{
+        source: siteText.vaccinaties.vaccination_coverage.bronnen.rivm,
+        date: data[0].date_unix,
+      }}
+    >
       <Box overflow="auto" spacing={3}>
         <StyledTable>
           <thead>

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -180,6 +180,10 @@ export const VaccinationsGmPage = (
                 siteText.vaccinaties.vr_choropleth_vaccinatie_graad
                   .legend_title,
             }}
+            metadata={{
+              source: siteText.vaccinaties.vaccination_coverage.bronnen.rivm,
+              date: choropleth.gm.vaccine_coverage_per_age_group[0].date_unix,
+            }}
           >
             <DynamicChoropleth
               renderTarget="canvas"

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -168,6 +168,10 @@ export const VaccinationsVrPage = (
                 siteText.vaccinaties.vr_choropleth_vaccinatie_graad
                   .legend_title,
             }}
+            metadata={{
+              source: siteText.vaccinaties.vaccination_coverage.bronnen.rivm,
+              date: choropleth.gm.vaccine_coverage_per_age_group[0].date_unix,
+            }}
           >
             <DynamicChoropleth
               renderTarget="canvas"


### PR DESCRIPTION
## Summary

Adds missing dates & source metadata to vaccine coverage tiles (NL, VR & GM)
