### PR TITLE
Update visual improvements metric page

### DIFF
--- a/packages/app/src/components/chart-tile.tsx
+++ b/packages/app/src/components/chart-tile.tsx
@@ -1,6 +1,7 @@
 import { assert, TimeframeOption } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { ReactNode, useState } from 'react';
+import { asResponsiveArray } from '~/style/utils';
 import { Box, Spacer } from './base';
 import { ChartTimeControls } from './chart-time-controls';
 import { ErrorBoundary } from './error-boundary';
@@ -82,7 +83,7 @@ function ChartTileHeader({
   return (
     <Box spacing={3}>
       {/* padding-right to make sure the title doesn't touch/overlap the full screen button */}
-      <Heading level={3} css={css({ pr: 5 })}>
+      <Heading level={3} css={css({ pr: asResponsiveArray({ md: 5 }) })}>
         {title}
       </Heading>
 

--- a/packages/app/src/components/fullscreen-chart-tile.tsx
+++ b/packages/app/src/components/fullscreen-chart-tile.tsx
@@ -62,7 +62,7 @@ export function FullscreenChartTile({
           <div
             css={css({
               position: 'absolute',
-              top: '10px',
+              top: '1.25rem',
               right: '10px',
               color: 'silver',
 

--- a/packages/app/src/components/fullscreen-chart-tile.tsx
+++ b/packages/app/src/components/fullscreen-chart-tile.tsx
@@ -62,7 +62,7 @@ export function FullscreenChartTile({
           <div
             css={css({
               position: 'absolute',
-              top: '1.25rem',
+              top: '1.85rem',
               right: '10px',
               color: 'silver',
 

--- a/packages/app/src/components/page-information-block/components/page-links.tsx
+++ b/packages/app/src/components/page-information-block/components/page-links.tsx
@@ -1,12 +1,15 @@
+import {
+  ChevronLarge,
+  External as ExternalIcon,
+} from '@corona-dashboard/icons';
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import { ChevronLarge } from '@corona-dashboard/icons';
-import { External as ExternalIcon } from '@corona-dashboard/icons';
 import { Box } from '~/components/base';
 import { ExternalLink } from '~/components/external-link';
 import { Anchor, InlineText, Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { spacingStyle } from '~/style/functions/spacing';
+import { space } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
 import { isAbsoluteUrl } from '~/utils/is-absolute-url';
 import { Link } from '~/utils/link';
@@ -73,8 +76,11 @@ const OrderedList = styled.ol(
 
 const ListItem = styled.li(
   css({
-    width: asResponsiveArray({ _: '100%', md: '50%' }),
-    pr: 4,
+    width: asResponsiveArray({ _: '100%', md: `calc(50% - ${space[4]})` }),
+
+    '&:nth-child(2n+1)': {
+      mr: asResponsiveArray({ md: 5 }),
+    },
   })
 );
 

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -79,7 +79,7 @@ export function PageInformationBlock({
 
       {description && (
         <Tile hasTitle={!!title}>
-          <Box spacing={3}>
+          <Box spacing={3} width="100%">
             <Box
               display={{ md: 'grid' }}
               gridTemplateColumns="repeat(2, 1fr)"
@@ -89,7 +89,7 @@ export function PageInformationBlock({
                 md: 0,
               }}
               css={css({
-                columnGap: 4,
+                columnGap: 5,
               })}
             >
               {articles && articles.length > 0 ? (

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -111,7 +111,7 @@ export function PageInformationBlock({
 
             {pageLinks && pageLinks.length > 0 && (
               <>
-                <Box height="1px" bg="border" />
+                <Box height={1} />
                 <PageLinks links={pageLinks} />
               </>
             )}

--- a/packages/app/src/components/tile-list.tsx
+++ b/packages/app/src/components/tile-list.tsx
@@ -4,7 +4,7 @@ import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
 
 export const TileList = styled(Box).attrs({ spacing: 5 })<{
-  hasActiveWarningTile: boolean | string;
+  hasActiveWarningTile?: boolean | string;
 }>(({ hasActiveWarningTile }) => {
   return css({
     pt: hasActiveWarningTile ? 4 : asResponsiveArray({ _: 3, md: 5 }),

--- a/packages/app/src/components/tile-list.tsx
+++ b/packages/app/src/components/tile-list.tsx
@@ -1,9 +1,13 @@
+import css from '@styled-system/css';
 import styled from 'styled-components';
 import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
 
-export const TileList = styled(Box).attrs({
-  spacing: 5,
-  pt: asResponsiveArray({ _: 3, md: 5 }),
-  px: asResponsiveArray({ _: 3, sm: 5 }),
-})({});
+export const TileList = styled(Box).attrs({ spacing: 5 })<{
+  hasActiveWarningTile: boolean | string;
+}>(({ hasActiveWarningTile }) => {
+  return css({
+    pt: hasActiveWarningTile ? 4 : asResponsiveArray({ _: 3, md: 5 }),
+    px: asResponsiveArray({ _: 3, sm: 5 }),
+  });
+});

--- a/packages/app/src/components/tile.tsx
+++ b/packages/app/src/components/tile.tsx
@@ -31,7 +31,7 @@ const StyledTile = styled.article<{
     position: 'relative',
     display: 'flex',
     flexDirection: 'column',
-    pt: x.noPadding ? undefined : asResponsiveArray({ _: 2, sm: 3 }),
+    pt: x.noPadding ? undefined : 4,
     pb: x.noPadding ? undefined : asResponsiveArray({ _: 3, sm: 4 }),
     height: x.height,
     backgroundColor: 'white',

--- a/packages/app/src/domain/restrictions/lockdown-table.tsx
+++ b/packages/app/src/domain/restrictions/lockdown-table.tsx
@@ -134,7 +134,14 @@ function DesktopLockdownTable(props: LockdownTableData) {
       <TableBody>
         {data.groups.map((group) => {
           return (
-            <Row key={group._key}>
+            <Row
+              key={group._key}
+              css={css({
+                '&:last-of-type': {
+                  borderBottom: '1px solid black',
+                },
+              })}
+            >
               <Cell
                 role="rowheader"
                 borderTop={'1px solid black'}

--- a/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-booster-kpi-section.tsx
@@ -18,7 +18,7 @@ export function VaccineBoosterKpiSection({
   const text = siteText.vaccinaties.booster_shots_kpi;
 
   return (
-    <TwoKpiSection spacing={4}>
+    <TwoKpiSection spacing={5}>
       <KpiTile
         title={text.total_section.title}
         metadata={{

--- a/packages/app/src/domain/vaccine/vaccine-coverage-toggle-tile.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-toggle-tile.tsx
@@ -75,7 +75,7 @@ export function VaccineCoverageToggleTile({
             ]}
           />
         </Box>
-        <TwoKpiSection spacing={4}>
+        <TwoKpiSection spacing={5}>
           {selectedTab === text.age_18_plus.label && (
             <>
               <AgeGroupBlock

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -266,11 +266,14 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
       lastValueIntensiveCareVaccinationStatus.date_end_unix
     );
 
+  const hasActiveWarningTile =
+    text.belangrijk_bericht && !isEmpty(text.belangrijk_bericht);
+
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NlLayout>
-        <TileList>
-          {text.belangrijk_bericht && !isEmpty(text.belangrijk_bericht) && (
+        <TileList hasActiveWarningTile={hasActiveWarningTile}>
+          {hasActiveWarningTile && (
             <WarningTile
               isFullWidth
               message={text.belangrijk_bericht}


### PR DESCRIPTION
Nothing too special, changing some CSS
Alignment of 2 columns on medium or higher is now the same everywhere
Added a prop on the tile list when a warning tile is active it should have less padding on top