### PR TITLE
Use markdown for CTA links

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -15,7 +15,7 @@ import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
-import { Anchor, InlineText, Text } from '~/components/typography';
+import { InlineText, Text } from '~/components/typography';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { GNumberBarChartTile } from '~/domain/tested/g-number-bar-chart-tile';
@@ -150,9 +150,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                     ),
                   })}
                 </Text>
-                <Anchor underline="hover" href="#ggd">
-                  {ggdText.summary_link_cta}
-                </Anchor>
+                <Markdown content={ggdText.summary_link_cta} />
               </Box>
             </KpiTile>
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -12,7 +12,7 @@ import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
-import { Anchor, InlineText, Text } from '~/components/typography';
+import { InlineText, Text } from '~/components/typography';
 import { gmCodesByVrCode } from '~/data/gm-codes-by-vr-code';
 import { Layout } from '~/domain/layout/layout';
 import { VrLayout } from '~/domain/layout/vr-layout';
@@ -160,9 +160,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                       ),
                     })}
                   </Text>
-                  <Anchor underline="hover" href="#ggd">
-                    {ggdText.summary_link_cta}
-                  </Anchor>
+                  <Markdown content={ggdText.summary_link_cta} />
                 </Box>
               </Box>
             </KpiTile>


### PR DESCRIPTION
## Summary

Use Markdown for CTA links

With this change, in Lokalize an adjustment to the `ggdText.summary_link_cta` needs to be done to include eg a link to the `#ggd` anchor.