### PR TITLE
Add workaround for combobox ordering bug

### DIFF
--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -99,15 +99,11 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
         <ComboboxPopover>
           {results.length > 0 ? (
             <ComboboxList>
-              {results.map((option) => (
-                // Wrapping the option in a div is a workaround for a bug with
-                // reordering the options: https://github.com/reach/reach-ui/issues/840
-                <div>
-                  <ComboboxOption
-                    key={option.name}
-                    value={option.displayName || option.name}
-                  />
-                </div>
+              {results.map((option, index) => (
+                <ComboboxOption
+                  key={`${index}-${option.name}`}
+                  value={option.displayName || option.name}
+                />
               ))}
             </ComboboxList>
           ) : (

--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -99,11 +99,15 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
         <ComboboxPopover>
           {results.length > 0 ? (
             <ComboboxList>
-              {results.map((option, index) => (
-                <ComboboxOption
-                  key={index}
-                  value={option.displayName || option.name}
-                />
+              {results.map((option) => (
+                // Wrapping the option in a div is a workaround for a bug with
+                // reordering the options: https://github.com/reach/reach-ui/issues/840
+                <div>
+                  <ComboboxOption
+                    key={option.name}
+                    value={option.displayName || option.name}
+                  />
+                </div>
               ))}
             </ComboboxList>
           ) : (


### PR DESCRIPTION
## Summary

When typing in different search terms in the combobox, the keyboard navigation order of the options would get scrambled. This seems to be a bug in the reach combobox we are using: https://github.com/reach/reach-ui/issues/840. This PR adds the workaround suggested in that issue, which indeed seems to work.

We should keep an eye on the issue, so we can remove this workaround when the bug is solved.
