### PR TITLE
Add booster shot per age group schema

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -4,7 +4,7 @@
   "title": "nl",
   "required": [
     "behavior",
-    "nl_booster_shot_per_age_group",
+    "booster_shot_per_age_group",
     "code",
     "corona_melder_app_download",
     "corona_melder_app_warning",

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -4,6 +4,7 @@
   "title": "nl",
   "required": [
     "behavior",
+    "nl_booster_shot_per_age_group",
     "code",
     "corona_melder_app_download",
     "corona_melder_app_warning",
@@ -70,6 +71,9 @@
     },
     "named_difference": {
       "$ref": "__named_difference.json"
+    },
+    "booster_shot_per_age_group": {
+      "$ref": "booster_shot_per_age_group.json"
     },
     "doctor": {
       "$ref": "doctor.json"

--- a/packages/app/schema/nl/booster_shot_per_age_group.json
+++ b/packages/app/schema/nl/booster_shot_per_age_group.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_booster_shot_per_age_group",
+  "type": "object",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    }
+  },
+  "definitions": {
+    "value": {
+      "title": "nl_booster_shot_per_age_group_value",
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "age_group_range",
+        "received_booster_amount",
+        "received_booster_percentage",
+        "date_start_unix",
+        "date_end_unix",
+        "date_of_insertion_unix",
+        "birthyear_range"
+      ],
+      "properties": {
+        "age_group_range": {
+          "type": "string",
+          "enum": [
+            "12-17",
+            "18-30",
+            "31-40",
+            "41-50",
+            "51-60",
+            "61-70",
+            "71-80",
+            "81+"
+          ]
+        },
+        "received_booster_amount": {
+          "type": "number"
+        },
+        "received_booster_percentage": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        },
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
+          "type": "integer"
+        },
+        "birthyear_range": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/schema/nl/booster_shot_per_age_group.json
+++ b/packages/app/schema/nl/booster_shot_per_age_group.json
@@ -19,7 +19,7 @@
       "type": "object",
       "required": [
         "age_group_range",
-        "received_booster_amount",
+        "received_booster_total",
         "received_booster_percentage",
         "date_start_unix",
         "date_end_unix",
@@ -40,7 +40,7 @@
             "81+"
           ]
         },
-        "received_booster_amount": {
+        "received_booster_total": {
           "type": "number"
         },
         "received_booster_percentage": {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -262,6 +262,7 @@ export interface Nl {
   code: NlId;
   difference: NlDifference;
   named_difference: NlNamedDifference;
+  booster_shot_per_age_group?: NlBoosterShotPerAgeGroup;
   doctor: NlDoctor;
   g_number: NlGNumber;
   infectious_people: NlInfectiousPeople;
@@ -352,6 +353,18 @@ export interface NamedDifferenceDecimal {
   difference: number;
   old_date_unix: number;
   new_date_unix: number;
+}
+export interface NlBoosterShotPerAgeGroup {
+  values: NlBoosterShotPerAgeGroupValue[];
+}
+export interface NlBoosterShotPerAgeGroupValue {
+  age_group_range: "12-17" | "18-30" | "31-40" | "41-50" | "51-60" | "61-70" | "71-80" | "81+";
+  received_booster_amount: number;
+  received_booster_percentage: number;
+  date_of_insertion_unix: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  birthyear_range: string;
 }
 export interface NlDoctor {
   values: NlDoctorValue[];

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -262,7 +262,7 @@ export interface Nl {
   code: NlId;
   difference: NlDifference;
   named_difference: NlNamedDifference;
-  booster_shot_per_age_group?: NlBoosterShotPerAgeGroup;
+  booster_shot_per_age_group: NlBoosterShotPerAgeGroup;
   doctor: NlDoctor;
   g_number: NlGNumber;
   infectious_people: NlInfectiousPeople;
@@ -359,7 +359,7 @@ export interface NlBoosterShotPerAgeGroup {
 }
 export interface NlBoosterShotPerAgeGroupValue {
   age_group_range: "12-17" | "18-30" | "31-40" | "41-50" | "51-60" | "61-70" | "71-80" | "81+";
-  received_booster_amount: number;
+  received_booster_total: number;
   received_booster_percentage: number;
   date_of_insertion_unix: number;
   date_start_unix: number;


### PR DESCRIPTION
Identical setup to [this schema](https://github.com/minvws/nl-covid19-data-dashboard/blob/develop/packages/app/schema/nl/vaccine_coverage_per_age_group.json).
In the `birthyear_range` we are expecting a structure like this so that we can parse it on the front end later.
`-1940` -> `1940 of eerder`
`1941-1950` `1941 - 1950`

We don't do any calculations on when the dates are on the front-end so we're expecting both from the backend.
They are always tied together with this structure, regarding the `birthyear_range` `and age_group_range`.