### PR TITLE
Add notification banner site wide

### DIFF
--- a/packages/app/src/components/notification-banner.tsx
+++ b/packages/app/src/components/notification-banner.tsx
@@ -1,0 +1,63 @@
+import { Warning } from '@corona-dashboard/icons';
+import css from '@styled-system/css';
+import { Box, Spacer } from '~/components/base';
+import { Markdown } from '~/components/markdown';
+import { MaxWidth } from '~/components/max-width';
+import { useCollapsible } from '~/utils/use-collapsible';
+import { InlineText } from './typography';
+
+interface NotificationBannerProps {
+  title: string;
+  description: string;
+}
+export function NotificationBanner({
+  title,
+  description,
+}: NotificationBannerProps) {
+  const collapsible = useCollapsible();
+
+  const hasDescription = description.length !== 0;
+
+  return (
+    <Box width="100%" backgroundColor="warningYellow">
+      <MaxWidth
+        px={{ _: 3, sm: 4 }}
+        py={3}
+        display="flex"
+        spacingHorizontal={3}
+      >
+        <Box display="flex">
+          <Warning fill="black" />
+        </Box>
+
+        <Box maxWidth="maxWidthText">
+          {hasDescription ? (
+            collapsible.button(
+              <Box
+                spacingHorizontal={2}
+                display="flex"
+                alignItems="center"
+                css={css({
+                  cursor: 'pointer',
+                })}
+              >
+                <InlineText fontWeight="bold">{title}</InlineText>
+                {collapsible.chevron}
+              </Box>
+            )
+          ) : (
+            <InlineText fontWeight="bold">{title}</InlineText>
+          )}
+
+          {hasDescription &&
+            collapsible.content(
+              <Box pb={2}>
+                <Spacer mt={3} />
+                <Markdown content={description} />
+              </Box>
+            )}
+        </Box>
+      </MaxWidth>
+    </Box>
+  );
+}

--- a/packages/app/src/domain/layout/layout.tsx
+++ b/packages/app/src/domain/layout/layout.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { AppFooter } from '~/components/layout/app-footer';
 import { AppHeader } from '~/components/layout/app-header';
+import { NotificationBanner } from '~/components/notification-banner';
 import { SEOHead } from '~/components/seo-head';
 import { SkipLinkMenu } from '~/components/skip-link-menu';
 import { useIntl } from '~/intl';
 import { CurrentDateProvider } from '~/utils/current-date-context';
-
 interface LayoutProps {
   title: string;
   url?: string;
@@ -38,7 +38,6 @@ export function Layout(
         twitterImage={twitterImage}
         url={url}
       />
-
       <SkipLinkMenu
         ariaLabel={siteText.aria_labels.skip_links}
         links={[
@@ -48,13 +47,18 @@ export function Layout(
           { href: '#footer-navigation', label: siteText.skiplinks.footer_nav },
         ]}
       />
-
       <AppHeader />
+
+      {siteText.dashboard_wide_notification.title.length !== 0 && (
+        <NotificationBanner
+          title={siteText.dashboard_wide_notification.title}
+          description={siteText.dashboard_wide_notification.description}
+        />
+      )}
 
       <CurrentDateProvider dateInSeconds={Number(lastGenerated)}>
         <div>{children}</div>
       </CurrentDateProvider>
-
       <AppFooter />
     </div>
   );

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -267,3 +267,5 @@ timestamp,action,key,document_id,move_to
 2021-09-30T14:57:03.121Z,delete,escalatie_niveau.sidebar_label,jF33EuwumlGuwav2FD3o4q,__
 2021-09-30T14:57:03.124Z,delete,nl_gedrag.sidebar.titel,jF33EuwumlGuwav2FD3sce,__
 2021-09-30T14:57:03.126Z,delete,regionaal_gedrag.sidebar.titel,jF33EuwumlGuwav2FD3tW0,__
+2021-10-04T11:26:16.902Z,add,dashboard_wide_notification.title,wzQp83DAUqyqV3ewGLiXxV,__
+2021-10-04T11:26:18.146Z,add,dashboard_wide_notification.description,tdf6s1l0srCSpeM2lEl1X2,__


### PR DESCRIPTION
Add a notification banner for the whole site right under the menu.
When in Lokalise the title field is empty it won't show anything.
But communication could add a description and turns into a dropdown or without and it's a regular text.
Markdown is supported for the description.