### PR TITLE
Add pie chart tooltip

### DIFF
--- a/packages/app/src/components/age-demographic/age-demographic.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic.tsx
@@ -79,11 +79,7 @@ export function AgeDemographic<T extends AgeDemographicDefaultValue>({
           />
         </div>
 
-        <Tooltip
-          controls="age-demographic-chart"
-          tooltipState={tooltipState}
-          width={AGE_GROUP_TOOLTIP_WIDTH}
-        >
+        <Tooltip tooltipState={tooltipState} width={AGE_GROUP_TOOLTIP_WIDTH}>
           {tooltipState.value && (
             <AgeDemographicTooltipContent
               value={tooltipState.value}

--- a/packages/app/src/components/pie-chart.tsx
+++ b/packages/app/src/components/pie-chart.tsx
@@ -160,6 +160,11 @@ export function PieChart<T>({
                   {(pie) => {
                     return pie.arcs.map((arc, index) => {
                       const arcPath = pie.path(arc);
+                      const side =
+                        (arc.startAngle + arc.endAngle) / 2 > Math.PI
+                          ? 'left'
+                          : 'right';
+                      const alternativeSide = side === 'left' ? 'end' : 'start';
 
                       return (
                         <WithTooltip
@@ -173,11 +178,20 @@ export function PieChart<T>({
                             />
                           }
                           key={`arc-${index}`}
-                          placement={
-                            (arc.startAngle + arc.endAngle) / 2 > Math.PI
-                              ? 'left'
-                              : 'right'
-                          }
+                          placement={side}
+                          popperOptions={{
+                            modifiers: [
+                              {
+                                name: 'flip',
+                                options: {
+                                  fallbackPlacements: [
+                                    `top-${alternativeSide}`,
+                                    `bottom-${alternativeSide}`,
+                                  ],
+                                },
+                              },
+                            ],
+                          }}
                           arrow={false}
                         >
                           <path
@@ -185,7 +199,6 @@ export function PieChart<T>({
                             fill={arc.data.color}
                             tabIndex={0}
                             pointerEvents="all"
-                            onClick={(e) => (e.target as SVGPathElement).blur()} // Prevent path keeping focus after click
                           />
                         </WithTooltip>
                       );

--- a/packages/app/src/components/pie-chart.tsx
+++ b/packages/app/src/components/pie-chart.tsx
@@ -199,6 +199,10 @@ export function PieChart<T>({
                             fill={arc.data.color}
                             tabIndex={0}
                             pointerEvents="all"
+                            // Prevents paths from keeping 0.4 opacity when clicked
+                            onMouseLeave={(e) =>
+                              (e.target as SVGPathElement).blur()
+                            }
                           />
                         </WithTooltip>
                       );

--- a/packages/app/src/components/pie-chart.tsx
+++ b/packages/app/src/components/pie-chart.tsx
@@ -6,18 +6,20 @@ import Pie from '@visx/shape/lib/shapes/Pie';
 import { isEmpty } from 'lodash';
 import { useMemo } from 'react';
 import { Box, Spacer } from '~/components/base';
+import { ErrorBoundary } from '~/components/error-boundary';
 import { LinkWithIcon } from '~/components/link-with-icon';
 import { Markdown } from '~/components/markdown';
 import { InlineText } from '~/components/typography';
 import { useIntl } from '~/intl';
+import { WithTooltip } from '~/lib/tooltip';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
-
 const ICON_SIZE = 55;
 
 interface SeriesConfigType<T> {
   metricProperty: KeysOfType<T, number, true>;
   color: string;
   label: string;
+  tooltipLabel: string;
 }
 
 export interface PieChartProps<T> {
@@ -60,6 +62,16 @@ export function PieChart<T>({
     formatDateSpan,
   } = useIntl();
 
+  const formatters = {
+    formatNumber,
+    formatPercentage,
+    formatDate,
+    formatDateFromSeconds,
+    formatDateFromMilliseconds,
+    formatRelativeDate,
+    formatDateSpan,
+  };
+
   const totalValue = dataConfig.reduce(
     (previousValue, currentValue) =>
       previousValue + data[currentValue.metricProperty],
@@ -86,142 +98,167 @@ export function PieChart<T>({
 
   return (
     <Box width="100%">
-      <Box
-        display="flex"
-        spacingHorizontal={{ sm: 4, lg: 5 }}
-        spacing={verticalLayout ? 4 : { _: 4, sm: 0 }}
-        alignItems={verticalLayout ? 'flex-start' : { sm: 'center' }}
-        flexDirection={verticalLayout ? 'column' : { _: 'column', sm: 'row' }}
-      >
+      <ErrorBoundary>
         <Box
-          alignSelf={{ _: 'center', xs: 'self-start' }}
-          height={innerSize}
-          position="relative"
-          marginLeft={{ xs: paddingLeft }}
+          display="flex"
+          spacingHorizontal={{ sm: 4, lg: 5 }}
+          spacing={verticalLayout ? 4 : { _: 4, sm: 0 }}
+          alignItems={verticalLayout ? 'flex-start' : { sm: 'center' }}
+          flexDirection={verticalLayout ? 'column' : { _: 'column', sm: 'row' }}
         >
-          {icon && (
-            <Box
-              width={ICON_SIZE}
-              height={ICON_SIZE}
-              top={`calc(50% - ${ICON_SIZE / 2}px)`}
-              left={`calc(50% - ${ICON_SIZE / 2}px)`}
-              position="absolute"
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              css={css({
-                svg: {
-                  height: '100%',
-                  fill: 'silver',
-                },
-              })}
-            >
-              {icon}
-            </Box>
-          )}
-
-          <svg
-            width={innerSize}
-            height={innerSize}
-            aria-hidden="true"
-            css={css({
-              minWidth: innerSize,
-            })}
-          >
-            <Group top={innerSize / 2} left={innerSize / 2}>
-              <Pie
-                data={mappedDataWithValues}
-                outerRadius={radius}
-                innerRadius={radius - donutWidth}
-                pieValue={(x) => x.__value}
-                // Sort by the order of the config
-                pieSortValues={(d, i) => i}
-                padAngle={padAngle}
-              >
-                {(pie) => {
-                  return pie.arcs.map((arc, index) => {
-                    const arcPath = pie.path(arc);
-
-                    return (
-                      <path
-                        d={arcPath as string}
-                        fill={arc.data.color}
-                        key={`arc-${index}`}
-                      />
-                    );
-                  });
-                }}
-              </Pie>
-            </Group>
-          </svg>
-        </Box>
-
-        <Box spacing={2}>
-          {title && (
-            <InlineText
-              fontWeight="bold"
-              css={css({
-                display: 'block',
-              })}
-            >
-              {title}
-            </InlineText>
-          )}
           <Box
-            spacing={2}
-            as="ol"
-            width={{ _: '100%', md: 'auto' }}
-            css={css({
-              listStyleType: 'none',
-            })}
+            alignSelf={{ _: 'center', xs: 'self-start' }}
+            height={innerSize}
+            position="relative"
+            marginLeft={{ xs: paddingLeft }}
           >
-            {dataConfig.map((item, index) => (
+            {icon && (
               <Box
-                as="li"
-                key={`${item.color}-${index}`}
+                width={ICON_SIZE}
+                height={ICON_SIZE}
+                top={`calc(50% - ${ICON_SIZE / 2}px)`}
+                left={`calc(50% - ${ICON_SIZE / 2}px)`}
+                position="absolute"
                 display="flex"
                 alignItems="center"
-                spacingHorizontal={2}
+                justifyContent="center"
+                css={css({
+                  svg: {
+                    height: '100%',
+                    fill: 'silver',
+                  },
+                })}
               >
-                <Box
-                  width={12}
-                  height={12}
-                  backgroundColor={item.color}
-                  borderRadius="50%"
-                />
-                <Markdown
-                  content={replaceVariablesInText(item.label, data as any, {
-                    formatNumber,
-                    formatPercentage,
-                    formatDate,
-                    formatDateFromSeconds,
-                    formatDateFromMilliseconds,
-                    formatRelativeDate,
-                    formatDateSpan,
-                  })}
-                />
+                {icon}
               </Box>
-            ))}
-          </Box>
-          {
-            /**
-             * Check also for empty link text, so that clearing it in Lokalize
-             * actually removes the link altogether
-             */
-            link && !isEmpty(link.text) && (
-              <LinkWithIcon
-                href={link.href}
-                icon={<Chevron />}
-                iconPlacement="right"
-              >
-                {link.text}
-              </LinkWithIcon>
-            )
-          }
-        </Box>
-      </Box>
+            )}
 
-      <Spacer mb={3} />
+            <svg
+              width={innerSize}
+              height={innerSize}
+              aria-hidden="true"
+              css={css({
+                minWidth: innerSize,
+                '&:hover, &:focus-within': {
+                  'path:not(:hover):not(:focus-visible)': {
+                    opacity: 0.4,
+                  },
+                },
+              })}
+              pointerEvents="none"
+            >
+              <Group top={innerSize / 2} left={innerSize / 2}>
+                <Pie
+                  data={mappedDataWithValues}
+                  outerRadius={radius}
+                  innerRadius={radius - donutWidth}
+                  pieValue={(x) => x.__value}
+                  // Sort by the order of the config
+                  pieSortValues={(d, i) => i}
+                  padAngle={padAngle}
+                >
+                  {(pie) => {
+                    return pie.arcs.map((arc, index) => {
+                      const arcPath = pie.path(arc);
+
+                      return (
+                        <WithTooltip
+                          content={
+                            <Markdown
+                              content={replaceVariablesInText(
+                                dataConfig[index].tooltipLabel,
+                                data as any,
+                                formatters
+                              )}
+                            />
+                          }
+                          key={`arc-${index}`}
+                          placement={
+                            (arc.startAngle + arc.endAngle) / 2 > Math.PI
+                              ? 'left'
+                              : 'right'
+                          }
+                          arrow={false}
+                        >
+                          <path
+                            d={arcPath as string}
+                            fill={arc.data.color}
+                            tabIndex={0}
+                            pointerEvents="all"
+                            onClick={(e) => (e.target as SVGPathElement).blur()} // Prevent path keeping focus after click
+                          />
+                        </WithTooltip>
+                      );
+                    });
+                  }}
+                </Pie>
+              </Group>
+            </svg>
+          </Box>
+
+          <Box spacing={2}>
+            {title && (
+              <InlineText
+                fontWeight="bold"
+                css={css({
+                  display: 'block',
+                })}
+              >
+                {title}
+              </InlineText>
+            )}
+            <Box
+              spacing={2}
+              as="ol"
+              width={{ _: '100%', md: 'auto' }}
+              css={css({
+                listStyleType: 'none',
+              })}
+            >
+              {dataConfig.map((item, index) => (
+                <Box
+                  as="li"
+                  key={`${item.color}-${index}`}
+                  display="flex"
+                  alignItems="center"
+                  spacingHorizontal={2}
+                >
+                  <Box
+                    width={12}
+                    height={12}
+                    backgroundColor={item.color}
+                    borderRadius="50%"
+                  />
+                  <Markdown
+                    content={replaceVariablesInText(
+                      item.label,
+                      data as any,
+                      formatters
+                    )}
+                  />
+                </Box>
+              ))}
+            </Box>
+            {
+              /**
+               * Check also for empty link text, so that clearing it in Lokalize
+               * actually removes the link altogether
+               */
+              link && !isEmpty(link.text) && (
+                <LinkWithIcon
+                  href={link.href}
+                  icon={<Chevron />}
+                  iconPlacement="right"
+                >
+                  {link.text}
+                </LinkWithIcon>
+              )
+            }
+          </Box>
+        </Box>
+
+        <Spacer mb={3} />
+      </ErrorBoundary>
     </Box>
   );
 }

--- a/packages/app/src/components/tooltip.tsx
+++ b/packages/app/src/components/tooltip.tsx
@@ -23,7 +23,6 @@ interface TooltipProps<T> {
   children: ReactNode;
   tooltipState: TooltipState<T>;
   width?: number;
-  controls?: string;
   tooltipArrow?: string;
 }
 
@@ -128,7 +127,6 @@ export function useTooltip<T>({
 }
 
 export function Tooltip<T>({
-  controls,
   children,
   tooltipState,
   width,
@@ -137,7 +135,6 @@ export function Tooltip<T>({
   return (
     <Box
       aria-live="assertive"
-      aria-controls={controls}
       role="tooltip"
       aria-hidden={!tooltipState.isVisible}
       css={css({

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -292,12 +292,18 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                     label:
                       text.vaccination_status_chart.labels
                         .has_one_shot_or_not_vaccinated,
+                    tooltipLabel:
+                      text.vaccination_status_chart.tooltip_labels
+                        .has_one_shot_or_not_vaccinated,
                   },
                   {
                     metricProperty: 'fully_vaccinated',
                     color: colors.data.primary,
                     label:
                       text.vaccination_status_chart.labels.fully_vaccinated,
+                    tooltipLabel:
+                      text.vaccination_status_chart.tooltip_labels
+                        .fully_vaccinated,
                   },
                 ]}
               />

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -2,6 +2,7 @@ import {
   colors,
   DAY_IN_SECONDS,
   getLastFilledValue,
+  NlHospitalVaccineIncidencePerAgeGroupValue,
   NlIntensiveCareVaccinationStatusValue,
   WEEK_IN_SECONDS,
 } from '@corona-dashboard/common';
@@ -49,8 +50,9 @@ import { countTrailingNullValues } from '~/utils/count-trailing-null-values';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
-// TODO: Update any to the proper type when the schema is merged.
-const AgeDemographic = dynamic<AgeDemographicProps<any>>(() =>
+const AgeDemographic = dynamic<
+  AgeDemographicProps<NlHospitalVaccineIncidencePerAgeGroupValue>
+>(() =>
   import('~/components/age-demographic').then((mod) => mod.AgeDemographic)
 );
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -344,6 +344,10 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                           label:
                             text.vaccination_status_ic_and_hospital_section
                               .hospital.labels.has_one_shot_or_not_vaccinated,
+                          tooltipLabel:
+                            text.vaccination_status_ic_and_hospital_section
+                              .hospital.tooltip_labels
+                              .has_one_shot_or_not_vaccinated,
                         },
                         {
                           metricProperty: 'fully_vaccinated',
@@ -351,6 +355,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                           label:
                             text.vaccination_status_ic_and_hospital_section
                               .hospital.labels.fully_vaccinated,
+                          tooltipLabel:
+                            text.vaccination_status_ic_and_hospital_section
+                              .hospital.tooltip_labels.fully_vaccinated,
                         },
                       ]}
                     />
@@ -394,6 +401,10 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                             text.vaccination_status_ic_and_hospital_section
                               .intensive_care.labels
                               .has_one_shot_or_not_vaccinated,
+                          tooltipLabel:
+                            text.vaccination_status_ic_and_hospital_section
+                              .intensive_care.tooltip_labels
+                              .has_one_shot_or_not_vaccinated,
                         },
                         {
                           metricProperty: 'fully_vaccinated',
@@ -401,6 +412,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                           label:
                             text.vaccination_status_ic_and_hospital_section
                               .intensive_care.labels.fully_vaccinated,
+                          tooltipLabel:
+                            text.vaccination_status_ic_and_hospital_section
+                              .intensive_care.tooltip_labels.fully_vaccinated,
                         },
                       ]}
                     />

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,4 +1,8 @@
-import { colors } from '@corona-dashboard/common';
+import {
+  colors,
+  NlHospitalVaccineIncidencePerAgeGroupValue,
+  NlIntensiveCareVaccinationStatusValue,
+} from '@corona-dashboard/common';
 import {
   Arts,
   Vaccinaties as VaccinatieIcon,
@@ -6,13 +10,14 @@ import {
 } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
+import dynamic from 'next/dynamic';
 import { isDefined } from 'ts-is-present';
-import { AgeDemographic } from '~/components/age-demographic';
+import { AgeDemographicProps } from '~/components/age-demographic';
 import { Box, Spacer } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { Metadata } from '~/components/metadata';
 import { PageInformationBlock } from '~/components/page-information-block';
-import { PieChart } from '~/components/pie-chart';
+import { PieChartProps } from '~/components/pie-chart';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { WarningTile } from '~/components/warning-tile';
@@ -60,6 +65,16 @@ import {
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useFormatDateRange } from '~/utils/use-format-date-range';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+
+const AgeDemographic = dynamic<
+  AgeDemographicProps<NlHospitalVaccineIncidencePerAgeGroupValue>
+>(() =>
+  import('~/components/age-demographic').then((mod) => mod.AgeDemographic)
+);
+
+const PieChart = dynamic<PieChartProps<NlIntensiveCareVaccinationStatusValue>>(
+  () => import('~/components/pie-chart').then((mod) => mod.PieChart)
+);
 
 export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -274,12 +274,18 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                     label:
                       text.vaccination_status_chart.labels
                         .has_one_shot_or_not_vaccinated,
+                    tooltipLabel:
+                      text.vaccination_status_chart.tooltip_labels
+                        .has_one_shot_or_not_vaccinated,
                   },
                   {
                     metricProperty: 'fully_vaccinated',
                     color: colors.data.primary,
                     label:
                       text.vaccination_status_chart.labels.fully_vaccinated,
+                    tooltipLabel:
+                      text.vaccination_status_chart.tooltip_labels
+                        .fully_vaccinated,
                   },
                 ]}
               />

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -3,6 +3,7 @@ import {
   DAY_IN_SECONDS,
   getLastFilledValue,
   NlHospitalVaccinationStatusValue,
+  NlHospitalVaccineIncidencePerAgeGroupValue,
   WEEK_IN_SECONDS,
 } from '@corona-dashboard/common';
 import { Ziekenhuis } from '@corona-dashboard/icons';
@@ -55,8 +56,9 @@ import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
-// TODO: Update any to the proper type when the schema is merged.
-const AgeDemographic = dynamic<AgeDemographicProps<any>>(() =>
+const AgeDemographic = dynamic<
+  AgeDemographicProps<NlHospitalVaccineIncidencePerAgeGroupValue>
+>(() =>
   import('~/components/age-demographic').then((mod) => mod.AgeDemographic)
 );
 

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -67,3 +67,11 @@ timestamp,action,key,document_id,move_to
 2021-11-09T14:51:54.576Z,add,vaccinations_incidence_age_demographic_chart.chart_text.right_tooltip,41m6S8Y6xAJZkZywfhj0HE,__
 2021-11-09T14:51:55.637Z,add,vaccinations_incidence_age_demographic_chart.description,L0R7Ua3YIau8O4TDxe1tlH,__
 2021-11-09T14:51:56.655Z,add,vaccinations_incidence_age_demographic_chart.title,41m6S8Y6xAJZkZywfhj0Oe,__
+2021-11-11T17:09:53.885Z,add,ic_opnames_per_dag.vaccination_status_chart.tooltip_labels.fully_vaccinated,z1CGDOfh23CnZYQwEjkuLl,__
+2021-11-11T17:09:54.909Z,add,ic_opnames_per_dag.vaccination_status_chart.tooltip_labels.has_one_shot_or_not_vaccinated,L0R7Ua3YIau8O4TDxwmFqZ,__
+2021-11-11T17:09:55.921Z,add,vaccinaties.vaccination_status_ic_and_hospital_section.hospital.tooltip_labels.fully_vaccinated,z1CGDOfh23CnZYQwEjkuhX,__
+2021-11-11T17:09:58.383Z,add,vaccinaties.vaccination_status_ic_and_hospital_section.hospital.tooltip_labels.has_one_shot_or_not_vaccinated,41m6S8Y6xAJZkZywfkP3re,__
+2021-11-11T17:09:59.308Z,add,vaccinaties.vaccination_status_ic_and_hospital_section.intensive_care.tooltip_labels.fully_vaccinated,41m6S8Y6xAJZkZywfkP3vM,__
+2021-11-11T17:10:00.334Z,add,vaccinaties.vaccination_status_ic_and_hospital_section.intensive_care.tooltip_labels.has_one_shot_or_not_vaccinated,z1CGDOfh23CnZYQwEjkv7f,__
+2021-11-11T17:10:01.324Z,add,ziekenhuisopnames_per_dag.vaccination_status_chart.tooltip_labels.fully_vaccinated,L0R7Ua3YIau8O4TDxwmIEN,__
+2021-11-11T17:10:02.350Z,add,ziekenhuisopnames_per_dag.vaccination_status_chart.tooltip_labels.has_one_shot_or_not_vaccinated,L0R7Ua3YIau8O4TDxwmIt9,__


### PR DESCRIPTION
This adds a tooltip to the pie-chart.

Opens on hover, touch, or keyboard focus. The other section of the pie will become slightly transparent to clarify which one belongs to the tooltip.