### PR TITLE
Clean up tile difference

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -32,24 +32,28 @@ export function TileDifference({
   );
 
   let content;
-  let icon;
+  let containerWithIcon;
 
   if (difference > 0) {
     content = hasHigherLowerText ? text.waarde_hoger : text.waarde_meer;
 
-    icon = <ContainerWithIcon icon={<Up />} color={'red'} />;
+    containerWithIcon = <ContainerWithIcon icon={<Up />} color={'red'} />;
   }
 
   if (difference < 0) {
     content = hasHigherLowerText ? text.waarde_lager : text.waarde_minder;
 
-    icon = <ContainerWithIcon icon={<Down />} color={'data.primary'} />;
+    containerWithIcon = (
+      <ContainerWithIcon icon={<Down />} color={'data.primary'} />
+    );
   }
 
   if (!content) {
     content = text.gelijk;
 
-    icon = <ContainerWithIcon icon={<Gelijk />} color={'data.neutral'} />;
+    containerWithIcon = (
+      <ContainerWithIcon icon={<Gelijk />} color={'data.neutral'} />
+    );
   }
 
   return (
@@ -58,7 +62,7 @@ export function TileDifference({
         display: 'flex',
       })}
     >
-      {icon}
+      {containerWithIcon}
       <Markdown
         rendererOptions={{
           paragraph: 'span',

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -49,11 +49,12 @@ export function TileDifference({
           <Up />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {differenceFormattedString}
-          {isPercentage ? '%' : ''} {splitText[0]}
+          {`${differenceFormattedString}${isPercentage ? '%' : ''} ${
+            splitText[0]
+          }`}
         </InlineText>{' '}
         <InlineText color="annotation">
-          {splitText[1]} {timespanTextNode}
+          {`${splitText[1]} ${timespanTextNode}`}
         </InlineText>
       </Container>
     );
@@ -70,12 +71,11 @@ export function TileDifference({
           <Down />
         </IconContainer>
         <InlineText fontWeight="bold">
-          {differenceFormattedString}
-          {isPercentage ? '%' : ''} {splitText[0]}
+          {`${differenceFormattedString}${isPercentage ? '%' : ''} ${
+            splitText[0]
+          }`}
         </InlineText>{' '}
-        <InlineText>
-          {splitText[1]} {timespanTextNode}
-        </InlineText>
+        <InlineText>{`${splitText[1]} ${timespanTextNode}`}</InlineText>
       </Container>
     );
   }
@@ -85,9 +85,7 @@ export function TileDifference({
       <IconContainer color="data.neutral" mr={1}>
         <Gelijk />
       </IconContainer>
-      <InlineText>
-        {text.gelijk} {timespanTextNode}
-      </InlineText>
+      <InlineText>{`${text.gelijk} ${timespanTextNode}`}</InlineText>
     </Container>
   );
 }

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -86,8 +86,7 @@ export function TileDifference({
         <Gelijk />
       </IconContainer>
       <InlineText>
-        {text.gelijk}
-        {timespanTextNode}
+        {text.gelijk} {timespanTextNode}
       </InlineText>
     </Container>
   );

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -1,10 +1,13 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
+import css from '@styled-system/css';
 import { Gelijk } from '@corona-dashboard/icons';
 import { Up } from '@corona-dashboard/icons';
 import { Down } from '@corona-dashboard/icons';
 import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
+import { Markdown } from '~/components/markdown';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
 export function TileDifference({
   value,
@@ -23,7 +26,6 @@ export function TileDifference({
 }) {
   const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
     useIntl();
-  const text = siteText.toe_en_afname;
 
   const { difference } = value;
 
@@ -33,6 +35,87 @@ export function TileDifference({
         maximumFractionDigits ? { maximumFractionDigits } : undefined
       )
     : formatNumber(Math.abs(difference));
+
+  let content;
+  let icon;
+
+  if (difference > 0) {
+    if (showOldDateUnix) {
+      content = hasHigherLowerText
+        ? '**{{amount}} hoger** dan de waarde van {{date}}'
+        : '**{{amount}} meer dan** de waarde van {{date}}';
+    } else {
+      content = hasHigherLowerText
+        ? '**{{amount}} hoger dan** de vorige waarde'
+        : '**{{amount}} meer dan** de vorige waarde';
+    }
+
+    icon = (
+      <IconContainer color="red" mr={1}>
+        <Up />
+      </IconContainer>
+    );
+  }
+
+  if (difference < 0) {
+    if (showOldDateUnix) {
+      content = hasHigherLowerText
+        ? '**{{amount}} minder dan** de waarde van {{date}}'
+        : '**{{amount}} lager dan de** waarde van {{date}}';
+    } else {
+      content = hasHigherLowerText
+        ? '**{{amount}} minder dan** de vorige waarde'
+        : '**{{amount}} lager dan** de vorige waarde';
+    }
+
+    icon = (
+      <IconContainer color="data.primary" mr={1}>
+        <Down />
+      </IconContainer>
+    );
+  }
+
+  // When there is no increase or decrease in the difference
+  if (!content) {
+    content = showOldDateUnix
+      ? 'gelijk dan de zelfde waarde als {{date}}'
+      : 'gelijk aan de vorige waarde';
+
+    icon = (
+      <IconContainer color="data.neutral" mr={1}>
+        <Gelijk />
+      </IconContainer>
+    );
+  }
+
+  return (
+    <Container
+      css={css({
+        display: 'flex',
+      })}
+    >
+      {icon}
+      <Markdown
+        content={replaceVariablesInText(content, {
+          amount: differenceFormattedString,
+          date: showOldDateUnix ? value.old_date_unix : '',
+        })}
+      />
+    </Container>
+  );
+
+  // const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
+  //   useIntl();
+  const text = siteText.toe_en_afname;
+
+  // const { difference } = value;
+
+  // const differenceFormattedString = isDecimal
+  //   ? formatPercentage(
+  //       Math.abs(difference),
+  //       maximumFractionDigits ? { maximumFractionDigits } : undefined
+  //     )
+  //   : formatNumber(Math.abs(difference));
 
   const timespanTextNode = showOldDateUnix
     ? formatDateFromSeconds(value.old_date_unix)

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -64,7 +64,7 @@ export function TileDifference({
     >
       {containerWithIcon}
       <Markdown
-        rendererOverrides={{
+        renderersOverrides={{
           paragraph: 'span',
           strong: (props) => (
             <InlineText fontWeight="bold">{props.children}</InlineText>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -37,14 +37,14 @@ export function TileDifference({
   if (difference > 0) {
     content = hasHigherLowerText ? text.waarde_hoger : text.waarde_meer;
 
-    containerWithIcon = <ContainerWithIcon icon={<Up />} color={'red'} />;
+    containerWithIcon = <ContainerWithIcon icon={<Up />} color="red" />;
   }
 
   if (difference < 0) {
     content = hasHigherLowerText ? text.waarde_lager : text.waarde_minder;
 
     containerWithIcon = (
-      <ContainerWithIcon icon={<Down />} color={'data.primary'} />
+      <ContainerWithIcon icon={<Down />} color="data.primary" />
     );
   }
 
@@ -52,7 +52,7 @@ export function TileDifference({
     content = text.gelijk;
 
     containerWithIcon = (
-      <ContainerWithIcon icon={<Gelijk />} color={'data.neutral'} />
+      <ContainerWithIcon icon={<Gelijk />} color="data.neutral" />
     );
   }
 

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -64,7 +64,7 @@ export function TileDifference({
     >
       {containerWithIcon}
       <Markdown
-        renderersOptions={{
+        rendererOverrides={{
           paragraph: 'span',
           strong: (props) => (
             <InlineText fontWeight="bold">{props.children}</InlineText>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -64,7 +64,7 @@ export function TileDifference({
     >
       {containerWithIcon}
       <Markdown
-        rendererOptions={{
+        renderersOptions={{
           paragraph: 'span',
           strong: (props) => (
             <InlineText fontWeight="bold">{props.children}</InlineText>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -3,89 +3,53 @@ import css from '@styled-system/css';
 import { Gelijk } from '@corona-dashboard/icons';
 import { Up } from '@corona-dashboard/icons';
 import { Down } from '@corona-dashboard/icons';
-import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
 import { Markdown } from '~/components/markdown';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { InlineText } from '~/components/typography';
 
 export function TileDifference({
   value,
-  isDecimal,
   maximumFractionDigits,
   isPercentage,
   showOldDateUnix,
   hasHigherLowerText,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
-  isDecimal?: boolean;
   maximumFractionDigits?: number;
   isPercentage?: boolean;
   showOldDateUnix?: boolean;
   hasHigherLowerText?: boolean;
 }) {
-  const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
-    useIntl();
-
+  const { siteText, formatNumber, formatDateFromSeconds } = useIntl();
+  const text = siteText.toe_en_afname;
   const { difference } = value;
 
-  const differenceFormattedString = isDecimal
-    ? formatPercentage(
-        Math.abs(difference),
-        maximumFractionDigits ? { maximumFractionDigits } : undefined
-      )
-    : formatNumber(Math.abs(difference));
+  const formattedDifference = formatNumber(
+    Math.abs(difference),
+    maximumFractionDigits ? maximumFractionDigits : undefined
+  );
 
   let content;
   let icon;
 
   if (difference > 0) {
-    if (showOldDateUnix) {
-      content = hasHigherLowerText
-        ? '**{{amount}} hoger** dan de waarde van {{date}}'
-        : '**{{amount}} meer dan** de waarde van {{date}}';
-    } else {
-      content = hasHigherLowerText
-        ? '**{{amount}} hoger dan** de vorige waarde'
-        : '**{{amount}} meer dan** de vorige waarde';
-    }
+    content = hasHigherLowerText ? text.waarde_hoger : text.waarde_meer;
 
-    icon = (
-      <IconContainer color="red" mr={1}>
-        <Up />
-      </IconContainer>
-    );
+    icon = <ContainerWithIcon icon={<Up />} color={'red'} />;
   }
 
   if (difference < 0) {
-    if (showOldDateUnix) {
-      content = hasHigherLowerText
-        ? '**{{amount}} minder dan** de waarde van {{date}}'
-        : '**{{amount}} lager dan de** waarde van {{date}}';
-    } else {
-      content = hasHigherLowerText
-        ? '**{{amount}} minder dan** de vorige waarde'
-        : '**{{amount}} lager dan** de vorige waarde';
-    }
+    content = hasHigherLowerText ? text.waarde_lager : text.waarde_minder;
 
-    icon = (
-      <IconContainer color="data.primary" mr={1}>
-        <Down />
-      </IconContainer>
-    );
+    icon = <ContainerWithIcon icon={<Down />} color={'data.primary'} />;
   }
 
-  // When there is no increase or decrease in the difference
   if (!content) {
-    content = showOldDateUnix
-      ? 'gelijk dan de zelfde waarde als {{date}}'
-      : 'gelijk aan de vorige waarde';
+    content = text.gelijk;
 
-    icon = (
-      <IconContainer color="data.neutral" mr={1}>
-        <Gelijk />
-      </IconContainer>
-    );
+    icon = <ContainerWithIcon icon={<Gelijk />} color={'data.neutral'} />;
   }
 
   return (
@@ -96,79 +60,35 @@ export function TileDifference({
     >
       {icon}
       <Markdown
-        content={replaceVariablesInText(content, {
-          amount: differenceFormattedString,
-          date: showOldDateUnix ? value.old_date_unix : '',
-        })}
+        rendererOptions={{
+          paragraph: 'span',
+          strong: (props) => (
+            <InlineText fontWeight="bold">{props.children}</InlineText>
+          ),
+        }}
+        content={replaceVariablesInText(
+          `${content} ${
+            showOldDateUnix ? text.dan_waarde_datum : text.vorige_waarde
+          }`,
+          {
+            amount: `${formattedDifference}${isPercentage ? '%' : ''}`,
+            date: formatDateFromSeconds(value.old_date_unix),
+          }
+        )}
       />
     </Container>
   );
+}
 
-  // const { siteText, formatNumber, formatPercentage, formatDateFromSeconds } =
-  //   useIntl();
-  const text = siteText.toe_en_afname;
+interface ContainerWithIconsProps {
+  icon: React.ReactNode;
+  color: string;
+}
 
-  // const { difference } = value;
-
-  // const differenceFormattedString = isDecimal
-  //   ? formatPercentage(
-  //       Math.abs(difference),
-  //       maximumFractionDigits ? { maximumFractionDigits } : undefined
-  //     )
-  //   : formatNumber(Math.abs(difference));
-
-  const timespanTextNode = showOldDateUnix
-    ? formatDateFromSeconds(value.old_date_unix)
-    : text.vorige_waarde;
-
-  if (difference > 0) {
-    const splitText = hasHigherLowerText
-      ? text.hoger.split(' ')
-      : text.toename.split(' ');
-
-    return (
-      <Container>
-        <IconContainer color="red" mr={1}>
-          <Up />
-        </IconContainer>
-        <InlineText fontWeight="bold">
-          {`${differenceFormattedString}${isPercentage ? '%' : ''} ${
-            splitText[0]
-          }`}
-        </InlineText>{' '}
-        <InlineText color="annotation">
-          {`${splitText[1]} ${timespanTextNode}`}
-        </InlineText>
-      </Container>
-    );
-  }
-
-  if (difference < 0) {
-    const splitText = hasHigherLowerText
-      ? text.lager.split(' ')
-      : text.afname.split(' ');
-
-    return (
-      <Container>
-        <IconContainer color="data.primary" mr={1}>
-          <Down />
-        </IconContainer>
-        <InlineText fontWeight="bold">
-          {`${differenceFormattedString}${isPercentage ? '%' : ''} ${
-            splitText[0]
-          }`}
-        </InlineText>{' '}
-        <InlineText>{`${splitText[1]} ${timespanTextNode}`}</InlineText>
-      </Container>
-    );
-  }
-
+function ContainerWithIcon({ icon, color }: ContainerWithIconsProps) {
   return (
-    <Container>
-      <IconContainer color="data.neutral" mr={1}>
-        <Gelijk />
-      </IconContainer>
-      <InlineText>{`${text.gelijk} ${timespanTextNode}`}</InlineText>
-    </Container>
+    <IconContainer color={color} mr={1}>
+      {icon}
+    </IconContainer>
   );
 }

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -13,7 +13,7 @@ import { Anchor } from './typography';
 import { ElementType } from 'react';
 interface MarkdownProps {
   content: string;
-  rendererOptions?: { [nodeType: string]: ElementType };
+  renderersOptions?: { [nodeType: string]: ElementType };
 }
 interface LinkProps {
   children: ReactNode;
@@ -58,7 +58,7 @@ const renderers = {
   },
 };
 
-export function Markdown({ content, rendererOptions }: MarkdownProps) {
+export function Markdown({ content, renderersOptions }: MarkdownProps) {
   const { dataset } = useIntl();
   const source = dataset === 'keys' ? `✅${content}` : content;
   return (
@@ -66,7 +66,7 @@ export function Markdown({ content, rendererOptions }: MarkdownProps) {
       source={source}
       renderers={{
         ...renderers,
-        ...rendererOptions,
+        ...renderersOptions,
       }}
     />
   );

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -13,7 +13,7 @@ import { Anchor } from './typography';
 import { ElementType } from 'react';
 interface MarkdownProps {
   content: string;
-  renderersOptions?: { [nodeType: string]: ElementType };
+  rendererOverrides?: { [nodeType: string]: ElementType };
 }
 interface LinkProps {
   children: ReactNode;
@@ -58,7 +58,7 @@ const renderers = {
   },
 };
 
-export function Markdown({ content, renderersOptions }: MarkdownProps) {
+export function Markdown({ content, rendererOverrides }: MarkdownProps) {
   const { dataset } = useIntl();
   const source = dataset === 'keys' ? `✅${content}` : content;
   return (
@@ -66,7 +66,7 @@ export function Markdown({ content, renderersOptions }: MarkdownProps) {
       source={source}
       renderers={{
         ...renderers,
-        ...renderersOptions,
+        ...rendererOverrides,
       }}
     />
   );

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -10,9 +10,10 @@ import { Link } from '~/utils/link';
 import { DisplayOnMatchingQueryCode } from './display-on-matching-query-code';
 import { Message } from './message';
 import { Anchor } from './typography';
-
+import { ElementType } from 'react';
 interface MarkdownProps {
   content: string;
+  rendererOptions?: { [nodeType: string]: ElementType };
 }
 interface LinkProps {
   children: ReactNode;
@@ -49,8 +50,6 @@ const renderers = {
     </DisplayOnMatchingQueryCode>
   ),
 
-  paragraph: 'span',
-
   /**
    * The blockquote element is hijacked for displaying "warning" messages.
    */
@@ -59,10 +58,18 @@ const renderers = {
   },
 };
 
-export function Markdown({ content }: MarkdownProps) {
+export function Markdown({ content, rendererOptions }: MarkdownProps) {
   const { dataset } = useIntl();
   const source = dataset === 'keys' ? `✅${content}` : content;
-  return <StyledReactMarkdown source={source} renderers={renderers} />;
+  return (
+    <StyledReactMarkdown
+      source={source}
+      renderers={{
+        ...renderers,
+        ...rendererOptions,
+      }}
+    />
+  );
 }
 
 const StyledReactMarkdown = styled(ReactMarkdown)(css(nestedHtml));

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -13,7 +13,7 @@ import { Anchor } from './typography';
 import { ElementType } from 'react';
 interface MarkdownProps {
   content: string;
-  rendererOverrides?: { [nodeType: string]: ElementType };
+  renderersOverrides?: { [nodeType: string]: ElementType };
 }
 interface LinkProps {
   children: ReactNode;
@@ -58,7 +58,7 @@ const renderers = {
   },
 };
 
-export function Markdown({ content, rendererOverrides }: MarkdownProps) {
+export function Markdown({ content, renderersOverrides }: MarkdownProps) {
   const { dataset } = useIntl();
   const source = dataset === 'keys' ? `✅${content}` : content;
   return (
@@ -66,7 +66,7 @@ export function Markdown({ content, rendererOverrides }: MarkdownProps) {
       source={source}
       renderers={{
         ...renderers,
-        ...rendererOverrides,
+        ...renderersOverrides,
       }}
     />
   );

--- a/packages/app/src/components/markdown.tsx
+++ b/packages/app/src/components/markdown.tsx
@@ -49,6 +49,8 @@ const renderers = {
     </DisplayOnMatchingQueryCode>
   ),
 
+  paragraph: 'span',
+
   /**
    * The blockquote element is hijacked for displaying "warning" messages.
    */

--- a/packages/app/src/components/page-barscale.tsx
+++ b/packages/app/src/components/page-barscale.tsx
@@ -142,7 +142,6 @@ export function PageBarScale<T>({
         ) : (
           <TileDifference
             value={differenceValue}
-            isDecimal={config.isDecimal}
             maximumFractionDigits={differenceFractionDigits}
             showOldDateUnix={showOldDateUnix}
             hasHigherLowerText={hasHigherLowerText}

--- a/packages/app/src/pages/sitemap.xml.tsx
+++ b/packages/app/src/pages/sitemap.xml.tsx
@@ -103,7 +103,7 @@ async function getAllPathsWithPriorities() {
     { path: 'regio', value: 0.8 },
   ];
 
-  const pathsWithPriorities = pathsFromPages.map((path) => {
+  const pathsWithPriorities = pathsFromPages.map((path: string) => {
     const priority = priorities.find((priority) =>
       path.includes(priority.path)
     );

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,2 +1,7 @@
 timestamp,action,key,document_id,move_to
 2021-09-06T09:52:56.741Z,add,nationaal_layout.headings.archief,srBRCALrLz9Y3ZpBCxW7jO,__
+2021-09-08T08:46:38.098Z,add,toe_en_afname.waarde_hoger,oFxmVAb3WhH1wXDkdmrhY7,__
+2021-09-08T08:46:39.531Z,add,toe_en_afname.waarde_meer,u2w2cmKrEkkhu4TKoNjc7M,__
+2021-09-08T08:46:40.740Z,add,toe_en_afname.waarde_lager,u2w2cmKrEkkhu4TKoNjcee,__
+2021-09-08T08:46:42.059Z,add,toe_en_afname.waarde_minder,oFxmVAb3WhH1wXDkdmrhr4,__
+2021-09-08T08:46:43.525Z,add,toe_en_afname.dan_waarde_datum,srBRCALrLz9Y3ZpBD68tp7,__


### PR DESCRIPTION
The tile difference is now a little bit more cleaner it has some new Lokalise keys that support markdown. 
So when they want to have a bold text they can just use `**{{amount}} hoger**`. 
Added a new prop `rendererOptions` to the markdown renderer to support extra renderer options. In this case it was needed because I didn't want to render the text as a paragraph and wanted to replace `bold` with a regular span.

For the end-user almost nothing has been changed. If I iron out the last feedback points I'll start also changing the moving average tile difference to be in line with the same structure as here.