### PR TITLE
Add date to VR positive tests text

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,5 +1,4 @@
 import { GgdTesten, Test } from '@corona-dashboard/icons';
-import css from '@styled-system/css';
 import { useState } from 'react';
 import { Box, Spacer } from '~/components/base';
 import { RegionControlOption } from '~/components/chart-region-controls';

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -139,10 +139,9 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 <Text variant="body2" fontWeight="bold">
                   {replaceComponentsInText(ggdText.summary_text, {
                     percentage: (
-                      <span css={css({ color: 'data.primary' })}>
-                        {formatPercentage(dataGgdLastValue.infected_percentage)}
-                        %
-                      </span>
+                      <InlineText color="data.primary">{`${formatPercentage(
+                        dataGgdLastValue.infected_percentage
+                      )}%`}</InlineText>
                     ),
                     dateTo: formatDateFromSeconds(
                       dataGgdLastValue.date_unix,

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -81,7 +81,8 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
     lastGenerated,
   } = props;
 
-  const { siteText, formatNumber, formatPercentage } = useIntl();
+  const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
+    useIntl();
 
   const reverseRouter = useReverseRouter();
 
@@ -157,6 +158,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                         <InlineText color="data.primary">{`${formatPercentage(
                           dataGgdLastValue.infected_percentage
                         )}%`}</InlineText>
+                      ),
+                      dateTo: formatDateFromSeconds(
+                        dataGgdLastValue.date_unix,
+                        'weekday-medium'
                       ),
                     })}
                   </Text>


### PR DESCRIPTION
## Summary

Was already present on NL but not on VR. This PR makes both texts the same.

Note that when releasing this, the content still has to be updated to include the date.
