### PR TITLE
Tighten security headers

### DIFF
--- a/packages/app/next-server.js
+++ b/packages/app/next-server.js
@@ -145,13 +145,13 @@ const STATIC_ASSET_HTTP_DATE = new Date(
   ) {
     const contentSecurityPolicy =
       IS_PRODUCTION_BUILD && !IS_DEVELOPMENT_PHASE
-        ? "default-src 'self' statistiek.rijksoverheid.nl; img-src 'self' statistiek.rijksoverheid.nl data:; style-src 'self' 'unsafe-inline'; script-src 'self' statistiek.rijksoverheid.nl; font-src 'self'"
-        : '';
+        ? "default-src 'self'; img-src 'self' statistiek.rijksoverheid.nl data:; style-src 'self' 'unsafe-inline'; script-src 'self' statistiek.rijksoverheid.nl; font-src 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'none';"
+        : "default-src 'self'; img-src 'self' statistiek.rijksoverheid.nl data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline' statistiek.rijksoverheid.nl; font-src 'self'; frame-ancestors 'none'; object-src 'none'; form-action 'none';";
 
     res.set('Content-Security-Policy', contentSecurityPolicy);
-    res.set('Referrer-Policy', 'origin');
+    res.set('Referrer-Policy', 'no-referrer');
     res.set('X-Content-Type-Options', 'nosniff');
-    res.set('X-Frame-Options', 'SAMEORIGIN');
+    res.set('X-Frame-Options', 'DENY');
     res.set('X-XSS-Protection', '1; mode=block');
     res.set(
       'Strict-Transport-Security',


### PR DESCRIPTION
## Summary

This PR tightens security headers, specifically disallowing iframe embedding the site as well as updating some CSP directives.

The ticket for this change suggests changing `default-src` to `'none'`, which I tried. This led to some JSON files as well as API routes failing to load. There doesn't seem to be an explicit CSP directive to allow 'data' files from `'self'`. If anyone has suggestions on which directive to use for that, please let me know.

I've also added CSP headers to our development environment, so that we'll have some early warning signs when we update things that we need to change CSP directives for.