### PR TITLE
Remove estimates from vaccination page

### DIFF
--- a/packages/app/src/domain/vaccine/data-selection/select-delivery-and-administration-data.ts
+++ b/packages/app/src/domain/vaccine/data-selection/select-delivery-and-administration-data.ts
@@ -3,7 +3,6 @@ import {
   NlVaccineAdministeredValue,
   NlVaccineDeliveryValue,
 } from '@corona-dashboard/common';
-import last from 'lodash/last';
 
 export type VaccineDeliveryAndAdministrationsValue = Optional<
   Omit<NlVaccineDeliveryValue, 'total' | 'date_start_unix' | 'date_end_unix'>,
@@ -40,7 +39,7 @@ export function selectDeliveryAndAdministrationData(nlData: Nl) {
     values.push(value);
   }
 
-  for (const [index] of vaccine_administered_estimate.values.entries()) {
+  /*for (const [index] of vaccine_administered_estimate.values.entries()) {
     const value = {
       total_delivered: vaccine_delivery_estimate.values[index].total,
       date_unix: vaccine_delivery_estimate.values[index].date_end_unix,
@@ -50,14 +49,11 @@ export function selectDeliveryAndAdministrationData(nlData: Nl) {
     delete (value as Record<string, number>).date_start_unix;
     delete (value as Record<string, number>).date_end_unix;
     values.push(value);
-  }
+  }*/
 
   const deliveryAndAdministration: DeliveryAndAdministrationData = {
     values,
-    estimatedRange: [
-      last(vaccine_delivery.values)?.date_end_unix || 0,
-      last(vaccine_delivery_estimate.values)?.date_end_unix || 0,
-    ],
+    estimatedRange: [0, 0],
   };
 
   return { deliveryAndAdministration };

--- a/packages/app/src/domain/vaccine/data-selection/select-delivery-and-administration-data.ts
+++ b/packages/app/src/domain/vaccine/data-selection/select-delivery-and-administration-data.ts
@@ -18,12 +18,7 @@ export type DeliveryAndAdministrationData = {
 };
 
 export function selectDeliveryAndAdministrationData(nlData: Nl) {
-  const {
-    vaccine_administered,
-    vaccine_administered_estimate,
-    vaccine_delivery,
-    vaccine_delivery_estimate,
-  } = nlData;
+  const { vaccine_administered, vaccine_delivery } = nlData;
 
   const values: VaccineDeliveryAndAdministrationsValue[] = [];
 

--- a/packages/app/src/domain/vaccine/vaccine-delivery-and-administrations-area-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-delivery-and-administrations-area-chart.tsx
@@ -51,26 +51,7 @@ export function VaccineDeliveryAndAdministrationsAreaChart({
         }}
         dataOptions={{
           valueAnnotation: siteText.waarde_annotaties.x_miljoen,
-          timespanAnnotations: [
-            {
-              fill: 'hatched',
-              start: data.estimatedRange[0],
-              end: data.estimatedRange[1],
-              label:
-                siteText.vaccinaties.data.vaccination_chart.legend.expected,
-            },
-          ],
           forcedMaximumValue: (seriesMax) => seriesMax * 1.1,
-          timeAnnotations: [
-            {
-              type: 'divider',
-              position: data.estimatedRange[0],
-              leftLabel:
-                siteText.vaccinaties.data.vaccination_chart.left_divider_label,
-              rightLabel:
-                siteText.vaccinaties.data.vaccination_chart.right_divider_label,
-            },
-          ],
         }}
         initialWidth={400}
         minHeight={breakpoints.md ? 400 : 250}

--- a/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
@@ -2,7 +2,7 @@ import {
   NlVaccineDeliveryPerSupplier,
   NlVaccineDeliveryPerSupplierValue,
 } from '@corona-dashboard/common';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
@@ -56,20 +56,13 @@ export function VaccineDeliveryBarChart({
 
   const formatTooltip: TooltipFormatter<
     NlVaccineDeliveryPerSupplierValue & StackedBarTooltipData
-  > = useCallback(
-    (
-      context: TooltipData<
-        NlVaccineDeliveryPerSupplierValue & StackedBarTooltipData
-      >
-    ) => {
-      const data = {
-        ...context,
-      };
-
-      return <TooltipSeriesList data={data} />;
-    },
-    [intl.siteText.vaccinaties.data.vaccination_chart.legend.expected]
-  );
+  > = (
+    context: TooltipData<
+      NlVaccineDeliveryPerSupplierValue & StackedBarTooltipData
+    >
+  ) => {
+    return <TooltipSeriesList data={context} />;
+  };
 
   return (
     <ChartTile

--- a/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-delivery-bar-chart.tsx
@@ -16,7 +16,6 @@ import {
   TooltipFormatter,
 } from '~/components/time-series-chart/components';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
-import { TimespanAnnotationConfig } from '~/components/time-series-chart/logic';
 import { Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
@@ -32,21 +31,23 @@ export function VaccineDeliveryBarChart({
   const text = intl.siteText.vaccinaties.grafiek_leveringen;
   const [timeframe, setTimeframe] = useState<Timeframe>('recent_and_coming');
 
+  data.values = data.values.filter((x) => !x.is_estimate);
+
   /**
    * The timeframe `recent_and_coming` should display 4 delivered values
    * and 4 expected values. We'll find the index of the first estimated value
    * and slice values based on that index.
    */
-  const estimateIndex = data.values.findIndex((value) => value.is_estimate);
+  // const estimateIndex = data.values.findIndex((value) => value.is_estimate);
 
   const timeframeOptions = [
     {
       label: intl.siteText.charts.time_controls.all,
-      value: 'all' as Timeframe,
+      value: 'all',
     },
     {
       label: text.timeframe_recent_en_verwacht,
-      value: 'recent_and_coming' as Timeframe,
+      value: 'recent_and_coming',
     },
   ];
 
@@ -63,14 +64,6 @@ export function VaccineDeliveryBarChart({
     ) => {
       const data = {
         ...context,
-
-        timespanAnnotation: context.value.isHatched
-          ? ({
-              label:
-                intl.siteText.vaccinaties.data.vaccination_chart.legend
-                  .expected,
-            } as TimespanAnnotationConfig)
-          : undefined,
       };
 
       return <TooltipSeriesList data={data} />;
@@ -98,7 +91,7 @@ export function VaccineDeliveryBarChart({
 
         <RadioGroup
           value={timeframe}
-          onChange={(x) => setTimeframe(x)}
+          onChange={(x) => setTimeframe(x as Timeframe)}
           items={timeframeOptions}
         />
       </Box>
@@ -111,7 +104,7 @@ export function VaccineDeliveryBarChart({
         values={
           timeframe === 'all'
             ? data.values
-            : data.values.slice(estimateIndex - 4, estimateIndex + 4)
+            : data.values.slice(data.values.length - 6)
         }
         valueAnnotation={intl.siteText.waarde_annotaties.x_100k}
         formatTickValue={(x) => `${x / 100_000}`}
@@ -145,9 +138,6 @@ export function VaccineDeliveryBarChart({
             label: text.totaal,
           },
         ].filter(isDefined)}
-        expectedLabel={
-          intl.siteText.vaccinaties.data.vaccination_chart.legend.expected
-        }
         formatTooltip={formatTooltip}
       />
     </ChartTile>

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -17,11 +17,11 @@ import { selectVaccineCoverageData } from '~/domain/vaccine/data-selection/selec
 import { MilestonesView } from '~/domain/vaccine/milestones-view';
 import { VaccineAdministrationsKpiSection } from '~/domain/vaccine/vaccine-administrations-kpi-section';
 import { VaccineCoverageChoroplethPerGm } from '~/domain/vaccine/vaccine-coverage-choropleth-per-gm';
+import { VaccineCoverageToggleTile } from '~/domain/vaccine/vaccine-coverage-toggle-tile';
 import { VaccineDeliveryAndAdministrationsAreaChart } from '~/domain/vaccine/vaccine-delivery-and-administrations-area-chart';
 import { VaccineDeliveryBarChart } from '~/domain/vaccine/vaccine-delivery-bar-chart';
 import { VaccinePageIntroductionNl } from '~/domain/vaccine/vaccine-page-introduction-nl';
 import { VaccineStockPerSupplierChart } from '~/domain/vaccine/vaccine-stock-per-supplier-chart';
-import { VaccineCoverageToggleTile } from '~/domain/vaccine/vaccine-coverage-toggle-tile';
 import { useIntl } from '~/intl';
 import { useFeature } from '~/lib/features';
 import {


### PR DESCRIPTION
## Summary

NOTE: This is a quick&dirty hotfix PR. Eventually the estimate data will be removed from the schema's as well,
this is a temporary fix which will need to be cleaned up once the backend data is updated.

Remove estimates from stacked area and stacked bar chart on vaccination page:
![image](https://user-images.githubusercontent.com/69849293/133121850-32f9d36a-8636-4369-b4dd-9e6d3bd48315.png)

and

![image](https://user-images.githubusercontent.com/69849293/133121902-c68f1405-9c8f-4267-91c8-cf1326c179b2.png)
