### PR TITLE
Add incidence graph to vaccinations and change position on hospital & IC 

### DIFF
--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -242,8 +242,8 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                 }}
                 rightColor="data.primary"
                 leftColor="data.yellow"
-                leftMetricProperty={'not_or_partially_vaccinated'}
-                rightMetricProperty={'fully_vaccinated'}
+                leftMetricProperty={'has_one_shot_or_not_vaccinated_per_100k'}
+                rightMetricProperty={'fully_vaccinated_per_100k'}
                 formatValue={(n: number) => `${n}`}
                 text={
                   siteText.ic_admissions_incidence_age_demographic_chart

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -224,6 +224,35 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
             </KpiTile>
           </TwoKpiSection>
 
+          {icVaccinationIncidencePerAgeGroupFeature.isEnabled && (
+            <ChartTile
+              title={
+                siteText.ic_admissions_incidence_age_demographic_chart.title
+              }
+              description={
+                siteText.ic_admissions_incidence_age_demographic_chart
+                  .description
+              }
+            >
+              <AgeDemographic
+                // This is correct, hospital admissions data is supposed to be displayed here.
+                data={data.hospital_vaccine_incidence_per_age_group}
+                accessibility={{
+                  key: 'ic_admissions_incidence_age_demographic_chart',
+                }}
+                rightColor="data.primary"
+                leftColor="data.yellow"
+                leftMetricProperty={'not_or_partially_vaccinated'}
+                rightMetricProperty={'fully_vaccinated'}
+                formatValue={(n: number) => `${n}`}
+                text={
+                  siteText.ic_admissions_incidence_age_demographic_chart
+                    .chart_text
+                }
+              />
+            </ChartTile>
+          )}
+
           {vaccinationStatusFeature.isEnabled && (
             <ChartTile
               title={text.vaccination_status_chart.title}
@@ -271,35 +300,6 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                       text.vaccination_status_chart.labels.fully_vaccinated,
                   },
                 ]}
-              />
-            </ChartTile>
-          )}
-
-          {icVaccinationIncidencePerAgeGroupFeature.isEnabled && (
-            <ChartTile
-              title={
-                siteText.ic_admissions_incidence_age_demographic_chart.title
-              }
-              description={
-                siteText.ic_admissions_incidence_age_demographic_chart
-                  .description
-              }
-            >
-              <AgeDemographic
-                // This is correct, hospital admissions data is supposed to be displayed here.
-                data={data.hospital_vaccine_incidence_per_age_group}
-                accessibility={{
-                  key: 'ic_admissions_incidence_age_demographic_chart',
-                }}
-                rightColor="data.primary"
-                leftColor="data.yellow"
-                leftMetricProperty={'not_or_partially_vaccinated'}
-                rightMetricProperty={'fully_vaccinated'}
-                formatValue={(n: number) => `${n}`}
-                text={
-                  siteText.ic_admissions_incidence_age_demographic_chart
-                    .chart_text
-                }
               />
             </ChartTile>
           )}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -3,6 +3,7 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { isDefined } from 'ts-is-present';
+import { AgeDemographic } from '~/components/age-demographic';
 import { Box, Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { Metadata } from '~/components/metadata';
@@ -72,6 +73,7 @@ export const getStaticProps = createGetStaticProps(
     'vaccine_vaccinated_or_support',
     'vaccine_coverage_per_age_group_estimated',
     'hospital_vaccination_status',
+    'hospital_vaccine_incidence_per_age_group',
     'intensive_care_vaccination_status'
   ),
   () => selectDeliveryAndAdministrationData(getNlData().data),
@@ -151,7 +153,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   const vaccineAdministeredGgdGhorFeature = useFeature(
     'nlVaccineAdministeredGgdGhor'
   );
-
+  const vaccinationsIncidencePerAgeGroupFeature = useFeature(
+    'nlVaccinationsIncidencePerAgeGroup'
+  );
   const vaccinationStatusHospitalFeature = useFeature(
     'nlVaccinationHospitalVaccinationStatus'
   );
@@ -264,6 +268,34 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               }}
               values={data.vaccine_coverage_per_age_group.values}
             />
