### PR TITLE
 Fix crashing sewer chart

### DIFF
--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -179,7 +179,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               thresholds: thresholds.vr.average,
             }}
           >
-            {selectedMap === 'gm' ? (
+            {selectedMap === 'gm' && (
               <DynamicChoropleth
                 renderTarget="canvas"
                 map="gm"
@@ -195,7 +195,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                   getLink: reverseRouter.gm.rioolwater,
                 }}
               />
-            ) : (
+            )}
+
+            {selectedMap === 'vr' && (
               <DynamicChoropleth
                 renderTarget="canvas"
                 map="vr"


### PR DESCRIPTION
With a tannery condition, it seems that react doesn't like that. This is a temporary solution to fix the chart when switching between a safety region and municipality.
We might need to aim in the future for a more solid solution to fix this bug in the choropleth (if it's a bug and worth fixing). 