### PR TITLE
Add booster shot KPI block

### DIFF
--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -4,6 +4,7 @@
   "title": "nl",
   "required": [
     "behavior",
+    "booster_shot",
     "code",
     "corona_melder_app_download",
     "corona_melder_app_warning",
@@ -70,6 +71,9 @@
     },
     "named_difference": {
       "$ref": "__named_difference.json"
+    },
+    "booster_shot": {
+      "$ref": "booster_shot.json"
     },
     "doctor": {
       "$ref": "doctor.json"

--- a/packages/app/schema/nl/booster_shot.json
+++ b/packages/app/schema/nl/booster_shot.json
@@ -51,8 +51,8 @@
         }
       },
       "required": [
-        "partially_or_fully_vaccinated_received_percentage",
-        "partially_or_fully_vaccinated_amount_of_people",
+        "partially_or_fully_vaccinated_total_received_percentage",
+        "partially_or_fully_vaccinated_total_amount_of_people",
         "total_date_start_unix",
         "total_date_end_unix",
         "received_booster_last_seven_days",

--- a/packages/app/schema/nl/booster_shot.json
+++ b/packages/app/schema/nl/booster_shot.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "nl_booster_shot",
+  "type": "object",
+  "properties": {
+    "values": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "$ref": "#/definitions/value"
+      }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
+    }
+  },
+  "required": ["values", "last_value"],
+  "additionalProperties": false,
+  "definitions": {
+    "value": {
+      "title": "nl_booster_shot_value",
+      "type": "object",
+      "properties": {
+        "partially_or_fully_vaccinated_total_received_percentage": {
+          "type": "integer"
+        },
+        "partially_or_fully_vaccinated_total_amount_of_people": {
+          "type": "number"
+        },
+        "total_date_start_unix": {
+          "type": "integer"
+        },
+        "total_date_end_unix": {
+          "type": "integer"
+        },
+        "received_booster_last_seven_days": {
+          "type": "number"
+        },
+        "total_shots_last_seven_days": {
+          "type": "number"
+        },
+        "last_seven_days_date_start_unix": {
+          "type": "integer"
+        },
+        "last_seven_days_date_end_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "partially_or_fully_vaccinated_received_percentage",
+        "partially_or_fully_vaccinated_amount_of_people",
+        "total_date_start_unix",
+        "total_date_end_unix",
+        "received_booster_last_seven_days",
+        "total_shots_last_seven_days",
+        "last_seven_days_date_start_unix",
+        "last_seven_days_date_end_unix",
+        "date_of_insertion_unix"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
@@ -47,7 +47,7 @@ export function VaccineBoosterKpiSection({
           source: text.last_week_section.sources,
         }}
       >
-        <KpiValue absolute={1694} />
+        <KpiValue absolute={data.total_shots_last_seven_days} />
         <Markdown
           content={replaceVariablesInText(text.last_week_section.description, {
             totalShots: formatNumber(data.total_shots_last_seven_days),

--- a/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
@@ -1,0 +1,62 @@
+import { NlBoosterShotValue } from '@corona-dashboard/common';
+import { KpiTile } from '~/components/kpi-tile';
+import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
+import { TwoKpiSection } from '~/components/two-kpi-section';
+import { useIntl } from '~/intl';
+import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+
+interface VaccineBoosterKpiSectionProps {
+  data: NlBoosterShotValue;
+}
+
+export function VaccineBoosterKpiSection({
+  data,
+}: VaccineBoosterKpiSectionProps) {
+  const { siteText, formatNumber } = useIntl();
+
+  const text = siteText.vaccinaties.booster_shots_kpi;
+
+  return (
+    <TwoKpiSection spacing={4}>
+      <KpiTile
+        title={text.total_section.title}
+        metadata={{
+          date: [data.total_date_start_unix, data.total_date_end_unix],
+          source: text.total_section.sources,
+        }}
+      >
+        <KpiValue
+          percentage={
+            data.partially_or_fully_vaccinated_total_received_percentage
+          }
+        />
+        <Markdown
+          content={replaceVariablesInText(text.total_section.description, {
+            amountOfPeople: formatNumber(
+              data.partially_or_fully_vaccinated_total_amount_of_people
+            ),
+          })}
+        />
+      </KpiTile>
+
+      <KpiTile
+        title={text.last_week_section.title}
+        metadata={{
+          date: [data.total_date_start_unix, data.total_date_end_unix],
+          source: text.last_week_section.sources,
+        }}
+      >
+        <KpiValue absolute={1694} />
+        <Markdown
+          content={replaceVariablesInText(text.last_week_section.description, {
+            totalShots: formatNumber(data.total_shots_last_seven_days),
+            receivedBoosters: formatNumber(
+              data.received_booster_last_seven_days
+            ),
+          })}
+        />
+      </KpiTile>
+    </TwoKpiSection>
+  );
+}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,7 +1,9 @@
 import {
   colors,
+  NlBoosterShotValue,
   NlHospitalVaccineIncidencePerAgeGroupValue,
   NlIntensiveCareVaccinationStatusValue,
+  WEEK_IN_SECONDS,
 } from '@corona-dashboard/common';
 import {
   Arts,
@@ -27,6 +29,7 @@ import { selectDeliveryAndAdministrationData } from '~/domain/vaccine/data-selec
 import { selectVaccineCoverageData } from '~/domain/vaccine/data-selection/select-vaccine-coverage-data';
 import { VaccinationsOverTimeTile } from '~/domain/vaccine/vaccinations-over-time-tile';
 import { VaccineAdministrationsKpiSection } from '~/domain/vaccine/vaccine-administrations-kpi-section';
+import { VaccineBoosterKpiSection } from '~/domain/vaccine/vaccine-booster-kpi-section';
 import { VaccineCoverageChoroplethPerGm } from '~/domain/vaccine/vaccine-coverage-choropleth-per-gm';
 import { VaccineCoveragePerAgeGroup } from '~/domain/vaccine/vaccine-coverage-per-age-group';
 import { VaccineCoverageToggleTile } from '~/domain/vaccine/vaccine-coverage-toggle-tile';
@@ -142,6 +145,21 @@ export const getStaticProps = createGetStaticProps(
   })
 );
 
+/**
+ * @TODO: Please remove once data becomes avaliable
+ */
+const DUMMY_DATA_BOOSTER_SHOTS_KPI = {
+  partially_or_fully_vaccinated_total_received_percentage: 99,
+  partially_or_fully_vaccinated_total_amount_of_people: 21944,
+  total_date_start_unix: 1637054676 - WEEK_IN_SECONDS,
+  total_date_end_unix: 1637054676,
+  received_booster_last_seven_days: 1694,
+  total_shots_last_seven_days: 610876,
+  last_seven_days_date_start_unix: 1637054676 - WEEK_IN_SECONDS,
+  last_seven_days_date_end_unix: 1637054676,
+  date_of_insertion_unix: 1637054676,
+} as NlBoosterShotValue;
+
 const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   const {
     content,
@@ -180,6 +198,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   );
   const vaccinationStatusIntensiveCareFeature = useFeature(
     'nlVaccinationIntensiveCareVaccinationStatus'
+  );
+  const vaccinationsBoosterShotsKpiFeature = useFeature(
+    'nlVaccinationsBoosterShotsKpi'
   );
 
   const metadata = {
@@ -480,6 +501,10 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             vaccineAdministeredGgdGhorFeature.isEnabled && (
               <VaccineAdministrationsKpiSection data={data} />
             )}
+
+          {vaccinationsBoosterShotsKpiFeature.isEnabled && (
+            <VaccineBoosterKpiSection data={DUMMY_DATA_BOOSTER_SHOTS_KPI} />
+          )}
 
           <Spacer pb={3} />
 

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -84,3 +84,11 @@ timestamp,action,key,document_id,move_to
 2021-11-11T17:10:00.334Z,add,vaccinaties.vaccination_status_ic_and_hospital_section.intensive_care.tooltip_labels.has_one_shot_or_not_vaccinated,z1CGDOfh23CnZYQwEjkv7f,__
 2021-11-11T17:10:01.324Z,add,ziekenhuisopnames_per_dag.vaccination_status_chart.tooltip_labels.fully_vaccinated,L0R7Ua3YIau8O4TDxwmIEN,__
 2021-11-11T17:10:02.350Z,add,ziekenhuisopnames_per_dag.vaccination_status_chart.tooltip_labels.has_one_shot_or_not_vaccinated,L0R7Ua3YIau8O4TDxwmIt9,__
+2021-11-16T09:45:29.792Z,add,vaccinaties.booster_shots_kpi.total_section.title,41m6S8Y6xAJZkZywfosqJi,__
+2021-11-16T09:45:30.655Z,add,vaccinaties.booster_shots_kpi.total_section.description,L0R7Ua3YIau8O4TDySLkTr,__
+2021-11-16T09:45:31.675Z,add,vaccinaties.booster_shots_kpi.total_section.sources.text,z1CGDOfh23CnZYQwEsi0F5,__
+2021-11-16T09:45:32.698Z,add,vaccinaties.booster_shots_kpi.total_section.sources.href,41m6S8Y6xAJZkZywfossIs,__
+2021-11-16T09:45:33.815Z,add,vaccinaties.booster_shots_kpi.last_week_section.title,L0R7Ua3YIau8O4TDySLukx,__
+2021-11-16T09:45:34.804Z,add,vaccinaties.booster_shots_kpi.last_week_section.description,L0R7Ua3YIau8O4TDySLy2p,__
+2021-11-16T09:45:35.934Z,add,vaccinaties.booster_shots_kpi.last_week_section.sources.text,41m6S8Y6xAJZkZywfostfS,__
+2021-11-16T09:45:36.770Z,add,vaccinaties.booster_shots_kpi.last_week_section.sources.href,z1CGDOfh23CnZYQwEsi4PT,__

--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -165,4 +165,10 @@ export const features: Feature[] = [
     dataScopes: ['nl'],
     metricName: 'hospital_vaccine_incidence_per_age_group',
   },
+  {
+    name: 'nlVaccinationsBoosterShotsKpi',
+    isEnabled: true,
+    dataScopes: ['nl'],
+    metricName: 'booster_shot',
+  },
 ];

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -262,6 +262,7 @@ export interface Nl {
   code: NlId;
   difference: NlDifference;
   named_difference: NlNamedDifference;
+  booster_shot: NlBoosterShot;
   doctor: NlDoctor;
   g_number: NlGNumber;
   infectious_people: NlInfectiousPeople;
@@ -352,6 +353,21 @@ export interface NamedDifferenceDecimal {
   difference: number;
   old_date_unix: number;
   new_date_unix: number;
+}
+export interface NlBoosterShot {
+  values: NlBoosterShotValue[];
+  last_value: NlBoosterShotValue;
+}
+export interface NlBoosterShotValue {
+  partially_or_fully_vaccinated_total_received_percentage?: number;
+  partially_or_fully_vaccinated_total_amount_of_people?: number;
+  total_date_start_unix: number;
+  total_date_end_unix: number;
+  received_booster_last_seven_days: number;
+  total_shots_last_seven_days: number;
+  last_seven_days_date_start_unix: number;
+  last_seven_days_date_end_unix: number;
+  date_of_insertion_unix: number;
 }
 export interface NlDoctor {
   values: NlDoctorValue[];

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -359,8 +359,8 @@ export interface NlBoosterShot {
   last_value: NlBoosterShotValue;
 }
 export interface NlBoosterShotValue {
-  partially_or_fully_vaccinated_total_received_percentage?: number;
-  partially_or_fully_vaccinated_total_amount_of_people?: number;
+  partially_or_fully_vaccinated_total_received_percentage: number;
+  partially_or_fully_vaccinated_total_amount_of_people: number;
   total_date_start_unix: number;
   total_date_end_unix: number;
   received_booster_last_seven_days: number;


### PR DESCRIPTION
Currently with dummy data behind a feature flag.
I've merged the schema in this branch. 