### PR TITLE
Add breadcrumbs

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -85,6 +85,11 @@ const nextConfig = {
         permanent: false,
       },
       {
+        source: '/actueel',
+        destination: '/',
+        permanent: false,
+      },
+      {
         source: '/apple-touch-icon-120x120-precomposed.png',
         destination: '/images/touch-icon.png',
         permanent: false,

--- a/packages/app/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/app/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,0 +1,63 @@
+import { useBreadcrumbs } from './logic/use-breadcrumbs';
+import { Link } from '~/utils/link';
+import css from '@styled-system/css';
+import { Box } from '../base';
+import { useIntl } from '~/intl';
+import { colors } from '~/style/theme';
+import { MaxWidth } from '../max-width';
+import { Anchor } from '../typography';
+
+export function Breadcrumbs() {
+  const breadcrumbs = useBreadcrumbs();
+  const { siteText } = useIntl();
+
+  return (
+    <Box
+      css={css({
+        borderBottom: `1px solid ${colors.border}`,
+        position: 'absolute',
+        top: -9999,
+        left: -9999,
+        '&:focus-within': {
+          position: 'static',
+        },
+      })}
+    >
+      <MaxWidth
+        css={css({
+          py: 3,
+          px: 4,
+        })}
+        as={'nav'}
+        aria-label={siteText.breadcrumbs.label}
+      >
+        <ol vocab="http://schema.org/" typeof="BreadcrumbList">
+          {breadcrumbs.map(({ title, href }, index) => (
+            <li
+              key={href}
+              css={css({
+                display: 'inline-block',
+                '&::after': { content: '">"', mx: 2 },
+                '&:last-of-type': { '&::after': { content: '""' } },
+              })}
+              property="itemListElement"
+              typeof="ListItem"
+            >
+              <Link href={href} passHref>
+                <Anchor
+                  underline="hover"
+                  property="item"
+                  typeof="WebPage"
+                  css={css({ outlineOffset: 2 })}
+                >
+                  <span property="name">{title}</span>
+                </Anchor>
+              </Link>
+              <meta property="position" content={`${index + 1}`} />
+            </li>
+          ))}
+        </ol>
+      </MaxWidth>
+    </Box>
+  );
+}

--- a/packages/app/src/components/breadcrumbs/index.ts
+++ b/packages/app/src/components/breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export * from './breadcrumbs';

--- a/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
+++ b/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
@@ -1,0 +1,114 @@
+import { useRouter } from 'next/router';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
+import { gmData } from '~/data/gm';
+import { vrData } from '~/data/vr';
+import { useIntl } from '~/intl';
+
+interface Breadcrumb {
+  href: string;
+  title: string;
+}
+
+export const BreadcrumbsDataContext = createContext<Record<string, string>>({});
+
+/*  
+  Sometimes a page's title can't be inferred from the slug or static content,
+  but needs to come from CMS data. For this context, we provide a context with
+  which you can inject the pageTitle into the component.
+  You should provide the pageTitle with the query parameter as the key, eg:
+  { 'some-page-slug': 'Some Page Title' } as the breadcrumbsData prop to Layout. 
+ */
+export const BreadcrumbsDataProvider = ({
+  value,
+  children,
+}: {
+  value: Record<string, string>;
+  children: ReactNode;
+}) => {
+  const mergedValue = useMemo(() => {
+    const gmMap = gmData.reduce(
+      (acc, curr) => ({ [curr.gemcode]: curr.name, ...acc }),
+      {}
+    );
+
+    const vrMap = vrData.reduce(
+      (acc, curr) => ({ [curr.code]: curr.name, ...acc }),
+      {}
+    );
+
+    return {
+      ...(value ? value : {}),
+      ...gmMap,
+      ...vrMap,
+    };
+  }, [value]);
+
+  return (
+    <BreadcrumbsDataContext.Provider value={mergedValue}>
+      {children}
+    </BreadcrumbsDataContext.Provider>
+  );
+};
+
+export function useBreadcrumbs(): Breadcrumb[] {
+  const { pathname, query } = useRouter();
+  const { siteText } = useIntl();
+  const ctx = useContext(BreadcrumbsDataContext);
+
+  return useMemo(() => {
+    const getQueryParameter = (str: string) => {
+      // Extract text between square brackets: https://stackoverflow.com/questions/2403122/regular-expression-to-extract-text-between-square-brackets
+      const regexp = /(?<=\[).*?(?=\])/;
+      const matches = str.match(regexp);
+      const param = matches?.[0];
+      return { key: param };
+    };
+
+    const convertQueryParameter = (str: string): string => {
+      const { key } = getQueryParameter(str);
+      return key ? (query[key] as string) : str;
+    };
+
+    const getTitle = (str: string): string => {
+      if (str === '') return siteText.breadcrumbs.paths.actueel;
+
+      const { key } = getQueryParameter(str);
+      str = convertQueryParameter(str);
+
+      if (key) {
+        // retrieve the page title from the context
+        const pageTitle = ctx[query[key] as string];
+        return pageTitle ? pageTitle : str;
+      }
+
+      return siteText.breadcrumbs.paths[
+        str as keyof typeof siteText.breadcrumbs.paths
+      ];
+    };
+
+    // '/' gets split into ['', '']. Make sure it doesn't.
+    let arr = pathname === '/' ? [''] : pathname.split('/');
+    // filter out '' when 'actueel' is in the path, as we'll have a double Actueel breadcrumb otherwise
+    arr = arr.includes('actueel') ? arr.filter((x) => x !== '') : arr;
+
+    const breadcrumbs = arr
+      .map((x, index, arr) => {
+        const href = [...arr.slice(0, index), x]
+          .map(convertQueryParameter)
+          .join('/');
+
+        return {
+          href: href === '' ? '/' : '/' + href,
+          title: getTitle(x),
+        };
+      })
+      .filter((x) => {
+        // filter out the link to Actueel on all pages but / and the /actueel/.../... pages
+        if (pathname === '/') return true;
+        if (pathname.includes('actueel')) return true;
+        return x.href !== '/';
+      });
+
+    return breadcrumbs;
+  }, [ctx, pathname, query, siteText]);
+}

--- a/packages/app/src/data/gm.ts
+++ b/packages/app/src/data/gm.ts
@@ -1,4 +1,4 @@
-type MunicipalityInfo = {
+export type MunicipalityInfo = {
   name: string;
   vrCode: string;
   gemcode: string;

--- a/packages/app/src/data/vr.ts
+++ b/packages/app/src/data/vr.ts
@@ -1,4 +1,11 @@
-export const vrData = [
+export interface SafetyRegionInfo {
+  name: string;
+  code: string;
+  id: number;
+  searchTerms?: string[];
+}
+
+export const vrData: SafetyRegionInfo[] = [
   { name: 'Groningen', code: 'VR01', id: 1 },
   { name: 'Fryslân', code: 'VR02', id: 2, searchTerms: ['Friesland'] },
   { name: 'Drenthe', code: 'VR03', id: 3 },

--- a/packages/app/src/domain/layout/components/gm-combo-box.tsx
+++ b/packages/app/src/domain/layout/components/gm-combo-box.tsx
@@ -4,7 +4,13 @@ import { gmData } from '~/data/gm';
 import { useIntl } from '~/intl';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
-export function GmComboBox() {
+interface GmComboBoxProps {
+  getLink?: (gmcode: string) => string;
+}
+
+export function GmComboBox(props: GmComboBoxProps) {
+  const { getLink } = props;
+
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
   const router = useRouter();
@@ -13,7 +19,13 @@ export function GmComboBox() {
     <ComboBox
       placeholder={siteText.common.zoekveld_placeholder_gemeente}
       options={gmData}
-      onSelect={({ gemcode }) => router.push(reverseRouter.gm.index(gemcode))}
+      onSelect={({ gemcode }) => {
+        router.push(
+          typeof getLink === 'function'
+            ? getLink(gemcode)
+            : reverseRouter.gm.index(gemcode)
+        );
+      }}
     />
   );
 }

--- a/packages/app/src/domain/layout/components/vr-combo-box.tsx
+++ b/packages/app/src/domain/layout/components/vr-combo-box.tsx
@@ -4,7 +4,13 @@ import { vrData } from '~/data/vr';
 import { useIntl } from '~/intl';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
-export function VrComboBox() {
+interface VrComboBoxProps {
+  getLink?: (code: string) => string;
+}
+
+export function VrComboBox(props: VrComboBoxProps) {
+  const { getLink } = props;
+
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
   const router = useRouter();
@@ -13,7 +19,11 @@ export function VrComboBox() {
     <ComboBox
       placeholder={siteText.common.zoekveld_placeholder_regio}
       options={vrData}
-      onSelect={(region) => router.push(reverseRouter.vr.index(region.code))}
+      onSelect={(region) =>
+        typeof getLink === 'function'
+          ? getLink(region.code)
+          : router.push(reverseRouter.vr.index(region.code))
+      }
     />
   );
 }

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -15,6 +15,7 @@ import { useSidebar } from './logic/use-sidebar';
 
 type GmLayoutProps = {
   children?: React.ReactNode;
+  getLink?: (code: string) => string;
 } & (
   | {
       code: string;
@@ -47,13 +48,14 @@ type GmLayoutProps = {
  * https://adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
 export function GmLayout(props: GmLayoutProps) {
-  const { children, municipalityName, code } = props;
+  const { children, municipalityName, code, getLink } = props;
 
   const { siteText } = useIntl();
   const router = useRouter();
   const reverseRouter = useReverseRouter();
 
-  const showMetricLinks = router.route !== '/gemeente';
+  const showMetricLinks =
+    router.route !== '/gemeente' && router.route !== '/actueel/gemeente';
 
   const isMainRoute =
     router.route === '/gemeente' || router.route === `/gemeente/[code]`;
@@ -91,7 +93,7 @@ export function GmLayout(props: GmLayoutProps) {
         hideMenuButton={isMainRoute}
         searchComponent={
           <Box height="100%" maxWidth={{ _: '38rem', md: undefined }} mx="auto">
-            <GmComboBox />
+            <GmComboBox getLink={getLink} />
           </Box>
         }
         sidebarComponent={

--- a/packages/app/src/domain/layout/layout.tsx
+++ b/packages/app/src/domain/layout/layout.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Breadcrumbs } from '~/components/breadcrumbs';
+import { BreadcrumbsDataProvider } from '~/components/breadcrumbs/logic/use-breadcrumbs';
 import { AppFooter } from '~/components/layout/app-footer';
 import { AppHeader } from '~/components/layout/app-header';
 import { SEOHead } from '~/components/seo-head';
@@ -12,12 +14,14 @@ interface LayoutProps {
   description?: string;
   openGraphImage?: string;
   twitterImage?: string;
+  breadcrumbsData?: Record<string, string>;
 }
 
 export function Layout(
   props: LayoutProps & { lastGenerated: string; children: React.ReactNode }
 ) {
   const {
+    breadcrumbsData,
     children,
     title,
     description,
@@ -50,6 +54,10 @@ export function Layout(
       />
 
       <AppHeader />
+
+      <BreadcrumbsDataProvider value={breadcrumbsData}>
+        <Breadcrumbs />
+      </BreadcrumbsDataProvider>
 
       <CurrentDateProvider dateInSeconds={Number(lastGenerated)}>
         <div>{children}</div>

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -13,6 +13,7 @@ import { useSidebar } from './logic/use-sidebar';
 type VrLayoutProps = {
   children?: React.ReactNode;
   isLandingPage?: boolean;
+  getLink?: (code: string) => string;
 } & (
   | {
       vrName: string;
@@ -44,7 +45,7 @@ type VrLayoutProps = {
  * https:adamwathan.me/2019/10/17/persistent-layout-patterns-in-nextjs/
  */
 export function VrLayout(props: VrLayoutProps) {
-  const { children, vrName, isLandingPage } = props;
+  const { children, vrName, isLandingPage, getLink } = props;
 
   const router = useRouter();
   const { siteText } = useIntl();
@@ -55,7 +56,9 @@ export function VrLayout(props: VrLayoutProps) {
     router.route === '/veiligheidsregio' ||
     router.route === `/veiligheidsregio/[code]`;
 
-  const showMetricLinks = router.route !== '/veiligheidsregio';
+  const showMetricLinks =
+    router.route !== '/veiligheidsregio' &&
+    router.route !== '/actueel/veiligheidsregio';
 
   const topItems = useSidebar({
     layout: 'vr',
@@ -103,7 +106,7 @@ export function VrLayout(props: VrLayoutProps) {
             maxWidth={{ _: '38rem', md: undefined }}
             mx="auto"
           >
-            <VrComboBox />
+            <VrComboBox getLink={getLink} />
           </Box>
         }
         sidebarComponent={

--- a/packages/app/src/pages/actueel/gemeente/index.tsx
+++ b/packages/app/src/pages/actueel/gemeente/index.tsx
@@ -1,0 +1,112 @@
+import { GmCollectionHospitalNice } from '@corona-dashboard/common';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { Box } from '~/components/base';
+import { TooltipContent } from '~/components/choropleth/tooltips';
+import { ErrorBoundary } from '~/components/error-boundary';
+import { Markdown } from '~/components/markdown';
+import { Heading } from '~/components/typography';
+import { gmData } from '~/data/gm';
+import { GmComboBox } from '~/domain/layout/components/gm-combo-box';
+import { GmLayout } from '~/domain/layout/gm-layout';
+import { Layout } from '~/domain/layout/layout';
+import { useIntl } from '~/intl';
+import {
+  createGetStaticProps,
+  StaticProps,
+} from '~/static-props/create-get-static-props';
+import { getLastGeneratedDate } from '~/static-props/get-data';
+import { colors } from '~/style/theme';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useReverseRouter } from '~/utils/use-reverse-router';
+import { DynamicChoropleth } from '~/components/choropleth';
+
+export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
+
+const Municipality = (props: StaticProps<typeof getStaticProps>) => {
+  const { lastGenerated } = props;
+  const { siteText } = useIntl();
+  const reverseRouter = useReverseRouter();
+  const router = useRouter();
+  const code = router.query.code as string;
+
+  const breakpoints = useBreakpoints();
+
+  const metadata = {
+    ...siteText.gemeente_actueel.index.metadata,
+  };
+
+  const data = useMemo(() => {
+    return gmData.map<GmCollectionHospitalNice>(
+      (x) =>
+        ({
+          gmcode: x.gemcode,
+          admissions_on_date_of_reporting: null,
+        } as unknown as GmCollectionHospitalNice)
+    );
+  }, []);
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <GmLayout isLandingPage code={code} getLink={reverseRouter.actueel.gm}>
+        {!breakpoints.md && (
+          <Box bg="white">
+            <GmComboBox getLink={reverseRouter.actueel.gm} />
+          </Box>
+        )}
+
+        <Box as="article" p={4}>
+          <Heading level={2} as="h1">
+            {siteText.gemeente_actueel.index.title}
+          </Heading>
+
+          <Markdown content={siteText.gemeente_actueel.index.description} />
+
+          <Box
+            display="flex"
+            flex="1"
+            justifyContent="center"
+            height="75vh"
+            maxWidth={750}
+            maxHeight={960}
+            flexDirection="column"
+            spacing={3}
+          >
+            <ErrorBoundary>
+              <DynamicChoropleth
+                renderTarget="canvas"
+                accessibility={{
+                  key: 'municipality_navigation_map',
+                  features: ['keyboard_choropleth'],
+                }}
+                map="gm"
+                data={data}
+                minHeight={650}
+                dataConfig={{
+                  metricName: 'gemeente' as any,
+                  metricProperty: 'admissions_on_date_of_reporting',
+                  areaStroke: colors.white,
+                  areaStrokeWidth: 1,
+                  hoverFill: colors.white,
+                  hoverStrokeWidth: 3,
+                  noDataFillColor: colors.lightGray,
+                }}
+                dataOptions={{
+                  getLink: reverseRouter.actueel.gm,
+                }}
+                formatTooltip={(context) => (
+                  <TooltipContent
+                    title={context.featureName}
+                    link={reverseRouter.actueel.gm(context.dataItem.gmcode)}
+                  />
+                )}
+              />
+            </ErrorBoundary>
+          </Box>
+        </Box>
+      </GmLayout>
+    </Layout>
+  );
+};
+
+export default Municipality;

--- a/packages/app/src/pages/actueel/veiligheidsregio/index.tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/index.tsx
@@ -1,0 +1,119 @@
+import { VrCollectionHospitalNice } from '@corona-dashboard/common';
+import { useMemo } from 'react';
+import { Box } from '~/components/base';
+import { TooltipContent } from '~/components/choropleth/tooltips';
+import { ErrorBoundary } from '~/components/error-boundary';
+import { Markdown } from '~/components/markdown';
+import { Heading } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
+import { vrData } from '~/data/vr';
+import { VrComboBox } from '~/domain/layout/components/vr-combo-box';
+import { Layout } from '~/domain/layout/layout';
+import { VrLayout } from '~/domain/layout/vr-layout';
+import { useIntl } from '~/intl';
+import {
+  createGetStaticProps,
+  StaticProps,
+} from '~/static-props/create-get-static-props';
+import { getLastGeneratedDate } from '~/static-props/get-data';
+import { colors } from '~/style/theme';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useReverseRouter } from '~/utils/use-reverse-router';
+import { DynamicChoropleth } from '~/components/choropleth';
+
+export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
+
+const VrIndexPage = (props: StaticProps<typeof getStaticProps>) => {
+  const breakpoints = useBreakpoints();
+  const reverseRouter = useReverseRouter();
+  const { siteText } = useIntl();
+
+  const { lastGenerated } = props;
+
+  const metadata = {
+    ...siteText.veiligheidsregio_actueel.index.metadata,
+  };
+
+  const data = useMemo(() => {
+    return vrData.map<VrCollectionHospitalNice>(
+      (x) =>
+        ({
+          vrcode: x.code,
+          admissions_on_date_of_reporting: null,
+        } as unknown as VrCollectionHospitalNice)
+    );
+  }, []);
+
+  return (
+    <Layout {...metadata} lastGenerated={lastGenerated}>
+      <VrLayout isLandingPage getLink={reverseRouter.actueel.vr}>
+        {!breakpoints.md && (
+          <Box bg="white">
+            <VrComboBox getLink={reverseRouter.actueel.vr} />
+          </Box>
+        )}
+
+        <Box as="article" p={4} spacing={3}>
+          {siteText.regionaal_index.belangrijk_bericht && (
+            <WarningTile
+              message={siteText.regionaal_index.belangrijk_bericht}
+              variant="emphasis"
+            />
+          )}
+
+          <Heading level={2} as="h1">
+            {siteText.veiligheidsregio_actueel.index.title}
+          </Heading>
+
+          <Markdown
+            content={siteText.veiligheidsregio_actueel.index.description}
+          />
+
+          <Box
+            display="flex"
+            flex="1"
+            justifyContent="center"
+            height="75vh"
+            maxWidth={750}
+            maxHeight={960}
+            flexDirection="column"
+            spacing={3}
+          >
+            <ErrorBoundary>
+              <DynamicChoropleth
+                renderTarget="canvas"
+                accessibility={{
+                  key: 'municipality_navigation_map',
+                  features: ['keyboard_choropleth'],
+                }}
+                map="vr"
+                data={data}
+                minHeight={650}
+                dataConfig={{
+                  metricName: 'veiligheidsregio' as any,
+                  metricProperty: 'admissions_on_date_of_reporting',
+                  areaStroke: colors.white,
+                  areaStrokeWidth: 1,
+                  hoverFill: colors.white,
+                  hoverStrokeWidth: 3,
+                  noDataFillColor: colors.lightGray,
+                }}
+                dataOptions={{
+                  getLink: reverseRouter.actueel.vr,
+                }}
+                formatTooltip={(context) => (
+                  <TooltipContent
+                    title={context.featureName}
+                    link={reverseRouter.actueel.vr(context.dataItem.vrcode)}
+                  />
+                )}
+              />
+            </ErrorBoundary>
+          </Box>
+        </Box>
+      </VrLayout>
+    </Layout>
+  );
+};
+
+export default VrIndexPage;

--- a/packages/app/src/pages/artikelen/[slug].tsx
+++ b/packages/app/src/pages/artikelen/[slug].tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 import { ArticleDetail } from '~/components/article-detail';
 import { Box } from '~/components/base';
 import { Layout } from '~/domain/layout/layout';
@@ -95,8 +96,17 @@ const ArticleDetailPage = (props: StaticProps<typeof getStaticProps>) => {
     twitterImage: imgPath,
   };
 
+  const breadcrumbsData = useMemo(
+    () => ({ [props.content.slug.current]: props.content.title }),
+    [props.content.slug, props.content.title]
+  );
+
   return (
-    <Layout {...metadata} lastGenerated={lastGenerated}>
+    <Layout
+      lastGenerated={lastGenerated}
+      breadcrumbsData={breadcrumbsData}
+      {...metadata}
+    >
       <Box backgroundColor="white">
         <ArticleDetail article={content} />
       </Box>

--- a/packages/app/src/pages/weekberichten/[slug].tsx
+++ b/packages/app/src/pages/weekberichten/[slug].tsx
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 import { Box } from '~/components/base';
 import { EditorialDetail } from '~/components/editorial-detail';
 import { Layout } from '~/domain/layout/layout';
@@ -96,8 +97,17 @@ export default function EditorialDetailPage(
     twitterImage: imgPath,
   };
 
+  const breadcrumbsData = useMemo(
+    () => ({ [props.content.slug.current]: props.content.title }),
+    [props.content.slug, props.content.title]
+  );
+
   return (
-    <Layout {...metadata} lastGenerated={lastGenerated}>
+    <Layout
+      breadcrumbsData={breadcrumbsData}
+      lastGenerated={lastGenerated}
+      {...metadata}
+    >
       <Box backgroundColor="white">
         <EditorialDetail editorial={content} />
       </Box>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     },
     "strict": true,
     "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

This PR adds a breadcrumbs trail to every page. It's hidden by default the same way that skip-links would be. Once one of the breadcrumbs links is focused, the trail will show up. The breadcrumbs are marked up with schema.org vocabulary.

As we don't have a homepage in the sense of a traditional content hierarchy, each 'set' of pages has their own breadcrumb trail, eg.:

- Actueel > Gemeentes > Aa en Hunze
- Landelijk > Vaccinaties
- Gemeentes > Aa en Hunze > Vaccinaties
- Toegankelijkheid
- ... and so on

When working on this I noticed there were some pages (`/actueel`, `/actueel/gemeente` and `/actueel/veiligheidsregio`) that did not have a corresponding page and navigating to them would lead to a 404. To alleviate this, I've added a redirect from `/actueel` to `/` and I've added two new pages at `/actueel/gemeente` and `/actueel/veiligheidsregio` with the same functional content as the pages as `/gemeente` and `/veiligheidsregio` respectively. I did add new lokalize keys for these pages.