### PR TITLE
fix: correct pointer-events property assignment

### DIFF
--- a/packages/app/src/components/choropleth/index.tsx
+++ b/packages/app/src/components/choropleth/index.tsx
@@ -127,7 +127,6 @@ export function Choropleth<T extends ChoroplethDataItem>({
   ...props
 }: ChoroplethProps<T>) {
   const [tooltip, setTooltip] = useState<TooltipSettings<T>>();
-  const isTouch = useIsTouchDevice();
   const { siteText } = useIntl();
   const hoverRef = useRef<SVGGElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -156,10 +155,7 @@ export function Choropleth<T extends ChoroplethDataItem>({
         />
 
         {tooltip && (
-          <div
-            ref={tooltipRef}
-            style={{ pointerEvents: isTouch ? 'all' : 'none' }}
-          >
+          <div ref={tooltipRef} style={{ pointerEvents: 'none' }}>
             <Tooltip
               placement={tooltipPlacement}
               left={tooltip.left}

--- a/packages/app/src/components/choropleth/index.tsx
+++ b/packages/app/src/components/choropleth/index.tsx
@@ -8,7 +8,6 @@ import { Box } from '~/components/base';
 import { useIntl } from '~/intl';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
-import { useIsTouchDevice } from '~/utils/use-is-touch-device';
 import { useOnClickOutside } from '~/utils/use-on-click-outside';
 import { useTabInteractiveButton } from '~/utils/use-tab-interactive-button';
 import { ChoroplethMap } from './components/choropleth-map';

--- a/packages/app/src/components/choropleth/tooltips/tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip.tsx
@@ -3,6 +3,7 @@ import { isDefined } from 'ts-is-present';
 import { Box } from '~/components/base';
 import { useBoundingBox } from '~/utils/use-bounding-box';
 import { useIsMounted } from '~/utils/use-is-mounted';
+import { useIsTouchDevice } from '~/utils/use-is-touch-device';
 import { useResizeObserver } from '~/utils/use-resize-observer';
 import { useViewport } from '~/utils/use-viewport';
 import { ChoroplethDataItem } from '../logic';
@@ -37,6 +38,7 @@ export function Tooltip<T extends ChoroplethDataItem>({
   const isMounted = useIsMounted({ delayMs: 10 });
   const [ref, { height = 0 }] = useResizeObserver<HTMLDivElement>();
   const [boundingBox, boundingBoxRef] = useBoundingBox<HTMLDivElement>();
+  const isTouch = useIsTouchDevice();
 
   const content = isDefined(formatTooltip) ? (
     formatTooltip(data)
@@ -99,6 +101,7 @@ export function Tooltip<T extends ChoroplethDataItem>({
             opacity: isMounted ? 1 : 0,
             transform: t(placement, top, left),
             maxWidth,
+            pointerEvents: isTouch ? 'all' : 'none',
           }}
           boxShadow="rgba(33, 33, 33, 0.2) 0px 1px 2px"
           borderRadius={1}


### PR DESCRIPTION
## Summary

After the refactor of tooltip positioning on the choropleth, the `pointer-events` attribute wasn't on the right element. I've moved it to the right place. This fixes choropleth interaction on touch devices.