### PR TITLE
Fix fullscreen size of canvas choropleth

### DIFF
--- a/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
@@ -146,6 +146,7 @@ export const CanvasChoroplethMap = (props: GenericChoroplethMapProps) => {
           minHeight: height,
           maxHeight: '75vh',
           maxWidth: '100%',
+          height: '100%',
           position: 'relative',
         }}
         onMouseOut={featureOutHandler}


### PR DESCRIPTION
## Summary

The new choropleth canvas implementation did not resize to fill the modal tile when clicking the fullscreen button. The SVG implementation increased in height automatically if the width increased, but this is not the case for the canvas. This PR sets the height of the canvas container explicitly to fill the available space.
