### PR TITLE
Fix 7-day-average period being inclusive

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -92,7 +92,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   );
 
   const sevenDayAverageDates: [number, number] = [
-    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - WEEK_IN_SECONDS,
     underReportedRange - DAY_IN_SECONDS,
   ];
 

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -34,7 +34,8 @@ import {
 } from '~/static-props/get-data';
 import { IntakeHospitalPageQuery } from '~/types/cms';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
-import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
@@ -80,7 +81,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
   );
 
   const sevenDayAverageDates: [number, number] = [
-    intakeUnderReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    intakeUnderReportedRange - WEEK_IN_SECONDS,
     intakeUnderReportedRange - DAY_IN_SECONDS,
   ];
 

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -21,22 +21,22 @@ import { useIntl } from '~/intl';
 import {
   createElementsQuery,
   ElementsQueryResult,
-  getTimelineEvents
+  getTimelineEvents,
 } from '~/queries/create-elements-query';
 import {
   createPageArticlesQuery,
-  PageArticlesQueryResult
+  PageArticlesQueryResult,
 } from '~/queries/create-page-articles-query';
 import { getHospitalAdmissionsPageQuery } from '~/queries/hospital-admissions-page-query';
 import {
   createGetStaticProps,
-  StaticProps
+  StaticProps,
 } from '~/static-props/create-get-static-props';
 import {
   createGetChoroplethData,
   createGetContent,
   getLastGeneratedDate,
-  selectNlData
+  selectNlData,
 } from '~/static-props/get-data';
 import { HospitalAdmissionsPageQuery } from '~/types/cms';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
@@ -92,7 +92,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   );
 
   const sevenDayAverageDates: [number, number] = [
-    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - WEEK_IN_SECONDS,
     underReportedRange - DAY_IN_SECONDS,
   ];
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/ziekenhuis-opnames.tsx
@@ -94,7 +94,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
   );
 
   const sevenDayAverageDates: [number, number] = [
-    underReportedRange - WEEK_IN_SECONDS - DAY_IN_SECONDS,
+    underReportedRange - WEEK_IN_SECONDS,
     underReportedRange - DAY_IN_SECONDS,
   ];
 


### PR DESCRIPTION
The 7 day period is inclusive which means we subtracted one day too many from the end date of the period.