### PR TITLE
Fix initialise disabled feature flags bugs

### DIFF
--- a/packages/app/src/static-props/feature-flags/__tests__/initialize-feature-flagged-data.spec.ts
+++ b/packages/app/src/static-props/feature-flags/__tests__/initialize-feature-flagged-data.spec.ts
@@ -36,7 +36,7 @@ describe('initializeFeatureFlaggedData', () => {
       if (pathStr.endsWith('__index.json')) {
         return gmCollectionSchema;
       }
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return gmCollectionTestCollectionSchema;
       }
     });
@@ -73,7 +73,7 @@ describe('initializeFeatureFlaggedData', () => {
       if (pathStr.endsWith('__index.json')) {
         return gmCollectionSchema;
       }
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return gmCollectionTestCollectionSchema;
       }
     });
@@ -107,7 +107,7 @@ describe('initializeFeatureFlaggedData', () => {
         return gmSchema;
       }
 
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return gmTestCollectionSchema;
       }
     });
@@ -159,7 +159,7 @@ describe('initializeFeatureFlaggedData', () => {
         return gmSchema;
       }
 
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return gmTestCollectionSchema;
       }
     });
@@ -193,7 +193,7 @@ describe('initializeFeatureFlaggedData', () => {
       if (pathStr.endsWith('__index.json')) {
         return vrCollectionSchema;
       }
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return vrCollectionTestCollectionSchema;
       }
     });
@@ -250,7 +250,7 @@ describe('initializeFeatureFlaggedData', () => {
       if (pathStr.endsWith('__index.json')) {
         return vrCollectionSchema;
       }
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return vrCollectionTestCollectionSchema;
       }
     });
@@ -284,7 +284,7 @@ describe('initializeFeatureFlaggedData', () => {
       if (pathStr.endsWith('__index.json')) {
         return vrCollectionSchema;
       }
-      if (pathStr.endsWith('testCollection')) {
+      if (pathStr.endsWith('testCollection.json')) {
         return vrCollectionTestCollectionEnumSchema;
       }
     });

--- a/packages/app/src/static-props/feature-flags/feature-flag-constants.ts
+++ b/packages/app/src/static-props/feature-flags/feature-flag-constants.ts
@@ -5,4 +5,4 @@ export const disabledMetrics = features
   .filter(isVerboseFeature)
   .filter((x) => !x.isEnabled);
 
-export const schemaRootPath = path.join(__dirname, '../../../schema');
+export const schemaRootPath = path.join(process.cwd(), 'schema');

--- a/packages/app/src/static-props/feature-flags/initialize-feature-flagged-data.ts
+++ b/packages/app/src/static-props/feature-flags/initialize-feature-flagged-data.ts
@@ -179,7 +179,11 @@ function initializeProperty(prop: AjvPropertyDef, schema: AjvSchema) {
 function getSchema(feature: VerboseFeature, scope: JsonDataScope) {
   const rootSchemaPath = path.join(schemaRootPath, scope, '__index.json');
   const rootSchema = loadJsonFromFile<AjvSchema>(rootSchemaPath);
-  const metricSchemaPath = path.join(schemaRootPath, scope, feature.metricName);
+  const metricSchemaPath = path.join(
+    schemaRootPath,
+    scope,
+    `${feature.metricName}.json`
+  );
   const metricSchema = loadJsonFromFile<AjvSchema>(metricSchemaPath);
   return [rootSchema, metricSchema] as const;
 }

--- a/packages/common/src/data-sorting.ts
+++ b/packages/common/src/data-sorting.ts
@@ -17,6 +17,11 @@ export function sortTimeSeriesInDataInPlace<T>(
   for (const propertyName of timeSeriesPropertyNames) {
     try {
       const timeSeries = data[propertyName] as unknown as TimeSeriesMetric;
+
+      if (timeSeries.values.length === 0) {
+        continue;
+      }
+
       timeSeries.values = sortTimeSeriesValues(timeSeries.values);
 
       if (setDatesToMiddleOfDay) {


### PR DESCRIPTION
## Summary

I ran into some bugs related to the new initialise disabled feature flags feature:

- Next server started looking for schema files in the wrong folder.
- It was looking for schema files without json extension
- The timeseries sorting code did not handle empty arrays yet