### PR TITLE
Remove 'value from' metadata from all SidebarMetrics

### DIFF
--- a/packages/app/src/components/sidebar-metric/sidebar-kpi-value.tsx
+++ b/packages/app/src/components/sidebar-metric/sidebar-kpi-value.tsx
@@ -13,21 +13,13 @@ type SidebarKpiValueProps = {
    * Currently only `Behavior` is doing that.
    */
   value?: number;
-  description?: string;
   valueAnnotation?: string;
   difference?: DifferenceDecimal | DifferenceInteger;
   isPercentage?: boolean;
 };
 
 export function SidebarKpiValue(props: SidebarKpiValueProps) {
-  const {
-    value,
-    isPercentage,
-    title,
-    description,
-    valueAnnotation,
-    difference,
-  } = props;
+  const { value, isPercentage, title, valueAnnotation, difference } = props;
 
   const { formatPercentage, formatNumber } = useIntl();
 
@@ -51,12 +43,6 @@ export function SidebarKpiValue(props: SidebarKpiValueProps) {
           <Box fontSize={3} display="flex" alignItems="center" marginRight={1}>
             <SidebarDifference value={difference} />
           </Box>
-        )}
-
-        {isDefined(description) && (
-          <InlineText variant="label1" color="annotation">
-            {description}
-          </InlineText>
         )}
       </Box>
 

--- a/packages/app/src/components/sidebar-metric/sidebar-metric.tsx
+++ b/packages/app/src/components/sidebar-metric/sidebar-metric.tsx
@@ -10,7 +10,6 @@ import { Box } from '~/components/base';
 import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
 import { assert } from '~/utils/assert';
