### PR TITLE
Add 7-day-average dates to IC & hospital tiles

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -65,6 +65,9 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
+const DAY_IN_SECONDS = 24 * 60 * 60;
+const WEEK_IN_SECONDS = 7 * DAY_IN_SECONDS;
+
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   const {
     selectedGmData: data,
@@ -84,6 +87,11 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
     data.hospital_nice.values,
     INACCURATE_ITEMS
   );
+
+  const sevenDayAverageDates: [number, number] = [
+    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - DAY_IN_SECONDS,
+  ];
 
   const metadata = {
     ...siteText.gemeente_index.metadata,
@@ -122,6 +130,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               title={text.barscale_titel}
               description={text.extra_uitleg}
               metadata={{
+                date: sevenDayAverageDates,
                 source: text.bronnen.rivm,
               }}
             >

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -60,6 +60,9 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
+const DAY_IN_SECONDS = 24 * 60 * 60;
+const WEEK_IN_SECONDS = 7 * DAY_IN_SECONDS;
+
 const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
   const { siteText, formatPercentage } = useIntl();
 
@@ -74,6 +77,11 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
     dataIntake.values,
     INACCURATE_ITEMS
   );
+
+  const sevenDayAverageDates: [number, number] = [
+    intakeUnderReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    intakeUnderReportedRange - DAY_IN_SECONDS,
+  ];
 
   const metadata = {
     ...siteText.nationaal_metadata,
@@ -108,6 +116,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
             <KpiTile
               title={text.barscale_titel}
               metadata={{
+                date: sevenDayAverageDates,
                 source: text.bronnen.nice,
               }}
             >

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -71,6 +71,9 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
+const DAY_IN_SECONDS = 24 * 60 * 60;
+const WEEK_IN_SECONDS = 7 * DAY_IN_SECONDS;
+
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   const { selectedNlData: data, choropleth, content, lastGenerated } = props;
   const reverseRouter = useReverseRouter();
@@ -85,6 +88,11 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
     dataHospitalNice.values,
     INACCURATE_ITEMS
   );
+
+  const sevenDayAverageDates: [number, number] = [
+    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - DAY_IN_SECONDS,
+  ];
 
   const bedsLastValue = getLastFilledValue(data.hospital_lcps);
 
@@ -123,6 +131,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               title={text.barscale_titel}
               description={text.extra_uitleg}
               metadata={{
+                date: sevenDayAverageDates,
                 source: text.bronnen.nice,
               }}
             >

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -64,6 +64,9 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
+const DAY_IN_SECONDS = 24 * 60 * 60;
+const WEEK_IN_SECONDS = 7 * DAY_IN_SECONDS;
+
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   const {
     selectedVrData: data,
@@ -86,6 +89,11 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
     data.hospital_nice.values,
     INACCURATE_ITEMS
   );
+
+  const sevenDayAverageDates: [number, number] = [
+    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - DAY_IN_SECONDS,
+  ];
 
   const metadata = {
     ...siteText.veiligheidsregio_index.metadata,
@@ -125,6 +133,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
               title={text.barscale_titel}
               description={text.extra_uitleg}
               metadata={{
+                date: sevenDayAverageDates,
                 source: text.bronnen.rivm,
               }}
             >


### PR DESCRIPTION
We can determine the dates on our end now. Since it's a 7 day average we show the full date range.