### PR TITLE
Move GM/VR toggle above map on smaller screens

### DIFF
--- a/packages/app/src/domain/actueel/vaccination-coverage-choropleth.tsx
+++ b/packages/app/src/domain/actueel/vaccination-coverage-choropleth.tsx
@@ -94,27 +94,12 @@ export function VaccinationCoverageChoropleth(
 
       <ChoroplethTwoColumnLayout
         legendComponent={
-          <>
-            {isNlCoverage(props) && (
-              <Box
-                display="flex"
-                justifyContent={{ _: 'center', lg: 'flex-start' }}
-              >
-                <ChartRegionControls
-                  value={chartRegion}
-                  onChange={onChartRegionChange}
-                />
-              </Box>
-            )}
-
-            <ChoroplethLegenda
-              thresholds={thresholds.gm.fully_vaccinated_percentage}
-              title={
-                siteText.vaccinaties.nl_choropleth_vaccinatie_graad
-                  .legenda_titel
-              }
-            />
-          </>
+          <ChoroplethLegenda
+            thresholds={thresholds.gm.fully_vaccinated_percentage}
+            title={
+              siteText.vaccinaties.nl_choropleth_vaccinatie_graad.legenda_titel
+            }
+          />
         }
       >
         <Box>
@@ -219,6 +204,18 @@ export function VaccinationCoverageChoropleth(
         <Box spacing={3}>
           <Markdown content={props.content} />
           <AgeGroupSelect onChange={setSelectedAgeGroup} />
+          {isNlCoverage(props) && (
+            <Box
+              display="flex"
+              justifyContent={{ _: 'center', md: 'flex-start' }}
+              mb={2}
+            >
+              <ChartRegionControls
+                value={chartRegion}
+                onChange={onChartRegionChange}
+              />
+            </Box>
+          )}
         </Box>
       </ChoroplethTwoColumnLayout>
     </TopicalTile>

--- a/packages/app/src/domain/topical/choropleth-two-column-layout.tsx
+++ b/packages/app/src/domain/topical/choropleth-two-column-layout.tsx
@@ -29,7 +29,16 @@ export function ChoroplethTwoColumnLayout(props: TopicalChoroplethTileProps) {
           <Box flex={{ _: '1 1 0%' }} px={{ _: 0, sm: '6rem' }} pb={4}>
             {childrenArray[0]}
           </Box>
-          <Box maxWidth={300}>{legendComponent}</Box>
+          <Box
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="space-around"
+          >
+            <Box maxWidth={300} flexBasis="100%">
+              {legendComponent}
+            </Box>
+          </Box>
         </>
       ) : (
         <>


### PR DESCRIPTION
## Summary

- Move the legend above the vaccination coverage choropleth and center it on smaller screens
- Center the `legendComponent` in the `ChoroplethTwoColumnLayout` component on smaller screens.

