### PR TITLE
Flip the timeline tooltip when there isn't enough space

### DIFF
--- a/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event.tsx
+++ b/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event.tsx
@@ -119,9 +119,6 @@ function TooltipTrigger({
       interactive={isTouch}
       visible={isSelected}
       maxWidth={breakpoints.sm ? '360px' : '100%'}
-      popperOptions={{
-        modifiers: [{ name: 'flip', enabled: false }],
-      }}
     >
       <div
         tabIndex={0}


### PR DESCRIPTION
## Summary

Makes sure the tooltip doesn't run out of the screen on smaller (tablet) screens where there isn't enough space on the bottom.