### PR TITLE
Fix VR/GM sparkbars still showing null values

### DIFF
--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -55,6 +55,7 @@ import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getVrForMunicipalityCode } from '~/utils/get-vr-for-municipality-code';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { trimNullValues } from '~/utils/trim-null-values';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export { getStaticPaths } from '~/static-paths/gm';
@@ -190,7 +191,10 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
                     label:
                       siteText.gemeente_actueel.mini_trend_tiles
                         .ziekenhuis_opnames.menu_item_label,
-                    data: dataHospitalIntake.values,
+                    data: trimNullValues(
+                      dataHospitalIntake.values,
+                      'admissions_on_date_of_admission_moving_average_rounded'
+                    ),
                     dataProperty:
                       'admissions_on_date_of_admission_moving_average_rounded',
                     value:

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -48,10 +48,11 @@ import {
   getLastGeneratedDate,
   selectVrData,
 } from '~/static-props/get-data';
-import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
+import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { trimNullValues } from '~/utils/trim-null-values';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export { getStaticPaths } from '~/static-paths/vr';
@@ -176,7 +177,10 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
                     label:
                       siteText.veiligheidsregio_actueel.mini_trend_tiles
                         .ziekenhuis_opnames.menu_item_label,
-                    data: dataHospitalIntake.values,
+                    data: trimNullValues(
+                      dataHospitalIntake.values,
+                      'admissions_on_date_of_admission_moving_average_rounded'
+                    ),
                     dataProperty:
                       'admissions_on_date_of_admission_moving_average_rounded',
                     value:


### PR DESCRIPTION
Since we get null values for the last x hospital/IC datapoints, the spark bars should ignore those. This was already implemented for the national topical page but not for VR/GM.