### PR TITLE
Make the logo RO clickable 

### DIFF
--- a/packages/app/src/components/layout/components/language-switcher.tsx
+++ b/packages/app/src/components/layout/components/language-switcher.tsx
@@ -11,7 +11,7 @@ export function LanguageSwitcher() {
   const [currentPath] = router.asPath.split('?');
 
   return (
-    <Box height={55} mt={-55} textAlign="right">
+    <Box height={55} mt={-55} textAlign="right" position="absolute" right={3}>
       <LanguageLink
         href={`https://coronadashboard.rijksoverheid.nl${currentPath}`}
         lang="nl"

--- a/packages/app/src/components/layout/components/logo.tsx
+++ b/packages/app/src/components/layout/components/logo.tsx
@@ -23,8 +23,8 @@ export function Logo() {
           position="relative"
           css={css({
             /**
-             * The logo has a bit of spacing on the right, with this clip path we're slicing
-             * a part of it so the user can only click only on the logo.
+             * The logo has a bit of empty space on the right, with this clip path we're slicing
+             * of that part so the user can only click on the logo.
              */
             clipPath: asResponsiveArray({
               xs: 'polygon(0 0, 155px 0, 155px 100%, 0% 100%)',

--- a/packages/app/src/components/layout/components/logo.tsx
+++ b/packages/app/src/components/layout/components/logo.tsx
@@ -66,7 +66,5 @@ const LogoImage = styled.img(
   css({
     width: '100%',
     height: '100%',
-    // marginLeft: asResponsiveArray({ xs: -50 }),
-    // transform: asResponsiveArray({ xs: 'translateX(50%)' }),
   })
 );

--- a/packages/app/src/components/layout/components/logo.tsx
+++ b/packages/app/src/components/layout/components/logo.tsx
@@ -1,29 +1,52 @@
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import { useIntl } from '~/intl';
-
+import { Link } from '~/utils/link';
 import logoRo from './logo-ro.svg';
 import logoRoSmall from './logo-ro-small.svg';
+import { Box } from '~/components/base';
+import { asResponsiveArray } from '~/style/utils';
 
 export function Logo() {
   const { siteText } = useIntl();
 
   return (
     <LogoWrapper>
-      <LogoImage
-        src={logoRo}
-        alt={siteText.header.logo_alt}
-        width={314}
-        height={125}
-        css={css({ display: ['none', 'block'] })}
-      />
-      <LogoImage
-        src={logoRoSmall}
-        alt={siteText.header.logo_alt}
-        width={40}
-        height={76}
-        css={css({ display: ['block', 'none'] })}
-      />
+      <Link href="/" passHref>
+        <Box
+          as="a"
+          display="block"
+          width={{ _: 40, xs: 314 }}
+          height={{ _: 76, xs: 125 }}
+          marginLeft={{ xs: '-50px' }}
+          transform={{ xs: 'translateX(50%)' }}
+          position="relative"
+          css={css({
+            /**
+             * The logo has a bit of spacing on the right, with this clip path we're slicing
+             * a part of it so the user can only click only on the logo.
+             */
+            clipPath: asResponsiveArray({
+              xs: 'polygon(0 0, 155px 0, 155px 100%, 0% 100%)',
+            }),
+          })}
+        >
+          <LogoImage
+            src={logoRo}
+            alt={siteText.header.logo_alt}
+            css={css({
+              display: asResponsiveArray({ _: 'none', xs: 'block' }),
+            })}
+          />
+          <LogoImage
+            src={logoRoSmall}
+            alt={siteText.header.logo_alt}
+            css={css({
+              display: asResponsiveArray({ _: 'block', xs: 'none' }),
+            })}
+          />
+        </Box>
+      </Link>
     </LogoWrapper>
   );
 }
@@ -41,7 +64,9 @@ const LogoWrapper = styled.div(
 
 const LogoImage = styled.img(
   css({
-    marginLeft: -50,
-    transform: 'translateX(50%)',
+    width: '100%',
+    height: '100%',
+    // marginLeft: asResponsiveArray({ xs: -50 }),
+    // transform: asResponsiveArray({ xs: 'translateX(50%)' }),
   })
 );


### PR DESCRIPTION
Had to do something funky with a clip-path to make not the full SVG clickable since it has some empty spacing on the right (which is weird if you can click on an anchor with nothing).
Not sure if it was intentional (since it's already been like this since the beginning of this project) to have that in the SVG. We could either export a new SVG without that or leave this as is.