### PR TITLE
Set minimum range for all graphs

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -39,9 +39,8 @@ export interface Feature {
   metricProperties?: string[];
 }
 
-export type MetricScope = 'in' | 'nl' | 'vr' | 'gm';
 export type JsonDataScope =
-  | MetricScope
+  | DataScopeKey
   | 'in_collection'
   | 'vr_collection'
   | 'gm_collection';

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -1,4 +1,10 @@
-import { ChartConfiguration, KpiConfiguration } from '@corona-dashboard/common';
+import {
+  ChartConfiguration,
+  DataScope,
+  DataScopeKey,
+  KpiConfiguration,
+  MetricKeys,
+} from '@corona-dashboard/common';
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 import css from '@styled-system/css';
 import { Fragment, FunctionComponent, ReactNode } from 'react';
@@ -122,7 +128,7 @@ export function RichContent({
           title: string;
           startDate?: string;
           endDate?: string;
-          config: ChartConfiguration;
+          config: ChartConfiguration<DataScopeKey, MetricKeys<DataScope>>;
         };
 
         return (

--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -13,7 +13,6 @@ export interface DataOptions {
   timeAnnotations?: TimeAnnotationConfig[];
   timelineEvents?: TimelineEventConfig[];
   renderNullAsZero?: boolean;
-  minimumRange?: number;
 }
 
 export interface BenchmarkConfig {

--- a/packages/app/src/components/time-series-chart/logic/common.ts
+++ b/packages/app/src/components/time-series-chart/logic/common.ts
@@ -13,6 +13,7 @@ export interface DataOptions {
   timeAnnotations?: TimeAnnotationConfig[];
   timelineEvents?: TimelineEventConfig[];
   renderNullAsZero?: boolean;
+  minimumRange?: number;
 }
 
 export interface BenchmarkConfig {

--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -37,14 +37,22 @@ export function useScales<T extends TimestampedValue>(args: {
   minimumValue: number;
   bounds: Bounds;
   numTicks: number;
+  minimumRange?: number;
 }): UseScalesResult {
   const today = useCurrentDate();
-  const { maximumValue, minimumValue, bounds, numTicks, values } = args;
+  const {
+    maximumValue,
+    minimumValue,
+    bounds,
+    numTicks,
+    values,
+    minimumRange = 10,
+  } = args;
 
   return useMemo(() => {
     const [start, end] = getTimeDomain({ values, today, withPadding: true });
     const yMin = Math.min(minimumValue, 0);
-    const yMax = Math.max(maximumValue, 0);
+    const yMax = Math.max(maximumValue, minimumRange);
 
     if (isEmpty(values)) {
       return {
@@ -72,13 +80,13 @@ export function useScales<T extends TimestampedValue>(args: {
     });
 
     /**
-     * For some reason visx-scaleLinear doesn't handle een domain of [0,0] correctly.
+     * For some reason visx-scaleLinear doesn't handle a domain of [0,0] correctly.
      * In that particular case calling yScale(0) will return the (bounds.height / 2), instead of just bounds.height.
      * A work-around turns out to be setting the max value to Infinity.
      */
-    const maximumDomainValue = maximumValue > 0 ? maximumValue : 10;
+    const maximumDomainValue = yMax > 0 ? yMax : Infinity;
     const yScale = scaleLinear({
-      domain: [yMin, maximumValue > 0 ? maximumValue : maximumDomainValue],
+      domain: [yMin, maximumDomainValue],
       range: [bounds.height, 0],
       nice: numTicks,
       round: true, // round the output values so we render on round pixels,
@@ -104,6 +112,7 @@ export function useScales<T extends TimestampedValue>(args: {
     bounds.width,
     bounds.height,
     numTicks,
+    minimumRange,
   ]);
 }
 

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -47,6 +47,10 @@ interface SeriesCommonDefinition {
    * values), or when using a second series as a backdrop.
    */
   noMarker?: boolean;
+  /**
+   * Specifies a different minimum range than the default for this series.
+   */
+  minimumRange?: number;
 }
 
 export interface GappedLineSeriesDefinition<T extends TimestampedValue>

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -195,6 +195,7 @@ export function TimeSeriesChart<
     timespanAnnotations,
     timeAnnotations,
     timelineEvents,
+    minimumRange,
   } = dataOptions || {};
 
   const {
@@ -258,6 +259,7 @@ export function TimeSeriesChart<
     minimumValue: calculatedSeriesMin,
     bounds,
     numTicks: yTickValues?.length || numGridLines,
+    minimumRange,
   });
 
   const legendItems = useLegendItems(

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -195,7 +195,6 @@ export function TimeSeriesChart<
     timespanAnnotations,
     timeAnnotations,
     timelineEvents,
-    minimumRange,
   } = dataOptions || {};
 
   const {
@@ -243,6 +242,13 @@ export function TimeSeriesChart<
       ? forcedMaximumValue(calculatedSeriesMax)
       : forcedMaximumValue
     : calculatedSeriesMax;
+
+  const minimumRanges = seriesConfig
+    .map((c) => c.minimumRange)
+    .filter(isDefined);
+  const minimumRange = minimumRanges.length
+    ? Math.max(...minimumRanges)
+    : undefined;
 
   const {
     xScale,

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -9,6 +9,7 @@ import { isPresent } from 'ts-is-present';
 import { ChartTile } from '~/components/chart-tile';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useIntl } from '~/intl';
+import { metricConfigs } from '~/metric-config';
 
 interface ReproductionChartTileProps {
   data: NlReproduction;
@@ -59,12 +60,11 @@ export function ReproductionChartTile({
               metricProperty: 'index_average',
               label: text.lineLegendLabel,
               color: colors.data.primary,
+              minimumRange:
+                metricConfigs?.nl?.reproduction?.index_average?.minimumRange,
             },
           ]}
           numGridLines={timeframe === 'all' ? 4 : 3}
-          dataOptions={{
-            minimumRange: 1,
-          }}
         />
       )}
     </ChartTile>

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -62,6 +62,9 @@ export function ReproductionChartTile({
             },
           ]}
           numGridLines={timeframe === 'all' ? 4 : 3}
+          dataOptions={{
+            minimumRange: 1,
+          }}
         />
       )}
     </ChartTile>

--- a/packages/app/src/metric-config/common.ts
+++ b/packages/app/src/metric-config/common.ts
@@ -1,4 +1,8 @@
-import { Gm, MetricKeys, Nl, Vr } from '@corona-dashboard/common';
+import {
+  DataScope,
+  MetricKeys,
+  MetricProperty,
+} from '@corona-dashboard/common';
 
 /**
  * These types are placed here to avoid a circular dependency. The nl/vr/gm
@@ -13,25 +17,17 @@ export type BarScaleConfig = {
   gradient: { color: string; value: number }[];
 };
 
-type MetricConfig = {
+export type MetricConfig = {
   barScale?: BarScaleConfig;
-};
-
-type ValueMetric<T> = {
-  values: T[];
-  last_value: T;
+  minimumRange?: number;
 };
 
 /**
  * This makes sure the object containing the metric configs follows the same
  * structure as the data object it is coupled with
  */
-export type ScopedMetricConfigs<S extends Nl | Vr | Gm> = {
-  [key in MetricKeys<S>]?: S[key] extends ValueMetric<infer T>
-    ? {
-        [metricKey in keyof T]?: MetricConfig;
-      }
-    : {
-        [metricKey in keyof S[key]]?: MetricConfig;
-      };
+export type ScopedMetricConfigs<S extends DataScope> = {
+  [metricKey in MetricKeys<S>]?: {
+    [property in MetricProperty<S, metricKey>]?: MetricConfig;
+  };
 };

--- a/packages/app/src/metric-config/index.ts
+++ b/packages/app/src/metric-config/index.ts
@@ -1,7 +1,13 @@
-import { assert } from '@corona-dashboard/common';
+import {
+  assert,
+  DataScopeKey,
+  MetricKeys,
+  MetricProperty,
+  ScopedData,
+} from '@corona-dashboard/common';
 import { get } from 'lodash';
 import { isDefined } from 'ts-is-present';
-import { BarScaleConfig } from './common';
+import { BarScaleConfig, ScopedMetricConfigs } from './common';
 import { nl } from './nl';
 
 /**
@@ -12,19 +18,17 @@ import { nl } from './nl';
  * a lot of the specialized components we now use to render everything.
  */
 
+type MetricConfigs = {
+  [key in DataScopeKey]?: ScopedMetricConfigs<ScopedData[key]>;
+};
+
 /**
  * The data is scoped at nl/vr/gm, because we can not assume that the same
  * things like min/max/gradients apply everywhere for the same KPI.
  */
-const metricConfig = {
+export const metricConfigs: MetricConfigs = {
   nl,
-} as const;
-
-type DataScope = keyof typeof metricConfig;
-
-type MetricName = keyof typeof metricConfig[DataScope];
-
-type KeysOfUnion<T> = T extends T ? keyof T : never;
+};
 
 /**
  * Special bar scale getter, so the assert is centralized.
@@ -33,13 +37,12 @@ type KeysOfUnion<T> = T extends T ? keyof T : never;
  * there seems to be no way of enforcing the structure of the config and
  * strictly typing it to the actual supplied config at the same time.
  */
-export function getBarScaleConfig<S extends DataScope, K extends MetricName>(
-  scope: S,
-  metricName: K,
-  metricProperty?: KeysOfUnion<typeof metricConfig[S][K]>
-) {
+export function getBarScaleConfig<
+  S extends DataScopeKey,
+  K extends MetricKeys<ScopedData[S]>
+>(scope: S, metricName: K, metricProperty?: MetricProperty<ScopedData[S], K>) {
   const config = get(
-    metricConfig,
+    metricConfigs,
     metricProperty ? [scope, metricName, metricProperty] : [scope, metricName]
   );
 

--- a/packages/app/src/metric-config/nl.ts
+++ b/packages/app/src/metric-config/nl.ts
@@ -37,4 +37,15 @@ export const nl: ScopedMetricConfigs<Nl> = {
       },
     },
   },
+  reproduction: {
+    index_low: {
+      minimumRange: 1,
+    },
+    index_average: {
+      minimumRange: 1,
+    },
+    index_high: {
+      minimumRange: 1,
+    },
+  },
 };

--- a/packages/app/src/queries/create-elements-query.ts
+++ b/packages/app/src/queries/create-elements-query.ts
@@ -1,4 +1,4 @@
-import { MetricScope } from '@corona-dashboard/common';
+import { DataScopeKey } from '@corona-dashboard/common';
 import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
 
 function formatStringArray(array: string[]) {
@@ -6,7 +6,7 @@ function formatStringArray(array: string[]) {
 }
 
 export function createElementsQuery(
-  scope: MetricScope,
+  scope: DataScopeKey,
   metricNames: string[],
   locale: string
 ) {
@@ -64,7 +64,7 @@ export function createElementsQuery(
 
 type ElementBase = {
   _id: string;
-  scope: MetricScope;
+  scope: DataScopeKey;
   metricName: string;
   metricProperty: string | null;
 };
@@ -78,7 +78,7 @@ type CmsTimelineEventConfig = {
 
 type CmsTimeSeriesElement = {
   _id: string;
-  scope: MetricScope;
+  scope: DataScopeKey;
   metricName: string;
   metricProperty: string | null;
   timelineEventCollections: CmsTimelineEventCollection[];

--- a/packages/cms/src/elements/add.ts
+++ b/packages/cms/src/elements/add.ts
@@ -1,3 +1,4 @@
+import { DataScopeKey } from '@corona-dashboard/common';
 import { snakeCase } from 'change-case';
 import prompts from 'prompts';
 import { isDefined } from 'ts-is-present';
@@ -5,11 +6,10 @@ import { getClient } from '../client';
 import {
   getSchemaMetricProperties,
   getSchemaMetrics,
-  Scope,
 } from './logic/get-schema';
 
 type Element = {
-  scope: Scope;
+  scope: DataScopeKey;
   metricName: string;
   metricProperty: string | undefined;
   _type: ElementType;
@@ -53,7 +53,7 @@ async function promptForElement(): Promise<Element | undefined> {
     message: 'Select the scope for this element:',
     choices,
     onState,
-  })) as { scope: Scope };
+  })) as { scope: DataScopeKey };
 
   element.scope = scopeResponse.scope;
 

--- a/packages/cms/src/elements/logic/get-schema.ts
+++ b/packages/cms/src/elements/logic/get-schema.ts
@@ -1,11 +1,10 @@
+import { DataScopeKey } from '@corona-dashboard/common';
 import fs from 'fs';
 import path from 'path';
 
-export type Scope = 'nl' | 'gm' | 'vr' | 'in';
-
 const schemaPath = path.join(__dirname, '..//..//..//..//app//schema');
 
-export function getSchemaMetrics(scope: Scope) {
+export function getSchemaMetrics(scope: DataScopeKey) {
   const schema = loadJsonFromFile(path.join(schemaPath, scope, '__index.json'));
 
   return Object.entries<{ type: string } | { $ref: string }>(schema.properties)
@@ -13,7 +12,10 @@ export function getSchemaMetrics(scope: Scope) {
     .map(([key]) => key);
 }
 
-export function getSchemaMetricProperties(scope: Scope, metricName: string) {
+export function getSchemaMetricProperties(
+  scope: DataScopeKey,
+  metricName: string
+) {
   const schema = loadJsonFromFile(
     path.join(schemaPath, scope, `${metricName}.json`)
   );

--- a/packages/common/src/types/choropleth.ts
+++ b/packages/common/src/types/choropleth.ts
@@ -1,4 +1,5 @@
 import type { FeatureCollection, MultiPolygon, Polygon } from 'geojson';
+import type { MetricKeys } from '.';
 import type {
   GmCollection,
   GmDifference,
@@ -62,11 +63,6 @@ export type Metric<T> = {
   values: T[];
   last_value: T;
 };
-
-export type MetricKeys<T> = keyof Omit<
-  T,
-  'last_generated' | 'proto_name' | 'name' | 'code'
->;
 
 export type GmCollectionMetricName = MetricKeys<GmCollection>;
 export type VrCollectionMetricName = MetricKeys<VrCollection>;

--- a/packages/common/src/types/data-utils.ts
+++ b/packages/common/src/types/data-utils.ts
@@ -1,0 +1,40 @@
+import { Gm, In, Nl, Vr } from '.';
+
+/**
+ * All possible datascopes. Can be used to access the types of a scope based on
+ * a given scope key.
+ */
+export type ScopedData = {
+  gm: Gm;
+  in: In;
+  nl: Nl;
+  vr: Vr;
+};
+
+export type DataScopeKey = keyof ScopedData;
+
+export type DataScope = ScopedData[DataScopeKey];
+
+export type MetricKeys<T> = keyof Omit<
+  T,
+  'last_generated' | 'proto_name' | 'name' | 'code'
+>;
+
+type ValuesMetric<T> = {
+  values: T[];
+};
+
+/**
+ * Recursively goes down 'values' arrays, returning the keys of the lowest-level
+ * value it can find. This way we can catch the properties of both 'normal'
+ * values as well as grouped values (i.e. 'sewer per installation' or 'variants')
+ */
+type ValueKeys<T> = T extends ValuesMetric<infer V> ? ValueKeys<V> : keyof T;
+
+/**
+ * The metric properties of metric M in data scope S (scope being In/Nl/Vr/Gm)
+ */
+export type MetricProperty<
+  S extends ScopedData[DataScopeKey],
+  M extends MetricKeys<S>
+> = ValueKeys<S[M]>;

--- a/packages/common/src/types/data-utils.ts
+++ b/packages/common/src/types/data-utils.ts
@@ -35,6 +35,6 @@ type ValueKeys<T> = T extends ValuesMetric<infer V> ? ValueKeys<V> : keyof T;
  * The metric properties of metric M in data scope S (scope being In/Nl/Vr/Gm)
  */
 export type MetricProperty<
-  S extends ScopedData[DataScopeKey],
+  S extends DataScope,
   M extends MetricKeys<S>
 > = ValueKeys<S[M]>;

--- a/packages/common/src/types/feature-flags.ts
+++ b/packages/common/src/types/feature-flags.ts
@@ -1,3 +1,5 @@
+import { DataScopeKey } from '.';
+
 export function isSimpleFeature(feature: Feature): feature is SimpleFeature {
   return !('dataScopes' in feature);
 }
@@ -37,9 +39,8 @@ export type VerboseFeature = {
   metricProperties?: string[];
 } & SimpleFeature;
 
-export type MetricScope = 'in' | 'nl' | 'vr' | 'gm';
 export type JsonDataScope =
-  | MetricScope
+  | DataScopeKey
   | 'in_collection'
   | 'vr_collection'
   | 'gm_collection';

--- a/packages/common/src/types/index.ts
+++ b/packages/common/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './choropleth';
 export * from './data';
+export * from './data-utils';
 export * from './feature-flags';
 export * from './inline-charts';

--- a/packages/common/src/types/inline-charts.ts
+++ b/packages/common/src/types/inline-charts.ts
@@ -1,11 +1,17 @@
+import {
+  DataScope,
+  DataScopeKey,
+  MetricKeys,
+  MetricProperty,
+  ScopedData,
+} from '.';
+
 export const areaTitles = {
   in: 'Internationaal',
   nl: 'Nationaal',
   vr: 'Veiligheidsregio',
   gm: 'Gemeente',
 };
-
-export type AreaType = 'in' | 'nl' | 'vr' | 'gm';
 
 export type TimespanAnnotationConfiguration = {
   fill: 'solid' | 'hatched' | 'dotted';
@@ -16,17 +22,13 @@ export type TimespanAnnotationConfiguration = {
   cutValuesForMetricProperties?: string[];
 };
 
-export type InlineChart = {
-  startDate?: string;
-  endDate?: string;
-  title: string;
-  config: ChartConfiguration;
-};
-
-export type ChartConfiguration = {
-  area: AreaType;
-  metricName: string;
-  metricProperties: MetricPropertyConfig[];
+export type ChartConfiguration<
+  S extends DataScopeKey,
+  M extends MetricKeys<ScopedData[S]>
+> = {
+  area: S;
+  metricName: M;
+  metricProperties: MetricPropertyConfig<ScopedData[S], M>[];
   timeframe: 'all' | '5weeks';
   accessibilityKey: string;
   code?: string;
@@ -38,8 +40,11 @@ export type ChartConfiguration = {
   timespanAnnotations?: TimespanAnnotationConfiguration[];
 };
 
-export type MetricPropertyConfig = {
-  propertyName: string;
+export type MetricPropertyConfig<
+  S extends DataScope,
+  M extends MetricKeys<S>
+> = {
+  propertyName: MetricProperty<S, M>;
   type:
     | 'line'
     | 'gapped-line'
@@ -65,7 +70,7 @@ export type KpiConfiguration = Omit<
 
 export type PartialKpiConfiguration = {
   icon?: string;
-  area?: AreaType;
+  area?: DataScopeKey;
   metricName?: string;
   metricProperty?: string;
   code?: string;


### PR DESCRIPTION
This makes the minimum range of all graphs 10, except for the R-number (since it will hopefully stay far away from 10 at all times)

Since exceptions will probably happen more often in the future, I made the minimum range configurable through metric configs. This way inline graphs can automatically pick up the right range as well. This needed some refinements to how we type data & metric configs. I made some utility types for our data which accommodate this, and replaced some repeated types through the codebase with these centralised utility types.