### PR TITLE
Update collapsible inline content alignment

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -96,7 +96,20 @@ export function RichContent({
         return (
           <ContentWrapper>
             <CollapsibleSection summary={props.node.title}>
-              <Box py={3}>
+              <Box
+                py={3}
+                css={css({
+                  p: { width: '100%' },
+
+                  /** This is for removing the inline charts default padding
+                   * and aligning the KPI's at the start of the flow
+                   */
+                  'div > div': {
+                    px: 0,
+                    alignSelf: 'flex-start',
+                  },
+                })}
+              >
                 <RichContent blocks={props.node.content.inlineBlockContent} />
               </Box>
             </CollapsibleSection>


### PR DESCRIPTION
And the reason why you see a `-` in the KPI value is that the moving_average doesn't understand how to trim null values. But that is a problem for another pull request.

Before this change:
![Screenshot 2021-10-27 at 13 42 22](https://user-images.githubusercontent.com/76471292/139058987-e285fa4e-fef1-4492-b962-6130313c8bd7.png)


After this change:
![Screenshot 2021-10-27 at 13 41 51](https://user-images.githubusercontent.com/76471292/139058901-253ce2ed-1bb3-4615-964e-dbf07843b037.png)
