### PR TITLE
Add sparkbars component to Actueel MiniTrendTiles

### DIFF
--- a/packages/app/src/components/spark-bars.tsx
+++ b/packages/app/src/components/spark-bars.tsx
@@ -1,0 +1,54 @@
+import type { KeysOfType, TimestampedValue } from '@corona-dashboard/common';
+import { scaleLinear } from '@visx/scale';
+import { colors } from '~/style/theme';
+import { Box } from './base';
+
+const BAR_WIDTH = 6;
+const BAR_HEIGHT = 24;
+
+type SparkBarsProps<T extends TimestampedValue> = {
+  averageProperty: KeysOfType<T, number | null, true>;
+  data: T[];
+};
+
+export function SparkBars<T extends TimestampedValue>(
+  props: SparkBarsProps<T>
+) {
+  const { data, averageProperty } = props;
+
+  const last7Days = data.slice(-7);
+
+  const min = Math.min(0, ...last7Days.map((d) => d[averageProperty]));
+  // the max y domain is at least 5 so we have decent visuals for lower values
+  const max = Math.max(5, ...last7Days.map((d) => d[averageProperty]));
+
+  const y = scaleLinear({
+    domain: [min, max],
+    range: [BAR_HEIGHT, 0],
+    round: true,
+    nice: true,
+  });
+
+  return (
+    <Box as="span" mr="3">
+      <svg width={7 * BAR_WIDTH} height={BAR_HEIGHT}>
+        {last7Days.map((d, i) => (
+          <rect
+            key={'date_unix' in d ? d.date_unix : d.date_start_unix}
+            x={i * BAR_WIDTH}
+            width={BAR_WIDTH}
+            y={y(Math.max(0, d[averageProperty]))}
+            height={
+              d[averageProperty] >= 0 ? y(0) - y(d[averageProperty]) : y(0)
+            }
+            fill={
+              d[averageProperty] >= 0
+                ? colors.data.positive
+                : colors.data.negative
+            }
+          />
+        ))}
+      </svg>
+    </Box>
+  );
+}

--- a/packages/app/src/components/spark-bars.tsx
+++ b/packages/app/src/components/spark-bars.tsx
@@ -30,8 +30,14 @@ export function SparkBars<T extends TimestampedValue>(
   });
 
   return (
-    <Box as="span" mr="3">
-      <svg width={7 * BAR_WIDTH} height={BAR_HEIGHT}>
+    <Box as="span" mr="3" aria-hidden="true">
+      <svg
+        width={7 * BAR_WIDTH}
+        height={BAR_HEIGHT}
+        role="img"
+        aria-hidden="true"
+        focusable="false"
+      >
         {last7Days.map((d, i) => (
           <rect
             key={'date_unix' in d ? d.date_unix : d.date_start_unix}

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary } from '~/components/error-boundary';
 import { InlineTooltip } from '~/components/inline-tooltip';
 import { HeadingLinkWithIcon } from '~/components/link-with-icon';
 import { MiniTrendChart } from '~/components/mini-trend-chart';
+import { SparkBars } from '~/components/spark-bars';
 import { Heading, Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
@@ -29,6 +30,7 @@ type MiniTrendTileProps<T extends TimestampedValue = TimestampedValue> = {
   timeframe?: TimeframeOption;
   trendData: T[];
   metricProperty: KeysOfType<T, number | null, true>;
+  averageProperty?: KeysOfType<T, number | null, true>;
   href: string;
   areas?: { header: string; chart: string };
   warning?: string;
@@ -47,6 +49,7 @@ export function MiniTrendTile<T extends TimestampedValue>(
     timeframe = '5weeks',
     trendData,
     metricProperty,
+    averageProperty,
     href,
     areas,
     warning,
@@ -69,8 +72,14 @@ export function MiniTrendTile<T extends TimestampedValue>(
             </HeadingLinkWithIcon>
           </Box>
         </Heading>
+
         <Text variant="h1" data-cy={metricProperty}>
+          {averageProperty && (
+            <SparkBars averageProperty={averageProperty} data={trendData} />
+          )}
+
           {formatNumber(value as unknown as number)}
+
           {warning && (
             <InlineTooltip content={warning}>
               <WarningIconWrapper aria-label={siteText.aria_labels.warning}>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -193,6 +193,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                 icon={<Test />}
                 trendData={dataInfectedTotal.values}
                 metricProperty="infected"
+                averageProperty="infected_per_100k_moving_average"
                 href={reverseRouter.nl.positiefGetesteMensen()}
                 accessibility={{ key: 'topical_tested_overall' }}
                 warning={getWarning(
@@ -219,6 +220,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                 icon={<Ziekenhuis />}
                 trendData={dataHospitalIntake.values}
                 metricProperty="admissions_on_date_of_reporting"
+                averageProperty="admissions_on_date_of_admission_moving_average"
                 href={reverseRouter.nl.ziekenhuisopnames()}
                 accessibility={{ key: 'topical_hospital_nice' }}
                 warning={getWarning(


### PR DESCRIPTION
## Summary

Adds a `SparkBars` component to the current MiniTrendTiles. This is not the right place and they will need to be moved to the new trend layout when that is finished but this allows us to review the spark-bars.