### PR TITLE
Remove dot metadata

### DIFF
--- a/packages/app/src/components/metadata.tsx
+++ b/packages/app/src/components/metadata.tsx
@@ -83,7 +83,7 @@ export function Metadata({
                   `${siteText.common.metadata.source}: ${source.text}`
                 ) : dataSources ? (
                   <>
-                    {` • ${siteText.common.metadata.source}: `}
+                    {`${siteText.common.metadata.source}: `}
                     {dataSources.map((item, index) => (
                       <InlineText key={index}>
                         {index > 0 &&


### PR DESCRIPTION
Seems like the only place where this dot was displayed was on the variants page. Not sure why it was there in the first place but removing it seems to have no side effects. 