### PR TITLE
Don't show hover state on area series minitrends

### DIFF
--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-items.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-items.tsx
@@ -52,7 +52,7 @@ export function TooltipSeriesListItems<T extends TimestampedValue>({
                 icon={<SeriesIcon config={x} />}
                 label={x.shortLabel ?? x.label}
                 displayTooltipValueOnly={displayTooltipValueOnly}
-                isVisuallyHidden={x.isNonInteractive}
+                isVisuallyHidden={x.hideInTooltip}
               >
                 <span css={css({ whiteSpace: 'nowrap' })}>
                   {formatSeriesValue(value, x, options.isPercentage)}
@@ -66,7 +66,7 @@ export function TooltipSeriesListItems<T extends TimestampedValue>({
                 key={key}
                 label={x.label}
                 displayTooltipValueOnly={displayTooltipValueOnly}
-                isVisuallyHidden={x.isNonInteractive}
+                isVisuallyHidden={x.hideInTooltip}
               >
                 {formatSeriesValue(
                   value,
@@ -89,7 +89,7 @@ export function TooltipSeriesListItems<T extends TimestampedValue>({
                 }
                 label={x.shortLabel ?? x.label}
                 displayTooltipValueOnly={displayTooltipValueOnly}
-                isVisuallyHidden={x.isNonInteractive}
+                isVisuallyHidden={x.hideInTooltip}
               >
                 {formatSeriesValue(value, x, options.isPercentage)}
               </TooltipListItem>
@@ -102,7 +102,7 @@ export function TooltipSeriesListItems<T extends TimestampedValue>({
                 icon={<SeriesIcon config={x} />}
                 label={x.shortLabel ?? x.label}
                 displayTooltipValueOnly={displayTooltipValueOnly}
-                isVisuallyHidden={x.isNonInteractive}
+                isVisuallyHidden={x.hideInTooltip}
               >
                 {formatSeriesValue(value, x, options.isPercentage)}
               </TooltipListItem>

--- a/packages/app/src/components/time-series-chart/logic/hover-state.ts
+++ b/packages/app/src/components/time-series-chart/logic/hover-state.ts
@@ -81,7 +81,7 @@ export function useHoverState<T extends TimestampedValue>({
   const interactiveMetricProperties = useMemo(
     () =>
       seriesConfig
-        .filter((x) => !x.isNonInteractive)
+        .filter((x) => !x.noHover)
         .filter(isVisible)
         .flatMap((x) => {
           switch (x.type) {
@@ -251,7 +251,7 @@ export function useHoverState<T extends TimestampedValue>({
 
     const barPoints: HoveredPoint<T>[] = seriesConfig
       .filter(isVisible)
-      .filter((x) => !x.isNonInteractive)
+      .filter((x) => !x.noHover)
       .map((config, index) => {
         const seriesValue = seriesList[index][valuesIndex] as
           | SeriesSingleValue
@@ -296,7 +296,7 @@ export function useHoverState<T extends TimestampedValue>({
 
     const linePoints: HoveredPoint<T>[] = seriesConfig
       .filter(isVisible)
-      .filter((x) => !x.isNonInteractive)
+      .filter((x) => !x.noHover)
       .map((config, index) => {
         const seriesValue = seriesList[index][valuesIndex] as
           | SeriesSingleValue
@@ -351,7 +351,7 @@ export function useHoverState<T extends TimestampedValue>({
      */
     const rangePoints: HoveredPoint<T>[] = seriesConfig
       .filter(isVisible)
-      .filter((x) => !x.isNonInteractive)
+      .filter((x) => !x.noHover)
       .flatMap((config, index) => {
         const seriesValue = seriesList[index][valuesIndex] as
           | SeriesDoubleValue

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -34,12 +34,18 @@ interface SeriesCommonDefinition {
    */
   shortLabel?: string;
   /**
-   * Non-interactive means the series will not have hover state and does not
-   * show up visually as part of the tooltip (only hidden). Sometimes we want to
-   * render a series as a backdrop to give context to another interactive
-   * series, like in the sewer chart when a location is selected.
+   * Hide in tooltip means the series will not show up visually as part of the
+   * tooltip (only hidden). Sometimes we want to render a series as a backdrop
+   * to give context to another interactive series, like in the sewer chart when
+   * a location is selected.
    */
-  isNonInteractive?: boolean;
+  hideInTooltip?: boolean;
+  /**
+   * No-hover means the series will not have a hover state. This can be useful
+   * when showing two variants of the same metric (like 7-day averages and daily
+   * values), or when using a second series as a backdrop.
+   */
+  noHover?: boolean;
 }
 
 export interface GappedLineSeriesDefinition<T extends TimestampedValue>
@@ -52,7 +58,6 @@ export interface GappedLineSeriesDefinition<T extends TimestampedValue>
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   curve?: 'linear' | 'step';
-  isNonInteractive?: boolean;
 }
 
 export interface LineSeriesDefinition<T extends TimestampedValue>
@@ -65,7 +70,6 @@ export interface LineSeriesDefinition<T extends TimestampedValue>
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   curve?: 'linear' | 'step';
-  isNonInteractive?: boolean;
 }
 
 export interface AreaSeriesDefinition<T extends TimestampedValue>
@@ -78,7 +82,6 @@ export interface AreaSeriesDefinition<T extends TimestampedValue>
   fillOpacity?: number;
   strokeWidth?: number;
   curve?: 'linear' | 'step';
-  isNonInteractive?: boolean;
 }
 
 export interface BarSeriesDefinition<T extends TimestampedValue>
@@ -89,7 +92,6 @@ export interface BarSeriesDefinition<T extends TimestampedValue>
   shortLabel?: string;
   color: string;
   fillOpacity?: number;
-  isNonInteractive?: boolean;
 }
 
 export interface SplitBarSeriesDefinition<T extends TimestampedValue>
@@ -100,7 +102,6 @@ export interface SplitBarSeriesDefinition<T extends TimestampedValue>
   shortLabel?: string;
   fillOpacity?: number;
   splitPoints: SplitPoint[];
-  isNonInteractive?: boolean;
 }
 
 export interface RangeSeriesDefinition<T extends TimestampedValue>
@@ -113,7 +114,6 @@ export interface RangeSeriesDefinition<T extends TimestampedValue>
   color: string;
   style?: 'solid' | 'dashed';
   fillOpacity?: number;
-  isNonInteractive?: boolean;
 }
 
 export interface StackedAreaSeriesDefinition<T extends TimestampedValue>
@@ -126,7 +126,6 @@ export interface StackedAreaSeriesDefinition<T extends TimestampedValue>
   style?: 'solid' | 'hatched';
   fillOpacity?: number;
   strokeWidth?: number;
-  isNonInteractive?: boolean;
   mixBlendMode?: Property.MixBlendMode;
 }
 
@@ -140,7 +139,6 @@ export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
   style?: 'solid' | 'hatched';
   fillOpacity?: number;
   strokeWidth?: number;
-  isNonInteractive?: boolean;
   mixBlendMode?: Property.MixBlendMode;
 }
 
@@ -162,7 +160,6 @@ export interface SplitAreaSeriesDefinition<T extends TimestampedValue>
   splitPoints: SplitPoint[];
   strokeWidth?: number;
   fillOpacity?: number;
-  isNonInteractive?: boolean;
 }
 
 /**
@@ -185,7 +182,6 @@ export interface InvisibleSeriesDefinition<T extends TimestampedValue>
    * indicate the format.
    */
   isPercentage?: boolean;
-  isNonInteractive?: boolean;
 }
 
 type CutValuesConfig = {

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -137,7 +137,8 @@ export function SewerChart({
                     metricProperty: 'average',
                     label: text.averagesDataLabel,
                     splitPoints: averageSplitPoints,
-                    isNonInteractive: true,
+                    hideInTooltip: true,
+                    noHover: true,
                   },
                 ]}
                 formatTooltip={(data) => {

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -174,6 +174,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     color: colors.data.primary,
                     curve: 'step',
                     strokeWidth: 0,
+                    noHover: true,
                   },
                 ]}
                 titleValue={
@@ -235,6 +236,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     color: colors.data.primary,
                     curve: 'step',
                     strokeWidth: 0,
+                    noHover: true,
                   },
                 ]}
                 titleValue={


### PR DESCRIPTION
## Summary

The mini trends currently show a double hover state (on both the moving average and the daily values). We only want to show it on the moving average.

We already had an option to make a series completely non-interactive for the sewer chart, but in this case we still want to show the daily values in the tooltip. I therefore split the non-interactive functionality up in not showing the series in the tooltip, and not showing a hover state.