### PR TITLE
Add aria-hidden to value annotation

### DIFF
--- a/packages/app/src/components/value-annotation.tsx
+++ b/packages/app/src/components/value-annotation.tsx
@@ -6,7 +6,7 @@ import { Text } from '~/components/typography';
  */
 export function ValueAnnotation({ children }: { children: ReactNode }) {
   return (
-    <Text as="div" color="annotation" variant="label2">
+    <Text as="div" color="annotation" variant="label2" aria-hidden={true}>
       {children}
     </Text>
   );


### PR DESCRIPTION
## Summary

The value annotation of the timeseries chart now has an aria-hidden attribute set to true
