### PR TITLE
Support relative URLs in rich text

### DIFF
--- a/packages/cms/src/schemas/objects/block-fields.ts
+++ b/packages/cms/src/schemas/objects/block-fields.ts
@@ -27,13 +27,14 @@ export const blockFields = [
         {
           name: 'link',
           type: 'object',
-          title: 'External link',
+          title: 'Link',
           icon: MdLink,
           fields: [
             {
               name: 'href',
               type: 'url',
               title: 'URL',
+              validation: (rule: Rule) => rule.uri({ allowRelative: true }),
             },
           ],
         },


### PR DESCRIPTION
Sanity upgrade made the validator not support relative URLs anymore