-import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { SidebarKpiValue } from './sidebar-kpi-value';
 interface SidebarMetricProps<T extends { difference: unknown }> {
   data: T;
@@ -36,10 +35,8 @@ export function SidebarMetric<T extends { difference: unknown }>({
   localeTextKey,
   differenceKey,
   annotationKey,
-  showDateOfInsertion,
-  hideDate,
 }: SidebarMetricProps<T>) {
-  const { siteText, formatDateFromSeconds } = useIntl();
+  const { siteText } = useIntl();
 
   /**
    * @TODO this is still a bit messy due to improper typing. Not sure how to
@@ -65,8 +62,6 @@ export function SidebarMetric<T extends { difference: unknown }>({
     );
   }
 
-  const commonText = siteText.common.metricKPI;
-
   /**
    * Because the locale files are not consistent in using kpi_titel and titel_kpi
    * we support both but kpi_titel has precedence.
@@ -85,40 +80,6 @@ export function SidebarMetric<T extends { difference: unknown }>({
       localeTextKey
     )}.kpi_titel or ${String(localeTextKey)}.titel_kpi`
   );
-
-  let description = '';
-
-  try {
-    if (showDateOfInsertion) {
-      description = replaceVariablesInText(commonText.dateOfInsertion, {
-        dateOfInsertion: formatDateFromSeconds(
-          lastValue.date_of_insertion_unix,
-          'medium'
-        ),
-      });
-    } else if (!hideDate) {
-      description =
-        'date_unix' in lastValue
-          ? replaceVariablesInText(commonText.dateOfReport, {
-              dateOfReport: formatDateFromSeconds(
-                lastValue.date_unix,
-                'medium'
-              ),
-            })
-          : replaceVariablesInText(commonText.dateRangeOfReport, {
-              startDate: formatDateFromSeconds(
-                lastValue.date_start_unix,
-                'axis'
-              ),
-              endDate: formatDateFromSeconds(lastValue.date_end_unix, 'axis'),
-            });
-    }
-  } catch (err) {
-    if (err instanceof Error)
-      throw new Error(
-        `Failed to format description for ${metricName}:${metricProperty}, likely due to a timestamp week/day configuration mismatch. Error: ${err.message}`
-      );
-  }
 
   const differenceValue = differenceKey
     ? get(data, ['difference', differenceKey as unknown as string])
@@ -149,7 +110,7 @@ export function SidebarMetric<T extends { difference: unknown }>({
   }
 
   if (!metricProperty) {
-    return <SidebarKpiValue title={title} description={description} />;
+    return <SidebarKpiValue title={title} />;
   }
 
   return (
@@ -157,7 +118,6 @@ export function SidebarMetric<T extends { difference: unknown }>({
       <SidebarKpiValue
         title={title}
         value={propertyValue}
-        description={description}
         difference={differenceValue}
         valueAnnotation={valueAnnotation}
       />

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -203,7 +203,6 @@ export function GmLayout(props: GmLayoutProps) {
                             metricName="hospital_nice"
                             metricProperty="admissions_on_date_of_admission_moving_average"
                             localeTextKey="gemeente_ziekenhuisopnames_per_dag"
-                            hideDate
                           />
                         </MetricMenuItemLink>
                       </CategoryMenu>

--- a/packages/app/src/domain/layout/nl-layout.tsx
+++ b/packages/app/src/domain/layout/nl-layout.tsx
@@ -183,7 +183,6 @@ export function NlLayout(props: NlLayoutProps) {
                     metricName="hospital_nice"
                     metricProperty="admissions_on_date_of_admission_moving_average"
                     localeTextKey="ziekenhuisopnames_per_dag"
-                    hideDate
                   />
                 </MetricMenuItemLink>
 
@@ -197,7 +196,6 @@ export function NlLayout(props: NlLayoutProps) {
                     metricName="intensive_care_nice"
                     metricProperty="admissions_on_date_of_admission_moving_average"
                     localeTextKey="ic_opnames_per_dag"
-                    hideDate
                   />
                 </MetricMenuItemLink>
               </CategoryMenu>
@@ -229,7 +227,6 @@ export function NlLayout(props: NlLayoutProps) {
                     metricProperty="index_average"
                     localeTextKey="reproductiegetal"
                     differenceKey="reproduction__index_average"
-                    showDateOfInsertion
                   />
                 </MetricMenuItemLink>
 
@@ -262,12 +259,7 @@ export function NlLayout(props: NlLayoutProps) {
                   icon={<Gedrag />}
                   title={siteText.brononderzoek.titel_sidebar}
                 >
-                  <SituationsSidebarMetric
-                    date_start_unix={
-                      data.situationsSidebarValue.date_start_unix
-                    }
-                    date_end_unix={data.situationsSidebarValue.date_end_unix}
-                  />
+                  <SituationsSidebarMetric />
                 </MetricMenuItemLink>
               </CategoryMenu>
 

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -269,14 +269,7 @@ export function VrLayout(props: VrLayoutProps) {
                       icon={<Gedrag />}
                       title={siteText.brononderzoek.titel_sidebar}
                     >
-                      <SituationsSidebarMetric
-                        date_start_unix={
-                          data.situationsSidebarValue.date_start_unix
-                        }
-                        date_end_unix={
-                          data.situationsSidebarValue.date_end_unix
-                        }
-                      />
+                      <SituationsSidebarMetric />
                     </MetricMenuItemLink>
                   </CategoryMenu>
 

--- a/packages/app/src/domain/situations/situations-sidebar-metric.tsx
+++ b/packages/app/src/domain/situations/situations-sidebar-metric.tsx
@@ -1,27 +1,7 @@
 import { SidebarKpiValue } from '~/components/sidebar-metric/sidebar-kpi-value';
 import { useIntl } from '~/intl';
-import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
-type SituationsSidebarMetricProps = {
-  date_start_unix: number;
-  date_end_unix: number;
-};
-
-export function SituationsSidebarMetric({
-  date_start_unix,
-  date_end_unix,
-}: SituationsSidebarMetricProps) {
-  const { siteText, formatDateFromSeconds } = useIntl();
-  const commonText = siteText.common.metricKPI;
-  const dateText = replaceVariablesInText(commonText.dateRangeOfReport, {
-    startDate: formatDateFromSeconds(date_start_unix, 'axis'),
-    endDate: formatDateFromSeconds(date_end_unix, 'axis'),
-  });
-
-  return (
-    <SidebarKpiValue
-      title={siteText.brononderzoek.kpi_titel}
-      description={dateText}
-    />
-  );
+export function SituationsSidebarMetric() {
+  const { siteText } = useIntl();
+  return <SidebarKpiValue title={siteText.brononderzoek.kpi_titel} />;
 }

--- a/packages/app/src/domain/vaccine/vaccine-sidebar-metric-vr-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-sidebar-metric-vr-gm.tsx
@@ -4,9 +4,8 @@ import {
 } from '@corona-dashboard/common';
 import { Box } from '~/components/base';
 import { InlineText, Text } from '~/components/typography';
-import { useIntl } from '~/intl';
-import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useVaccineCoveragePercentageFormatter } from './logic/use-vaccine-coverage-percentage-formatter';
+
 interface VariantsSidebarMetricProps {
   data:
     | VrVaccineCoveragePerAgeGroupValue[]
@@ -18,9 +17,6 @@ export function VaccineSidebarMetricVrGm({
   data,
   description,
 }: VariantsSidebarMetricProps) {
-  const { siteText, formatDateFromSeconds } = useIntl();
-  const commonText = siteText.common.metricKPI;
-
   const formatCoveragePercentage = useVaccineCoveragePercentageFormatter();
 
   /**
@@ -29,10 +25,6 @@ export function VaccineSidebarMetricVrGm({
   const filteredAgeGroup = data.filter(
     (item) => item.age_group_range === '18+'
   )[0] as VrVaccineCoveragePerAgeGroupValue | GmVaccineCoveragePerAgeGroupValue;
-
-  const dateText = replaceVariablesInText(commonText.dateOfReport, {
-    dateOfReport: formatDateFromSeconds(filteredAgeGroup.date_unix, 'medium'),
-  });
 
   return (
     <Box width="100%" minHeight="4rem" spacing={2}>
@@ -50,12 +42,6 @@ export function VaccineSidebarMetricVrGm({
             'fully_vaccinated_percentage'
           )}
         </InlineText>
-
-        <Box pt="2px">
-          <InlineText variant="label1" color="annotation">
-            {dateText}
-          </InlineText>
-        </Box>
       </Box>
     </Box>
   );

--- a/packages/app/src/domain/variants/variants-sidebar-metric.tsx
+++ b/packages/app/src/domain/variants/variants-sidebar-metric.tsx
@@ -3,22 +3,12 @@ import { Box } from '~/components/base';
 import { InlineText, Text } from '~/components/typography';
 import { VariantSidebarValue } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
-import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 interface VariantsSidebarMetricProps {
   data: VariantSidebarValue;
 }
 
 export function VariantsSidebarMetric({ data }: VariantsSidebarMetricProps) {
-  const { siteText, formatDateFromSeconds, formatPercentage } = useIntl();
-  const commonText = siteText.common.metricKPI;
-
-  /**
-   * Filter all the keys that end with a _percentage and find the highest value.
-   */
-  const dateText = replaceVariablesInText(commonText.dateRangeOfReport, {
-    startDate: formatDateFromSeconds(data.date_start_unix, 'axis'),
-    endDate: formatDateFromSeconds(data.date_end_unix, 'axis'),
-  });
+  const { siteText, formatPercentage } = useIntl();
 
   const variantName = (
     siteText.covid_varianten.varianten as Record<string, string>
@@ -39,12 +29,6 @@ export function VariantsSidebarMetric({ data }: VariantsSidebarMetricProps) {
         <InlineText variant="h3">
           {`${formatPercentage(data.percentage)}% ${variantName}`}
         </InlineText>
-
-        <Box pt="2px">
-          <InlineText variant="label1" color="annotation">
-            {dateText}
-          </InlineText>
-        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

Removes the 'value from' metadata description from each SidebarMetric component.

