### PR TITLE
Cut all values that are not needed on the homepage

### DIFF
--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -52,6 +52,7 @@ import {
 } from '~/static-props/get-data';
 import { assert } from '~/utils/assert';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
+import { cutValuesFromTimeframe } from '~/utils/cut-values-from-timeframe';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getVrForMunicipalityCode } from '~/utils/get-vr-for-municipality-code';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
@@ -63,12 +64,21 @@ export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectGmData(
-    'hospital_nice',
-    'sewer',
-    'difference',
-    'vaccine_coverage_per_age_group'
-  ),
+  (context) => {
+    const data = selectGmData(
+      'hospital_nice',
+      'sewer',
+      'difference',
+      'vaccine_coverage_per_age_group'
+    )(context);
+
+    data.selectedGmData.hospital_nice.values = cutValuesFromTimeframe(
+      data.selectedGmData.hospital_nice.values,
+      '5weeks'
+    );
+
+    return data;
+  },
   createGetChoroplethData({
     gm: ({ vaccine_coverage_per_age_group }, ctx) => {
       if (!isDefined(vaccine_coverage_per_age_group)) {

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -50,6 +50,7 @@ import {
   selectVrData,
 } from '~/static-props/get-data';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
+import { cutValuesFromTimeframe } from '~/utils/cut-values-from-timeframe';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -60,12 +61,22 @@ export { getStaticPaths } from '~/static-paths/vr';
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
-  selectVrData(
-    'vaccine_coverage_per_age_group',
-    'hospital_nice',
-    'code',
-    'difference'
-  ),
+
+  (context) => {
+    const data = selectVrData(
+      'vaccine_coverage_per_age_group',
+      'hospital_nice',
+      'code',
+      'difference'
+    )(context);
+
+    data.selectedVrData.hospital_nice.values = cutValuesFromTimeframe(
+      data.selectedVrData.hospital_nice.values,
+      '5weeks'
+    );
+
+    return data;
+  },
   createGetChoroplethData({
     gm: ({ vaccine_coverage_per_age_group }, ctx) => {
       if (!isDefined(vaccine_coverage_per_age_group)) {

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -59,6 +59,7 @@ import {
   selectNlData,
 } from '~/static-props/get-data';
 import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
+import { cutValuesFromTimeframe } from '~/utils/cut-values-from-timeframe';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -98,15 +99,29 @@ export const getStaticProps = createGetStaticProps(
       'vaccine_coverage_per_age_group_estimated',
     ])
   ),
-  selectNlData(
-    'intensive_care_nice',
-    'intensive_care_lcps',
-    'hospital_nice',
-    'hospital_lcps',
-    'difference',
-    'vaccine_administered_total',
-    'vaccine_coverage_per_age_group_estimated'
-  )
+  () => {
+    const { selectedNlData: data } = selectNlData(
+      'intensive_care_nice',
+      'intensive_care_lcps',
+      'hospital_nice',
+      'hospital_lcps',
+      'difference',
+      'vaccine_administered_total',
+      'vaccine_coverage_per_age_group_estimated'
+    )();
+
+    data.hospital_nice.values = cutValuesFromTimeframe(
+      data.hospital_nice.values,
+      '5weeks'
+    );
+
+    data.intensive_care_nice.values = cutValuesFromTimeframe(
+      data.intensive_care_nice.values,
+      '5weeks'
+    );
+
+    return { selectedNlData: data };
+  }
 );
 
 const Home = (props: StaticProps<typeof getStaticProps>) => {

--- a/packages/app/src/utils/cut-values-from-timeframe.ts
+++ b/packages/app/src/utils/cut-values-from-timeframe.ts
@@ -1,0 +1,11 @@
+import { getDaysForTimeframe, TimeframeOption } from '@corona-dashboard/common';
+import { takeRight } from 'lodash';
+
+export function cutValuesFromTimeframe<T>(
+  values: T[],
+  timeframe: TimeframeOption
+) {
+  const amountOfDays = getDaysForTimeframe(timeframe);
+
+  return takeRight(values, amountOfDays);
+}


### PR DESCRIPTION
A new util function that will cut values based on the existing timeframes, this will result that only the last 35 values are being added to the page compared the all the 600+ per metric.