### PR TITLE
Create mandatory amount prop for difference tiles  & fix difference labels everywhere

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -1,7 +1,5 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
-import { Gelijk } from '@corona-dashboard/icons';
-import { Up } from '@corona-dashboard/icons';
-import { Down } from '@corona-dashboard/icons';
+import { Down, Gelijk, Up } from '@corona-dashboard/icons';
 import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
@@ -9,9 +7,11 @@ import { Container, IconContainer } from './containers';
 export function TileAverageDifference({
   value,
   isPercentage,
+  isAmount,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
   isPercentage?: boolean;
+  isAmount: boolean;
 }) {
   const { difference, old_value } = value;
   const { siteText, formatNumber } = useIntl();
@@ -22,6 +22,8 @@ export function TileAverageDifference({
     })`}</InlineText>
   );
 
+  const text = siteText.toe_en_afname;
+
   if (difference > 0)
     return (
       <Container>
@@ -29,10 +31,11 @@ export function TileAverageDifference({
           <Up />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {formatNumber(Math.abs(difference))} {siteText.toe_en_afname.hoger}{' '}
+          {formatNumber(Math.abs(difference))}{' '}
+          {isAmount ? text.toename : text.hoger}{' '}
         </InlineText>
         <InlineText>
-          {siteText.toe_en_afname.zeven_daags_gemiddelde}
+          {text.zeven_daags_gemiddelde}
           {oldValue}
         </InlineText>
       </Container>
@@ -45,10 +48,11 @@ export function TileAverageDifference({
           <Down />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {formatNumber(Math.abs(difference))} {siteText.toe_en_afname.lager}{' '}
+          {formatNumber(Math.abs(difference))}{' '}
+          {isAmount ? text.afname : text.lager}{' '}
         </InlineText>
         <InlineText>
-          {siteText.toe_en_afname.zeven_daags_gemiddelde}
+          {text.zeven_daags_gemiddelde}
           {oldValue}
         </InlineText>
       </Container>
@@ -59,11 +63,9 @@ export function TileAverageDifference({
       <IconContainer color="data.neutral">
         <Gelijk />
       </IconContainer>
-      <InlineText fontWeight="bold">
-        {siteText.toe_en_afname.gelijk}{' '}
-      </InlineText>
+      <InlineText fontWeight="bold">{text.gelijk} </InlineText>
       <InlineText>
-        {siteText.toe_en_afname.zeven_daags_gemiddelde}
+        {text.zeven_daags_gemiddelde}
         {oldValue}
       </InlineText>
     </Container>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -1,7 +1,5 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
-import { Gelijk } from '@corona-dashboard/icons';
-import { Up } from '@corona-dashboard/icons';
-import { Down } from '@corona-dashboard/icons';
+import { Down, Gelijk, Up } from '@corona-dashboard/icons';
 import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
@@ -12,14 +10,14 @@ export function TileDifference({
   maximumFractionDigits,
   isPercentage,
   showOldDateUnix,
-  hasHigherLowerText,
+  isAmount,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
   isDecimal?: boolean;
   maximumFractionDigits?: number;
   isPercentage?: boolean;
   showOldDateUnix?: boolean;
-  hasHigherLowerText?: boolean;
+  isAmount: boolean;
 }) {
   const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
     useIntl();
@@ -39,9 +37,9 @@ export function TileDifference({
     : text.vorige_waarde;
 
   if (difference > 0) {
-    const splitText = hasHigherLowerText
-      ? text.hoger.split(' ')
-      : text.toename.split(' ');
+    const splitText = isAmount
+      ? text.toename.split(' ')
+      : text.hoger.split(' ');
 
     return (
       <Container>
@@ -60,9 +58,7 @@ export function TileDifference({
   }
 
   if (difference < 0) {
-    const splitText = hasHigherLowerText
-      ? text.lager.split(' ')
-      : text.afname.split(' ');
+    const splitText = isAmount ? text.afname.split(' ') : text.lager.split(' ');
 
     return (
       <Container>

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -10,15 +10,26 @@ import {
 import { ValueAnnotation } from '~/components/value-annotation';
 import { useIntl } from '~/intl';
 
-interface KpiValueProps {
+interface KpiValueBaseProps {
   absolute?: number;
   percentage?: number;
   valueAnnotation?: string;
-  difference?: DifferenceDecimal | DifferenceInteger;
   text?: string;
   color?: string;
   isMovingAverageDifference?: boolean;
 }
+
+type DifferenceProps =
+  | {
+      difference?: never;
+      isAmount?: boolean;
+    }
+  | {
+      difference: DifferenceDecimal | DifferenceInteger;
+      isAmount: boolean;
+    };
+
+type KpiValueProps = KpiValueBaseProps & DifferenceProps;
 
 /**
  * When we need to style something specific there is no real reason to use the
@@ -52,6 +63,7 @@ export function KpiValue({
   text,
   color = 'data.primary',
   isMovingAverageDifference,
+  isAmount,
   ...otherProps
 }: KpiValueProps) {
   const { formatPercentage, formatNumber } = useIntl();
@@ -77,15 +89,18 @@ export function KpiValue({
       )}
 
       {isDefined(difference) &&
+        isDefined(isAmount) &&
         (isMovingAverageDifference ? (
           <TileAverageDifference
             value={difference}
             isPercentage={isDefined(percentage) && !isDefined(absolute)}
+            isAmount={isAmount}
           />
         ) : (
           <TileDifference
             value={difference}
             isPercentage={isDefined(percentage) && !isDefined(absolute)}
+            isAmount={isAmount}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}

--- a/packages/app/src/components/page-barscale.tsx
+++ b/packages/app/src/components/page-barscale.tsx
@@ -23,19 +23,29 @@ import { TileAverageDifference, TileDifference } from './difference-indicator';
  *
  * I think we can come up with a better name, maybe later.
  */
-interface PageBarScaleProps<T> {
+interface PageBarScaleBaseProps<T> {
   scope: DataScope;
   data: T;
   localeTextKey: keyof SiteText;
   metricName: MetricKeys<T>;
   metricProperty: string;
-  differenceKey?: string;
   differenceFractionDigits?: number;
   currentValue?: number;
   isMovingAverageDifference?: boolean;
   showOldDateUnix?: boolean;
-  hasHigherLowerText?: boolean;
 }
+
+type DifferenceProps =
+  | {
+      differenceKey?: never;
+      isAmount?: boolean;
+    }
+  | {
+      differenceKey: string;
+      isAmount: boolean;
+    };
+
+type PageBarScaleProps<T> = PageBarScaleBaseProps<T> & DifferenceProps;
 
 export function PageBarScale<T>({
   data,
@@ -47,7 +57,7 @@ export function PageBarScale<T>({
   differenceFractionDigits,
   isMovingAverageDifference,
   showOldDateUnix,
-  hasHigherLowerText,
+  isAmount,
 }: PageBarScaleProps<T>) {
   const { siteText } = useIntl();
 
@@ -137,15 +147,16 @@ export function PageBarScale<T>({
       />
 
       {isDefined(differenceKey) &&
+        isDefined(isAmount) &&
         (isMovingAverageDifference ? (
-          <TileAverageDifference value={differenceValue} />
+          <TileAverageDifference value={differenceValue} isAmount={isAmount} />
         ) : (
           <TileDifference
             value={differenceValue}
             isDecimal={config.isDecimal}
             maximumFractionDigits={differenceFractionDigits}
             showOldDateUnix={showOldDateUnix}
-            hasHigherLowerText={hasHigherLowerText}
+            isAmount={isAmount}
           />
         ))}
     </Box>

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -133,6 +133,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.tested_overall__infected_moving_average
                 }
+                isAmount
                 isMovingAverageDifference
               />
               <Text>
@@ -163,6 +164,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   data.difference
                     .tested_overall__infected_per_100k_moving_average
                 }
+                isAmount
                 isMovingAverageDifference
               />
               <Text>{text.barscale_toelichting}</Text>

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -157,6 +157,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={sewerAverages.last_value.average}
                 valueAnnotation={siteText.waarde_annotaties.riool_normalized}
                 difference={data.difference.sewer__average}
+                isAmount
               />
               <Text>
                 {replaceComponentsInText(

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -99,6 +99,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="covid_daily"
                 absolute={dataRivm.last_value.covid_daily}
                 difference={difference.deceased_rivm__covid_daily}
+                isAmount
               />
               <Markdown
                 content={text.section_deceased_rivm.kpi_covid_daily_description}

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -134,6 +134,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                   data.difference
                     .hospital_nice__admissions_on_date_of_reporting_moving_average
                 }
+                isAmount
                 isMovingAverageDifference
               />
             </KpiTile>

--- a/packages/app/src/pages/landelijk/coronamelder.tsx
+++ b/packages/app/src/pages/landelijk/coronamelder.tsx
@@ -1,10 +1,10 @@
+import { External, Phone } from '@corona-dashboard/icons';
 import { css } from '@styled-system/css';
 import styled from 'styled-components';
-import { External } from '@corona-dashboard/icons';
-import { Phone } from '@corona-dashboard/icons';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { Tile } from '~/components/tile';
 import { TileList } from '~/components/tile-list';
@@ -25,7 +25,6 @@ import {
 import { colors } from '~/style/theme';
 import { Link } from '~/utils/link';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
-import { Markdown } from '~/components/markdown';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -78,6 +77,7 @@ const CoronamelderPage = (props: StaticProps<typeof getStaticProps>) => {
               <KpiValue
                 absolute={warningLastValue.count}
                 difference={data.difference.corona_melder_app_warning__count}
+                isAmount
               />
 
               <Markdown

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -104,6 +104,7 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.disability_care__newly_infected_people
                 }
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>
@@ -188,6 +189,7 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.disability_care__infected_locations_total
                 }
+                isAmount
               />
               <Text>{infectedLocationsText.kpi_toelichting}</Text>
             </KpiTile>

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -106,6 +106,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                 metricProperty="admissions_on_date_of_reporting"
                 localeTextKey="ic_opnames_per_dag"
                 differenceKey="intensive_care_nice__admissions_on_date_of_reporting_moving_average"
+                isAmount
                 isMovingAverageDifference
               />
               <Markdown content={text.extra_uitleg} />
@@ -127,6 +128,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                       difference={
                         data.difference.intensive_care_lcps__beds_occupied_covid
                       }
+                      isAmount
                     />
 
                     <Markdown

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -130,6 +130,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={dataOverallLastValue.infected}
                 difference={difference.tested_overall__infected_moving_average}
                 isMovingAverageDifference
+                isAmount
               />
 
               <Markdown content={text.kpi_toelichting} />
@@ -168,6 +169,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 localeTextKey="positief_geteste_personen"
                 differenceKey="tested_overall__infected_per_100k_moving_average"
                 isMovingAverageDifference
+                isAmount
               />
 
               <Text>{text.barscale_toelichting}</Text>
@@ -339,6 +341,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={dataGgdLastValue.tested_total}
                 difference={difference.tested_ggd__tested_total_moving_average}
                 isMovingAverageDifference
+                isAmount
               />
               <Text>{ggdText.totaal_getest_week_uitleg}</Text>
             </KpiTile>
@@ -357,6 +360,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   difference.tested_ggd__infected_percentage_moving_average
                 }
                 isMovingAverageDifference
+                isAmount={false}
               />
 
               <Text>{ggdText.positief_getest_week_uitleg}</Text>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -90,7 +90,7 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
                 differenceKey="reproduction__index_average"
                 differenceFractionDigits={2}
                 showOldDateUnix
-                hasHigherLowerText
+                isAmount={false}
               />
               <Markdown content={text.barscale_toelichting} />
             </KpiWithIllustrationTile>

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -131,6 +131,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={sewerAverages.last_value.average}
                 valueAnnotation={siteText.waarde_annotaties.riool_normalized}
                 difference={data.difference.sewer__average}
+                isAmount
               />
             </KpiTile>
 

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -1,11 +1,12 @@
 import { Coronavirus } from '@corona-dashboard/icons';
 import { AgeDemographic } from '~/components/age-demographic';
 import { ArticleSummary } from '~/components/article-teaser';
+import { Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
 import { PageInformationBlock } from '~/components/page-information-block';
-import { Spacer } from '~/components/base';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
@@ -25,7 +26,6 @@ import {
   selectNlPageMetricData,
 } from '~/static-props/get-data';
 import { colors } from '~/style/theme';
-import { Markdown } from '~/components/markdown';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -95,6 +95,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="covid_daily"
                 absolute={dataRivm.last_value.covid_daily}
                 difference={data.difference.deceased_rivm__covid_daily}
+                isAmount
               />
               <Markdown
                 content={text.section_deceased_rivm.kpi_covid_daily_description}

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -107,6 +107,7 @@ const ElderlyAtHomeNationalPage = (
                 difference={
                   data.difference.elderly_at_home__positive_tested_daily
                 }
+                isAmount
               />
               <Markdown
                 content={text.section_positive_tested.kpi_daily_description}

--- a/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -89,6 +89,7 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={lastValue.covid_symptoms}
                 data-cy="covid_symptoms"
                 difference={data.difference.doctor__covid_symptoms}
+                isAmount
               />
               <Markdown content={text.barscale_toelichting} />
             </KpiTile>
@@ -103,6 +104,7 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={lastValue.covid_symptoms_per_100k}
                 data-cy="covid_symptoms_per_100k"
                 difference={data.difference.doctor__covid_symptoms_per_100k}
+                isAmount
               />
               <Text>{text.normalized_kpi_toelichting}</Text>
             </KpiTile>

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -108,6 +108,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="newly_infected_people"
                 absolute={nursinghomeDataLastValue.newly_infected_people}
                 difference={data.difference.nursing_home__newly_infected_people}
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>
@@ -200,6 +201,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.nursing_home__infected_locations_total
                 }
+                isAmount
               />
               <Text>{infectedLocationsText.kpi_toelichting}</Text>
             </KpiTile>

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -123,6 +123,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                 localeTextKey="ziekenhuisopnames_per_dag"
                 differenceKey="hospital_nice__admissions_on_date_of_reporting_moving_average"
                 isMovingAverageDifference
+                isAmount
               />
             </KpiTile>
 
@@ -141,6 +142,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                   difference={
                     data.difference.hospital_lcps__beds_occupied_covid
                   }
+                  isAmount
                 />
               )}
             </KpiTile>

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -1,6 +1,8 @@
-import { Coronavirus } from '@corona-dashboard/icons';
-import { GehandicaptenZorg } from '@corona-dashboard/icons';
-import { Locatie } from '@corona-dashboard/icons';
+import {
+  Coronavirus,
+  GehandicaptenZorg,
+  Locatie,
+} from '@corona-dashboard/icons';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
@@ -110,6 +112,7 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.disability_care__newly_infected_people
                 }
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>
@@ -193,6 +196,7 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.disability_care__infected_locations_total
                 }
+                isAmount
               />
               <Text>{locationsText.kpi_toelichting}</Text>
             </KpiTile>

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -147,6 +147,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                     data.difference.tested_overall__infected_moving_average
                   }
                   isMovingAverageDifference
+                  isAmount
                 />
 
                 <Markdown content={text.kpi_toelichting} />
@@ -185,6 +186,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 localeTextKey="veiligheidsregio_positief_geteste_personen"
                 differenceKey="tested_overall__infected_per_100k_moving_average"
                 isMovingAverageDifference
+                isAmount
               />
               <Text>{text.barscale_toelichting}</Text>
             </KpiTile>
@@ -308,6 +310,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={dataGgdLastValue.tested_total}
                 difference={difference.tested_ggd__tested_total_moving_average}
                 isMovingAverageDifference
+                isAmount
               />
               <Text>{ggdText.totaal_getest_week_uitleg}</Text>
             </KpiTile>
@@ -324,6 +327,7 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   difference.tested_ggd__infected_percentage_moving_average
                 }
                 isMovingAverageDifference
+                isAmount={false}
               />
               <Text>{ggdText.positief_getest_week_uitleg}</Text>
               <Text fontWeight="bold">

--- a/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/rioolwater.tsx
@@ -124,6 +124,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 absolute={data.sewer.last_value.average}
                 valueAnnotation={siteText.waarde_annotaties.riool_normalized}
                 difference={data.difference.sewer__average}
+                isAmount
               />
             </KpiTile>
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -98,6 +98,7 @@ const DeceasedRegionalPage = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="covid_daily"
                 absolute={dataRivm.last_value.covid_daily}
                 difference={difference.deceased_rivm__covid_daily}
+                isAmount
               />
               <Markdown
                 content={text.section_deceased_rivm.kpi_covid_daily_description}

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -1,9 +1,9 @@
 import { Elderly } from '@corona-dashboard/icons';
+import { Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { PageInformationBlock } from '~/components/page-information-block';
-import { Spacer } from '~/components/base';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
@@ -110,6 +110,7 @@ const ElderlyAtHomeRegionalPage = (
                 data-cy="positive_tested_daily"
                 absolute={elderly_at_home.last_value.positive_tested_daily}
                 difference={difference.elderly_at_home__positive_tested_daily}
+                isAmount
               />
               <Text>{text.section_positive_tested.kpi_daily_description}</Text>
             </KpiTile>

--- a/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/verpleeghuiszorg.tsx
@@ -1,11 +1,13 @@
-import { Coronavirus } from '@corona-dashboard/icons';
-import { Locatie } from '@corona-dashboard/icons';
-import { Verpleeghuiszorg } from '@corona-dashboard/icons';
+import {
+  Coronavirus,
+  Locatie,
+  Verpleeghuiszorg,
+} from '@corona-dashboard/icons';
+import { Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { PageInformationBlock } from '~/components/page-information-block';
-import { Spacer } from '~/components/base';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
@@ -114,6 +116,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="newly_infected_people"
                 absolute={nursinghomeLastValue.newly_infected_people}
                 difference={data.difference.nursing_home__newly_infected_people}
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>
@@ -205,6 +208,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                 difference={
                   data.difference.nursing_home__infected_locations_total
                 }
+                isAmount
               />
               <Text>{infectedLocationsText.kpi_toelichting}</Text>
             </KpiTile>
@@ -281,6 +285,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
                 data-cy="deceased_daily"
                 absolute={nursinghomeLastValue.deceased_daily}
                 difference={data.difference.nursing_home__deceased_daily}
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -129,6 +129,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                     .hospital_nice__admissions_on_date_of_reporting_moving_average
                 }
                 isMovingAverageDifference
+                isAmount
               />
             </KpiTile>
           </TwoKpiSection>


### PR DESCRIPTION
## Summary

Made average difference tiles support higher/lower as well as more/less, then went through the site setting all difference labels (higher/lower vs. more/less) correctly.
Also made it mandatory to tell a difference tile which one it should be to prevent issues like this in the future.

FYI currently only the reproduction number & percentage of positive tests are values which are _not_ amounts (as in: the data is not talking about countable things).
