### PR TITLE
Add moving average date start unix

### DIFF
--- a/packages/app/schema/gm/hospital_nice.json
+++ b/packages/app/schema/gm/hospital_nice.json
@@ -7,6 +7,7 @@
       "required": [
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
+        "admissions_on_date_of_admission_moving_average_date_start_unix",
         "admissions_on_date_of_reporting",
         "date_unix",
         "date_of_insertion_unix"
@@ -20,6 +21,9 @@
         },
         "admissions_on_date_of_admission_moving_average": {
           "type": ["number", "null"]
+        },
+        "admissions_on_date_of_admission_moving_average_date_start_unix": {
+          "type": "integer"
         },
         "admissions_on_date_of_reporting": {
           "type": "integer"

--- a/packages/app/schema/nl/hospital_nice.json
+++ b/packages/app/schema/nl/hospital_nice.json
@@ -29,6 +29,9 @@
         "admissions_on_date_of_reporting": {
           "type": "integer"
         },
+        "admissions_on_date_of_admission_moving_average_date_start_unix": {
+          "type": "integer"
+        },
         "date_unix": {
           "type": "integer"
         },
@@ -39,6 +42,7 @@
       "required": [
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
+        "admissions_on_date_of_admission_moving_average_date_start_unix",
         "admissions_on_date_of_reporting",
         "date_unix",
         "date_of_insertion_unix"

--- a/packages/app/schema/nl/intensive_care_nice.json
+++ b/packages/app/schema/nl/intensive_care_nice.json
@@ -7,6 +7,7 @@
       "required": [
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
+        "admissions_on_date_of_admission_moving_average_date_start_unix",
         "admissions_on_date_of_reporting",
         "date_unix",
         "date_of_insertion_unix"
@@ -17,6 +18,9 @@
         },
         "admissions_on_date_of_admission_moving_average": {
           "type": ["number", "null"]
+        },
+        "admissions_on_date_of_admission_moving_average_date_start_unix": {
+          "type": "integer"
         },
         "admissions_on_date_of_reporting": {
           "type": "integer"

--- a/packages/app/schema/vr/hospital_nice.json
+++ b/packages/app/schema/vr/hospital_nice.json
@@ -26,6 +26,9 @@
         "admissions_on_date_of_admission_moving_average": {
           "type": ["number", "null"]
         },
+        "admissions_on_date_of_admission_moving_average_date_start_unix": {
+          "type": "integer"
+        },
         "admissions_on_date_of_reporting": {
           "type": "integer"
         },
@@ -39,6 +42,7 @@
       "required": [
         "admissions_on_date_of_admission",
         "admissions_on_date_of_admission_moving_average",
+        "admissions_on_date_of_admission_moving_average_date_start_unix",
         "admissions_on_date_of_reporting",
         "date_unix",
         "date_of_insertion_unix"

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -73,6 +73,7 @@ export interface GmHospitalNiceValue {
   date_unix: number;
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
+  admissions_on_date_of_admission_moving_average_date_start_unix: number;
   admissions_on_date_of_reporting: number;
   date_of_insertion_unix: number;
 }
@@ -389,6 +390,7 @@ export interface NlIntensiveCareNice {
 export interface NlIntensiveCareNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
+  admissions_on_date_of_admission_moving_average_date_start_unix: number;
   admissions_on_date_of_reporting: number;
   date_unix: number;
   date_of_insertion_unix: number;
@@ -474,6 +476,7 @@ export interface NlHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
   admissions_on_date_of_reporting: number;
+  admissions_on_date_of_admission_moving_average_date_start_unix: number;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -1065,6 +1068,7 @@ export interface VrHospitalNice {
 export interface VrHospitalNiceValue {
   admissions_on_date_of_admission: number;
   admissions_on_date_of_admission_moving_average: number | null;
+  admissions_on_date_of_admission_moving_average_date_start_unix: number;
   admissions_on_date_of_reporting: number;
   date_unix: number;
   date_of_insertion_unix: number;


### PR DESCRIPTION
For the hospital/icu admissions add a moving average when it starts counting the 7-day average date. So e.g. the average is from 17 September the new property should hold a unix timestamp for the date of 10 September.

I know the key names get a little long, but I will rather be as descriptive as possible.