### PR TITLE
Explicitly set width: auto on Icon

### DIFF
--- a/packages/app/src/components/page-information-block/components/header.tsx
+++ b/packages/app/src/components/page-information-block/components/header.tsx
@@ -71,6 +71,7 @@ const Icon = styled.span<{ gridArea: 'topIcon' | 'sideIcon' }>((x) =>
 
     svg: {
       height: '3.5rem',
+      width: 'auto',
     },
   })
 );


### PR DESCRIPTION
## Summary

This fix explicitly sets `width: auto` on the `PageInformationBlock::Header::Icon` component, making sure that icon's will scale correctly upon setting their height.

**Voor**

<img width="721" alt="Screenshot 2021-09-27 at 09 14 18" src="https://user-images.githubusercontent.com/89384854/134861667-8c120b50-5222-41ec-95c4-c6265a043851.png">

**Na**

<img width="570" alt="Screenshot 2021-09-27 at 09 14 41" src="https://user-images.githubusercontent.com/89384854/134861690-c52a5714-4205-4102-b948-ef8ca75a0768.png">