### PR TITLE
Make the AgeDemographicChart more generic

### DIFF
--- a/packages/app/src/components/age-demographic/age-demographic-tooltip-content.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic-tooltip-content.tsx
@@ -6,18 +6,29 @@ import { AgeDemographicChartText, AgeDemographicDefaultValue } from './types';
 import { formatAgeGroupRange } from './utils';
 import { useIntl } from '~/intl';
 import { Box } from '../base';
+import type { Color, KeysOfType } from '@corona-dashboard/common';
 
 interface AgeDemographicTooltipContentProps<
   T extends AgeDemographicDefaultValue
 > {
   value: T;
-  metricProperty: keyof T;
+  rightMetricProperty: KeysOfType<T, number, true>;
+  leftMetricProperty: KeysOfType<T, number, true>;
+  rightColor: Color;
+  leftColor: Color;
   text: AgeDemographicChartText;
 }
 
 export function AgeDemographicTooltipContent<
   T extends AgeDemographicDefaultValue
->({ value, metricProperty, text }: AgeDemographicTooltipContentProps<T>) {
+>({
+  value,
+  rightMetricProperty,
+  leftMetricProperty,
+  rightColor,
+  leftColor,
+  text,
+}: AgeDemographicTooltipContentProps<T>) {
   const { formatPercentage } = useIntl();
 
   return (
@@ -30,22 +41,19 @@ export function AgeDemographicTooltipContent<
         </Text>
       </Box>
       <Legend>
-        <LegendItem color="data.primary">
+        <LegendItem color={rightColor}>
           <InlineText fontWeight="bold">
-            {formatPercentage(
-              (value[metricProperty] as unknown as number) * 100
-            )}
-            %
+            {formatPercentage(value[rightMetricProperty] * 100)}%
           </InlineText>{' '}
-          {replaceVariablesInText(text.value_percentage_tooltip, {
+          {replaceVariablesInText(text.right_tooltip, {
             ageGroupRange: formatAgeGroupRange(value.age_group_range),
           })}
         </LegendItem>
-        <LegendItem color="data.neutral">
+        <LegendItem color={leftColor}>
           <InlineText fontWeight="bold">
-            {formatPercentage(value.age_group_percentage * 100)}%
+            {formatPercentage(value[leftMetricProperty] * 100)}%
           </InlineText>{' '}
-          {replaceVariablesInText(text.age_group_percentage_tooltip, {
+          {replaceVariablesInText(text.left_tooltip, {
             ageGroupRange: formatAgeGroupRange(value.age_group_range),
           })}
         </LegendItem>

--- a/packages/app/src/components/age-demographic/age-demographic.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic.tsx
@@ -1,3 +1,4 @@
+import type { Color, KeysOfType } from '@corona-dashboard/common';
 import { Box } from '~/components/base';
 import { ErrorBoundary } from '~/components/error-boundary';
 import { Tooltip, useTooltip } from '~/components/tooltip';
@@ -15,13 +16,19 @@ import { AgeDemographicChartText, AgeDemographicDefaultValue } from './types';
 
 export function AgeDemographic<T extends AgeDemographicDefaultValue>({
   data,
-  metricProperty,
+  rightMetricProperty,
+  leftMetricProperty,
+  rightColor,
+  leftColor,
   displayMaxPercentage,
   text,
   accessibility,
 }: {
   data: { values: T[] };
-  metricProperty: keyof T;
+  rightMetricProperty: KeysOfType<T, number, true>;
+  leftMetricProperty: KeysOfType<T, number, true>;
+  rightColor: Color;
+  leftColor: Color;
   /**
    * The mandatory AccessibilityDefinition provides a reference to annotate the
    * graph with a label and description.
@@ -32,7 +39,8 @@ export function AgeDemographic<T extends AgeDemographicDefaultValue>({
 }) {
   const [ref, coordinates] = useAgeDemographicCoordinates(
     data,
-    metricProperty,
+    rightMetricProperty,
+    leftMetricProperty,
     displayMaxPercentage
   );
 
@@ -58,7 +66,10 @@ export function AgeDemographic<T extends AgeDemographicDefaultValue>({
             onMouseLeaveBar={closeTooltip}
             onKeyInput={keyboardNavigateTooltip}
             displayMaxPercentage={displayMaxPercentage}
-            metricProperty={metricProperty}
+            rightMetricProperty={rightMetricProperty}
+            leftMetricProperty={leftMetricProperty}
+            rightColor={rightColor}
+            leftColor={leftColor}
             text={text}
           />
         </div>
@@ -71,7 +82,10 @@ export function AgeDemographic<T extends AgeDemographicDefaultValue>({
           {tooltipState.value && (
             <AgeDemographicTooltipContent
               value={tooltipState.value}
-              metricProperty={metricProperty}
+              rightMetricProperty={rightMetricProperty}
+              leftMetricProperty={leftMetricProperty}
+              rightColor={rightColor}
+              leftColor={leftColor}
               text={text}
             />
           )}

--- a/packages/app/src/components/age-demographic/types.ts
+++ b/packages/app/src/components/age-demographic/types.ts
@@ -1,14 +1,13 @@
 export interface AgeDemographicDefaultValue {
-  age_group_percentage: number;
   age_group_range: string;
 }
 
 export interface AgeDemographicChartText {
   accessibility_description: string;
   clipped_value_message: string;
-  age_group_percentage_title: string;
-  age_group_percentage_tooltip: string;
   age_group_range_tooltip: string;
-  value_percentage_title: string;
-  value_percentage_tooltip: string;
+  left_title: string;
+  left_tooltip: string;
+  right_title: string;
+  right_tooltip: string;
 }

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -179,7 +179,10 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
                 key: 'deceased_per_age_group_over_time_chart',
               }}
               data={dataDeceasedPerAgeGroup}
-              metricProperty="covid_percentage"
+              rightMetricProperty="covid_percentage"
+              leftMetricProperty="age_group_percentage"
+              rightColor={'data.primary'}
+              leftColor={'data.neutral'}
               displayMaxPercentage={45}
               text={siteText.deceased_age_groups.graph}
             />

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -6,6 +6,7 @@ import {
 } from '@corona-dashboard/common';
 import { Ziekenhuis } from '@corona-dashboard/icons';
 import { useState } from 'react';
+import { AgeDemographicChart } from '~/components/age-demographic/age-demographic-chart';
 import { RegionControlOption } from '~/components/chart-region-controls';
 import { ChartTile } from '~/components/chart-tile';
 import { DynamicChoropleth } from '~/components/choropleth';

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -6,7 +6,6 @@ import {
 } from '@corona-dashboard/common';
 import { Ziekenhuis } from '@corona-dashboard/icons';
 import { useState } from 'react';
-import { AgeDemographicChart } from '~/components/age-demographic/age-demographic-chart';
 import { RegionControlOption } from '~/components/chart-region-controls';
 import { ChartTile } from '~/components/chart-tile';
 import { DynamicChoropleth } from '~/components/choropleth';

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,2 +1,10 @@
 timestamp,action,key,document_id,move_to
 2021-11-01T08:20:26.361Z,add,positief_geteste_personen.tooltip_labels.infected_overall,Pei0Nqv2MstfonnkJ0CTdL,__
+2021-11-01T14:00:00.698Z,add,deceased_age_groups.graph.left_title,Pei0Nqv2MstfonnkJ2rQ7D,__
+2021-11-01T14:00:02.131Z,add,deceased_age_groups.graph.left_tooltip,Pei0Nqv2MstfonnkJ2rQcZ,__
+2021-11-01T14:00:03.260Z,add,deceased_age_groups.graph.right_title,XIsMg3WYidPwwGdwwxpZkm,__
+2021-11-01T14:00:04.795Z,add,deceased_age_groups.graph.right_tooltip,G6M7GhzH8XbtdKiRsGFHGQ,__
+2021-11-01T14:00:04.803Z,delete,deceased_age_groups.graph.age_group_percentage_title,jF33EuwumlGuwav2FD45dU,__
+2021-11-01T14:00:04.811Z,delete,deceased_age_groups.graph.age_group_percentage_tooltip,jF33EuwumlGuwav2FD45fA,__
+2021-11-01T14:00:04.818Z,delete,deceased_age_groups.graph.value_percentage_title,jF33EuwumlGuwav2FD45gq,__
+2021-11-01T14:00:04.842Z,delete,deceased_age_groups.graph.value_percentage_tooltip,jF33EuwumlGuwav2FD45iW,__


### PR DESCRIPTION
## Summary

This PR makes sure that the `AgeDemographic` chart is more generally applicable and it updates the configuration of currently used `AgeDemographic` components to make sure they comply to the new props required.

In general, most of the updates were renames of existing variables to make them more generic. Additionally, I've added the requirement to pass both a left- and rightPropertyMetric for each side of the graph, as well as colors for each side's bars. Data shape is the same as it was, but more generic.