### PR TITLE
Hide irrelevant content from screenreaders

### DIFF
--- a/packages/app/src/components/choropleth-legenda.tsx
+++ b/packages/app/src/components/choropleth-legenda.tsx
@@ -21,7 +21,12 @@ export function ChoroplethLegenda({
   const [endLabelRef, endLabelSize] = useResizeObserver<HTMLSpanElement>();
 
   return (
-    <Box width="100%" pr={`${endLabelSize.width ?? 0 / 2}px`} spacing={2}>
+    <Box
+      width="100%"
+      pr={`${endLabelSize.width ?? 0 / 2}px`}
+      spacing={2}
+      aria-hidden="true"
+    >
       {title && <Text variant="subtitle1">{title}</Text>}
       <List>
         {thresholds.map(({ color, threshold, label, endLabel }, index) => {

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -205,7 +205,7 @@ export const Axes = memo(function Axes({
   const numDarkGridLines = allZeroValues ? 1 : numGridLines;
 
   return (
-    <g css={css({ pointerEvents: 'none' })}>
+    <g css={css({ pointerEvents: 'none' })} aria-hidden="true">
       <GridRows
         /**
          * Lighter gray grid lines are used for the lines that have no label on

--- a/packages/app/src/domain/vaccine/components/vaccine-ticker.tsx
+++ b/packages/app/src/domain/vaccine/components/vaccine-ticker.tsx
@@ -74,6 +74,7 @@ export function VaccineTicker({ data }: VaccineTickerProps) {
           width={CONTAINER_WIDTH}
           height={CONTAINER_HEIGHT}
           position="relative"
+          aria-hidden="true"
         >
           <Clock progress={animationProgress} />
 


### PR DESCRIPTION
## Summary

During the a11y review there were some elements that were read by the screenreader which either are irrelevant or make no sense for screenreader users. In these cases it is better to hide this information since screenreader users get that information elsewhere, or don't need it at all.

I could not easily test if the graph axes values are indeed not read out by the screenreader since Voiceover did not do that to begin with, but I'm quite confident this solution will work for a screenreader like JAWS (where the problem occured).
