### PR TITLE
Properly size article teaser images

### DIFF
--- a/packages/app/src/components/cms/sanity-image.tsx
+++ b/packages/app/src/components/cms/sanity-image.tsx
@@ -19,7 +19,13 @@ export function SanityImage(props: SanityImageProps) {
   return (
     <picture className={props.className}>
       <source srcSet={srcSet} sizes={sizes} type={`image/${extension}`} />
-      <Image src={src} srcSet={srcSet} sizes={sizes} {...imageProps} />
+      <Image
+        loading="lazy"
+        src={src}
+        srcSet={srcSet}
+        sizes={sizes}
+        {...imageProps}
+      />
     </picture>
   );
 }

--- a/packages/app/src/components/content-teaser.tsx
+++ b/packages/app/src/components/content-teaser.tsx
@@ -32,6 +32,7 @@ export function ContentTeaser({
 }: ContentTeaserProps) {
   const { siteText } = useIntl();
   const breakpoints = useBreakpoints(true);
+  const imageWidth = variant === 'normal' ? (breakpoints.sm ? 186 : 90) : 90;
 
   return (
     <Box
@@ -41,14 +42,11 @@ export function ContentTeaser({
       alignItems="center"
       pr={3}
     >
-      <Box
-        maxWidth={variant === 'normal' ? (breakpoints.sm ? 186 : 90) : 90}
-        width="100%"
-      >
+      <Box maxWidth={imageWidth} width="100%">
         <BackgroundImage
           image={cover}
           height={variant === 'normal' ? (breakpoints.sm ? 108 : 66) : 66}
-          sizes={[[1200, 438]]}
+          sizes={[[imageWidth]]}
         />
       </Box>
       <Box maxWidth="25rem" spacing={publicationDate || category ? 2 : 0}>

--- a/packages/app/src/lib/sanity.tsx
+++ b/packages/app/src/lib/sanity.tsx
@@ -2,6 +2,7 @@
 import { imageResizeTargets } from '@corona-dashboard/common';
 import BlockContent from '@sanity/block-content-to-react';
 import { ClientConfig } from '@sanity/client';
+import { isPresent } from 'ts-is-present';
 import { ImageBlock, SanityFileProps, SanityImageProps } from '~/types/cms';
 import { findClosestSize } from '~/utils/find-closest-size';
 
@@ -133,7 +134,11 @@ export function getImageProps<T extends ImageBlock>(
    * viewport-widths.
    */
   const sizes = sizesOption
-    ?.map(([viewport, size]) => `(min-width: ${viewport}px) ${size}px`)
+    ?.map(([viewportOrSize, size]) =>
+      isPresent(size)
+        ? `(min-width: ${viewportOrSize}px) ${size}px`
+        : `${viewportOrSize}px`
+    )
     .join(', ');
 
   return {


### PR DESCRIPTION
Article teaser images were downloaded as being 100vw wide on mobile and a quite random size on 1200px+ screens, probably from some time the design of these teasers was different. Since the size of these teaser images is semi-fixed, the sizes attribute can also contain a fixed size.

A fixed size for all screen sizes was not supported yet, so I added support for that.