### PR TITLE
Add page links to hospital admissions and IC page and rename useful links

### DIFF
--- a/packages/app/src/components/page-information-block/components/page-links.tsx
+++ b/packages/app/src/components/page-information-block/components/page-links.tsx
@@ -11,14 +11,14 @@ import { asResponsiveArray } from '~/style/utils';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 import { Link } from '~/utils/link';
 
-interface usefulLinksProps {
+interface pageLinksProps {
   links: {
     title: string;
     href: string;
   }[];
 }
 
-export function UsefulLinks({ links }: usefulLinksProps) {
+export function PageLinks({ links }: pageLinksProps) {
   const { siteText } = useIntl();
 
   return (

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -11,14 +11,14 @@ import { RichContentBlock } from '~/types/cms';
 import { Articles } from './components/articles';
 import { Header } from './components/header';
 import { Metadata, MetadataProps } from './components/metadata';
-import { UsefulLinks } from './components/useful-links';
+import { PageLinks } from './components/page-links';
 
 interface InformationBlockProps {
   title?: string;
   icon?: JSX.Element;
   description?: string | RichContentBlock[] | ReactNode;
   articles?: ArticleSummary[];
-  usefulLinks?: {
+  pageLinks?: {
     title: string;
     href: string;
   }[];
@@ -35,7 +35,7 @@ export function PageInformationBlock({
   icon,
   description,
   articles,
-  usefulLinks,
+  pageLinks,
   metadata,
   referenceLink,
   id,
@@ -83,7 +83,7 @@ export function PageInformationBlock({
               gridTemplateColumns="repeat(2, 1fr)"
               width="100%"
               spacing={{
-                _: usefulLinks && usefulLinks.length > 0 ? 0 : 3,
+                _: pageLinks && pageLinks.length > 0 ? 0 : 3,
                 md: 0,
               }}
               css={css({
@@ -107,10 +107,10 @@ export function PageInformationBlock({
               )}
             </Box>
 
-            {usefulLinks && usefulLinks.length > 0 && (
+            {pageLinks && pageLinks.length > 0 && (
               <>
                 <Box height="1px" bg="border" />
-                <UsefulLinks links={usefulLinks} />
+                <PageLinks links={pageLinks} />
               </>
             )}
           </Box>

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -150,7 +150,7 @@ export const VaccinationsGmPage = (
               dateOfInsertionUnix: filteredAgeGroup.date_of_insertion_unix,
               dataSources: [],
             }}
-            usefulLinks={content.page.usefulLinks}
+            pageLinks={content.page.pageLinks}
             referenceLink={text.informatie_blok.reference.href}
             articles={content.highlight.articles}
           />

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -36,6 +36,8 @@ import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+import { HospitalAdmissionsPageQuery } from '~/types/cms';
+import { getHospitalAdmissionsPageQuery } from '~/queries/hospital-admissions-page-query';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -48,13 +50,15 @@ export const getStaticProps = createGetStaticProps(
     }),
   }),
   createGetContent<{
-    page: PageArticlesQueryResult;
+    page: HospitalAdmissionsPageQuery;
+    highlight: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
     const { locale } = context;
 
     return `{
-      "page": ${createPageArticlesQuery('hospitalPage', locale)},
+      "page": ${getHospitalAdmissionsPageQuery(context)},
+      "highlight": ${createPageArticlesQuery('hospitalPage', locale)},
       "elements": ${createElementsQuery('gm', ['hospital_nice'], locale)}
     }`;
   })
@@ -115,7 +119,8 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [text.bronnen.rivm],
             }}
             referenceLink={text.reference.href}
-            articles={content.page.articles}
+            pageLinks={content.page.pageLinks}
+            articles={content.highlight.articles}
           />
 
           <TwoKpiSection>

--- a/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/internationaal/positief-geteste-mensen.tsx
@@ -147,7 +147,7 @@ export default function PositiefGetesteMensenPage(
             }}
             referenceLink={text.reference.href}
             articles={content.highlight.articles}
-            usefulLinks={content.page.usefulLinks}
+            pageLinks={content.page.pageLinks}
           />
 
           <InformationTile message={text.informatie_tegel} />

--- a/packages/app/src/pages/internationaal/varianten.tsx
+++ b/packages/app/src/pages/internationaal/varianten.tsx
@@ -63,14 +63,14 @@ export const getStaticProps = withFeatureNotFoundPage(
     },
     createGetContent<{
       page: {
-        usefulLinks?: LinkProps[];
+        pageLinks?: LinkProps[];
       };
       highlight: PageArticlesQueryResult;
     }>((context) => {
       const { locale } = context;
       return `{
         "page": *[_type=='in_variantsPage']{
-          "usefulLinks": [...pageLinks[]{
+          "pageLinks": [...pageLinks[]{
             "title": title.${locale},
             "href": href,
           }]
@@ -162,7 +162,7 @@ export default function VariantenPage(
             }}
             referenceLink={text.reference.href}
             articles={content.highlight?.articles}
-            usefulLinks={content.page?.usefulLinks}
+            pageLinks={content.page?.pageLinks}
           />
 
           <InformationTile message={text.informatie_tegel} />

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -34,17 +34,21 @@ import {
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { IntakeHospitalPageQuery } from '~/types/cms';
+import { getIntakeHospitalPageQuery } from '~/queries/intake-hospital-page-query';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectNlPageMetricData('intensive_care_lcps'),
   createGetContent<{
-    page: PageArticlesQueryResult;
+    page: IntakeHospitalPageQuery;
+    highlight: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
     const { locale } = context;
     return `{
-      "page": ${createPageArticlesQuery('intensiveCarePage', locale)},
+      "page": ${getIntakeHospitalPageQuery(context)},
+      "highlight": ${createPageArticlesQuery('intensiveCarePage', locale)},
       "elements": ${createElementsQuery('nl', ['intensive_care_nice'], locale)}
     }`;
   })
@@ -88,7 +92,8 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [text.bronnen.nice, text.bronnen.lnaz],
             }}
             referenceLink={text.reference.href}
-            articles={content.page.articles}
+            pageLinks={content.page.pageLinks}
+            articles={content.highlight.articles}
           />
 
           <TwoKpiSection>

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -132,7 +132,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                   .date_of_insertion_unix,
               dataSources: [],
             }}
-            usefulLinks={content.page.usefulLinks}
+            pageLinks={content.page.pageLinks}
             referenceLink={text.reference.href}
             articles={content.highlight.articles}
           />

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -98,7 +98,7 @@ export default function CovidVariantenPage(
               dataSources: [text.bronnen.rivm],
             }}
             referenceLink={text.reference.href}
-            usefulLinks={content.page.pageLinks}
+            pageLinks={content.page.pageLinks}
             articles={content.highlight.articles}
           />
 

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -40,6 +40,8 @@ import {
 import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+import { HospitalAdmissionsPageQuery } from '~/types/cms';
+import { getHospitalAdmissionsPageQuery } from '~/queries/hospital-admissions-page-query';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -49,13 +51,15 @@ export const getStaticProps = createGetStaticProps(
     gm: ({ hospital_nice }) => ({ hospital_nice }),
   }),
   createGetContent<{
-    page: PageArticlesQueryResult;
+    page: HospitalAdmissionsPageQuery;
+    highlight: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
     const { locale } = context;
 
     return `{
-      "page": ${createPageArticlesQuery('hospitalPage', locale)},
+      "page": ${getHospitalAdmissionsPageQuery(context)},
+      "highlight": ${createPageArticlesQuery('hospitalPage', locale)},
       "elements": ${createElementsQuery('nl', ['hospital_nice'], locale)}
     }`;
   })
@@ -103,7 +107,8 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [text.bronnen.nice, text.bronnen.lnaz],
             }}
             referenceLink={text.reference.href}
-            articles={content.page.articles}
+            pageLinks={content.page.pageLinks}
+            articles={content.highlight.articles}
           />
 
           <TwoKpiSection>

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -142,7 +142,7 @@ export const VaccinationsVrPage = (
               dateOfInsertionUnix: filteredAgeGroup.date_of_insertion_unix,
               dataSources: [],
             }}
-            usefulLinks={content.page.usefulLinks}
+            pageLinks={content.page.pageLinks}
             referenceLink={text.informatie_blok.reference.href}
             articles={content.highlight.articles}
           />

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -36,6 +36,8 @@ import { colors } from '~/style/theme';
 import { getBoundaryDateStartUnix } from '~/utils/get-trailing-date-range';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+import { HospitalAdmissionsPageQuery } from '~/types/cms';
+import { getHospitalAdmissionsPageQuery } from '~/queries/hospital-admissions-page-query';
 
 export { getStaticPaths } from '~/static-paths/vr';
 
@@ -46,13 +48,15 @@ export const getStaticProps = createGetStaticProps(
     gm: ({ hospital_nice }) => ({ hospital_nice }),
   }),
   createGetContent<{
-    page: PageArticlesQueryResult;
+    page: HospitalAdmissionsPageQuery;
+    highlight: PageArticlesQueryResult;
     elements: ElementsQueryResult;
   }>((context) => {
     const { locale } = context;
 
     return `{
-      "page": ${createPageArticlesQuery('hospitalPage', locale)},
+      "page": ${getHospitalAdmissionsPageQuery(context)},
+      "highlight": ${createPageArticlesQuery('hospitalPage', locale)},
       "elements": ${createElementsQuery('vr', ['hospital_nice'], locale)}
     }`;
   })
@@ -109,7 +113,8 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [text.bronnen.rivm],
             }}
             referenceLink={text.reference.href}
-            articles={content.page.articles}
+            pageLinks={content.page.pageLinks}
+            articles={content.highlight.articles}
           />
 
           <TwoKpiSection>

--- a/packages/app/src/queries/hospital-admissions-page-query.ts
+++ b/packages/app/src/queries/hospital-admissions-page-query.ts
@@ -1,10 +1,10 @@
 import { GetStaticPropsContext } from 'next';
 
-export function getInPositiveTestsQuery(context: GetStaticPropsContext) {
+export function getHospitalAdmissionsPageQuery(context: GetStaticPropsContext) {
   const { locale } = context;
 
   return `
-  *[_type=='in_positiveTestsPage']{
+  *[_type=='hospitalPage']{
     "pageLinks": [...pageLinks[]{
       "title": title.${locale},
       "href": href,

--- a/packages/app/src/queries/intake-hospital-page-query.ts
+++ b/packages/app/src/queries/intake-hospital-page-query.ts
@@ -1,10 +1,10 @@
 import { GetStaticPropsContext } from 'next';
 
-export function getInPositiveTestsQuery(context: GetStaticPropsContext) {
+export function getIntakeHospitalPageQuery(context: GetStaticPropsContext) {
   const { locale } = context;
 
   return `
-  *[_type=='in_positiveTestsPage']{
+  *[_type=='intensiveCarePage']{
     "pageLinks": [...pageLinks[]{
       "title": title.${locale},
       "href": href,

--- a/packages/app/src/queries/vaccine-page-query.ts
+++ b/packages/app/src/queries/vaccine-page-query.ts
@@ -2,7 +2,7 @@ export function getVaccinePageQuery(locale: string) {
   return `
   *[_type=='vaccinationsPage']{
     "pageDescription": pageDescription.${locale},
-    "usefulLinks": [...usefulLinks[]{
+    "pageLinks": [...usefulLinks[]{
       "title": title.${locale},
       "category": category.${locale},
       "href": href,
@@ -20,7 +20,7 @@ export function getVaccinePageQuery(locale: string) {
     }],
     "expectedMilestones": [...expected[]{
       "item": ${locale}
-    }] 
+    }]
   }[0]
 `;
 }

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -171,11 +171,19 @@ export interface LokalizeText {
 
 export type VaccinationPageQuery = {
   pageDescription: RichContentBlock[];
-  usefulLinks: LinkProps[];
+  pageLinks: LinkProps[];
   title: string;
   description: RichContentBlock[];
   milestones: Milestones[];
   expectedMilestones: ExpectedMilestones[];
+};
+
+export type HospitalAdmissionsPageQuery = {
+  pageLinks: LinkProps[];
+};
+
+export type IntakeHospitalPageQuery = {
+  pageLinks: LinkProps[];
 };
 
 export type InlineLink = {
@@ -194,5 +202,5 @@ export type VariantsPageQuery = {
 };
 
 export type InPositiveTestsQuery = {
-  usefulLinks?: LinkProps[];
+  pageLinks?: LinkProps[];
 };

--- a/packages/cms/src/schemas/documents/pages/hospital-page.ts
+++ b/packages/cms/src/schemas/documents/pages/hospital-page.ts
@@ -1,8 +1,9 @@
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const hospitalPage = {
   title: 'Ziekenhuis opnames',
   name: 'hospitalPage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLES],
+  fields: [HIGHLIGHTED_ARTICLES, PAGE_LINKS],
 };

--- a/packages/cms/src/schemas/documents/pages/in-positive-tests-page.ts
+++ b/packages/cms/src/schemas/documents/pages/in-positive-tests-page.ts
@@ -1,19 +1,9 @@
-import { Rule } from '~/sanity';
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const in_positiveTestsPage = {
   title: 'Positieve testen Internationaal',
   name: 'in_positiveTestsPage',
   type: 'document',
-  fields: [
-    HIGHLIGHTED_ARTICLES,
-    {
-      title: "'Ook interessant' links",
-      description: 'Maximaal 4 links naar interessante onderwerpen.',
-      name: 'pageLinks',
-      type: 'array',
-      of: [{ type: 'link' }],
-      validation: (rule: Rule) => rule.required().min(1).max(4),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLES, PAGE_LINKS],
 };

--- a/packages/cms/src/schemas/documents/pages/in-variants-page.ts
+++ b/packages/cms/src/schemas/documents/pages/in-variants-page.ts
@@ -1,19 +1,9 @@
-import { Rule } from '~/sanity';
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const in_variantsPage = {
   title: 'Varianten Internationaal',
   name: 'in_variantsPage',
   type: 'document',
-  fields: [
-    HIGHLIGHTED_ARTICLES,
-    {
-      title: "'Ook interessant' links",
-      description: 'Maximaal 4 links naar interessante onderwerpen.',
-      name: 'pageLinks',
-      type: 'array',
-      of: [{ type: 'link' }],
-      validation: (rule: Rule) => rule.required().min(1).max(4),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLES, PAGE_LINKS],
 };

--- a/packages/cms/src/schemas/documents/pages/intensive-care-page.ts
+++ b/packages/cms/src/schemas/documents/pages/intensive-care-page.ts
@@ -1,8 +1,9 @@
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const intensiveCarePage = {
   title: 'Intensive care pagina',
   name: 'intensiveCarePage',
   type: 'document',
-  fields: [HIGHLIGHTED_ARTICLES],
+  fields: [HIGHLIGHTED_ARTICLES, PAGE_LINKS],
 };

--- a/packages/cms/src/schemas/documents/pages/vaccinations-page.ts
+++ b/packages/cms/src/schemas/documents/pages/vaccinations-page.ts
@@ -1,5 +1,6 @@
 import { Rule } from '~/sanity';
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const vaccinationsPage = {
   title: 'Vaccinaties pagina',
@@ -12,14 +13,7 @@ export const vaccinationsPage = {
       name: 'pageDescription',
       type: 'localeBlock',
     },
-    {
-      title: "'Ook interessant' links",
-      description: 'Maximaal 4 links naar interessante onderwerpen.',
-      name: 'usefulLinks',
-      type: 'array',
-      of: [{ type: 'link' }],
-      validation: (rule: Rule) => rule.required().min(1).max(4),
-    },
+    PAGE_LINKS,
     {
       fieldset: 'milestones',
       name: 'title',

--- a/packages/cms/src/schemas/documents/pages/variants-page.ts
+++ b/packages/cms/src/schemas/documents/pages/variants-page.ts
@@ -1,19 +1,9 @@
-import { Rule } from '~/sanity';
 import { HIGHLIGHTED_ARTICLES } from '../../fields/highlighted-articles';
+import { PAGE_LINKS } from '../../fields/page-links';
 
 export const variantsPage = {
   title: 'Covid varianten',
   name: 'variantsPage',
   type: 'document',
-  fields: [
-    HIGHLIGHTED_ARTICLES,
-    {
-      title: "'Ook interessant' links",
-      description: 'Maximaal 4 links naar interessante onderwerpen.',
-      name: 'pageLinks',
-      type: 'array',
-      of: [{ type: 'link' }],
-      validation: (rule: Rule) => rule.required().min(1).max(4),
-    },
-  ],
+  fields: [HIGHLIGHTED_ARTICLES, PAGE_LINKS],
 };

--- a/packages/cms/src/schemas/fields/index.ts
+++ b/packages/cms/src/schemas/fields/index.ts
@@ -1,2 +1,3 @@
 export * from './article-fields';
 export * from './highlighted-articles';
+export * from './page-links';

--- a/packages/cms/src/schemas/fields/page-links.ts
+++ b/packages/cms/src/schemas/fields/page-links.ts
@@ -1,0 +1,10 @@
+import { Rule } from '~/sanity';
+
+export const PAGE_LINKS = {
+  title: "'Ook interessant' links",
+  description: 'Maximaal 4 links naar interessante onderwerpen.',
+  name: 'pageLinks',
+  type: 'array',
+  of: [{ type: 'link' }],
+  validation: (rule: Rule) => rule.required().min(1).max(4),
+};


### PR DESCRIPTION
- Add new page links to the hospital admissions (NL/VR/GM) page and the hospital intake page (NL).
- Made the `page-link` a bit more generic in the CMS structure and easier to use.
- Renamed useful links to `page-links` to avoid confusion and be more consistent.
- The reason why I did choose `page-links` is actually that it was already defined in the CMS like that and I thought creating a migration script for such a minor thing wasn't worth it.