### PR TITLE
Fix higher lower use on Actueel & fix 'gelijk' lokalize key

### DIFF
--- a/packages/app/src/components/data-driven-text.tsx
+++ b/packages/app/src/components/data-driven-text.tsx
@@ -43,6 +43,7 @@ interface DataDrivenTextProps<T extends DataKeys, K = DataFile<T>> {
   metricProperty: string;
   valueTexts: PluralizationTexts;
   differenceText: string;
+  isAmount: boolean;
 }
 
 export function DataDrivenText<T extends DataKeys, K = DataFile<T>>({
@@ -52,6 +53,7 @@ export function DataDrivenText<T extends DataKeys, K = DataFile<T>>({
   metricProperty,
   valueTexts,
   differenceText: differenceTexts,
+  isAmount,
 }: DataDrivenTextProps<T, K>) {
   const { siteText, formatNumber } = useIntl();
 
@@ -100,7 +102,9 @@ export function DataDrivenText<T extends DataKeys, K = DataFile<T>>({
         ),
       })}{' '}
       {replaceComponentsInText(differenceTexts, {
-        differenceTrend: <InlineDifference value={differenceValue} />,
+        differenceTrend: (
+          <InlineDifference isAmount={isAmount} value={differenceValue} />
+        ),
         differenceAverage: (
           <InlineText fontWeight="bold">
             {formatNumber(differenceValue.old_value)}

--- a/packages/app/src/components/difference-indicator/inline-difference.tsx
+++ b/packages/app/src/components/difference-indicator/inline-difference.tsx
@@ -1,14 +1,15 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
-import { Up } from '@corona-dashboard/icons';
-import { Down } from '@corona-dashboard/icons';
+import { Down, Up } from '@corona-dashboard/icons';
 import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Container, IconContainer } from './containers';
 
 export function InlineDifference({
   value,
+  isAmount,
 }: {
   value: DifferenceDecimal | DifferenceInteger;
+  isAmount: boolean;
 }) {
   const { siteText } = useIntl();
   const text = siteText.common_actueel;
@@ -16,7 +17,9 @@ export function InlineDifference({
   if (value.difference > 0)
     return (
       <Container>
-        <InlineText fontWeight="bold">{text.trend_hoger}</InlineText>
+        <InlineText fontWeight="bold">
+          {isAmount ? text.trend_meer : text.trend_hoger}
+        </InlineText>
         <IconContainer color="red">
           <Up />
         </IconContainer>
@@ -25,7 +28,9 @@ export function InlineDifference({
   if (value.difference < 0)
     return (
       <Container>
-        <InlineText fontWeight="bold">{text.trend_lager}</InlineText>
+        <InlineText fontWeight="bold">
+          {isAmount ? text.trend_minder : text.trend_lager}
+        </InlineText>
         <IconContainer color="data.primary">
           <Down />
         </IconContainer>

--- a/packages/app/src/components/difference-indicator/tile-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-difference.tsx
@@ -1,13 +1,11 @@
 import { DifferenceDecimal, DifferenceInteger } from '@corona-dashboard/common';
+import { Down, Gelijk, Up } from '@corona-dashboard/icons';
 import css from '@styled-system/css';
-import { Gelijk } from '@corona-dashboard/icons';
-import { Up } from '@corona-dashboard/icons';
-import { Down } from '@corona-dashboard/icons';
-import { useIntl } from '~/intl';
-import { Container, IconContainer } from './containers';
 import { Markdown } from '~/components/markdown';
-import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { InlineText } from '~/components/typography';
+import { useIntl } from '~/intl';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { Container, IconContainer } from './containers';
 
 export function TileDifference({
   value,
@@ -72,7 +70,7 @@ export function TileDifference({
         }}
         content={replaceVariablesInText(
           `${content} ${
-            showOldDateUnix ? text.dan_waarde_datum : text.waarde_gelijk
+            showOldDateUnix ? text.vorige_waarde_datum : text.vorige_waarde
           }`,
           {
             amount: `${formattedDifference}${isPercentage ? '%' : ''}`,

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -178,6 +178,7 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Test />}
@@ -199,6 +200,7 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Ziekenhuis />}

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -163,6 +163,7 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Test />}
@@ -184,6 +185,7 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Ziekenhuis />}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -187,6 +187,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Test />}
@@ -212,6 +213,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     differenceText={
                       siteText.common_actueel.secties.kpi.zeven_daags_gemiddelde
                     }
+                    isAmount
                   />
                 }
                 icon={<Ziekenhuis />}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -82,3 +82,5 @@ timestamp,action,key,document_id,move_to
 2021-09-14T07:45:37.422Z,delete,vaccinaties.vaccination_coverage.bronnen.rivm.download,hV7FtoXjFTieHrDRGlLXLi,__
 2021-09-16T09:38:58.357Z,add,toe_en_afname.vorige_waarde,4Hn4MB4VRci1fnngMXoJXo,__
 2021-09-16T09:38:58.359Z,move,toe_en_afname.dan_waarde_datum,srBRCALrLz9Y3ZpBD68tp7,toe_en_afname.vorige_waarde_datum
+2021-09-16T09:59:12.094Z,add,common_actueel.trend_meer,Q0Ac8gjemD8winez2MsSX5,__
+2021-09-16T09:59:13.110Z,add,common_actueel.trend_minder,4Hn4MB4VRci1fnngMXslwu,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -80,7 +80,7 @@ timestamp,action,key,document_id,move_to
 2021-09-14T07:45:36.382Z,add,veiligheidsregio_vaccinaties.vaccination_coverage.bronnen.rivm.href,TfQKtohu9HBbEmilvQe9Sl,__
 2021-09-14T07:45:37.422Z,add,veiligheidsregio_vaccinaties.vaccination_coverage.bronnen.rivm.text,iLvivnjMZ7igG7VqB1KDRi,__
 2021-09-14T07:45:37.422Z,delete,vaccinaties.vaccination_coverage.bronnen.rivm.download,hV7FtoXjFTieHrDRGlLXLi,__
-2021-09-16T09:38:58.357Z,add,toe_en_afname.vorige_waarde,4Hn4MB4VRci1fnngMXoJXo,__
 2021-09-16T09:38:58.359Z,move,toe_en_afname.dan_waarde_datum,srBRCALrLz9Y3ZpBD68tp7,toe_en_afname.vorige_waarde_datum
 2021-09-16T09:59:12.094Z,add,common_actueel.trend_meer,Q0Ac8gjemD8winez2MsSX5,__
 2021-09-16T09:59:13.110Z,add,common_actueel.trend_minder,4Hn4MB4VRci1fnngMXslwu,__
+2021-09-16T10:23:51.039Z,add,toe_en_afname.vorige_waarde,4Hn4MB4VRci1fnngMXwLNw,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -80,3 +80,5 @@ timestamp,action,key,document_id,move_to
 2021-09-14T07:45:36.382Z,add,veiligheidsregio_vaccinaties.vaccination_coverage.bronnen.rivm.href,TfQKtohu9HBbEmilvQe9Sl,__
 2021-09-14T07:45:37.422Z,add,veiligheidsregio_vaccinaties.vaccination_coverage.bronnen.rivm.text,iLvivnjMZ7igG7VqB1KDRi,__
 2021-09-14T07:45:37.422Z,delete,vaccinaties.vaccination_coverage.bronnen.rivm.download,hV7FtoXjFTieHrDRGlLXLi,__
+2021-09-16T09:38:58.357Z,add,toe_en_afname.vorige_waarde,4Hn4MB4VRci1fnngMXoJXo,__
+2021-09-16T09:38:58.359Z,move,toe_en_afname.dan_waarde_datum,srBRCALrLz9Y3ZpBD68tp7,toe_en_afname.vorige_waarde_datum


### PR DESCRIPTION
## Summary

Somehow the wrong lokalize key was used for 'gelijk aan' in a difference tile. Also, InlineDifference still used higher/lower while it should be meer/minder.
