### PR TITLE
Add percentage bar to minitile selector button

### DIFF
--- a/packages/app/src/components/percentage-bar.tsx
+++ b/packages/app/src/components/percentage-bar.tsx
@@ -47,9 +47,8 @@ export function PercentageBar({
                 backgroundColor,
               }
         )}
-        width="100%"
-        height="100%"
-        position="absolute"
+        flex={1}
+        height={height}
         top={0}
         left={0}
       />
@@ -61,7 +60,6 @@ const Wrapper = styled.div(
   css({
     display: 'flex',
     position: 'relative',
-    minWidth: '4em',
     width: '100%',
   })
 );

--- a/packages/app/src/components/spark-bars.tsx
+++ b/packages/app/src/components/spark-bars.tsx
@@ -1,7 +1,6 @@
 import type { KeysOfType, TimestampedValue } from '@corona-dashboard/common';
 import { colors } from '@corona-dashboard/common';
 import { scaleLinear } from '@visx/scale';
-import { Box } from './base';
 
 const BAR_WIDTH = 5;
 const BAR_HEIGHT = 16;
@@ -9,13 +8,12 @@ const BAR_HEIGHT = 16;
 type SparkBarsProps<T extends TimestampedValue> = {
   averageProperty: KeysOfType<T, number | null, true>;
   data: T[];
-  hide?: boolean;
 };
 
 export function SparkBars<T extends TimestampedValue>(
   props: SparkBarsProps<T>
 ) {
-  const { data, averageProperty, hide } = props;
+  const { data, averageProperty } = props;
 
   const last7Days = data.slice(-7);
 
@@ -31,36 +29,29 @@ export function SparkBars<T extends TimestampedValue>(
   });
 
   return (
-    <Box as="span" mr="3" aria-hidden="true">
-      <svg
-        width={7 * BAR_WIDTH}
-        height={BAR_HEIGHT}
-        role="img"
-        aria-hidden="true"
-        focusable="false"
-      >
-        {!hide && (
-          <>
-            {last7Days.map((d, i) => (
-              <rect
-                key={'date_unix' in d ? d.date_unix : d.date_start_unix}
-                x={i * BAR_WIDTH}
-                width={BAR_WIDTH}
-                opacity="0.5"
-                y={y(Math.max(0, d[averageProperty]))}
-                height={
-                  d[averageProperty] >= 0 ? y(0) - y(d[averageProperty]) : y(0)
-                }
-                fill={
-                  d[averageProperty] >= 0
-                    ? colors.data.positive
-                    : colors.data.negative
-                }
-              />
-            ))}
-          </>
-        )}
-      </svg>
-    </Box>
+    <svg
+      width="100%"
+      height={BAR_HEIGHT}
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      viewBox={`0 0 ${BAR_WIDTH * 7} ${BAR_HEIGHT}`}
+    >
+      {last7Days.map((d, i) => (
+        <rect
+          key={'date_unix' in d ? d.date_unix : d.date_start_unix}
+          x={i * BAR_WIDTH}
+          width={BAR_WIDTH}
+          opacity="0.5"
+          y={y(Math.max(0, d[averageProperty]))}
+          height={d[averageProperty] >= 0 ? y(0) - y(d[averageProperty]) : y(0)}
+          fill={
+            d[averageProperty] >= 0
+              ? colors.data.positive
+              : colors.data.negative
+          }
+        />
+      ))}
+    </svg>
   );
 }