+          )}
+
+          {vaccinationsIncidencePerAgeGroupFeature.isEnabled && (
+            <ChartTile
+              title={
+                siteText.vaccinations_incidence_age_demographic_chart.title
+              }
+              description={
+                siteText.vaccinations_incidence_age_demographic_chart
+                  .description
+              }
+            >
+              <AgeDemographic
+                data={data.hospital_vaccine_incidence_per_age_group}
+                accessibility={{
+                  key: 'vaccinations_incidence_age_demographic_chart',
+                }}
+                rightColor="data.primary"
+                leftColor="data.yellow"
+                leftMetricProperty={'has_one_shot_or_not_vaccinated_per_100k'}
+                rightMetricProperty={'fully_vaccinated_per_100k'}
+                formatValue={(n) => `${n}`}
+                text={
+                  siteText.vaccinations_incidence_age_demographic_chart
+                    .chart_text
+                }
+              />
+            </ChartTile>
           )}
 
           {vaccinationStatusHospitalFeature.isEnabled &&

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -206,6 +206,35 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
             </KpiTile>
           </TwoKpiSection>
 
+          {isVaccinationIncidenceChartShown.isEnabled && (
+            <ChartTile
+              title={
+                siteText.hospital_admissions_incidence_age_demographic_chart
+                  .title
+              }
+              description={
+                siteText.hospital_admissions_incidence_age_demographic_chart
+                  .description
+              }
+            >
+              <AgeDemographic
+                data={data.hospital_vaccine_incidence_per_age_group}
+                accessibility={{
+                  key: 'hospital_admissions_incidence_age_demographic_chart',
+                }}
+                rightColor="data.primary"
+                leftColor="data.yellow"
+                leftMetricProperty={'has_one_shot_or_not_vaccinated_per_100k'}
+                rightMetricProperty={'fully_vaccinated_per_100k'}
+                formatValue={(n) => `${n}`}
+                text={
+                  siteText.hospital_admissions_incidence_age_demographic_chart
+                    .chart_text
+                }
+              />
+            </ChartTile>
+          )}
+
           {vaccinationStatusFeature.isEnabled && (
             <ChartTile
               title={text.vaccination_status_chart.title}
@@ -253,35 +282,6 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                       text.vaccination_status_chart.labels.fully_vaccinated,
                   },
                 ]}
-              />
-            </ChartTile>
-          )}
-
-          {isVaccinationIncidenceChartShown.isEnabled && (
-            <ChartTile
-              title={
-                siteText.hospital_admissions_incidence_age_demographic_chart
-                  .title
-              }
-              description={
-                siteText.hospital_admissions_incidence_age_demographic_chart
-                  .description
-              }
-            >
-              <AgeDemographic
-                data={data.hospital_vaccine_incidence_per_age_group}
-                accessibility={{
-                  key: 'hospital_admissions_incidence_age_demographic_chart',
-                }}
-                rightColor="data.primary"
-                leftColor="data.yellow"
-                leftMetricProperty={'has_one_shot_or_not_vaccinated_per_100k'}
-                rightMetricProperty={'fully_vaccinated_per_100k'}
-                formatValue={(n) => `${n}`}
-                text={
-                  siteText.hospital_admissions_incidence_age_demographic_chart
-                    .chart_text
-                }
               />
             </ChartTile>
           )}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -56,3 +56,14 @@ timestamp,action,key,document_id,move_to
 2021-11-01T16:12:02.826Z,delete,ic_opnames_per_dag.vaccination_status_chart.labels.not_vaccinated,kEfMsz3QZs49YXq5jn3hR7,__
 2021-11-01T16:12:02.826Z,delete,ziekenhuisopnames_per_dag.vaccination_status_chart.labels.has_one_shot,jDbv30Y7XYH5kl8Zamawpq,__
 2021-11-01T16:12:02.826Z,delete,ziekenhuisopnames_per_dag.vaccination_status_chart.labels.not_vaccinated,kEfMsz3QZs49YXq5jn3lpZ,__
