### PR TITLE
Change breadcrumb regex

### DIFF
--- a/packages/app/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/app/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,11 +1,11 @@
-import { useBreadcrumbs } from './logic/use-breadcrumbs';
-import { Link } from '~/utils/link';
 import css from '@styled-system/css';
-import { Box } from '../base';
 import { useIntl } from '~/intl';
 import { colors } from '~/style/theme';
+import { Link } from '~/utils/link';
+import { Box } from '../base';
 import { MaxWidth } from '../max-width';
 import { Anchor } from '../typography';
+import { useBreadcrumbs } from './logic/use-breadcrumbs';
 
 export function Breadcrumbs() {
   const breadcrumbs = useBreadcrumbs();

--- a/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
+++ b/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
@@ -58,9 +58,9 @@ export function useBreadcrumbs(): Breadcrumb[] {
   return useMemo(() => {
     const getQueryParameter = (str: string) => {
       // Extract text between square brackets: https://stackoverflow.com/questions/2403122/regular-expression-to-extract-text-between-square-brackets
-      const regexp = /(?<=\[).*?(?=\])/;
+      const regexp = /(\[([^\]]+)\])/;
       const matches = str.match(regexp);
-      const param = matches?.[0];
+      const param = matches?.[2];
       return { key: param };
     };
 


### PR DESCRIPTION
Safari didn't support the lookbehind expression (https://caniuse.com/js-regexp-lookbehind).
Changed the regex a bit so Safari is working again.