### PR TITLE
Give gapped area a trend icon as well

### DIFF
--- a/packages/app/src/components/time-series-chart/components/series-icon.tsx
+++ b/packages/app/src/components/time-series-chart/components/series-icon.tsx
@@ -38,6 +38,7 @@ export function SeriesIcon<T extends TimestampedValue>({
         <RangeTrendIcon color={config.color} fillOpacity={config.fillOpacity} />
       );
     case 'area':
+    case 'gapped-area':
       return (
         <AreaTrendIcon
           color={config.color}


### PR DESCRIPTION
We switched to a gapped-area chart for the IC & hospital bed occupancy, but it did not have a trend icon yet. Gave it the same icon as the normal area chart.