### PR TITLE
Update tile selector to show the correct layout based on the viewport

### DIFF
--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -257,8 +257,8 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
 }
 
 /**
- * Using this container is so that the user can see the correct layout of
- * the tile selector depending on their screen size.
+ * Using his container so that the user can see the correct layout of
+ * the tile selector depending on their screen size when the page is loading and not hydrated yet.
  */
 const ContainerTileSelector = styled.div<{
   narrowId: string;

--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -256,6 +256,10 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
   );
 }
 
+/**
+ * Using this container is so that the user can see the correct layout of
+ * the tile selector depending on their screen size.
+ */
 const ContainerTileSelector = styled.div<{
   narrowId: string;
   wideId: string;

--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -19,8 +19,8 @@ import { InlineText, Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { space } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
-import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useCollapsible } from '~/utils/use-collapsible';
+import { useUniqueId } from '~/utils/use-unique-id';
 import { Bar } from '../vaccine/vaccine-coverage-per-age-group/components/bar';
 
 export type MiniTileSelectorItem<T extends TimestampedValue> = {
@@ -39,6 +39,7 @@ export type MiniTileSelectorItem<T extends TimestampedValue> = {
 type MiniTileSelectorLayoutProps = {
   menuItems: MiniTileSelectorItem<any>[];
   children: ReactNode[];
+  id?: string;
   link?: {
     href: string;
     text: string;
@@ -46,19 +47,22 @@ type MiniTileSelectorLayoutProps = {
 };
 
 export function MiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
-  const breakpoints = useBreakpoints(false);
-
   const { siteText } = useIntl();
 
-  return breakpoints.md ? (
-    <WideMiniTileSelectorLayout {...props} />
-  ) : (
-    <Box spacing={3}>
-      <Text variant="label1" color="bodyLight">
-        {siteText.common_actueel.tile_selector_uitleg}
-      </Text>
-      <NarrowMiniTileSelectorLayout {...props} />
-    </Box>
+  const narrowId = useUniqueId();
+  const wideId = useUniqueId();
+
+  return (
+    <ContainerTileSelector narrowId={narrowId} wideId={wideId}>
+      <WideMiniTileSelectorLayout {...props} id={wideId} />
+
+      <Box spacing={3} id={narrowId}>
+        <Text variant="label1" color="bodyLight">
+          {siteText.common_actueel.tile_selector_uitleg}
+        </Text>
+        <NarrowMiniTileSelectorLayout {...props} />
+      </Box>
+    </ContainerTileSelector>
   );
 }
 
@@ -161,12 +165,12 @@ function NarrowMenuListItem(props: NarrowMenuListItemProps) {
 }
 
 function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
-  const { menuItems, children, link } = props;
+  const { menuItems, children, link, id } = props;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { siteText, formatNumber, formatPercentage } = useIntl();
 
   return (
-    <Box display="grid" gridTemplateColumns="30% 1fr" minHeight={265}>
+    <Box display="grid" gridTemplateColumns="30% 1fr" minHeight={265} id={id}>
       <Box borderRight="1px" borderRightStyle="solid" borderRightColor="border">
         <ul>
           {menuItems.map((item, index) => (
@@ -251,6 +255,21 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
     </Box>
   );
 }
+
+const ContainerTileSelector = styled.div<{
+  narrowId: string;
+  wideId: string;
+}>((x) =>
+  css({
+    [`#${x.narrowId}`]: {
+      display: asResponsiveArray({ _: 'block', md: 'none' }),
+    },
+
+    [`#${x.wideId}`]: {
+      display: asResponsiveArray({ _: 'none', md: 'grid' }),
+    },
+  })
+);
 
 const NarrowMenuList = styled.ul(
   css({

--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -2,7 +2,7 @@ import {
   colors,
   KeysOfType,
   TimestampedValue,
-  Unpack,
+  Unpack
 } from '@corona-dashboard/common';
 import { Warning } from '@corona-dashboard/icons';
 import css from '@styled-system/css';
@@ -20,7 +20,6 @@ import { useIntl } from '~/intl';
 import { space } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { useCollapsible } from '~/utils/use-collapsible';
-import { useUniqueId } from '~/utils/use-unique-id';
 import { Bar } from '../vaccine/vaccine-coverage-per-age-group/components/bar';
 
 export type MiniTileSelectorItem<T extends TimestampedValue> = {
@@ -39,7 +38,7 @@ export type MiniTileSelectorItem<T extends TimestampedValue> = {
 type MiniTileSelectorLayoutProps = {
   menuItems: MiniTileSelectorItem<any>[];
   children: ReactNode[];
-  id?: string;
+
   link?: {
     href: string;
     text: string;
@@ -49,20 +48,19 @@ type MiniTileSelectorLayoutProps = {
 export function MiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
   const { siteText } = useIntl();
 
-  const narrowId = useUniqueId();
-  const wideId = useUniqueId();
-
   return (
-    <ContainerTileSelector narrowId={narrowId} wideId={wideId}>
-      <WideMiniTileSelectorLayout {...props} id={wideId} />
+    <>
+      <Box display={{ _: 'none', md: 'block' }}>
+        <WideMiniTileSelectorLayout {...props} />
+      </Box>
 
-      <Box spacing={3} id={narrowId}>
+      <Box spacing={3} display={{ _: 'block', md: 'none' }}>
         <Text variant="label1" color="bodyLight">
           {siteText.common_actueel.tile_selector_uitleg}
         </Text>
         <NarrowMiniTileSelectorLayout {...props} />
       </Box>
-    </ContainerTileSelector>
+    </>
   );
 }
 
@@ -165,12 +163,12 @@ function NarrowMenuListItem(props: NarrowMenuListItemProps) {
 }
 
 function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
-  const { menuItems, children, link, id } = props;
+  const { menuItems, children, link } = props;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { siteText, formatNumber, formatPercentage } = useIntl();
 
   return (
-    <Box display="grid" gridTemplateColumns="30% 1fr" minHeight={265} id={id}>
+    <Box display="grid" gridTemplateColumns="30% 1fr" minHeight={265} >
       <Box borderRight="1px" borderRightStyle="solid" borderRightColor="border">
         <ul>
           {menuItems.map((item, index) => (
@@ -255,25 +253,6 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
     </Box>
   );
 }
-
-/**
- * Using his container so that the user can see the correct layout of
- * the tile selector depending on their screen size when the page is loading and not hydrated yet.
- */
-const ContainerTileSelector = styled.div<{
-  narrowId: string;
-  wideId: string;
-}>((x) =>
-  css({
-    [`#${x.narrowId}`]: {
-      display: asResponsiveArray({ _: 'block', md: 'none' }),
-    },
-
-    [`#${x.wideId}`]: {
-      display: asResponsiveArray({ _: 'none', md: 'grid' }),
-    },
-  })
-);
 
 const NarrowMenuList = styled.ul(
   css({


### PR DESCRIPTION
This seems to work, comparing when building the develop branch and this branch this one shows the correct layout instantly. The only drawback is that we're indeed shipping a bit more code to the user.