### PR TITLE
Upgrade framer-motion@5.x.x and reduce bundle size

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,7 +35,7 @@
     "date-fns": "^2.25.0",
     "express": "^4.17.1",
     "flat": "^5.0.2",
-    "framer-motion": "^4.1.17",
+    "framer-motion": "^5.0.1",
     "geojson": "^0.5.0",
     "globby": "^12.0.2",
     "hash-sum": "^2.0.0",

--- a/packages/app/src/components/base/box.tsx
+++ b/packages/app/src/components/base/box.tsx
@@ -1,5 +1,5 @@
 import css from '@styled-system/css';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled from 'styled-components';
 import {
   borders,
@@ -66,4 +66,4 @@ export const Box = styled.div.withConfig({
  * The MotionBox component is enriched with framer-motion to support animated
  * properties.
  */
-export const MotionBox = motion(Box);
+export const MotionBox = m(Box);

--- a/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event-highlight.tsx
+++ b/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event-highlight.tsx
@@ -1,5 +1,5 @@
 import { colors } from '@corona-dashboard/common';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, m } from 'framer-motion';
 import { transparentize } from 'polished';
 import { TimelineState } from '../logic';
 
@@ -21,7 +21,7 @@ export function TimelineEventHighlight({
   return (
     <AnimatePresence>
       {timelineState.current && (
-        <motion.rect
+        <m.rect
           key={`${event?.start}-${event?.end}`}
           pointerEvents="none"
           height={height}

--- a/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event.tsx
+++ b/packages/app/src/components/time-series-chart/components/timeline/components/timeline-event.tsx
@@ -1,6 +1,6 @@
 import { colors } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { transparentize } from 'polished';
 import { ReactNode, RefObject, useRef } from 'react';
 import styled from 'styled-components';
@@ -149,7 +149,7 @@ const StyledEvent = styled.div(
   })
 );
 
-const TimespanBar = styled(motion.div)<{
+const TimespanBar = styled(m.div)<{
   height: number;
   disableBorderRadius?: boolean;
 }>((x) =>

--- a/packages/app/src/components/time-series-chart/components/timeline/components/timeline-marker.tsx
+++ b/packages/app/src/components/time-series-chart/components/timeline/components/timeline-marker.tsx
@@ -1,6 +1,6 @@
 import { colors } from '@corona-dashboard/common';
 import css from '@styled-system/css';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled from 'styled-components';
 
 export function TimelineMarker({
@@ -36,7 +36,7 @@ export function TimelineMarker({
   );
 }
 
-const StyledPointMarker = styled(motion.div)<{
+const StyledPointMarker = styled(m.div)<{
   color: string;
   size: number;
   borderWidth: number;

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-container.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-container.tsx
@@ -61,7 +61,6 @@ export function TooltipSeriesListContainer<T extends TimestampedValue>({
           <AnimatePresence>
             {timespanAnnotation && (
               <AppearTransition key="1">
-                TEST 1
                 <Text
                   variant="label2"
                   color={colors.annotation}

--- a/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-container.tsx
+++ b/packages/app/src/components/time-series-chart/components/tooltip/tooltip-series-list-container.tsx
@@ -52,7 +52,6 @@ export function TooltipSeriesListContainer<T extends TimestampedValue>({
       }}
     >
       <VisuallyHidden>{dateString}</VisuallyHidden>
-
       {!displayTooltipValueOnly && isMounted && (
         /**
          * The width of the list is potentially influenced by long annotations,
@@ -62,6 +61,7 @@ export function TooltipSeriesListContainer<T extends TimestampedValue>({
           <AnimatePresence>
             {timespanAnnotation && (
               <AppearTransition key="1">
+                TEST 1
                 <Text
                   variant="label2"
                   color={colors.annotation}
@@ -90,7 +90,6 @@ export function TooltipSeriesListContainer<T extends TimestampedValue>({
           </AnimatePresence>
         </Box>
       )}
-
       <div ref={listRef}>{children}</div>
     </section>
   );

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { assert } from '@corona-dashboard/common';
 import '@reach/combobox/styles.css';
+import { LazyMotion } from 'framer-motion';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -20,6 +21,9 @@ const pagesWithSmoothScroll = [
   'veiligheidsregio',
   'gemeente',
 ] as const;
+
+const loadAnimationFeatures = () =>
+  import('~/style/animations').then((mod) => mod.default);
 
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
@@ -77,11 +81,13 @@ export default function App(props: AppProps) {
       <ThemeProvider theme={theme}>
         <IntlContext.Provider value={intlContext}>
           <GlobalStyle />
-          <BreakpointContextProvider>
-            <IsTouchDeviceContextProvider>
-              <Component {...pageProps} />
-            </IsTouchDeviceContextProvider>
-          </BreakpointContextProvider>
+          <LazyMotion strict features={loadAnimationFeatures}>
+            <BreakpointContextProvider>
+              <IsTouchDeviceContextProvider>
+                <Component {...pageProps} />
+              </IsTouchDeviceContextProvider>
+            </BreakpointContextProvider>
+          </LazyMotion>
         </IntlContext.Provider>
         {toggleHotReloadButton}
       </ThemeProvider>

--- a/packages/app/src/style/animations.ts
+++ b/packages/app/src/style/animations.ts
@@ -1,0 +1,2 @@
+import { domAnimation } from 'framer-motion';
+export default domAnimation;

--- a/packages/app/src/utils/use-collapsible.tsx
+++ b/packages/app/src/utils/use-collapsible.tsx
@@ -92,6 +92,7 @@ export function useCollapsible(options: { isOpen?: boolean } = {}) {
   const content = (children: ReactNode) => (
     <MotionBox
       id={id}
+      layout
       aria-hidden={isOpen ? 'false' : 'true'}
       width="100%"
       overflow={isOpen ? 'visible' : 'hidden'}

--- a/packages/app/src/utils/use-collapsible.tsx
+++ b/packages/app/src/utils/use-collapsible.tsx
@@ -1,6 +1,6 @@
 import { Chevron } from '@corona-dashboard/icons';
 import css from '@styled-system/css';
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { isBoolean } from 'lodash';
 import {
   cloneElement,
@@ -147,7 +147,7 @@ export function useCollapsible(options: { isOpen?: boolean } = {}) {
   };
 }
 
-const MotionChevron = styled(motion(Chevron))(
+const MotionChevron = styled(m(Chevron))(
   css({
     backgroundSize: '1.4em 0.9em',
     backgroundPosition: '0 50%',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,7 +1540,7 @@ __metadata:
     eslint-plugin-risxss: ^2.1.0
     express: ^4.17.1
     flat: ^5.0.2
-    framer-motion: ^4.1.17
+    framer-motion: ^5.0.1
     geojson: ^0.5.0
     globby: ^12.0.2
     hash-sum: ^2.0.0
@@ -13601,12 +13601,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "framer-motion@npm:5.0.1"
+  dependencies:
+    "@emotion/is-prop-valid": ^0.8.2
+    framesync: 6.0.1
+    hey-listen: ^1.0.8
+    popmotion: 10.0.2
+    style-value-types: 5.0.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ">=16.8 || ^17.0.0"
+    react-dom: ">=16.8 || ^17.0.0"
+  dependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+  checksum: f3b5c8879c8a04b7340f18086add982727a4d24489d09fe4cdabff61d70667da869b51013474deef579a95369fbd4fb979af4cdb3ac819aac9d491a1e644fd61
+  languageName: node
+  linkType: hard
+
 "framesync@npm:5.3.0":
   version: 5.3.0
   resolution: "framesync@npm:5.3.0"
   dependencies:
     tslib: ^2.1.0
   checksum: 9ebbb2863e6a1cfd2e9dd1b73af427d23caa03c92dd49ea767ebdd208c3a573bba4a1026f67068d856a21704f79adcdf2f750cc852ff73bc1f0e80edaaecded8
+  languageName: node
+  linkType: hard
+
+"framesync@npm:6.0.1, framesync@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "framesync@npm:6.0.1"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: a23ebe8f7e20a32c0b99c2f8175b6f07af3ec6316aad52a2316316a6d011d717af8d2175dcc2827031c59fabb30232ed3e19a720a373caba7f070e1eae436325
   languageName: node
   linkType: hard
 
@@ -19757,6 +19786,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"popmotion@npm:10.0.2":
+  version: 10.0.2
+  resolution: "popmotion@npm:10.0.2"
+  dependencies:
+    framesync: ^6.0.1
+    hey-listen: ^1.0.8
+    style-value-types: 5.0.0
+    tslib: ^2.1.0
+  checksum: 6c793f637a5dd9861edca257eac523c2d6c1d895399e9320562c26c2f2a2d1288af1892925af5bc88e091e0444b4478f352772b7d1a5ba1b972cd889d1560d4a
+  languageName: node
+  linkType: hard
+
 "popmotion@npm:9.3.6":
   version: 9.3.6
   resolution: "popmotion@npm:9.3.6"
@@ -24370,6 +24411,16 @@ __metadata:
     hey-listen: ^1.0.8
     tslib: ^2.1.0
   checksum: 96189770076a2717bf579f7d73a49953f0c3d633b90fed9b44b8285cbbe7facd19d6d7a0d2802fb493b45995791f62b87983c3d3c24128818a69e593b6d77aed
+  languageName: node
+  linkType: hard
+
+"style-value-types@npm:5.0.0":
+  version: 5.0.0
+  resolution: "style-value-types@npm:5.0.0"
+  dependencies:
+    hey-listen: ^1.0.8
+    tslib: ^2.1.0
+  checksum: 16d198302cd102edf9dba94e7752a2364c93b1eaa5cc7c32b42b28eef4af4ccb5149a3f16bc2a256adc02616a2404f4612bd15f3081c1e8ca06132cae78be6c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrades `framer-motion` to the latest version and reduces bundle size by lazy loading animation functionality.

### Bundle size reductions

Bundle size savings are around 20kB per page.

**Before**

```sh
Page                                                                                                   Size     First Load JS
┌ ● /                                                                                                  11.9 kB         542 kB
├   /_app                                                                                              0 B             263 kB
├ ○ /404                                                                                               813 B           299 kB
├ ● /500                                                                                               810 B           299 kB
├ ● /actueel/gemeente                                                                                  4.63 kB         528 kB
├ ● /actueel/gemeente/[code] (273290 ms)                                                               2.88 kB         533 kB
├   ├ /nl/actueel/gemeente/GM0400 (1097 ms)
├   ├ /nl/actueel/gemeente/GM1903 (1070 ms)
├   ├ /nl/actueel/gemeente/GM0163 (1039 ms)
├   ├ /nl/actueel/gemeente/GM0531 (1030 ms)
├   ├ /nl/actueel/gemeente/GM0277 (1029 ms)
├   ├ /nl/actueel/gemeente/GM1724 (1028 ms)
├   ├ /nl/actueel/gemeente/GM0794 (1025 ms)
├   └ [+345 more paths] (avg 771 ms)
├ ● /actueel/veiligheidsregio                                                                          5.3 kB          529 kB
├ ● /actueel/veiligheidsregio/[code] (19980 ms)                                                        2.81 kB         533 kB
├   ├ /nl/actueel/veiligheidsregio/VR04 (993 ms)
├   ├ /nl/actueel/veiligheidsregio/VR03 (987 ms)
├   ├ /nl/actueel/veiligheidsregio/VR06 (962 ms)
├   ├ /nl/actueel/veiligheidsregio/VR07 (921 ms)
├   ├ /nl/actueel/veiligheidsregio/VR09 (919 ms)
├   ├ /nl/actueel/veiligheidsregio/VR25 (894 ms)
├   ├ /nl/actueel/veiligheidsregio/VR08 (880 ms)
├   └ [+18 more paths] (avg 746 ms)
├ λ /api/choropleth/[...param]                                                                         0 B             263 kB
├ λ /api/choropleth/konva-node.d                                                                       0 B             263 kB
├ λ /api/choropleth/topojson-client.d                                                                  0 B             263 kB
├ λ /api/choropleth/topology                                                                           0 B             263 kB
├ λ /api/data/timeseries/[...param]                                                                    0 B             263 kB
├ λ /api/topo-json/[type]                                                                              0 B             263 kB
├ ● /artikelen                                                                                         4.55 kB         303 kB
├ ● /artikelen/[slug] (34009 ms)                                                                       2.88 kB         508 kB
├   ├ /en/artikelen/hoeveel-covid-19-patienten-liggen-op-de-ic (1716 ms)
├   ├ /nl/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-8-maart-2021 (1716 ms)
├   ├ /nl/artikelen/wat-zeggen-de-uitslagen-van-de-ggd-teststraten (1319 ms)
├   ├ /nl/artikelen/hoe-weten-we-hoeveel-besmettelijke-mensen-er-zijn (1084 ms)
├   ├ /en/artikelen/klopt-het-risiconiveau-in-mijn-regio-wel (920 ms)
├   ├ /nl/artikelen/hoeveel-covid-19-patienten-liggen-op-de-ic (892 ms)
├   ├ /en/artikelen/hoe-weten-we-welke-varianten-van-het-coronavirus-er-zijn (890 ms)
├   └ [+47 more paths] (avg 542 ms)
├ ● /contact                                                                                           2.68 kB         506 kB
├ ● /gemeente                                                                                          4.63 kB         528 kB
├ ● /gemeente/[code] (47554 ms)                                                                        4.18 kB         528 kB
├   ├ /nl/gemeente/GM1699 (310 ms)
├   ├ /nl/gemeente/GM1680
├   ├ /nl/gemeente/GM0358
├   ├ /nl/gemeente/GM0197
├   ├ /nl/gemeente/GM0059
├   ├ /nl/gemeente/GM0482
├   ├ /nl/gemeente/GM0613
├   └ [+345 more paths]
├ ● /gemeente/[code]/positief-geteste-mensen (194911 ms)                                               5.58 kB         550 kB
├   ├ /nl/gemeente/GM0312/positief-geteste-mensen (957 ms)
├   ├ /nl/gemeente/GM0589/positief-geteste-mensen (899 ms)
├   ├ /nl/gemeente/GM1876/positief-geteste-mensen (866 ms)
├   ├ /nl/gemeente/GM0375/positief-geteste-mensen (864 ms)
├   ├ /nl/gemeente/GM0313/positief-geteste-mensen (863 ms)
├   ├ /nl/gemeente/GM0899/positief-geteste-mensen (861 ms)
├   ├ /nl/gemeente/GM0209/positief-geteste-mensen (850 ms)
├   └ [+345 more paths] (avg 547 ms)
├ ● /gemeente/[code]/rioolwater (130617 ms)                                                            6.35 kB         552 kB
├   ├ /nl/gemeente/GM0034/rioolwater (3032 ms)
├   ├ /nl/gemeente/GM0059/rioolwater (3007 ms)
├   ├ /nl/gemeente/GM1723/rioolwater (3002 ms)
├   ├ /nl/gemeente/GM0141/rioolwater (2997 ms)
├   ├ /nl/gemeente/GM1680/rioolwater (2963 ms)
├   ├ /nl/gemeente/GM0613/rioolwater (2951 ms)
├   ├ /nl/gemeente/GM0197/rioolwater (2934 ms)
├   └ [+345 more paths] (avg 318 ms)
├ ● /gemeente/[code]/sterfte (139459 ms)                                                               6.63 kB         547 kB
├   ├ /nl/gemeente/GM1942/sterfte (739 ms)
├   ├ /nl/gemeente/GM0957/sterfte (704 ms)
├   ├ /nl/gemeente/GM1723/sterfte (658 ms)
├   ├ /nl/gemeente/GM0736/sterfte (646 ms)
├   ├ /nl/gemeente/GM0399/sterfte (634 ms)
├   ├ /nl/gemeente/GM0441/sterfte (628 ms)
├   ├ /nl/gemeente/GM0606/sterfte (625 ms)
├   └ [+345 more paths] (avg 391 ms)
├ ● /gemeente/[code]/vaccinaties (114796 ms)                                                           4.42 kB         558 kB
├   ├ /nl/gemeente/GM0310/vaccinaties (831 ms)
├   ├ /nl/gemeente/GM0376/vaccinaties (628 ms)
├   ├ /nl/gemeente/GM0755/vaccinaties (606 ms)
├   ├ /nl/gemeente/GM1728/vaccinaties (584 ms)
├   ├ /nl/gemeente/GM0654/vaccinaties (574 ms)
├   ├ /nl/gemeente/GM0613/vaccinaties (571 ms)
├   ├ /nl/gemeente/GM0512/vaccinaties (568 ms)
├   └ [+345 more paths] (avg 320 ms)
├ ● /gemeente/[code]/ziekenhuis-opnames (170370 ms)                                                    5.62 kB         550 kB
├   ├ /nl/gemeente/GM0385/ziekenhuis-opnames (842 ms)
├   ├ /nl/gemeente/GM0294/ziekenhuis-opnames (813 ms)
├   ├ /nl/gemeente/GM0074/ziekenhuis-opnames (783 ms)
├   ├ /nl/gemeente/GM1690/ziekenhuis-opnames (765 ms)
├   ├ /nl/gemeente/GM0398/ziekenhuis-opnames (762 ms)
├   ├ /nl/gemeente/GM0340/ziekenhuis-opnames (736 ms)
├   ├ /nl/gemeente/GM0342/ziekenhuis-opnames (729 ms)
├   └ [+345 more paths] (avg 478 ms)
├ ● /internationaal                                                                                    1.11 kB         515 kB
├ ● /internationaal/positief-geteste-mensen                                                            15.4 kB         550 kB
├ ● /internationaal/varianten                                                                          5.85 kB         548 kB
├ ● /landelijk                                                                                         1.48 kB         515 kB
├ ● /landelijk/besmettelijke-mensen                                                                    5.19 kB         536 kB
├ ● /landelijk/brononderzoek                                                                           4.42 kB         546 kB
├ ● /landelijk/coronamelder                                                                            5.39 kB         536 kB
├ ● /landelijk/gedrag                                                                                  5.17 kB         555 kB
├ ● /landelijk/gehandicaptenzorg                                                                       3.67 kB         538 kB
├ ● /landelijk/intensive-care-opnames                                                                  6.45 kB         549 kB
├ ● /landelijk/maatregelen                                                                             1.64 kB         533 kB
├ ● /landelijk/positief-geteste-mensen                                                                 7.08 kB         541 kB
├ ● /landelijk/reproductiegetal                                                                        5.21 kB         536 kB
├ ● /landelijk/rioolwater                                                                              2.4 kB          542 kB
├ ● /landelijk/sterfte                                                                                 6.18 kB         541 kB
├ ● /landelijk/thuiswonende-ouderen                                                                    3.47 kB         538 kB
├ ● /landelijk/vaccinaties                                                                             8.59 kB         559 kB
├ ● /landelijk/varianten                                                                               1.89 kB         540 kB
├ ● /landelijk/verdenkingen-huisartsen                                                                 5.63 kB         536 kB
├ ● /landelijk/verpleeghuiszorg                                                                        3.68 kB         538 kB
├ ● /landelijk/ziekenhuis-opnames                                                                      2.5 kB          549 kB
├ ● /over                                                                                              2.69 kB         506 kB
├ ● /over-risiconiveaus                                                                                1.14 kB         507 kB
├ λ /sitemap.xml                                                                                       306 B           263 kB
├ ● /toegankelijkheid                                                                                  2.69 kB         506 kB
├ ● /veelgestelde-vragen                                                                               1.22 kB         507 kB
├ ● /veiligheidsregio                                                                                  5.29 kB         529 kB
├ ● /veiligheidsregio/[code] (3258 ms)                                                                 4.16 kB         528 kB
├   ├ /nl/veiligheidsregio/VR01
├   ├ /nl/veiligheidsregio/VR02
├   ├ /nl/veiligheidsregio/VR03
├   └ [+22 more paths]
├ ● /veiligheidsregio/[code]/brononderzoek (11627 ms)                                                  7.47 kB         558 kB
├   ├ /nl/veiligheidsregio/VR05/brononderzoek (566 ms)
├   ├ /nl/veiligheidsregio/VR03/brononderzoek (564 ms)
├   ├ /nl/veiligheidsregio/VR01/brononderzoek (541 ms)
├   ├ /nl/veiligheidsregio/VR02/brononderzoek (533 ms)
├   ├ /nl/veiligheidsregio/VR07/brononderzoek (532 ms)
├   ├ /nl/veiligheidsregio/VR04/brononderzoek (530 ms)
├   ├ /nl/veiligheidsregio/VR06/brononderzoek (526 ms)
├   └ [+18 more paths] (avg 435 ms)
├ ● /veiligheidsregio/[code]/gedrag (8128 ms)                                                          4.24 kB         564 kB
├   ├ /nl/veiligheidsregio/VR01/gedrag (429 ms)
├   ├ /nl/veiligheidsregio/VR14/gedrag (410 ms)
├   ├ /nl/veiligheidsregio/VR09/gedrag (406 ms)
├   ├ /nl/veiligheidsregio/VR10/gedrag (403 ms)
├   ├ /nl/veiligheidsregio/VR12/gedrag (387 ms)
├   ├ /nl/veiligheidsregio/VR15/gedrag (362 ms)
├   ├ /nl/veiligheidsregio/VR13/gedrag (358 ms)
├   └ [+18 more paths]
├ ● /veiligheidsregio/[code]/gehandicaptenzorg (14770 ms)                                              7.12 kB         547 kB
├   ├ /nl/veiligheidsregio/VR06/gehandicaptenzorg (965 ms)
├   ├ /nl/veiligheidsregio/VR19/gehandicaptenzorg (738 ms)
├   ├ /nl/veiligheidsregio/VR07/gehandicaptenzorg (704 ms)
├   ├ /nl/veiligheidsregio/VR05/gehandicaptenzorg (666 ms)
├   ├ /nl/veiligheidsregio/VR13/gehandicaptenzorg (643 ms)
├   ├ /nl/veiligheidsregio/VR11/gehandicaptenzorg (629 ms)
├   ├ /nl/veiligheidsregio/VR10/gehandicaptenzorg (625 ms)
├   └ [+18 more paths] (avg 544 ms)
├ ● /veiligheidsregio/[code]/maatregelen (6173 ms)                                                     4.2 kB          545 kB
├   ├ /nl/veiligheidsregio/VR09/maatregelen (398 ms)
├   ├ /nl/veiligheidsregio/VR15/maatregelen (322 ms)
├   ├ /nl/veiligheidsregio/VR19/maatregelen (301 ms)
├   ├ /nl/veiligheidsregio/VR01/maatregelen
├   ├ /nl/veiligheidsregio/VR02/maatregelen
├   ├ /nl/veiligheidsregio/VR03/maatregelen
├   ├ /nl/veiligheidsregio/VR04/maatregelen
├   └ [+18 more paths]
├ ● /veiligheidsregio/[code]/positief-geteste-mensen (24278 ms)                                        7.05 kB         551 kB
├   ├ /nl/veiligheidsregio/VR06/positief-geteste-mensen (1227 ms)
├   ├ /nl/veiligheidsregio/VR09/positief-geteste-mensen (1179 ms)
├   ├ /nl/veiligheidsregio/VR07/positief-geteste-mensen (1172 ms)
├   ├ /nl/veiligheidsregio/VR11/positief-geteste-mensen (1157 ms)
├   ├ /nl/veiligheidsregio/VR02/positief-geteste-mensen (1153 ms)
├   ├ /nl/veiligheidsregio/VR10/positief-geteste-mensen (1140 ms)
├   ├ /nl/veiligheidsregio/VR23/positief-geteste-mensen (1105 ms)
├   └ [+18 more paths] (avg 897 ms)
├ ● /veiligheidsregio/[code]/rioolwater (9927 ms)                                                      5.91 kB         551 kB
├   ├ /nl/veiligheidsregio/VR05/rioolwater (564 ms)
├   ├ /nl/veiligheidsregio/VR04/rioolwater (537 ms)
├   ├ /nl/veiligheidsregio/VR09/rioolwater (505 ms)
├   ├ /nl/veiligheidsregio/VR07/rioolwater (495 ms)
├   ├ /nl/veiligheidsregio/VR10/rioolwater (482 ms)
├   ├ /nl/veiligheidsregio/VR06/rioolwater (469 ms)
├   ├ /nl/veiligheidsregio/VR15/rioolwater (462 ms)
├   └ [+18 more paths] (avg 356 ms)
├ ● /veiligheidsregio/[code]/sterfte (10913 ms)                                                        4.09 kB         548 kB
├   ├ /nl/veiligheidsregio/VR11/sterfte (591 ms)
├   ├ /nl/veiligheidsregio/VR10/sterfte (572 ms)
├   ├ /nl/veiligheidsregio/VR22/sterfte (545 ms)
├   ├ /nl/veiligheidsregio/VR19/sterfte (515 ms)
├   ├ /nl/veiligheidsregio/VR20/sterfte (501 ms)
├   ├ /nl/veiligheidsregio/VR24/sterfte (500 ms)
├   ├ /nl/veiligheidsregio/VR25/sterfte (483 ms)
├   └ [+18 more paths] (avg 400 ms)
├ ● /veiligheidsregio/[code]/thuiswonende-ouderen (12973 ms)                                           6.93 kB         547 kB
├   ├ /nl/veiligheidsregio/VR11/thuiswonende-ouderen (658 ms)
├   ├ /nl/veiligheidsregio/VR23/thuiswonende-ouderen (618 ms)
├   ├ /nl/veiligheidsregio/VR02/thuiswonende-ouderen (611 ms)
├   ├ /nl/veiligheidsregio/VR07/thuiswonende-ouderen (603 ms)
├   ├ /nl/veiligheidsregio/VR03/thuiswonende-ouderen (600 ms)
├   ├ /nl/veiligheidsregio/VR12/thuiswonende-ouderen (600 ms)
├   ├ /nl/veiligheidsregio/VR08/thuiswonende-ouderen (590 ms)
├   └ [+18 more paths] (avg 483 ms)
├ ● /veiligheidsregio/[code]/vaccinaties (7977 ms)                                                     4.46 kB         558 kB
├   ├ /nl/veiligheidsregio/VR10/vaccinaties (508 ms)
├   ├ /nl/veiligheidsregio/VR11/vaccinaties (493 ms)
├   ├ /nl/veiligheidsregio/VR12/vaccinaties (486 ms)
├   ├ /nl/veiligheidsregio/VR13/vaccinaties (480 ms)
├   ├ /nl/veiligheidsregio/VR15/vaccinaties (434 ms)
├   ├ /nl/veiligheidsregio/VR14/vaccinaties (432 ms)
├   ├ /nl/veiligheidsregio/VR19/vaccinaties (429 ms)
├   └ [+18 more paths]
├ ● /veiligheidsregio/[code]/verpleeghuiszorg (16172 ms)                                               7.13 kB         547 kB
├   ├ /nl/veiligheidsregio/VR14/verpleeghuiszorg (819 ms)
├   ├ /nl/veiligheidsregio/VR12/verpleeghuiszorg (766 ms)
├   ├ /nl/veiligheidsregio/VR13/verpleeghuiszorg (755 ms)
├   ├ /nl/veiligheidsregio/VR06/verpleeghuiszorg (723 ms)
├   ├ /nl/veiligheidsregio/VR17/verpleeghuiszorg (706 ms)
├   ├ /nl/veiligheidsregio/VR19/verpleeghuiszorg (704 ms)
├   ├ /nl/veiligheidsregio/VR15/verpleeghuiszorg (700 ms)
├   └ [+18 more paths] (avg 611 ms)
├ ● /veiligheidsregio/[code]/ziekenhuis-opnames (11588 ms)                                             5.67 kB         550 kB
├   ├ /nl/veiligheidsregio/VR04/ziekenhuis-opnames (598 ms)
├   ├ /nl/veiligheidsregio/VR21/ziekenhuis-opnames (576 ms)
├   ├ /nl/veiligheidsregio/VR19/ziekenhuis-opnames (557 ms)
├   ├ /nl/veiligheidsregio/VR18/ziekenhuis-opnames (531 ms)
├   ├ /nl/veiligheidsregio/VR03/ziekenhuis-opnames (511 ms)
├   ├ /nl/veiligheidsregio/VR05/ziekenhuis-opnames (508 ms)
├   ├ /nl/veiligheidsregio/VR14/ziekenhuis-opnames (502 ms)
├   └ [+18 more paths] (avg 434 ms)
├ ● /verantwoording                                                                                    1.22 kB         507 kB
└ ● /weekberichten/[slug] (24952 ms)                                                                   4.06 kB         507 kB
    ├ /nl/weekberichten/weekbericht-alle-wijzers-in-het-rood (476 ms)
    ├ /nl/weekberichten/dalende-trend-zet-door (471 ms)
    ├ /en/weekberichten/weekbericht-situatie-in-nederland-blijft-zorgelijk (464 ms)
    ├ /en/weekberichten/weekbericht-alle-wijzers-in-het-rood (464 ms)
    ├ /en/weekberichten/kleine-landelijke-daling-maar-niet-in-alle-regio-s (463 ms)
    ├ /nl/weekberichten/nieuwe-varianten-gooien-roet-in-het-eten (463 ms)
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-21-september (463 ms)
    └ [+73 more paths]
+ First Load JS shared by all                                                                          263 kB
  ├ chunks/framework.56dc96.js                                                                         42.7 kB
  ├ chunks/main.c39766.js                                                                              28.3 kB
  ├ chunks/pages/_app.6943af.js                                                                        190 kB
  ├ chunks/webpack.3afcd7.js                                                                           2.07 kB
  └ css/fc7993b8fa7f45665623.css                                                                       329 B
```

**After**

```sh
Page                                                                                                  Size     First Load JS
┌ ● /                                                                                                 11.9 kB         519 kB
├   /_app                                                                                             0 B             240 kB
├ ○ /404                                                                                              813 B           276 kB
├ ● /500                                                                                              810 B           276 kB
├ ● /actueel/gemeente                                                                                 4.63 kB         505 kB
├ ● /actueel/gemeente/[code] (255453 ms)                                                              2.88 kB         510 kB
├   ├ /nl/actueel/gemeente/GM0183 (1668 ms)
├   ├ /nl/actueel/gemeente/GM1883 (1660 ms)
├   ├ /nl/actueel/gemeente/GM0865 (1587 ms)
├   ├ /nl/actueel/gemeente/GM0164 (1583 ms)
├   ├ /nl/actueel/gemeente/GM0096 (1573 ms)
├   ├ /nl/actueel/gemeente/GM0866 (1524 ms)
├   ├ /nl/actueel/gemeente/GM0358 (1400 ms)
├   └ [+345 more paths] (avg 709 ms)
├ ● /actueel/veiligheidsregio                                                                         5.3 kB          506 kB
├ ● /actueel/veiligheidsregio/[code] (21885 ms)                                                       2.81 kB         510 kB
├   ├ /nl/actueel/veiligheidsregio/VR23 (1644 ms)
├   ├ /nl/actueel/veiligheidsregio/VR02 (1100 ms)
├   ├ /nl/actueel/veiligheidsregio/VR05 (1072 ms)
├   ├ /nl/actueel/veiligheidsregio/VR07 (1064 ms)
├   ├ /nl/actueel/veiligheidsregio/VR08 (1055 ms)
├   ├ /nl/actueel/veiligheidsregio/VR04 (1052 ms)
├   ├ /nl/actueel/veiligheidsregio/VR09 (1003 ms)
├   └ [+18 more paths] (avg 772 ms)
├ λ /api/choropleth/[...param]                                                                        0 B             240 kB
├ λ /api/choropleth/konva-node.d                                                                      0 B             240 kB
├ λ /api/choropleth/topojson-client.d                                                                 0 B             240 kB
├ λ /api/choropleth/topology                                                                          0 B             240 kB
├ λ /api/data/timeseries/[...param]                                                                   0 B             240 kB
├ λ /api/topo-json/[type]                                                                             0 B             240 kB
├ ● /artikelen                                                                                        4.55 kB         280 kB
├ ● /artikelen/[slug] (33231 ms)                                                                      2.88 kB         485 kB
├   ├ /nl/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (1085 ms)
├   ├ /en/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (1084 ms)
├   ├ /en/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-23-maart (1079 ms)
├   ├ /nl/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-23-maart (1070 ms)
├   ├ /en/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-8-maart-2021 (971 ms)
├   ├ /nl/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-8-maart-2021 (945 ms)
├   ├ /nl/artikelen/hoeveel-mensen-liggen-er-in-het-ziekenhuis (894 ms)
├   └ [+47 more paths] (avg 555 ms)
├ ● /contact                                                                                          2.68 kB         483 kB
├ ● /gemeente                                                                                         4.63 kB         505 kB
├ ● /gemeente/[code] (66643 ms)                                                                       4.18 kB         505 kB
├   ├ /nl/gemeente/GM0141 (2118 ms)
├   ├ /nl/gemeente/GM0613 (2104 ms)
├   ├ /nl/gemeente/GM0358 (2100 ms)
├   ├ /nl/gemeente/GM1723 (2096 ms)
├   ├ /nl/gemeente/GM0034 (2033 ms)
├   ├ /nl/gemeente/GM1680 (2025 ms)
├   ├ /nl/gemeente/GM0361 (2016 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/positief-geteste-mensen (181625 ms)                                              5.58 kB         527 kB
├   ├ /nl/gemeente/GM0158/positief-geteste-mensen (841 ms)
├   ├ /nl/gemeente/GM1884/positief-geteste-mensen (836 ms)
├   ├ /nl/gemeente/GM0794/positief-geteste-mensen (828 ms)
├   ├ /nl/gemeente/GM1705/positief-geteste-mensen (821 ms)
├   ├ /nl/gemeente/GM0244/positief-geteste-mensen (812 ms)
├   ├ /nl/gemeente/GM0402/positief-geteste-mensen (805 ms)
├   ├ /nl/gemeente/GM0232/positief-geteste-mensen (776 ms)
├   └ [+345 more paths] (avg 510 ms)
├ ● /gemeente/[code]/rioolwater (96347 ms)                                                            6.35 kB         529 kB
├   ├ /nl/gemeente/GM1970/rioolwater (542 ms)
├   ├ /nl/gemeente/GM0221/rioolwater (529 ms)
├   ├ /nl/gemeente/GM0296/rioolwater (514 ms)
├   ├ /nl/gemeente/GM1695/rioolwater (503 ms)
├   ├ /nl/gemeente/GM0893/rioolwater (487 ms)
├   ├ /nl/gemeente/GM0748/rioolwater (473 ms)
├   ├ /nl/gemeente/GM0823/rioolwater (469 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/sterfte (134848 ms)                                                              6.63 kB         524 kB
├   ├ /nl/gemeente/GM0505/sterfte (617 ms)
├   ├ /nl/gemeente/GM1685/sterfte (611 ms)
├   ├ /nl/gemeente/GM1730/sterfte (598 ms)
├   ├ /nl/gemeente/GM0856/sterfte (596 ms)
├   ├ /nl/gemeente/GM1621/sterfte (591 ms)
├   ├ /nl/gemeente/GM0417/sterfte (578 ms)
├   ├ /nl/gemeente/GM0786/sterfte (573 ms)
├   └ [+345 more paths] (avg 379 ms)
├ ● /gemeente/[code]/vaccinaties (106081 ms)                                                          4.42 kB         535 kB
├   ├ /nl/gemeente/GM1911/vaccinaties (2132 ms)
├   ├ /nl/gemeente/GM0370/vaccinaties (547 ms)
├   ├ /nl/gemeente/GM0221/vaccinaties (546 ms)
├   ├ /nl/gemeente/GM0981/vaccinaties (540 ms)
├   ├ /nl/gemeente/GM0351/vaccinaties (527 ms)
├   ├ /nl/gemeente/GM0321/vaccinaties (514 ms)
├   ├ /nl/gemeente/GM1507/vaccinaties (505 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/ziekenhuis-opnames (180532 ms)                                                   5.62 kB         527 kB
├   ├ /nl/gemeente/GM0358/ziekenhuis-opnames (2162 ms)
├   ├ /nl/gemeente/GM0059/ziekenhuis-opnames (2127 ms)
├   ├ /nl/gemeente/GM0361/ziekenhuis-opnames (2022 ms)
├   ├ /nl/gemeente/GM1680/ziekenhuis-opnames (2014 ms)
├   ├ /nl/gemeente/GM0034/ziekenhuis-opnames (1984 ms)
├   ├ /nl/gemeente/GM0141/ziekenhuis-opnames (1979 ms)
├   ├ /nl/gemeente/GM0484/ziekenhuis-opnames (1978 ms)
├   └ [+345 more paths] (avg 482 ms)
├ ● /internationaal                                                                                   1.11 kB         492 kB
├ ● /internationaal/positief-geteste-mensen                                                           15.4 kB         527 kB
├ ● /internationaal/varianten                                                                         5.85 kB         525 kB
├ ● /landelijk                                                                                        1.48 kB         492 kB
├ ● /landelijk/besmettelijke-mensen                                                                   5.19 kB         513 kB
├ ● /landelijk/brononderzoek                                                                          4.42 kB         523 kB
├ ● /landelijk/coronamelder                                                                           5.39 kB         513 kB
├ ● /landelijk/gedrag                                                                                 5.17 kB         532 kB
├ ● /landelijk/gehandicaptenzorg                                                                      3.67 kB         515 kB
├ ● /landelijk/intensive-care-opnames                                                                 6.45 kB         526 kB
├ ● /landelijk/maatregelen                                                                            1.64 kB         510 kB
├ ● /landelijk/positief-geteste-mensen                                                                7.08 kB         518 kB
├ ● /landelijk/reproductiegetal                                                                       5.21 kB         513 kB
├ ● /landelijk/rioolwater                                                                             2.4 kB          519 kB
├ ● /landelijk/sterfte                                                                                6.18 kB         518 kB
├ ● /landelijk/thuiswonende-ouderen                                                                   3.47 kB         515 kB
├ ● /landelijk/vaccinaties                                                                            8.59 kB         536 kB
├ ● /landelijk/varianten                                                                              1.89 kB         517 kB
├ ● /landelijk/verdenkingen-huisartsen                                                                5.63 kB         513 kB
├ ● /landelijk/verpleeghuiszorg                                                                       3.68 kB         515 kB
├ ● /landelijk/ziekenhuis-opnames                                                                     2.5 kB          526 kB
├ ● /over                                                                                             2.69 kB         483 kB
├ ● /over-risiconiveaus                                                                               1.14 kB         484 kB
├ λ /sitemap.xml                                                                                      306 B           240 kB
├ ● /toegankelijkheid                                                                                 2.69 kB         483 kB
├ ● /veelgestelde-vragen                                                                              1.22 kB         484 kB
├ ● /veiligheidsregio                                                                                 5.29 kB         506 kB
├ ● /veiligheidsregio/[code] (4257 ms)                                                                4.16 kB         505 kB
├   ├ /nl/veiligheidsregio/VR01
├   ├ /nl/veiligheidsregio/VR02
├   ├ /nl/veiligheidsregio/VR03
├   └ [+22 more paths]
├ ● /veiligheidsregio/[code]/brononderzoek (11136 ms)                                                 7.47 kB         535 kB
├   ├ /nl/veiligheidsregio/VR09/brononderzoek (716 ms)
├   ├ /nl/veiligheidsregio/VR13/brononderzoek (603 ms)
├   ├ /nl/veiligheidsregio/VR06/brononderzoek (575 ms)
├   ├ /nl/veiligheidsregio/VR08/brononderzoek (569 ms)
├   ├ /nl/veiligheidsregio/VR11/brononderzoek (561 ms)
├   ├ /nl/veiligheidsregio/VR12/brononderzoek (559 ms)
├   ├ /nl/veiligheidsregio/VR10/brononderzoek (540 ms)
├   └ [+18 more paths] (avg 390 ms)
├ ● /veiligheidsregio/[code]/gedrag (9671 ms)                                                         4.24 kB         541 kB
├   ├ /nl/veiligheidsregio/VR04/gedrag (573 ms)
├   ├ /nl/veiligheidsregio/VR05/gedrag (539 ms)
├   ├ /nl/veiligheidsregio/VR07/gedrag (529 ms)
├   ├ /nl/veiligheidsregio/VR03/gedrag (508 ms)
├   ├ /nl/veiligheidsregio/VR01/gedrag (494 ms)
├   ├ /nl/veiligheidsregio/VR02/gedrag (487 ms)
├   ├ /nl/veiligheidsregio/VR08/gedrag (485 ms)
├   └ [+18 more paths] (avg 336 ms)
├ ● /veiligheidsregio/[code]/gehandicaptenzorg (13405 ms)                                             7.12 kB         524 kB
├   ├ /nl/veiligheidsregio/VR11/gehandicaptenzorg (773 ms)
├   ├ /nl/veiligheidsregio/VR15/gehandicaptenzorg (698 ms)
├   ├ /nl/veiligheidsregio/VR13/gehandicaptenzorg (649 ms)
├   ├ /nl/veiligheidsregio/VR17/gehandicaptenzorg (642 ms)
├   ├ /nl/veiligheidsregio/VR10/gehandicaptenzorg (637 ms)
├   ├ /nl/veiligheidsregio/VR09/gehandicaptenzorg (617 ms)
├   ├ /nl/veiligheidsregio/VR18/gehandicaptenzorg (609 ms)
├   └ [+18 more paths] (avg 488 ms)
├ ● /veiligheidsregio/[code]/maatregelen (8991 ms)                                                    4.2 kB          522 kB
├   ├ /nl/veiligheidsregio/VR02/maatregelen (530 ms)
├   ├ /nl/veiligheidsregio/VR01/maatregelen (516 ms)
├   ├ /nl/veiligheidsregio/VR03/maatregelen (506 ms)
├   ├ /nl/veiligheidsregio/VR05/maatregelen (491 ms)
├   ├ /nl/veiligheidsregio/VR04/maatregelen (487 ms)
├   ├ /nl/veiligheidsregio/VR10/maatregelen (451 ms)
├   ├ /nl/veiligheidsregio/VR08/maatregelen (431 ms)
├   └ [+18 more paths] (avg 310 ms)
├ ● /veiligheidsregio/[code]/positief-geteste-mensen (22256 ms)                                       7.05 kB         528 kB
├   ├ /nl/veiligheidsregio/VR20/positief-geteste-mensen (1132 ms)
├   ├ /nl/veiligheidsregio/VR07/positief-geteste-mensen (1120 ms)
├   ├ /nl/veiligheidsregio/VR09/positief-geteste-mensen (1106 ms)
├   ├ /nl/veiligheidsregio/VR08/positief-geteste-mensen (1104 ms)
├   ├ /nl/veiligheidsregio/VR05/positief-geteste-mensen (1103 ms)
├   ├ /nl/veiligheidsregio/VR19/positief-geteste-mensen (1102 ms)
├   ├ /nl/veiligheidsregio/VR10/positief-geteste-mensen (1008 ms)
├   └ [+18 more paths] (avg 810 ms)
├ ● /veiligheidsregio/[code]/rioolwater (9666 ms)                                                     5.91 kB         528 kB
├   ├ /nl/veiligheidsregio/VR04/rioolwater (567 ms)
├   ├ /nl/veiligheidsregio/VR06/rioolwater (498 ms)
├   ├ /nl/veiligheidsregio/VR05/rioolwater (494 ms)
├   ├ /nl/veiligheidsregio/VR02/rioolwater (466 ms)
├   ├ /nl/veiligheidsregio/VR07/rioolwater (466 ms)
├   ├ /nl/veiligheidsregio/VR17/rioolwater (466 ms)
├   ├ /nl/veiligheidsregio/VR09/rioolwater (464 ms)
├   └ [+18 more paths] (avg 347 ms)
├ ● /veiligheidsregio/[code]/sterfte (10680 ms)                                                       4.09 kB         525 kB
├   ├ /nl/veiligheidsregio/VR07/sterfte (613 ms)
├   ├ /nl/veiligheidsregio/VR08/sterfte (596 ms)
├   ├ /nl/veiligheidsregio/VR11/sterfte (518 ms)
├   ├ /nl/veiligheidsregio/VR06/sterfte (514 ms)
├   ├ /nl/veiligheidsregio/VR09/sterfte (501 ms)
├   ├ /nl/veiligheidsregio/VR21/sterfte (487 ms)
├   ├ /nl/veiligheidsregio/VR10/sterfte (486 ms)
├   └ [+18 more paths] (avg 387 ms)
├ ● /veiligheidsregio/[code]/thuiswonende-ouderen (13693 ms)                                          6.93 kB         524 kB
├   ├ /nl/veiligheidsregio/VR02/thuiswonende-ouderen (729 ms)
├   ├ /nl/veiligheidsregio/VR01/thuiswonende-ouderen (711 ms)
├   ├ /nl/veiligheidsregio/VR06/thuiswonende-ouderen (708 ms)
├   ├ /nl/veiligheidsregio/VR08/thuiswonende-ouderen (694 ms)
├   ├ /nl/veiligheidsregio/VR09/thuiswonende-ouderen (685 ms)
├   ├ /nl/veiligheidsregio/VR07/thuiswonende-ouderen (684 ms)
├   ├ /nl/veiligheidsregio/VR10/thuiswonende-ouderen (684 ms)
├   └ [+18 more paths] (avg 489 ms)
├ ● /veiligheidsregio/[code]/vaccinaties (8211 ms)                                                    4.46 kB         535 kB
├   ├ /nl/veiligheidsregio/VR09/vaccinaties (529 ms)
├   ├ /nl/veiligheidsregio/VR25/vaccinaties (516 ms)
├   ├ /nl/veiligheidsregio/VR01/vaccinaties (411 ms)
├   ├ /nl/veiligheidsregio/VR10/vaccinaties (410 ms)
├   ├ /nl/veiligheidsregio/VR03/vaccinaties (391 ms)
├   ├ /nl/veiligheidsregio/VR02/vaccinaties (386 ms)
├   ├ /nl/veiligheidsregio/VR05/vaccinaties (383 ms)
├   └ [+18 more paths]
├ ● /veiligheidsregio/[code]/verpleeghuiszorg (15520 ms)                                              7.13 kB         524 kB
├   ├ /nl/veiligheidsregio/VR18/verpleeghuiszorg (862 ms)
├   ├ /nl/veiligheidsregio/VR05/verpleeghuiszorg (823 ms)
├   ├ /nl/veiligheidsregio/VR07/verpleeghuiszorg (809 ms)
├   ├ /nl/veiligheidsregio/VR06/verpleeghuiszorg (802 ms)
├   ├ /nl/veiligheidsregio/VR04/verpleeghuiszorg (722 ms)
├   ├ /nl/veiligheidsregio/VR25/verpleeghuiszorg (688 ms)
├   ├ /nl/veiligheidsregio/VR17/verpleeghuiszorg (682 ms)
├   └ [+18 more paths] (avg 563 ms)
├ ● /veiligheidsregio/[code]/ziekenhuis-opnames (13434 ms)                                            5.67 kB         527 kB
├   ├ /nl/veiligheidsregio/VR09/ziekenhuis-opnames (798 ms)
├   ├ /nl/veiligheidsregio/VR11/ziekenhuis-opnames (744 ms)
├   ├ /nl/veiligheidsregio/VR01/ziekenhuis-opnames (708 ms)
├   ├ /nl/veiligheidsregio/VR07/ziekenhuis-opnames (681 ms)
├   ├ /nl/veiligheidsregio/VR10/ziekenhuis-opnames (680 ms)
├   ├ /nl/veiligheidsregio/VR14/ziekenhuis-opnames (661 ms)
├   ├ /nl/veiligheidsregio/VR12/ziekenhuis-opnames (617 ms)
├   └ [+18 more paths] (avg 475 ms)
├ ● /verantwoording                                                                                   1.22 kB         484 kB
└ ● /weekberichten/[slug] (27869 ms)                                                                  4.06 kB         484 kB
    ├ /en/weekberichten/sterke-stijging-ziekenhuisopnames-jongere-leeftijdsgroepen (1448 ms)
    ├ /nl/weekberichten/wekelijkse-update-coronacijfers-24-augustus (1213 ms)
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-05-oktober (492 ms)
    ├ /nl/weekberichten/wekelijkse-update-coronacijfers-05-oktober (486 ms)
    ├ /en/weekberichten/kleine-landelijke-daling-maar-niet-in-alle-regio-s (485 ms)
    ├ /en/weekberichten/dalende-trend-zet-door (484 ms)
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-26-oktober (484 ms)
    └ [+73 more paths] (avg 312 ms)
+ First Load JS shared by all                                                                         240 kB
  ├ chunks/framework.56dc96.js                                                                        42.7 kB
  ├ chunks/main.c39766.js                                                                             28.3 kB
  ├ chunks/pages/_app.2ef8c7.js                                                                       167 kB
  ├ chunks/webpack.08f3a6.js                                                                          2.12 kB
  └ css/fc7993b8fa7f45665623.css                                                                      329 B
```