+2021-11-09T14:51:46.400Z,add,accessibility.charts.vaccinations_incidence_age_demographic_chart.description,z1CGDOfh23CnZYQwEeXFeR,__
+2021-11-09T14:51:47.424Z,add,accessibility.charts.vaccinations_incidence_age_demographic_chart.label,L0R7Ua3YIau8O4TDxe1pyp,__
+2021-11-09T14:51:48.457Z,add,vaccinations_incidence_age_demographic_chart.chart_text.accessibility_description,41m6S8Y6xAJZkZywfhizrG,__
+2021-11-09T14:51:49.465Z,add,vaccinations_incidence_age_demographic_chart.chart_text.age_group_range_tooltip,41m6S8Y6xAJZkZywfhizuy,__
+2021-11-09T14:51:50.489Z,add,vaccinations_incidence_age_demographic_chart.chart_text.clipped_value_message,41m6S8Y6xAJZkZywfhj01e,__
+2021-11-09T14:51:51.507Z,add,vaccinations_incidence_age_demographic_chart.chart_text.left_title,L0R7Ua3YIau8O4TDxe1s2F,__
+2021-11-09T14:51:52.535Z,add,vaccinations_incidence_age_demographic_chart.chart_text.left_tooltip,z1CGDOfh23CnZYQwEeXGLz,__
+2021-11-09T14:51:53.577Z,add,vaccinations_incidence_age_demographic_chart.chart_text.right_title,L0R7Ua3YIau8O4TDxe1srD,__
+2021-11-09T14:51:54.576Z,add,vaccinations_incidence_age_demographic_chart.chart_text.right_tooltip,41m6S8Y6xAJZkZywfhj0HE,__
+2021-11-09T14:51:55.637Z,add,vaccinations_incidence_age_demographic_chart.description,L0R7Ua3YIau8O4TDxe1tlH,__
+2021-11-09T14:51:56.655Z,add,vaccinations_incidence_age_demographic_chart.title,41m6S8Y6xAJZkZywfhj0Oe,__

--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -159,4 +159,10 @@ export const features: Feature[] = [
     dataScopes: ['nl'],
     // metricName: 'intensive_care_vaccine_incidence_per_age_group', // uncomment when we merge the schema
   },
+  {
+    name: 'nlVaccinationsIncidencePerAgeGroup',
+    isEnabled: true,
+    dataScopes: ['nl'],
+    metricName: 'hospital_vaccine_incidence_per_age_group',
+  },
 ];

--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -151,13 +151,13 @@ export const features: Feature[] = [
     name: 'nlHospitalAdmissionsVaccineIncidencePerAgeGroup',
     isEnabled: true,
     dataScopes: ['nl'],
-    // metricName: 'hospital_vaccine_incidence_per_age_group', // uncomment when we merge the schema
+    metricName: 'hospital_vaccine_incidence_per_age_group',
   },
   {
     name: 'nlIcAdmissionsIncidencePerAgeGroup',
     isEnabled: true,
     dataScopes: ['nl'],
-    // metricName: 'intensive_care_vaccine_incidence_per_age_group', // uncomment when we merge the schema
+    metricName: 'hospital_vaccine_incidence_per_age_group',
   },
   {
     name: 'nlVaccinationsIncidencePerAgeGroup',


### PR DESCRIPTION
- Adds the incidence graph to the vaccination page
- Switches the order of vaccination status & incidence around on the hospital & IC pages
- Fixes a bug where the IC incidence graph still used the old properties, which do not exist anymore on the actual data