--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -21,6 +21,7 @@ import { space } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useCollapsible } from '~/utils/use-collapsible';
+import { Bar } from '../vaccine/vaccine-coverage-per-age-group/components/bar';
 
 export type MiniTileSelectorItem<T extends TimestampedValue> = {
   label: string;
@@ -29,7 +30,10 @@ export type MiniTileSelectorItem<T extends TimestampedValue> = {
   value: number | string;
   valueIsPercentage?: boolean;
   warning?: string;
-  hideSparkBar?: boolean;
+  percentageBar?: {
+    value: number | null;
+    label?: string | null;
+  };
 };
 
 type MiniTileSelectorLayoutProps = {
@@ -69,7 +73,6 @@ function NarrowMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
         {menuItems.map((x, index) => (
           <NarrowMenuListItem
             key={x.label}
-            hideSparkBar={x.hideSparkBar}
             item={x}
             content={children[index]}
           />
@@ -100,11 +103,10 @@ function NarrowMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
 type NarrowMenuListItemProps = {
   content: ReactNode;
   item: MiniTileSelectorItem<any>;
-  hideSparkBar?: boolean;
 };
 
 function NarrowMenuListItem(props: NarrowMenuListItemProps) {
-  const { content, item, hideSparkBar } = props;
+  const { content, item } = props;
   const { siteText, formatNumber, formatPercentage } = useIntl();
   const collapsible = useCollapsible();
 
@@ -118,11 +120,19 @@ function NarrowMenuListItem(props: NarrowMenuListItemProps) {
         pl={{ _: 0, md: 1 }}
         onClick={collapsible.toggle}
       >
-        <SparkBars
-          data={item.data}
-          averageProperty={item.dataProperty}
-          hide={hideSparkBar}
-        />
+        <Box width={35} mr="3" aria-hidden="true">
+          {item.percentageBar ? (
+            <Bar
+              value={item.percentageBar.value}
+              color={`${colors.data.positive}80`} // We need the color to be transparent so we make an 8-digit hex code
+              backgroundColor="rgba(0, 0, 0, 0.1)"
+              label={item.percentageBar.label}
+              height={10}
+            />
+          ) : (
+            <SparkBars data={item.data} averageProperty={item.dataProperty} />
+          )}
+        </Box>
         <InlineText>{item.label}</InlineText>
         <Box ml="auto" display="flex" pr={1}>
           {item.warning && (
@@ -167,11 +177,22 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
                 onClick={() => setSelectedIndex(index)}
                 selected={selectedIndex === index}
               >
-                <SparkBars
-                  data={item.data}
-                  averageProperty={item.dataProperty}
-                  hide={item.hideSparkBar}
-                />
+                <Box width={35} mr="3" aria-hidden="true">
+                  {item.percentageBar ? (
+                    <Bar
+                      value={item.percentageBar.value}
+                      color={`${colors.data.positive}80`}
+                      backgroundColor="rgba(0, 0, 0, 0.1)"
+                      label={item.percentageBar.label}
+                      height={10}
+                    />
+                  ) : (
+                    <SparkBars
+                      data={item.data}
+                      averageProperty={item.dataProperty}
+                    />
+                  )}
+                </Box>
                 <InlineText>{item.label}</InlineText>
                 <Box
                   ml="auto"

--- a/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group/components/bar.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group/components/bar.tsx
@@ -9,6 +9,7 @@ import { useIntl } from '~/intl';
 interface BarProps {
   value: number | null;
   color: string;
+  backgroundColor?: string;
   label?: string | null;
   height?: number;
   showAxisValues?: boolean;
@@ -17,6 +18,7 @@ interface BarProps {
 export function Bar({
   value,
   color,
+  backgroundColor = colors.data.underReported,
   label,
   height = 8,
   showAxisValues,
@@ -45,9 +47,7 @@ export function Bar({
             parsedVaccinatedLabel.sign === '>' ? 'hatched' : 'normal'
           }
           backgroundColor={
-            parsedVaccinatedLabel.sign === '>'
-              ? color
-              : colors.data.underReported
+            parsedVaccinatedLabel.sign === '>' ? color : backgroundColor
           }
         />
       ) : (
@@ -55,7 +55,7 @@ export function Bar({
           percentage={barValue}
           height={height}
           color={color}
-          backgroundColor="data.underReported"
+          backgroundColor={backgroundColor}
         />
       )}
       {showAxisValues && (

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -218,8 +218,13 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
                       content.elements.warning,
                       'vaccinatiegraad'
                     ),
-                    hideSparkBar:
-                      data.vaccine_coverage_per_age_group.values.length < 7,
+                    percentageBar: {
+                      value:
+                        filteredAgeGroup18Plus?.fully_vaccinated_percentage ??
+                        null,
+                      label:
+                        filteredAgeGroup18Plus?.fully_vaccinated_percentage_label,
+                    },
                   } as MiniTileSelectorItem<GmVaccineCoveragePerAgeGroupValue>,
                 ]}
               >

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -205,8 +205,13 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
                       content.elements.warning,
                       'vaccinatiegraad'
                     ),
-                    hideSparkBar:
-                      data.vaccine_coverage_per_age_group.values.length < 7,
+                    percentageBar: {
+                      value:
+                        filteredAgeGroup18Plus?.fully_vaccinated_percentage ??
+                        null,
+                      label:
+                        filteredAgeGroup18Plus?.fully_vaccinated_percentage_label,
+                    },
                   } as MiniTileSelectorItem<VrVaccineCoveragePerAgeGroupValue>,
                 ]}
               >

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -227,15 +227,17 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     dataProperty: 'age_18_plus_fully_vaccinated',
                     value:
                       data.vaccine_coverage_per_age_group_estimated.last_value
-                        ?.age_18_plus_fully_vaccinated ?? 0,
+                        ?.age_18_plus_fully_vaccinated,
                     valueIsPercentage: true,
                     warning: getWarning(
                       content.elements.warning,
                       'vaccine_coverage_per_age_group_estimated'
                     ),
-                    hideSparkBar:
-                      data.vaccine_coverage_per_age_group_estimated.values
-                        .length < 7,
+                    percentageBar: {
+                      value:
+                        data.vaccine_coverage_per_age_group_estimated.last_value
+                          ?.age_18_plus_fully_vaccinated,
+                    },
                   } as MiniTileSelectorItem<NlVaccineCoveragePerAgeGroupEstimated>,
                 ]}
               >


### PR DESCRIPTION
Vaccination coverage is not a time series but one percentage value. Therefore showing sparkbars there does not make sense and did not work. 

This PR adds a possibility to add a percentage bar to the mini tile selector buttons.

![image](https://user-images.githubusercontent.com/85888969/139202690-91b5ef10-22ba-4643-a84d-42556dd56ca4.png)
