### PR TITLE
Update combobox to work properly with arrows

### DIFF
--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -10,13 +10,12 @@ import { matchSorter } from 'match-sorter';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createGlobalStyle } from 'styled-components';
+import searchUrl from '~/assets/search.svg';
 import { Box } from '~/components/base';
 import { useIntl } from '~/intl';
 import { assert } from '~/utils/assert';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useThrottle } from '~/utils/use-throttle';
-
-import searchUrl from '~/assets/search.svg';
 
 type TOption = {
   displayName?: string;
@@ -100,9 +99,9 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
         <ComboboxPopover>
           {results.length > 0 ? (
             <ComboboxList persistSelection>
-              {results.map((option) => (
+              {results.map((option, index) => (
                 <ComboboxOption
-                  key={option.name}
+                  key={index}
                   value={option.displayName || option.name}
                 />
               ))}


### PR DESCRIPTION
Updating the key to use an index instead of a value fixes the arrow order bug.