### PR TITLE
Update moving average tile difference in line with the other difference

### DIFF
--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -1,73 +1,93 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
 import { Down, Gelijk, Up } from '@corona-dashboard/icons';
 import { InlineText } from '~/components/typography';
+import css from '@styled-system/css';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
+import { Markdown } from '~/components/markdown';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
 export function TileAverageDifference({
   value,
   isPercentage,
   isAmount,
+  maximumFractionDigits,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
   isPercentage?: boolean;
   isAmount: boolean;
+  maximumFractionDigits?: number;
 }) {
-  const { difference, old_value } = value;
   const { siteText, formatNumber } = useIntl();
-
-  const oldValue = (
-    <InlineText fontWeight="bold">{` (${formatNumber(old_value)}${
-      isPercentage ? '%' : ''
-    })`}</InlineText>
-  );
-
+  const { difference, old_value } = value;
   const text = siteText.toe_en_afname;
 
-  if (difference > 0)
-    return (
-      <Container>
-        <IconContainer color="red">
-          <Up />
-        </IconContainer>
-        <InlineText fontWeight="bold">
-          {formatNumber(Math.abs(difference))}{' '}
-          {isAmount ? text.toename : text.hoger}{' '}
-        </InlineText>
-        <InlineText>
-          {text.zeven_daags_gemiddelde}
-          {oldValue}
-        </InlineText>
-      </Container>
-    );
+  const formattedDifference = formatNumber(
+    Math.abs(difference),
+    maximumFractionDigits ? maximumFractionDigits : undefined
+  );
 
-  if (difference < 0)
-    return (
-      <Container>
-        <IconContainer color="data.primary">
-          <Down />
-        </IconContainer>
-        <InlineText fontWeight="bold">
-          {formatNumber(Math.abs(difference))}{' '}
-          {isAmount ? text.afname : text.lager}{' '}
-        </InlineText>
-        <InlineText>
-          {text.zeven_daags_gemiddelde}
-          {oldValue}
-        </InlineText>
-      </Container>
+  let content;
+  let containerWithIcon;
+
+  if (difference > 0) {
+    content = isAmount
+      ? text.zeven_daags_gemiddelde_waarde_hoger
+      : text.zeven_daags_gemiddelde_waarde_meer;
+
+    containerWithIcon = <ContainerWithIcon icon={<Up />} color="red" />;
+  }
+
+  if (difference < 0) {
+    content = isAmount
+      ? text.zeven_daags_gemiddelde_waarde_lager
+      : text.zeven_daags_gemiddelde_waarde_minder;
+
+    containerWithIcon = (
+      <ContainerWithIcon icon={<Down />} color="data.primary" />
     );
+  }
+
+  if (!content) {
+    content = text.zeven_daags_gemiddelde_waarde_gelijk;
+
+    containerWithIcon = (
+      <ContainerWithIcon icon={<Gelijk />} color="data.neutral" />
+    );
+  }
 
   return (
-    <Container>
-      <IconContainer color="data.neutral">
-        <Gelijk />
-      </IconContainer>
-      <InlineText fontWeight="bold">{text.gelijk} </InlineText>
-      <InlineText>
-        {text.zeven_daags_gemiddelde}
-        {oldValue}
-      </InlineText>
+    <Container
+      css={css({
+        display: 'flex',
+      })}
+    >
+      {containerWithIcon}
+      <Markdown
+        renderersOverrides={{
+          paragraph: 'span',
+          strong: (props) => (
+            <InlineText fontWeight="bold">{props.children}</InlineText>
+          ),
+        }}
+        content={replaceVariablesInText(content, {
+          amount: `${formattedDifference}${isPercentage ? '%' : ''}`,
+          totalAverage: old_value,
+        })}
+      />
     </Container>
   );
+
+  interface ContainerWithIconsProps {
+    icon: React.ReactNode;
+    color: string;
+  }
+
+  function ContainerWithIcon({ icon, color }: ContainerWithIconsProps) {
+    return (
+      <IconContainer color={color} mr={1}>
+        {icon}
+      </IconContainer>
+    );
+  }
 }

--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -32,16 +32,16 @@ export function TileAverageDifference({
 
   if (difference > 0) {
     content = isAmount
-      ? text.zeven_daags_gemiddelde_waarde_hoger
-      : text.zeven_daags_gemiddelde_waarde_meer;
+      ? text.zeven_daags_gemiddelde_waarde_meer
+      : text.zeven_daags_gemiddelde_waarde_hoger;
 
     containerWithIcon = <ContainerWithIcon icon={<Up />} color="red" />;
   }
 
   if (difference < 0) {
     content = isAmount
-      ? text.zeven_daags_gemiddelde_waarde_lager
-      : text.zeven_daags_gemiddelde_waarde_minder;
+      ? text.zeven_daags_gemiddelde_waarde_minder
+      : text.zeven_daags_gemiddelde_waarde_lager;
 
     containerWithIcon = (
       <ContainerWithIcon icon={<Down />} color="data.primary" />

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -49,7 +49,7 @@ export function TileDifference({
   }
 
   if (!content) {
-    content = text.gelijk;
+    content = text.waarde_gelijk;
 
     containerWithIcon = (
       <ContainerWithIcon icon={<Gelijk />} color="data.neutral" />
@@ -72,7 +72,7 @@ export function TileDifference({
         }}
         content={replaceVariablesInText(
           `${content} ${
-            showOldDateUnix ? text.dan_waarde_datum : text.vorige_waarde
+            showOldDateUnix ? text.dan_waarde_datum : text.waarde_gelijk
           }`,
           {
             amount: `${formattedDifference}${isPercentage ? '%' : ''}`,

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -35,13 +35,13 @@ export function TileDifference({
   let containerWithIcon;
 
   if (difference > 0) {
-    content = isAmount ? text.waarde_hoger : text.waarde_meer;
+    content = isAmount ? text.waarde_meer : text.waarde_hoger;
 
     containerWithIcon = <ContainerWithIcon icon={<Up />} color="red" />;
   }
 
   if (difference < 0) {
-    content = isAmount ? text.waarde_lager : text.waarde_minder;
+    content = isAmount ? text.waarde_minder : text.waarde_lager;
 
     containerWithIcon = (
       <ContainerWithIcon icon={<Down />} color="data.primary" />

--- a/packages/app/src/components/kpi-value.tsx
+++ b/packages/app/src/components/kpi-value.tsx
@@ -17,6 +17,7 @@ interface KpiValueBaseProps {
   text?: string;
   color?: string;
   isMovingAverageDifference?: boolean;
+  differenceFractionDigits?: number;
 }
 
 type DifferenceProps =
@@ -64,6 +65,7 @@ export function KpiValue({
   color = 'data.primary',
   isMovingAverageDifference,
   isAmount,
+  differenceFractionDigits,
   ...otherProps
 }: KpiValueProps) {
   const { formatPercentage, formatNumber } = useIntl();
@@ -95,12 +97,14 @@ export function KpiValue({
             value={difference}
             isPercentage={isDefined(percentage) && !isDefined(absolute)}
             isAmount={isAmount}
+            maximumFractionDigits={differenceFractionDigits}
           />
         ) : (
           <TileDifference
             value={difference}
             isPercentage={isDefined(percentage) && !isDefined(absolute)}
             isAmount={isAmount}
+            maximumFractionDigits={differenceFractionDigits}
           />
         ))}
       {valueAnnotation && <ValueAnnotation>{valueAnnotation}</ValueAnnotation>}

--- a/packages/app/src/components/page-barscale.tsx
+++ b/packages/app/src/components/page-barscale.tsx
@@ -149,7 +149,11 @@ export function PageBarScale<T>({
       {isDefined(differenceKey) &&
         isDefined(isAmount) &&
         (isMovingAverageDifference ? (
-          <TileAverageDifference value={differenceValue} isAmount={isAmount} />
+          <TileAverageDifference
+            value={differenceValue}
+            isAmount={isAmount}
+            maximumFractionDigits={differenceFractionDigits}
+          />
         ) : (
           <TileDifference
             value={differenceValue}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -5,3 +5,16 @@ timestamp,action,key,document_id,move_to
 2021-09-08T08:46:40.740Z,add,toe_en_afname.waarde_lager,u2w2cmKrEkkhu4TKoNjcee,__
 2021-09-08T08:46:42.059Z,add,toe_en_afname.waarde_minder,oFxmVAb3WhH1wXDkdmrhr4,__
 2021-09-08T08:46:43.525Z,add,toe_en_afname.dan_waarde_datum,srBRCALrLz9Y3ZpBD68tp7,__
+2021-09-08T10:13:01.031Z,add,toe_en_afname.waarde_gelijk,srBRCALrLz9Y3ZpBD6TYII,__
+2021-09-08T10:35:20.019Z,add,toe_en_afname.zeven_daags_gemiddelde_waarde_hoger,oFxmVAb3WhH1wXDkdn0zrU,__
+2021-09-08T10:35:21.043Z,add,toe_en_afname.zeven_daags_gemiddelde_waarde_meer,u2w2cmKrEkkhu4TKoO7xpL,__
+2021-09-08T10:35:22.067Z,add,toe_en_afname.zeven_daags_gemiddelde_waarde_lager,u2w2cmKrEkkhu4TKoO7xva,__
+2021-09-08T10:35:23.091Z,add,toe_en_afname.zeven_daags_gemiddelde_waarde_minder,srBRCALrLz9Y3ZpBD6Zpv9,__
+2021-09-08T10:35:24.012Z,add,toe_en_afname.zeven_daags_gemiddelde_waarde_gelijk,srBRCALrLz9Y3ZpBD6Zq1s,__
+2021-09-08T10:35:24.013Z,delete,toe_en_afname.afname,jF33EuwumlGuwav2FD3uDc,__
+2021-09-08T10:35:24.013Z,delete,toe_en_afname.gelijk,jF33EuwumlGuwav2FD3uFI,__
+2021-09-08T10:35:24.013Z,delete,toe_en_afname.hoger,p4JeWnX1BdBjLeRfpOCEGE,__
+2021-09-08T10:35:24.014Z,delete,toe_en_afname.lager,p4JeWnX1BdBjLeRfpOCJjC,__
+2021-09-08T10:35:24.014Z,delete,toe_en_afname.toename,jF33EuwumlGuwav2FD3uBw,__
+2021-09-08T10:35:24.014Z,delete,toe_en_afname.vorige_waarde,jF33EuwumlGuwav2FD3uW4,__
+2021-09-08T10:35:24.014Z,delete,toe_en_afname.zeven_daags_gemiddelde,6QpSQ1LKij6fvuYEHTebU7,__


### PR DESCRIPTION
Same structure as the `tileDifference` that got merged in this morning to be a bit more consistent. 
Added some new Lokalise keys e.g. `"**{{amount}} lager** dan het gemiddelde van de afgelopen 7 dagen **({{totalAverage}})**` and deleted the old ones to avoid confusion.