### PR TITLE
Allow mailto scheme in Sanity

### DIFF
--- a/packages/cms/src/schemas/objects/block-fields.ts
+++ b/packages/cms/src/schemas/objects/block-fields.ts
@@ -34,7 +34,11 @@ export const blockFields = [
               name: 'href',
               type: 'url',
               title: 'URL',
-              validation: (rule: Rule) => rule.uri({ allowRelative: true }),
+              validation: (rule: Rule) =>
+                rule.uri({
+                  allowRelative: true,
+                  scheme: ['http', 'https', 'mailto'],
+                }),
             },
           ],
         },


### PR DESCRIPTION
## Summary

Sanity got a bit stricter again, before 'mailto' links were allowed by default. Not anymore. So, this allows the scheme explicitly.
