### PR TITLE
Make sure each breadcrumb href starts with /

### DIFF
--- a/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
+++ b/packages/app/src/components/breadcrumbs/logic/use-breadcrumbs.tsx
@@ -147,7 +147,7 @@ export function useBreadcrumbs(): Breadcrumb[] {
           .join('/');
 
         return {
-          href: href === '' ? '/' : href,
+          href: href.startsWith('/') ? href : `/${href}`,
           title: getTitle(x),
           redirectLabel: getRedirectLabel(x),
         };


### PR DESCRIPTION
Constructing actueel breadcrumb hrefs works a bit differently which made that it missed a starting forward slash and thus pointed to the wrong location.