### PR TITLE
Use right day for metrics with inaccurate days

### DIFF
--- a/packages/app/src/utils/adjust-data-to-last-accurate-value.ts
+++ b/packages/app/src/utils/adjust-data-to-last-accurate-value.ts
@@ -18,7 +18,7 @@ export function adjustDataToLastAccurateValue<T>(
       last_value: {
         ...data.last_value,
         [metricProperty]:
-          data.values[data.values.length - numberOfItems][
+          data.values[data.values.length - numberOfItems - 1][
             metricProperty as keyof T
           ],
       },
@@ -27,7 +27,7 @@ export function adjustDataToLastAccurateValue<T>(
 
   return {
     ...data,
-    last_value: data.values[data.values.length - numberOfItems],
+    last_value: data.values[data.values.length - numberOfItems - 1],
   };
 }
 


### PR DESCRIPTION
The 3 and 4 days that were already in the code for hospital & IC did not actually indicate the number of days we would have to go back to get the first accurate day, but indicated the _number of inaccurate days_. Using the same number for hiding those days on the graph and for getting the number for KPIs meant there was a mismatch between the number shown as KPI and the last number visible on the graph.

This PR fixes this by actually going one item back more than the number of inaccurate data items, ending up on the actual last accurate value.