### PR TITLE
Also parse has_one_shot label for choropleth value

### DIFF
--- a/packages/app/src/domain/vaccine/data-selection/select-vaccine-coverage-data.ts
+++ b/packages/app/src/domain/vaccine/data-selection/select-vaccine-coverage-data.ts
@@ -13,19 +13,32 @@ export function selectVaccineCoverageData<
     | VrVaccineCoveragePerAgeGroupValue
 >(data: T[]) {
   return data.map((el) => {
+    const parsedLabels: {
+      fully_vaccinated_percentage?: number;
+      has_one_shot_percentage?: number;
+    } = {};
+
     if (isPresent(el.fully_vaccinated_percentage_label)) {
       const result = parseFullyVaccinatedPercentageLabel(
         el.fully_vaccinated_percentage_label
       );
 
       if (isPresent(result)) {
-        return {
-          ...el,
-          fully_vaccinated_percentage: result.sign === '>' ? 100 : 0,
-        };
+        parsedLabels.fully_vaccinated_percentage =
+          result.sign === '>' ? 100 : 0;
       }
     }
 
-    return el;
+    if (isPresent(el.has_one_shot_percentage_label)) {
+      const result = parseFullyVaccinatedPercentageLabel(
+        el.has_one_shot_percentage_label
+      );
+
+      if (isPresent(result)) {
+        parsedLabels.has_one_shot_percentage = result.sign === '>' ? 100 : 0;
+      }
+    }
+
+    return { ...el, ...parsedLabels };
   });
 }


### PR DESCRIPTION
## Summary

We parsed the `fully_vaccinated_percentage_label` into `fully_vaccinated_percentage` to be able to give a region the right color on the choropleth. However, we did not do the same for the `has_one_shot_percentage` value yet, which made the regions with a label white on the map, which is incorrect.
