### PR TITLE
Switch back to fully vaccinated metrics on the topical page

### DIFF
--- a/packages/app/src/domain/topical/mini-vaccination-coverage-tile.tsx
+++ b/packages/app/src/domain/topical/mini-vaccination-coverage-tile.tsx
@@ -33,16 +33,16 @@ export function MiniVaccinationCoverageTile(
     <MiniTile {...tileProps}>
       <Box display="flex" flexDirection="column" spacing={3}>
         <LabeledBar
-          value={oneShotPercentage}
-          color={COLOR_HAS_ONE_SHOT}
-          valueLabel={oneShotPercentageLabel}
-          barLabel={oneShotBarLabel}
-        />
-        <LabeledBar
           value={fullyVaccinatedPercentage}
           color={COLOR_FULLY_VACCINATED}
           valueLabel={fullyVaccinatedPercentageLabel}
           barLabel={fullyVaccinatedBarLabel}
+        />
+        <LabeledBar
+          value={oneShotPercentage}
+          color={COLOR_HAS_ONE_SHOT}
+          valueLabel={oneShotPercentageLabel}
+          barLabel={oneShotBarLabel}
         />
       </Box>
     </MiniTile>

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -204,8 +204,9 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.gemeente_actueel.mini_trend_tiles.vaccinatiegraad
                         .menu_item_label,
                     data: data.vaccine_coverage_per_age_group.values,
-                    dataProperty: 'has_one_shot_percentage',
-                    value: renderedAgeGroup18Pluslabels.has_one_shot_percentage,
+                    dataProperty: 'fully_vaccinated_percentage',
+                    value:
+                      renderedAgeGroup18Pluslabels.fully_vaccinated_percentage,
                     valueIsPercentage: true,
                     warning: getWarning(
                       content.elements.warning,

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -190,8 +190,9 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.veiligheidsregio_actueel.mini_trend_tiles
                         .vaccinatiegraad.menu_item_label,
                     data: data.vaccine_coverage_per_age_group.values,
-                    dataProperty: 'has_one_shot_percentage',
-                    value: renderedAgeGroup18Pluslabels.has_one_shot_percentage,
+                    dataProperty: 'fully_vaccinated_percentage',
+                    value:
+                      renderedAgeGroup18Pluslabels.fully_vaccinated_percentage,
                     valueIsPercentage: true,
                     warning: getWarning(
                       content.elements.warning,

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -200,10 +200,10 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                       siteText.nationaal_actueel.mini_trend_tiles
                         .vaccinatiegraad.menu_item_label,
                     data: data.vaccine_coverage_per_age_group_estimated.values,
-                    dataProperty: 'age_18_plus_has_one_shot',
+                    dataProperty: 'age_18_plus_fully_vaccinated',
                     value:
                       data.vaccine_coverage_per_age_group_estimated.last_value
-                        ?.age_18_plus_has_one_shot ?? 0,
+                        ?.age_18_plus_fully_vaccinated ?? 0,
                     valueIsPercentage: true,
                     warning: getWarning(
                       content.elements.warning,


### PR DESCRIPTION
From partial to fully on the topical page metrics.
Also switched the order of the bars.