### PR TITLE
Enable SSR fallback again so EN GM/VR pages do not 404 anymore

### DIFF
--- a/packages/app/src/static-paths/gm.ts
+++ b/packages/app/src/static-paths/gm.ts
@@ -4,9 +4,12 @@ import { gmData } from '~/data/gm';
  * getStaticPaths creates an array of all the allowed `/gemeente/[code]` routes.
  */
 export function getStaticPaths() {
-  const paths = gmData.map((x) => ({
-    params: { code: x.gemcode },
-  }));
+  const paths = gmData.flatMap((x) =>
+    ['nl', 'en'].map((locale) => ({
+      locale,
+      params: { code: x.gemcode },
+    }))
+  );
 
   return {
     paths,

--- a/packages/app/src/static-paths/gm.ts
+++ b/packages/app/src/static-paths/gm.ts
@@ -4,16 +4,14 @@ import { gmData } from '~/data/gm';
  * getStaticPaths creates an array of all the allowed `/gemeente/[code]` routes.
  */
 export function getStaticPaths() {
-  const paths = gmData.flatMap((x) =>
-    ['nl', 'en'].map((locale) => ({
-      locale,
-      params: { code: x.gemcode },
-    }))
-  );
+  const paths = gmData.map((x) => ({
+    locale: 'nl',
+    params: { code: x.gemcode },
+  }));
 
   return {
     paths,
     // other routes should 404
-    fallback: false,
+    fallback: 'blocking',
   };
 }

--- a/packages/app/src/static-paths/gm.ts
+++ b/packages/app/src/static-paths/gm.ts
@@ -5,7 +5,6 @@ import { gmData } from '~/data/gm';
  */
 export function getStaticPaths() {
   const paths = gmData.map((x) => ({
-    locale: 'nl',
     params: { code: x.gemcode },
   }));
 

--- a/packages/app/src/static-paths/vr.ts
+++ b/packages/app/src/static-paths/vr.ts
@@ -6,16 +6,13 @@ import { vrData } from '~/data/vr';
  */
 export function getStaticPaths() {
   const filteredRegions = vrData.filter((x) => x.code.startsWith('VR'));
-  const paths = filteredRegions.flatMap((x) =>
-    ['nl', 'en'].map((locale) => ({
-      locale,
-      params: { code: x.code },
-    }))
-  );
+  const paths = filteredRegions.map((x) => ({
+    params: { code: x.code },
+  }));
 
   return {
     paths,
     // other routes should 404
-    fallback: false,
+    fallback: 'blocking',
   };
 }

--- a/packages/app/src/static-paths/vr.ts
+++ b/packages/app/src/static-paths/vr.ts
@@ -6,9 +6,12 @@ import { vrData } from '~/data/vr';
  */
 export function getStaticPaths() {
   const filteredRegions = vrData.filter((x) => x.code.startsWith('VR'));
-  const paths = filteredRegions.map((x) => ({
-    params: { code: x.code },
-  }));
+  const paths = filteredRegions.flatMap((x) =>
+    ['nl', 'en'].map((locale) => ({
+      locale,
+      params: { code: x.code },
+    }))
+  );
 
   return {
     paths,


### PR DESCRIPTION
## Summary

We did not render dynamic pages (all VR/GM specific pages) during build. Since we turned the SSR fallback of those dynamic routes off a while ago, the pages return a 404 at the moment.

This PR makes sure the `getStaticPaths()` method of these routes returns both locales, so they are both rendered during build. (https://nextjs.org/docs/advanced-features/i18n-routing#dynamic-routes-and-getstaticprops-pages)