### PR TITLE
Improve navigation performance, reduce bundle sizes

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -80,11 +80,6 @@ const nextConfig = {
   async redirects() {
     return [
       {
-        source: '/landelijk',
-        destination: '/landelijk/vaccinaties',
-        permanent: false,
-      },
-      {
         source: '/actueel',
         destination: '/',
         permanent: false,
@@ -148,9 +143,15 @@ const nextConfig = {
       ['d3-array', '../../node_modules/d3-array'],
       ['d3-color', '../../node_modules/d3-scale/node_modules/d3-color'],
       ['d3-geo', '../../node_modules/d3-geo'],
-      ['d3-interpolate', '../../node_modules/d3-scale/node_modules/d3-interpolate'],
+      [
+        'd3-interpolate',
+        '../../node_modules/d3-scale/node_modules/d3-interpolate',
+      ],
       ['react-is', '../../node_modules/react-is'],
-      ['unist-util-visit-parents', '../../node_modules/unist-util-visit-parents',],
+      [
+        'unist-util-visit-parents',
+        '../../node_modules/unist-util-visit-parents',
+      ],
     ];
 
     duplicatePackageResolves.forEach(([packageName, resolvedPath]) => {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -94,6 +94,7 @@
     "@types/styled-system__should-forward-prop": "^5.1.2",
     "@types/unist": "^2.0.6",
     "@types/webpack": "^5.28.0",
+    "@types/webpack-env": "^1.16.3",
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "autoprefixer": "^10.4.0",

--- a/packages/app/src/components/error-boundary/logic/use-component-props-report.ts
+++ b/packages/app/src/components/error-boundary/logic/use-component-props-report.ts
@@ -7,7 +7,7 @@ import {
   useRef,
 } from 'react';
 import { isDefined } from 'ts-is-present';
-import { Choropleth } from '~/components/choropleth';
+import type { ChoroplethComponent } from '~/components/choropleth';
 import { StackedChart } from '~/components/stacked-chart';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 
@@ -21,33 +21,25 @@ function keyCheck<T>(keys: (keyof T)[]) {
 
 type FunctionComponentProps<T extends (...args: any) => any> = Parameters<T>[0];
 
-const relevantComponentProps = new Map<(...args: any) => any, string[]>();
-relevantComponentProps.set(
-  TimeSeriesChart,
-  keyCheck<FunctionComponentProps<typeof TimeSeriesChart>>([
-    'values',
-    'dataOptions',
-    'seriesConfig',
-    'timeframe',
-  ])
-);
-relevantComponentProps.set(
-  Choropleth,
-  keyCheck<FunctionComponentProps<typeof Choropleth>>([
-    'map',
-    'data',
-    'dataConfig',
-    'dataOptions',
-  ])
-);
-relevantComponentProps.set(
-  StackedChart,
-  keyCheck<FunctionComponentProps<typeof StackedChart>>([
-    'values',
-    'config',
-    'timeframe',
-  ])
-);
+/**
+ * We work with resolveWeak since we don't want to import these components just
+ * to be able to check if a component is one of these types later. Instead, we
+ * resolve the paths here and later check webpack's require cache to compare
+ * components. That way we can check if a component is one of these types
+ * without importing them in this file: we'll only compare if the component was
+ * imported somewhere else.
+ */
+const relevantComponentPathProps: Record<string, string[]> = {
+  [require.resolveWeak('~/components/choropleth')]: keyCheck<
+    FunctionComponentProps<ChoroplethComponent>
+  >(['map', 'data', 'dataConfig', 'dataOptions']),
+  [require.resolveWeak('~/components/stacked-chart')]: keyCheck<
+    FunctionComponentProps<typeof StackedChart>
+  >(['values', 'config', 'timeframe']),
+  [require.resolveWeak('~/components/time-series-chart')]: keyCheck<
+    FunctionComponentProps<typeof TimeSeriesChart>
+  >(['values', 'dataOptions', 'seriesConfig', 'timeframe']),
+};
 
 /**
  * This hook will return two methods. The first one accepts a components children
@@ -81,6 +73,7 @@ export function useComponentPropsReport(
     try {
       return extractPropsAndFillReport(children, propsReportRef);
     } catch (e) {
+      console.error(e);
       return children;
     }
   };
@@ -111,9 +104,9 @@ function extractPropsAndFillReport(
 function extractComponentProps(
   reactNode: ReactElement | ReactNode[]
 ): Record<string, unknown> | undefined {
-  const [element, type] = findComponentNode(reactNode);
-  if (element && type) {
-    const propNames = relevantComponentProps.get(type);
+  const [element, type, path] = findComponentNode(reactNode);
+  if (element && type && path) {
+    const propNames = relevantComponentPathProps[path];
     return propNames
       ? Object.assign(
           Object.fromEntries(
@@ -127,20 +120,26 @@ function extractComponentProps(
   }
 }
 
-function isKnownComponentType(type: any) {
-  return relevantComponentProps.has(type);
+function findComponentPath(componentName: string) {
+  const paths = Object.keys(relevantComponentPathProps);
+
+  for (let i = 0; i < paths.length; i++) {
+    const imported = require.cache[paths[i]];
+    if (imported && componentName in imported.exports) {
+      return paths[i];
+    }
+  }
 }
 
 function findComponentNode(
   node: ReactNode | ReactNode[]
-): [ReactElement | undefined, any] {
+): [ReactElement | undefined, any, string | undefined] {
   if (isReactElement(node)) {
-    if (
-      isObject(node.type) &&
-      'name' in node.type &&
-      isKnownComponentType(node.type)
-    ) {
-      return [node, node.type];
+    if (isObject(node.type) && 'name' in node.type) {
+      const path = findComponentPath(node.type.name);
+      if (path) {
+        return [node, node.type, path];
+      }
     } else if (isArray(node.props.children)) {
       for (let i = 0; i < node.props.children.length; i++) {
         const result = findComponentNode(node.props.children[i]);
@@ -155,11 +154,11 @@ function findComponentNode(
       .filter(isReactElement)
       .find(
         (x) =>
-          isObject(x.type) && 'name' in x.type && isKnownComponentType(x.type)
+          isObject(x.type) && 'name' in x.type && findComponentPath(x.type.name)
       );
     if (isDefined(element)) {
       return findComponentNode(element);
     }
   }
-  return [undefined, undefined];
+  return [undefined, undefined, undefined];
 }

--- a/packages/app/src/components/error-boundary/logic/use-component-props-report.ts
+++ b/packages/app/src/components/error-boundary/logic/use-component-props-report.ts
@@ -73,7 +73,6 @@ export function useComponentPropsReport(
     try {
       return extractPropsAndFillReport(children, propsReportRef);
     } catch (e) {
-      console.error(e);
       return children;
     }
   };

--- a/packages/app/src/components/layout/app-content.tsx
+++ b/packages/app/src/components/layout/app-content.tsx
@@ -35,7 +35,11 @@ export function AppContent({
    * but it's good enough for now I guess
    */
   const isMenuOpen =
-    router.pathname == '/landelijk' || router.query.menu === '1';
+    router.pathname == '/internationaal' ||
+    router.pathname == '/landelijk' ||
+    router.pathname == '/veiligheidsregio/[code]' ||
+    router.pathname == '/gemeente/[code]' ||
+    router.query.menu === '1';
 
   const menuOpenText = router.pathname.startsWith('/internationaal')
     ? siteText.nav.terug_naar_alle_cijfers_internationaal

--- a/packages/app/src/pages/gemeente/[code]/index.tsx
+++ b/packages/app/src/pages/gemeente/[code]/index.tsx
@@ -8,6 +8,7 @@ import {
   StaticProps,
 } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate, selectGmData } from '~/static-props/get-data';
+import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export { getStaticPaths } from '~/static-paths/gm';
@@ -22,11 +23,13 @@ const Municipality = (props: StaticProps<typeof getStaticProps>) => {
   const router = useRouter();
   const { siteText } = useIntl();
   const reverseRouter = useReverseRouter();
+  const breakpoints = useBreakpoints();
 
   useEffect(() => {
-    const route = reverseRouter.gm.index(selectedGmData.code);
-    router.replace(route);
-  }, [reverseRouter.gm, reverseRouter.vr, router, selectedGmData.code]);
+    if (breakpoints.md) {
+      router.replace(reverseRouter.gm.vaccinaties(router.query.code as string));
+    }
+  }, [breakpoints.md, reverseRouter.gm, router]);
 
   return (
     <Layout {...siteText.gemeente_index.metadata} lastGenerated={lastGenerated}>

--- a/packages/app/src/pages/internationaal/index.tsx
+++ b/packages/app/src/pages/internationaal/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { InLayout } from '~/domain/layout/in-layout';
 import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
@@ -7,6 +9,8 @@ import {
   StaticProps,
 } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export const getStaticProps = withFeatureNotFoundPage(
   'inHomePage',
@@ -18,6 +22,16 @@ export default function InternationalPage(
 ) {
   const intl = useIntl();
   const { lastGenerated } = props;
+
+  const router = useRouter();
+  const reverseRouter = useReverseRouter();
+  const breakpoints = useBreakpoints();
+
+  useEffect(() => {
+    if (breakpoints.md) {
+      router.replace(reverseRouter.in.positiefGetesteMensen());
+    }
+  }, [breakpoints.md, reverseRouter.in, router]);
 
   return (
     <Layout

--- a/packages/app/src/pages/landelijk/index.tsx
+++ b/packages/app/src/pages/landelijk/index.tsx
@@ -8,6 +8,8 @@ import {
   StaticProps,
 } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate } from '~/static-props/get-data';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useReverseRouter } from '~/utils/use-reverse-router';
 
 export const getStaticProps = createGetStaticProps(getLastGeneratedDate);
 
@@ -16,10 +18,14 @@ const National = (props: StaticProps<typeof getStaticProps>) => {
   const { lastGenerated } = props;
 
   const router = useRouter();
+  const reverseRouter = useReverseRouter();
+  const breakpoints = useBreakpoints();
 
   useEffect(() => {
-    router.push('/landelijk/vaccinaties');
-  }, [router]);
+    if (breakpoints.md) {
+      router.replace(reverseRouter.nl.vaccinaties());
+    }
+  }, [breakpoints.md, reverseRouter.nl, router]);
 
   return (
     <Layout {...siteText.nationaal_metadata} lastGenerated={lastGenerated}>

--- a/packages/app/src/pages/veiligheidsregio/[code]/index.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/index.tsx
@@ -8,8 +8,8 @@ import {
   StaticProps,
 } from '~/static-props/create-get-static-props';
 import { getLastGeneratedDate, selectVrData } from '~/static-props/get-data';
+import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useReverseRouter } from '~/utils/use-reverse-router';
-
 export { getStaticPaths } from '~/static-paths/vr';
 
 export const getStaticProps = createGetStaticProps(
@@ -22,11 +22,13 @@ const VrIndexPage = (props: StaticProps<typeof getStaticProps>) => {
   const { siteText } = useIntl();
   const router = useRouter();
   const reverseRouter = useReverseRouter();
+  const breakpoints = useBreakpoints();
 
   useEffect(() => {
-    const route = reverseRouter.vr.index(router.query.code as string);
-    router.replace(route);
-  }, [reverseRouter.vr, router]);
+    if (breakpoints.md) {
+      router.replace(reverseRouter.vr.vaccinaties(router.query.code as string));
+    }
+  }, [breakpoints.md, reverseRouter.vr, router]);
 
   return (
     <Layout

--- a/packages/app/src/utils/__tests__/use-reverse-router.spec.tsx
+++ b/packages/app/src/utils/__tests__/use-reverse-router.spec.tsx
@@ -15,6 +15,8 @@ import { useReverseRouter } from '../use-reverse-router';
 const UseReverseRouter = suite('useReverseRouter');
 
 let largeScreen = false;
+const vrCode = 'VR25';
+const gmCode = 'GM001';
 
 UseReverseRouter.before((context) => {
   context.cleanupJsDom = injectJsDom();
@@ -64,15 +66,15 @@ const TestBed = () => {
   return (
     <>
       <div data-testid="nl">{router.nl.index()}</div>
-      <div data-testid="vr">{router.vr.index('VR25')}</div>
-      <div data-testid="gm">{router.gm.index('GM001')}</div>
+      <div data-testid="vr">{router.vr.index(vrCode)}</div>
+      <div data-testid="gm">{router.gm.index(gmCode)}</div>
       <div data-testid="in">{router.in.index()}</div>
     </>
   );
 };
 
 UseReverseRouter(
-  'indexes should have menu suffix on small pages',
+  'indexes should link to the actual index on small screens',
   (context) => {
     largeScreen = false;
     const result = render(<TestContainer />);
@@ -81,41 +83,38 @@ UseReverseRouter(
     const gmDiv = result.getByTestId('gm');
     const inDiv = result.getByTestId('in');
 
-    assert.equal(nlDiv.textContent?.endsWith('?menu=1'), true);
-    assert.equal(vrDiv.textContent?.endsWith('?menu=1'), true);
-    assert.equal(gmDiv.textContent?.endsWith('?menu=1'), true);
-    assert.equal(inDiv.textContent?.endsWith('?menu=1'), true);
+    assert.equal(nlDiv.textContent?.endsWith('/landelijk'), true);
+    assert.equal(vrDiv.textContent?.endsWith(vrCode), true);
+    assert.equal(gmDiv.textContent?.endsWith(gmCode), true);
+    assert.equal(inDiv.textContent?.endsWith('/internationaal'), true);
   }
 );
 
-UseReverseRouter(
-  'indexes should not have menu suffix on large pages',
-  (context) => {
-    largeScreen = true;
-    const result = render(<TestContainer />);
-    const nlDiv = result.getByTestId('nl');
-    const vrDiv = result.getByTestId('vr');
-    const gmDiv = result.getByTestId('gm');
-    const inDiv = result.getByTestId('in');
+UseReverseRouter("indexes should 'redirect' to child pages", (context) => {
+  largeScreen = true;
+  const result = render(<TestContainer />);
+  const nlDiv = result.getByTestId('nl');
+  const vrDiv = result.getByTestId('vr');
+  const gmDiv = result.getByTestId('gm');
+  const inDiv = result.getByTestId('in');
 
-    assert.equal(nlDiv.textContent?.endsWith('?menu=1'), false);
-    assert.equal(vrDiv.textContent?.endsWith('?menu=1'), false);
-    assert.equal(gmDiv.textContent?.endsWith('?menu=1'), false);
-    assert.equal(inDiv.textContent?.endsWith('?menu=1'), false);
-  }
-);
+  assert.equal(nlDiv.textContent?.endsWith('/vaccinaties'), true);
+  assert.equal(vrDiv.textContent?.endsWith('/vaccinaties'), true);
+  assert.equal(gmDiv.textContent?.endsWith('/vaccinaties'), true);
+  assert.equal(inDiv.textContent?.endsWith('/positief-geteste-mensen'), true);
+});
 
 UseReverseRouter('VR routes should have the VR code in them', (context) => {
   const { result } = renderHook(() => useReverseRouter());
 
   const keys = Object.keys(result.current.vr);
   keys.forEach((name) => {
-    const route = (result.current.vr as any)[name]('VR25');
-    assert.equal(route.indexOf('VR25') > -1, true);
+    const route = (result.current.vr as any)[name](vrCode);
+    assert.equal(route.indexOf(vrCode) > -1, true);
   });
 
-  const route = result.current.actueel.vr('VR25');
-  assert.equal(route.indexOf('VR25') > -1, true);
+  const route = result.current.actueel.vr(vrCode);
+  assert.equal(route.indexOf(vrCode) > -1, true);
 });
 
 UseReverseRouter('GM routes should have the GM code in them', (context) => {
@@ -123,12 +122,12 @@ UseReverseRouter('GM routes should have the GM code in them', (context) => {
 
   const keys = Object.keys(result.current.gm);
   keys.forEach((name) => {
-    const route = (result.current.gm as any)[name]('GM001');
-    assert.equal(route.indexOf('GM001') > -1, true);
+    const route = (result.current.gm as any)[name](gmCode);
+    assert.equal(route.indexOf(gmCode) > -1, true);
   });
 
-  const route = result.current.actueel.gm('GM001');
-  assert.equal(route.indexOf('GM001') > -1, true);
+  const route = result.current.actueel.gm(gmCode);
+  assert.equal(route.indexOf(gmCode) > -1, true);
 });
 
 UseReverseRouter.run();

--- a/packages/app/src/utils/use-reverse-router.ts
+++ b/packages/app/src/utils/use-reverse-router.ts
@@ -6,7 +6,7 @@ export type ReverseRouter = ReturnType<typeof useReverseRouter>;
 
 export function useReverseRouter() {
   const breakpoints = useBreakpoints();
-  const openMenuSuffix = !breakpoints.md ? '?menu=1' : '';
+  const isMobile = !breakpoints.md;
 
   const vaccinationGmPagefeature = useFeature('gmVaccinationPage');
 
@@ -27,13 +27,17 @@ export function useReverseRouter() {
       },
 
       in: {
-        index: () => reverseRouter.in.positiefGetesteMensen() + openMenuSuffix,
+        index: () =>
+          isMobile
+            ? `/internationaal`
+            : reverseRouter.in.positiefGetesteMensen(),
         positiefGetesteMensen: () => `/internationaal/positief-geteste-mensen`,
         varianten: () => `/internationaal/varianten`,
       },
 
       nl: {
-        index: () => reverseRouter.nl.vaccinaties() + openMenuSuffix,
+        index: () =>
+          isMobile ? `/landelijk/` : reverseRouter.nl.vaccinaties(),
         vaccinaties: () => `/landelijk/vaccinaties`,
         positiefGetesteMensen: () => `/landelijk/positief-geteste-mensen`,
         besmettelijkeMensen: () => `/landelijk/besmettelijke-mensen`,
@@ -56,7 +60,9 @@ export function useReverseRouter() {
       vr: {
         index: (code?: string) =>
           code
-            ? reverseRouter.vr.vaccinaties(code) + openMenuSuffix
+            ? isMobile
+              ? `/veiligheidsregio/${code}`
+              : reverseRouter.vr.vaccinaties(code)
             : '/veiligheidsregio',
         maatregelen: (code: string) => `/veiligheidsregio/${code}/maatregelen`,
         vaccinaties: (code: string) => `/veiligheidsregio/${code}/vaccinaties`,
@@ -81,8 +87,12 @@ export function useReverseRouter() {
         index: (code?: string) =>
           code
             ? vaccinationGmPagefeature.isEnabled
-              ? reverseRouter.gm.vaccinaties(code) + openMenuSuffix
-              : reverseRouter.gm.ziekenhuisopnames(code) + openMenuSuffix
+              ? isMobile
+                ? `/gemeente/${code}`
+                : reverseRouter.gm.vaccinaties(code)
+              : isMobile
+              ? `/gemeente/${code}`
+              : reverseRouter.gm.ziekenhuisopnames(code)
             : `/gemeente`,
         positiefGetesteMensen: (code: string) =>
           `/gemeente/${code}/positief-geteste-mensen`,
@@ -95,5 +105,5 @@ export function useReverseRouter() {
     } as const;
 
     return reverseRouter;
-  }, [openMenuSuffix, vaccinationGmPagefeature]);
+  }, [isMobile, vaccinationGmPagefeature]);
 }

--- a/packages/app/src/utils/use-reverse-router.ts
+++ b/packages/app/src/utils/use-reverse-router.ts
@@ -36,8 +36,7 @@ export function useReverseRouter() {
       },
 
       nl: {
-        index: () =>
-          isMobile ? `/landelijk/` : reverseRouter.nl.vaccinaties(),
+        index: () => (isMobile ? `/landelijk` : reverseRouter.nl.vaccinaties()),
         vaccinaties: () => `/landelijk/vaccinaties`,
         positiefGetesteMensen: () => `/landelijk/positief-geteste-mensen`,
         besmettelijkeMensen: () => `/landelijk/besmettelijke-mensen`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,6 +2570,7 @@ __metadata:
     "@types/styled-system__should-forward-prop": ^5.1.2
     "@types/unist": ^2.0.6
     "@types/webpack": ^5.28.0
+    "@types/webpack-env": ^1.16.3
     "@typescript-eslint/eslint-plugin": ^5.3.1
     "@typescript-eslint/parser": ^5.3.1
     "@visx/axis": ^2.4.0
@@ -7449,6 +7450,13 @@ __metadata:
   version: 3.0.0
   resolution: "@types/warning@npm:3.0.0"
   checksum: 120dcf90600d583c68a60872200061eab9318ae15ea898581f8e9a6dc71b7941095dd81d8324e36d2a6006e5e12b6fc1cf8eda00cc514ee12bb39a912cc4e040
+  languageName: node
+  linkType: hard
+
+"@types/webpack-env@npm:^1.16.3":
+  version: 1.16.3
+  resolution: "@types/webpack-env@npm:1.16.3"
+  checksum: faefa7c0a75289fb469b9a5ae44059a00009de840e0e62d13b3f837d77647da76808e7839cdc414b8c585969cf6b6a7f290dc2cb437a9ccdf04cb214c68f3223
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently, when going to /landelijk (or veiligheidsregio/[code] and gemeente/[code]), you get redirected to the vaccinations page. On mobile the `menu=1` query parameter is added so you get to see the metrics menu, which is otherwise hidden. This means that on mobile, the full vaccinations page needs to be loaded before the menu is visible, which can be really slow on some older devices. 

This PR changes this logic a little bit. It will now only redirect on desktop, and mobile gets to see the actual /landelijk page, which contains _only_ the metrics menu now. When testing this in Chrome with 'Slow 3G' and a 6x CPU throttle, it saves a full second of loading time going from the homepage to the NL metrics menu (from 3.25s to 2.25s). Lighthouse performance scores improve from ±26 to ±73. Data savings go towards 500kB for these metric menu's.

I left the `menu=1` logic in there since it is actually still a clean way of opening the menu on mobile once you are on one of the metric pages. To be exact, it offers a clean way of _closing_ the menu again since the menu just needs to link to the same page without the menu query parameter, while we otherwise would need to add a context & hook to offer a closing method to the menu link list, which would need to make a button of the link linking to the current page..., etc.

While testing this solution I discovered that a bundle related to the choropleth was still included in the page. After some investigation I found out our ErrorBoundary naively imports the Choropleth, TimeseriesChart and StackedChart, _just to be able to check if a given component is one of these types_. This meant that regardless of the content of a page, as long as there was an ErrorBoundary on there, all three of these components were imported. I rewrote that logic so it doesn't need to actually import those components anymore, which shaved off at least 3kB on most pages, but up to 180kB on pages which did not use any of those components.

**Before**
```
Page                                                                                       Size     First Load JS
┌ ● /                                                                                      11.9 kB         517 kB
├   /_app                                                                                  0 B             248 kB
├ ○ /404                                                                                   809 B           284 kB
├ ● /500                                                                                   808 B           284 kB
├ ● /actueel/gemeente                                                                      4.62 kB         503 kB
├ ● /actueel/gemeente/[code] (158143 ms)                                                   2.88 kB         508 kB
├   ├ /nl/actueel/gemeente/GM1659 (932 ms)
├   ├ /nl/actueel/gemeente/GM0809 (928 ms)
├   ├ /nl/actueel/gemeente/GM0995 (893 ms)
├   ├ /nl/actueel/gemeente/GM0263 (890 ms)
├   ├ /nl/actueel/gemeente/GM0420 (862 ms)
├   ├ /nl/actueel/gemeente/GM1948 (859 ms)
├   ├ /nl/actueel/gemeente/GM0168 (751 ms)
├   └ [+345 more paths] (avg 441 ms)
├ ● /actueel/veiligheidsregio                                                              5.28 kB         503 kB
├ ● /actueel/veiligheidsregio/[code] (15212 ms)                                            2.81 kB         508 kB
├   ├ /nl/actueel/veiligheidsregio/VR04 (840 ms)
├   ├ /nl/actueel/veiligheidsregio/VR07 (782 ms)
├   ├ /nl/actueel/veiligheidsregio/VR05 (779 ms)
├   ├ /nl/actueel/veiligheidsregio/VR09 (752 ms)
├   ├ /nl/actueel/veiligheidsregio/VR03 (725 ms)
├   ├ /nl/actueel/veiligheidsregio/VR10 (725 ms)
├   ├ /nl/actueel/veiligheidsregio/VR11 (713 ms)
├   └ [+18 more paths] (avg 550 ms)
├ λ /api/choropleth/[...param]                                                             0 B             248 kB
├ λ /api/choropleth/konva-node.d                                                           0 B             248 kB
├ λ /api/choropleth/topojson-client.d                                                      0 B             248 kB
├ λ /api/choropleth/topology                                                               0 B             248 kB
├ λ /api/data/timeseries/__tests__/[...param]                                              0 B             248 kB
├ λ /api/data/timeseries/[...param]                                                        0 B             248 kB
├ λ /api/topo-json/[type]                                                                  0 B             248 kB
├ ● /artikelen                                                                             4.56 kB         288 kB
├ ● /artikelen/[slug] (25937 ms)                                                           2.87 kB         483 kB
├   ├ /en/artikelen/hoeveel-covid-19-patienten-liggen-op-de-ic (1198 ms)
├   ├ /en/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (1176 ms)
├   ├ /en/artikelen/klopt-het-risiconiveau-in-mijn-regio-wel (1098 ms)
├   ├ /nl/artikelen/wat-zeggen-de-uitslagen-van-de-ggd-teststraten (965 ms)
├   ├ /nl/artikelen/hoe-weten-we-hoeveel-besmettelijke-mensen-er-zijn (880 ms)
├   ├ /nl/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (867 ms)
├   ├ /nl/artikelen/hoeveel-covid-19-patienten-liggen-op-de-ic (730 ms)
├   └ [+47 more paths] (avg 405 ms)
├ ● /contact                                                                               2.76 kB         481 kB
├ ● /gemeente                                                                              4.62 kB         503 kB
├ ● /gemeente/[code] (58836 ms)                                                            4.18 kB         502 kB
├   ├ /nl/gemeente/GM1723 (668 ms)
├   ├ /nl/gemeente/GM0059 (638 ms)
├   ├ /nl/gemeente/GM1680 (625 ms)
├   ├ /nl/gemeente/GM0484 (616 ms)
├   ├ /nl/gemeente/GM0358 (586 ms)
├   ├ /nl/gemeente/GM0613 (565 ms)
├   ├ /nl/gemeente/GM0361 (543 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/positief-geteste-mensen (280792 ms)                                   5.62 kB         525 kB
├   ├ /nl/gemeente/GM0197/positief-geteste-mensen (1483 ms)
├   ├ /nl/gemeente/GM1961/positief-geteste-mensen (1387 ms)
├   ├ /nl/gemeente/GM0059/positief-geteste-mensen (1365 ms)
├   ├ /nl/gemeente/GM1680/positief-geteste-mensen (1302 ms)
├   ├ /nl/gemeente/GM0484/positief-geteste-mensen (1266 ms)
├   ├ /nl/gemeente/GM0358/positief-geteste-mensen (1235 ms)
├   ├ /nl/gemeente/GM0840/positief-geteste-mensen (1207 ms)
├   └ [+345 more paths] (avg 787 ms)
├ ● /gemeente/[code]/rioolwater (91299 ms)                                                 6.35 kB         527 kB
├   ├ /nl/gemeente/GM0879/rioolwater (438 ms)
├   ├ /nl/gemeente/GM0173/rioolwater (433 ms)
├   ├ /nl/gemeente/GM0269/rioolwater (427 ms)
├   ├ /nl/gemeente/GM0981/rioolwater (422 ms)
├   ├ /nl/gemeente/GM0498/rioolwater (419 ms)
├   ├ /nl/gemeente/GM0501/rioolwater (416 ms)
├   ├ /nl/gemeente/GM0293/rioolwater (410 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/sterfte (171338 ms)                                                   6.87 kB         522 kB
├   ├ /nl/gemeente/GM1954/sterfte (839 ms)
├   ├ /nl/gemeente/GM0513/sterfte (832 ms)
├   ├ /nl/gemeente/GM0141/sterfte (737 ms)
├   ├ /nl/gemeente/GM0512/sterfte (676 ms)
├   ├ /nl/gemeente/GM0059/sterfte (675 ms)
├   ├ /nl/gemeente/GM0518/sterfte (671 ms)
├   ├ /nl/gemeente/GM0856/sterfte (668 ms)
├   └ [+345 more paths] (avg 482 ms)
├ ● /gemeente/[code]/vaccinaties (84756 ms)                                                4.42 kB         533 kB
├   ├ /nl/gemeente/GM0114/vaccinaties (424 ms)
├   ├ /nl/gemeente/GM0770/vaccinaties (418 ms)
├   ├ /nl/gemeente/GM0716/vaccinaties (404 ms)
├   ├ /nl/gemeente/GM0183/vaccinaties (383 ms)
├   ├ /nl/gemeente/GM1731/vaccinaties (382 ms)
├   ├ /nl/gemeente/GM1730/vaccinaties (376 ms)
├   ├ /nl/gemeente/GM0356/vaccinaties (364 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/ziekenhuis-opnames (190446 ms)                                        5.66 kB         525 kB
├   ├ /nl/gemeente/GM0034/ziekenhuis-opnames (1126 ms)
├   ├ /nl/gemeente/GM0361/ziekenhuis-opnames (985 ms)
├   ├ /nl/gemeente/GM0762/ziekenhuis-opnames (947 ms)
├   ├ /nl/gemeente/GM0770/ziekenhuis-opnames (946 ms)
├   ├ /nl/gemeente/GM0228/ziekenhuis-opnames (931 ms)
├   ├ /nl/gemeente/GM0772/ziekenhuis-opnames (923 ms)
├   ├ /nl/gemeente/GM0141/ziekenhuis-opnames (894 ms)
├   └ [+345 more paths] (avg 532 ms)
├ ● /internationaal                                                                        1.11 kB         490 kB
├ ● /internationaal/positief-geteste-mensen                                                15.4 kB         525 kB
├ ● /internationaal/varianten                                                              5.79 kB         523 kB
├ ● /landelijk                                                                             1.48 kB         490 kB
├ ● /landelijk/besmettelijke-mensen                                                        5.2 kB          511 kB
├ ● /landelijk/brononderzoek                                                               4.4 kB          520 kB
├ ● /landelijk/coronamelder                                                                5.4 kB          511 kB
├ ● /landelijk/gedrag                                                                      5.16 kB         530 kB
├ ● /landelijk/gehandicaptenzorg                                                           3.9 kB          513 kB
├ ● /landelijk/intensive-care-opnames                                                      6.55 kB         516 kB
├ ● /landelijk/maatregelen                                                                 1.65 kB         508 kB
├ ● /landelijk/positief-geteste-mensen                                                     7.15 kB         516 kB
├ ● /landelijk/reproductiegetal                                                            5.49 kB         511 kB
├ ● /landelijk/rioolwater                                                                  2.39 kB         517 kB
├ ● /landelijk/sterfte                                                                     6.27 kB         516 kB
├ ● /landelijk/thuiswonende-ouderen                                                        3.73 kB         513 kB
├ ● /landelijk/vaccinaties                                                                 9.64 kB         528 kB
├ ● /landelijk/varianten                                                                   1.89 kB         515 kB
├ ● /landelijk/verdenkingen-huisartsen                                                     5.63 kB         511 kB
├ ● /landelijk/verpleeghuiszorg                                                            3.94 kB         513 kB
├ ● /landelijk/ziekenhuis-opnames                                                          2.78 kB         516 kB
├ ● /over                                                                                  2.78 kB         481 kB
├ ● /over-risiconiveaus                                                                    1.14 kB         481 kB
├ λ /sitemap.xml                                                                           305 B           248 kB
├ ● /toegankelijkheid                                                                      2.77 kB         481 kB
├ ● /veelgestelde-vragen                                                                   1.21 kB         482 kB
├ ● /veiligheidsregio                                                                      5.28 kB         503 kB
├ ● /veiligheidsregio/[code] (5331 ms)                                                     4.15 kB         502 kB
├   ├ /nl/veiligheidsregio/VR01
├   ├ /nl/veiligheidsregio/VR02
├   ├ /nl/veiligheidsregio/VR03
├   └ [+22 more paths]
├ ● /veiligheidsregio/[code]/brononderzoek (15467 ms)                                      7.67 kB         533 kB
├   ├ /nl/veiligheidsregio/VR07/brononderzoek (904 ms)
├   ├ /nl/veiligheidsregio/VR19/brononderzoek (812 ms)
├   ├ /nl/veiligheidsregio/VR20/brononderzoek (791 ms)
├   ├ /nl/veiligheidsregio/VR18/brononderzoek (762 ms)
├   ├ /nl/veiligheidsregio/VR21/brononderzoek (755 ms)
├   ├ /nl/veiligheidsregio/VR23/brononderzoek (722 ms)
├   ├ /nl/veiligheidsregio/VR16/brononderzoek (708 ms)
├   └ [+18 more paths] (avg 556 ms)
├ ● /veiligheidsregio/[code]/gedrag (8428 ms)                                              4.24 kB         539 kB
├   ├ /nl/veiligheidsregio/VR03/gedrag (504 ms)
├   ├ /nl/veiligheidsregio/VR02/gedrag (495 ms)
├   ├ /nl/veiligheidsregio/VR06/gedrag (422 ms)
├   ├ /nl/veiligheidsregio/VR05/gedrag (413 ms)
├   ├ /nl/veiligheidsregio/VR04/gedrag (388 ms)
├   ├ /nl/veiligheidsregio/VR01/gedrag (384 ms)
├   ├ /nl/veiligheidsregio/VR09/gedrag (373 ms)
├   └ [+18 more paths] (avg 303 ms)
├ ● /veiligheidsregio/[code]/gehandicaptenzorg (19377 ms)                                  7.37 kB         523 kB
├   ├ /nl/veiligheidsregio/VR09/gehandicaptenzorg (959 ms)
├   ├ /nl/veiligheidsregio/VR13/gehandicaptenzorg (829 ms)
├   ├ /nl/veiligheidsregio/VR05/gehandicaptenzorg (828 ms)
├   ├ /nl/veiligheidsregio/VR14/gehandicaptenzorg (823 ms)
├   ├ /nl/veiligheidsregio/VR21/gehandicaptenzorg (821 ms)
├   ├ /nl/veiligheidsregio/VR06/gehandicaptenzorg (817 ms)
├   ├ /nl/veiligheidsregio/VR01/gehandicaptenzorg (799 ms)
├   └ [+18 more paths] (avg 750 ms)
├ ● /veiligheidsregio/[code]/maatregelen (6921 ms)                                         4.19 kB         520 kB
├   ├ /nl/veiligheidsregio/VR01/maatregelen (406 ms)
├   ├ /nl/veiligheidsregio/VR06/maatregelen (359 ms)
├   ├ /nl/veiligheidsregio/VR12/maatregelen (329 ms)
├   ├ /nl/veiligheidsregio/VR09/maatregelen (325 ms)
├   ├ /nl/veiligheidsregio/VR19/maatregelen (316 ms)
├   ├ /nl/veiligheidsregio/VR05/maatregelen (304 ms)
├   ├ /nl/veiligheidsregio/VR02/maatregelen
├   └ [+18 more paths]
├ ● /veiligheidsregio/[code]/positief-geteste-mensen (32855 ms)                            7.09 kB         526 kB
├   ├ /nl/veiligheidsregio/VR07/positief-geteste-mensen (1587 ms)
├   ├ /nl/veiligheidsregio/VR05/positief-geteste-mensen (1563 ms)
├   ├ /nl/veiligheidsregio/VR03/positief-geteste-mensen (1541 ms)
├   ├ /nl/veiligheidsregio/VR01/positief-geteste-mensen (1481 ms)
├   ├ /nl/veiligheidsregio/VR06/positief-geteste-mensen (1472 ms)
├   ├ /nl/veiligheidsregio/VR08/positief-geteste-mensen (1432 ms)
├   ├ /nl/veiligheidsregio/VR04/positief-geteste-mensen (1409 ms)
├   └ [+18 more paths] (avg 1243 ms)
├ ● /veiligheidsregio/[code]/rioolwater (14253 ms)                                         5.91 kB         526 kB
├   ├ /nl/veiligheidsregio/VR06/rioolwater (797 ms)
├   ├ /nl/veiligheidsregio/VR09/rioolwater (737 ms)
├   ├ /nl/veiligheidsregio/VR20/rioolwater (673 ms)
├   ├ /nl/veiligheidsregio/VR04/rioolwater (669 ms)
├   ├ /nl/veiligheidsregio/VR11/rioolwater (667 ms)
├   ├ /nl/veiligheidsregio/VR02/rioolwater (646 ms)
├   ├ /nl/veiligheidsregio/VR05/rioolwater (645 ms)
├   └ [+18 more paths] (avg 523 ms)
├ ● /veiligheidsregio/[code]/sterfte (15406 ms)                                            4.14 kB         524 kB
├   ├ /nl/veiligheidsregio/VR09/sterfte (769 ms)
├   ├ /nl/veiligheidsregio/VR02/sterfte (754 ms)
├   ├ /nl/veiligheidsregio/VR01/sterfte (744 ms)
├   ├ /nl/veiligheidsregio/VR03/sterfte (739 ms)
├   ├ /nl/veiligheidsregio/VR04/sterfte (690 ms)
├   ├ /nl/veiligheidsregio/VR08/sterfte (686 ms)
├   ├ /nl/veiligheidsregio/VR06/sterfte (676 ms)
├   └ [+18 more paths] (avg 575 ms)
├ ● /veiligheidsregio/[code]/thuiswonende-ouderen (21365 ms)                               7.17 kB         522 kB
├   ├ /nl/veiligheidsregio/VR08/thuiswonende-ouderen (1107 ms)
├   ├ /nl/veiligheidsregio/VR02/thuiswonende-ouderen (1099 ms)
├   ├ /nl/veiligheidsregio/VR17/thuiswonende-ouderen (1042 ms)
├   ├ /nl/veiligheidsregio/VR07/thuiswonende-ouderen (1024 ms)
├   ├ /nl/veiligheidsregio/VR03/thuiswonende-ouderen (1012 ms)
├   ├ /nl/veiligheidsregio/VR04/thuiswonende-ouderen (931 ms)
├   ├ /nl/veiligheidsregio/VR01/thuiswonende-ouderen (924 ms)
├   └ [+18 more paths] (avg 790 ms)
├ ● /veiligheidsregio/[code]/vaccinaties (10671 ms)                                        4.45 kB         533 kB
├   ├ /nl/veiligheidsregio/VR03/vaccinaties (591 ms)
├   ├ /nl/veiligheidsregio/VR01/vaccinaties (498 ms)
├   ├ /nl/veiligheidsregio/VR04/vaccinaties (496 ms)
├   ├ /nl/veiligheidsregio/VR21/vaccinaties (496 ms)
├   ├ /nl/veiligheidsregio/VR05/vaccinaties (489 ms)
├   ├ /nl/veiligheidsregio/VR02/vaccinaties (478 ms)
├   ├ /nl/veiligheidsregio/VR06/vaccinaties (469 ms)
├   └ [+18 more paths] (avg 397 ms)
├ ● /veiligheidsregio/[code]/verpleeghuiszorg (24045 ms)                                   7.38 kB         523 kB
├   ├ /nl/veiligheidsregio/VR09/verpleeghuiszorg (1111 ms)
├   ├ /nl/veiligheidsregio/VR12/verpleeghuiszorg (1096 ms)
├   ├ /nl/veiligheidsregio/VR25/verpleeghuiszorg (1040 ms)
├   ├ /nl/veiligheidsregio/VR08/verpleeghuiszorg (1037 ms)
├   ├ /nl/veiligheidsregio/VR24/verpleeghuiszorg (1018 ms)
├   ├ /nl/veiligheidsregio/VR23/verpleeghuiszorg (1016 ms)
├   ├ /nl/veiligheidsregio/VR06/verpleeghuiszorg (1014 ms)
├   └ [+18 more paths] (avg 929 ms)
├ ● /veiligheidsregio/[code]/ziekenhuis-opnames (16065 ms)                                 5.71 kB         525 kB
├   ├ /nl/veiligheidsregio/VR02/ziekenhuis-opnames (775 ms)
├   ├ /nl/veiligheidsregio/VR03/ziekenhuis-opnames (768 ms)
├   ├ /nl/veiligheidsregio/VR09/ziekenhuis-opnames (738 ms)
├   ├ /nl/veiligheidsregio/VR01/ziekenhuis-opnames (722 ms)
├   ├ /nl/veiligheidsregio/VR04/ziekenhuis-opnames (710 ms)
├   ├ /nl/veiligheidsregio/VR11/ziekenhuis-opnames (705 ms)
├   ├ /nl/veiligheidsregio/VR07/ziekenhuis-opnames (704 ms)
├   └ [+18 more paths] (avg 608 ms)
├ ● /verantwoording                                                                        1.29 kB         482 kB
└ ● /weekberichten/[slug] (13472 ms)                                                       4.05 kB         482 kB
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-14-september
    ├ /nl/weekberichten/wekelijkse-update-coronacijfers-14-september
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-7-september
    └ [+77 more paths]
+ First Load JS shared by all                                                              248 kB
  ├ chunks/framework-bbe16bb72ca1ef54.js                                                   42.6 kB
  ├ chunks/main-5d31c7f85d93bd09.js                                                        31.5 kB
  ├ chunks/pages/_app-ac18e684796cefb0.js                                                  171 kB
  ├ chunks/webpack-35e10115854aae51.js                                                     2.17 kB
  └ css/2fa5746e266317e3.css                                                               325 B
```

**After**
```
Page                                                                                                  Size     First Load JS
┌ ● /                                                                                                 11.9 kB         513 kB
├   /_app                                                                                             0 B             248 kB
├ ○ /404                                                                                              809 B           284 kB
├ ● /500                                                                                              808 B           284 kB
├ ● /actueel/gemeente                                                                                 3.82 kB         436 kB
├ ● /actueel/gemeente/[code] (179731 ms)                                                              2.89 kB         504 kB
├   ├ /nl/actueel/gemeente/GM0074 (1077 ms)
├   ├ /nl/actueel/gemeente/GM0879 (1002 ms)
├   ├ /nl/actueel/gemeente/GM0358 (972 ms)
├   ├ /nl/actueel/gemeente/GM0163 (969 ms)
├   ├ /nl/actueel/gemeente/GM0141 (952 ms)
├   ├ /nl/actueel/gemeente/GM1680 (951 ms)
├   ├ /nl/actueel/gemeente/GM0059 (945 ms)
├   └ [+345 more paths] (avg 501 ms)
├ ● /actueel/veiligheidsregio                                                                         4.7 kB          449 kB
├ ● /actueel/veiligheidsregio/[code] (15985 ms)                                                       2.83 kB         504 kB
├   ├ /nl/actueel/veiligheidsregio/VR02 (999 ms)
├   ├ /nl/actueel/veiligheidsregio/VR03 (904 ms)
├   ├ /nl/actueel/veiligheidsregio/VR05 (888 ms)
├   ├ /nl/actueel/veiligheidsregio/VR04 (872 ms)
├   ├ /nl/actueel/veiligheidsregio/VR01 (837 ms)
├   ├ /nl/actueel/veiligheidsregio/VR06 (773 ms)
├   ├ /nl/actueel/veiligheidsregio/VR10 (770 ms)
├   └ [+18 more paths] (avg 552 ms)
├ λ /api/choropleth/[...param]                                                                        0 B             248 kB
├ λ /api/choropleth/konva-node.d                                                                      0 B             248 kB
├ λ /api/choropleth/topojson-client.d                                                                 0 B             248 kB
├ λ /api/choropleth/topology                                                                          0 B             248 kB
├ λ /api/data/timeseries/__tests__/[...param]                                                         0 B             248 kB
├ λ /api/data/timeseries/[...param]                                                                   0 B             248 kB
├ λ /api/topo-json/[type]                                                                             0 B             248 kB
├ ● /artikelen                                                                                        4.56 kB         288 kB
├ ● /artikelen/[slug] (20345 ms)                                                                      2.97 kB         378 kB
├   ├ /en/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-23-maart (659 ms)
├   ├ /nl/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-23-maart (651 ms)
├   ├ /en/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (643 ms)
├   ├ /nl/artikelen/wat-is-het-covid-19-sterftecijfer-op-basis-van-doodsoorzaak (604 ms)
├   ├ /nl/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-8-maart-2021 (566 ms)
├   ├ /en/artikelen/cijfers-van-het-coronadashboard-bij-de-persconferentie-van-8-maart-2021 (556 ms)
├   ├ /en/artikelen/wat-is-het-reproductiegetal-en-waarom-komt-het-twee-weken-later (519 ms)
├   └ [+47 more paths] (avg 344 ms)
├ ● /contact                                                                                          1.03 kB         376 kB
├ ● /gemeente                                                                                         3.82 kB         436 kB
├ ● /gemeente/[code] (49407 ms)                                                                       6.84 kB         320 kB
├   ├ /nl/gemeente/GM1680
├   ├ /nl/gemeente/GM0358
├   ├ /nl/gemeente/GM0197
├   └ [+349 more paths]
├ ● /gemeente/[code]/positief-geteste-mensen (201125 ms)                                              6.18 kB         522 kB
├   ├ /nl/gemeente/GM0677/positief-geteste-mensen (886 ms)
├   ├ /nl/gemeente/GM0335/positief-geteste-mensen (857 ms)
├   ├ /nl/gemeente/GM0473/positief-geteste-mensen (841 ms)
├   ├ /nl/gemeente/GM0845/positief-geteste-mensen (810 ms)
├   ├ /nl/gemeente/GM0986/positief-geteste-mensen (803 ms)
├   ├ /nl/gemeente/GM0785/positief-geteste-mensen (782 ms)
├   ├ /nl/gemeente/GM1685/positief-geteste-mensen (781 ms)
├   └ [+345 more paths] (avg 566 ms)
├ ● /gemeente/[code]/rioolwater (94077 ms)                                                            5.36 kB         423 kB
├   ├ /nl/gemeente/GM1774/rioolwater (570 ms)
├   ├ /nl/gemeente/GM0893/rioolwater (528 ms)
├   ├ /nl/gemeente/GM0203/rioolwater (467 ms)
├   ├ /nl/gemeente/GM1723/rioolwater (409 ms)
├   ├ /nl/gemeente/GM1911/rioolwater (386 ms)
├   ├ /nl/gemeente/GM0484/rioolwater (382 ms)
├   ├ /nl/gemeente/GM1729/rioolwater (377 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/sterfte (231672 ms)                                                              4.45 kB         417 kB
├   ├ /nl/gemeente/GM0358/sterfte (2017 ms)
├   ├ /nl/gemeente/GM1680/sterfte (1357 ms)
├   ├ /nl/gemeente/GM0197/sterfte (1278 ms)
├   ├ /nl/gemeente/GM0484/sterfte (1267 ms)
├   ├ /nl/gemeente/GM0361/sterfte (1250 ms)
├   ├ /nl/gemeente/GM0613/sterfte (1221 ms)
├   ├ /nl/gemeente/GM1723/sterfte (1218 ms)
├   └ [+345 more paths] (avg 644 ms)
├ ● /gemeente/[code]/vaccinaties (91182 ms)                                                           4.43 kB         530 kB
├   ├ /nl/gemeente/GM0824/vaccinaties (555 ms)
├   ├ /nl/gemeente/GM0273/vaccinaties (549 ms)
├   ├ /nl/gemeente/GM1895/vaccinaties (546 ms)
├   ├ /nl/gemeente/GM0302/vaccinaties (482 ms)
├   ├ /nl/gemeente/GM0748/vaccinaties (469 ms)
├   ├ /nl/gemeente/GM0823/vaccinaties (469 ms)
├   ├ /nl/gemeente/GM1676/vaccinaties (459 ms)
├   └ [+345 more paths]
├ ● /gemeente/[code]/ziekenhuis-opnames (172671 ms)                                                   6.22 kB         522 kB
├   ├ /nl/gemeente/GM0085/ziekenhuis-opnames (799 ms)
├   ├ /nl/gemeente/GM0603/ziekenhuis-opnames (765 ms)
├   ├ /nl/gemeente/GM0537/ziekenhuis-opnames (758 ms)
├   ├ /nl/gemeente/GM0397/ziekenhuis-opnames (712 ms)
├   ├ /nl/gemeente/GM0856/ziekenhuis-opnames (693 ms)
├   ├ /nl/gemeente/GM0233/ziekenhuis-opnames (671 ms)
├   ├ /nl/gemeente/GM0847/ziekenhuis-opnames (671 ms)
├   └ [+345 more paths] (avg 486 ms)
├ ● /internationaal                                                                                   3.9 kB          308 kB
├ ● /internationaal/positief-geteste-mensen                                                           15.4 kB         523 kB
├ ● /internationaal/varianten                                                                         5.8 kB          418 kB
├ ● /landelijk                                                                                        4.23 kB         308 kB
├ ● /landelijk/besmettelijke-mensen                                                                   6.18 kB         405 kB
├ ● /landelijk/brononderzoek                                                                          7.76 kB         518 kB
├ ● /landelijk/coronamelder                                                                           2.82 kB         406 kB
├ ● /landelijk/gedrag                                                                                 5.18 kB         528 kB
├ ● /landelijk/gehandicaptenzorg                                                                      4.47 kB         511 kB
├ ● /landelijk/intensive-care-opnames                                                                 6.69 kB         414 kB
├ ● /landelijk/maatregelen                                                                            3.65 kB         403 kB
├ ● /landelijk/positief-geteste-mensen                                                                5.06 kB         515 kB
├ ● /landelijk/reproductiegetal                                                                       2.92 kB         406 kB
├ ● /landelijk/rioolwater                                                                             3.69 kB         514 kB
├ ● /landelijk/sterfte                                                                                7.38 kB         411 kB
├ ● /landelijk/thuiswonende-ouderen                                                                   4.28 kB         510 kB
├ ● /landelijk/vaccinaties                                                                            14.2 kB         530 kB
├ ● /landelijk/varianten                                                                              2.94 kB         410 kB
├ ● /landelijk/verdenkingen-huisartsen                                                                3.12 kB         406 kB
├ ● /landelijk/verpleeghuiszorg                                                                       4.49 kB         511 kB
├ ● /landelijk/ziekenhuis-opnames                                                                     4.14 kB         514 kB
├ ● /over                                                                                             1.04 kB         376 kB
├ ● /over-risiconiveaus                                                                               1.26 kB         376 kB
├ λ /sitemap.xml                                                                                      305 B           248 kB
├ ● /toegankelijkheid                                                                                 1.04 kB         376 kB
├ ● /veelgestelde-vragen                                                                              1.41 kB         376 kB
├ ● /veiligheidsregio                                                                                 4.69 kB         449 kB
├ ● /veiligheidsregio/[code] (13397 ms)                                                               6.77 kB         320 kB
├   ├ /nl/veiligheidsregio/VR09 (1087 ms)
├   ├ /nl/veiligheidsregio/VR10 (968 ms)
├   ├ /nl/veiligheidsregio/VR06 (936 ms)
├   ├ /nl/veiligheidsregio/VR05 (897 ms)
├   ├ /nl/veiligheidsregio/VR08 (865 ms)
├   ├ /nl/veiligheidsregio/VR04 (593 ms)
├   ├ /nl/veiligheidsregio/VR11 (574 ms)
├   └ [+18 more paths] (avg 415 ms)
├ ● /veiligheidsregio/[code]/brononderzoek (11476 ms)                                                 7.53 kB         429 kB
├   ├ /nl/veiligheidsregio/VR16/brononderzoek (627 ms)
├   ├ /nl/veiligheidsregio/VR24/brononderzoek (575 ms)
├   ├ /nl/veiligheidsregio/VR20/brononderzoek (517 ms)
├   ├ /nl/veiligheidsregio/VR09/brononderzoek (497 ms)
├   ├ /nl/veiligheidsregio/VR13/brononderzoek (492 ms)
├   ├ /nl/veiligheidsregio/VR01/brononderzoek (487 ms)
├   ├ /nl/veiligheidsregio/VR21/brononderzoek (482 ms)
├   └ [+18 more paths] (avg 433 ms)
├ ● /veiligheidsregio/[code]/gedrag (9982 ms)                                                         4.39 kB         434 kB
├   ├ /nl/veiligheidsregio/VR20/gedrag (504 ms)
├   ├ /nl/veiligheidsregio/VR11/gedrag (483 ms)
├   ├ /nl/veiligheidsregio/VR04/gedrag (456 ms)
├   ├ /nl/veiligheidsregio/VR01/gedrag (439 ms)
├   ├ /nl/veiligheidsregio/VR02/gedrag (432 ms)
├   ├ /nl/veiligheidsregio/VR09/gedrag (432 ms)
├   ├ /nl/veiligheidsregio/VR08/gedrag (426 ms)
├   └ [+18 more paths] (avg 378 ms)
├ ● /veiligheidsregio/[code]/gehandicaptenzorg (22516 ms)                                             5.73 kB         419 kB
├   ├ /nl/veiligheidsregio/VR21/gehandicaptenzorg (1031 ms)
├   ├ /nl/veiligheidsregio/VR20/gehandicaptenzorg (1029 ms)
├   ├ /nl/veiligheidsregio/VR08/gehandicaptenzorg (977 ms)
├   ├ /nl/veiligheidsregio/VR17/gehandicaptenzorg (969 ms)
├   ├ /nl/veiligheidsregio/VR06/gehandicaptenzorg (962 ms)
├   ├ /nl/veiligheidsregio/VR22/gehandicaptenzorg (947 ms)
├   ├ /nl/veiligheidsregio/VR24/gehandicaptenzorg (940 ms)
├   └ [+18 more paths] (avg 870 ms)
├ ● /veiligheidsregio/[code]/maatregelen (9461 ms)                                                    6.11 kB         415 kB
├   ├ /nl/veiligheidsregio/VR01/maatregelen (635 ms)
├   ├ /nl/veiligheidsregio/VR09/maatregelen (537 ms)
├   ├ /nl/veiligheidsregio/VR18/maatregelen (492 ms)
├   ├ /nl/veiligheidsregio/VR19/maatregelen (446 ms)
├   ├ /nl/veiligheidsregio/VR06/maatregelen (420 ms)
├   ├ /nl/veiligheidsregio/VR04/maatregelen (389 ms)
├   ├ /nl/veiligheidsregio/VR16/maatregelen (383 ms)
├   └ [+18 more paths] (avg 342 ms)
├ ● /veiligheidsregio/[code]/positief-geteste-mensen (29591 ms)                                       4.99 kB         524 kB
├   ├ /nl/veiligheidsregio/VR23/positief-geteste-mensen (1479 ms)
├   ├ /nl/veiligheidsregio/VR25/positief-geteste-mensen (1408 ms)
├   ├ /nl/veiligheidsregio/VR21/positief-geteste-mensen (1373 ms)
├   ├ /nl/veiligheidsregio/VR08/positief-geteste-mensen (1318 ms)
├   ├ /nl/veiligheidsregio/VR03/positief-geteste-mensen (1305 ms)
├   ├ /nl/veiligheidsregio/VR04/positief-geteste-mensen (1296 ms)
├   ├ /nl/veiligheidsregio/VR19/positief-geteste-mensen (1264 ms)
├   └ [+18 more paths] (avg 1119 ms)
├ ● /veiligheidsregio/[code]/rioolwater (18401 ms)                                                    4.84 kB         422 kB
├   ├ /nl/veiligheidsregio/VR04/rioolwater (997 ms)
├   ├ /nl/veiligheidsregio/VR17/rioolwater (889 ms)
├   ├ /nl/veiligheidsregio/VR19/rioolwater (889 ms)
├   ├ /nl/veiligheidsregio/VR23/rioolwater (865 ms)
├   ├ /nl/veiligheidsregio/VR25/rioolwater (864 ms)
├   ├ /nl/veiligheidsregio/VR20/rioolwater (863 ms)
├   ├ /nl/veiligheidsregio/VR24/rioolwater (845 ms)
├   └ [+18 more paths] (avg 677 ms)
├ ● /veiligheidsregio/[code]/sterfte (22718 ms)                                                       5.31 kB         418 kB
├   ├ /nl/veiligheidsregio/VR01/sterfte (1348 ms)
├   ├ /nl/veiligheidsregio/VR02/sterfte (1149 ms)
├   ├ /nl/veiligheidsregio/VR20/sterfte (1093 ms)
├   ├ /nl/veiligheidsregio/VR24/sterfte (1088 ms)
├   ├ /nl/veiligheidsregio/VR22/sterfte (986 ms)
├   ├ /nl/veiligheidsregio/VR03/sterfte (980 ms)
├   ├ /nl/veiligheidsregio/VR06/sterfte (944 ms)
├   └ [+18 more paths] (avg 841 ms)
├ ● /veiligheidsregio/[code]/thuiswonende-ouderen (21977 ms)                                          4.7 kB          418 kB
├   ├ /nl/veiligheidsregio/VR02/thuiswonende-ouderen (1286 ms)
├   ├ /nl/veiligheidsregio/VR01/thuiswonende-ouderen (1152 ms)
├   ├ /nl/veiligheidsregio/VR03/thuiswonende-ouderen (999 ms)
├   ├ /nl/veiligheidsregio/VR11/thuiswonende-ouderen (979 ms)
├   ├ /nl/veiligheidsregio/VR07/thuiswonende-ouderen (965 ms)
├   ├ /nl/veiligheidsregio/VR04/thuiswonende-ouderen (964 ms)
├   ├ /nl/veiligheidsregio/VR08/thuiswonende-ouderen (956 ms)
├   └ [+18 more paths] (avg 815 ms)
├ ● /veiligheidsregio/[code]/vaccinaties (10173 ms)                                                   4.47 kB         530 kB
├   ├ /nl/veiligheidsregio/VR01/vaccinaties (557 ms)
├   ├ /nl/veiligheidsregio/VR02/vaccinaties (509 ms)
├   ├ /nl/veiligheidsregio/VR06/vaccinaties (490 ms)
├   ├ /nl/veiligheidsregio/VR09/vaccinaties (485 ms)
├   ├ /nl/veiligheidsregio/VR21/vaccinaties (442 ms)
├   ├ /nl/veiligheidsregio/VR20/vaccinaties (434 ms)
├   ├ /nl/veiligheidsregio/VR04/vaccinaties (428 ms)
├   └ [+18 more paths] (avg 379 ms)
├ ● /veiligheidsregio/[code]/verpleeghuiszorg (22306 ms)                                              5.75 kB         419 kB
├   ├ /nl/veiligheidsregio/VR01/verpleeghuiszorg (1065 ms)
├   ├ /nl/veiligheidsregio/VR24/verpleeghuiszorg (1064 ms)
├   ├ /nl/veiligheidsregio/VR02/verpleeghuiszorg (999 ms)
├   ├ /nl/veiligheidsregio/VR20/verpleeghuiszorg (996 ms)
├   ├ /nl/veiligheidsregio/VR21/verpleeghuiszorg (993 ms)
├   ├ /nl/veiligheidsregio/VR03/verpleeghuiszorg (977 ms)
├   ├ /nl/veiligheidsregio/VR08/verpleeghuiszorg (944 ms)
├   └ [+18 more paths] (avg 848 ms)
├ ● /veiligheidsregio/[code]/ziekenhuis-opnames (16250 ms)                                            6.28 kB         522 kB
├   ├ /nl/veiligheidsregio/VR02/ziekenhuis-opnames (906 ms)
├   ├ /nl/veiligheidsregio/VR01/ziekenhuis-opnames (894 ms)
├   ├ /nl/veiligheidsregio/VR16/ziekenhuis-opnames (786 ms)
├   ├ /nl/veiligheidsregio/VR18/ziekenhuis-opnames (725 ms)
├   ├ /nl/veiligheidsregio/VR07/ziekenhuis-opnames (716 ms)
├   ├ /nl/veiligheidsregio/VR11/ziekenhuis-opnames (716 ms)
├   ├ /nl/veiligheidsregio/VR05/ziekenhuis-opnames (696 ms)
├   └ [+18 more paths] (avg 601 ms)
├ ● /verantwoording                                                                                   1.49 kB         376 kB
└ ● /weekberichten/[slug] (15380 ms)                                                                  2.43 kB         377 kB
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-14-september
    ├ /nl/weekberichten/wekelijkse-update-coronacijfers-14-september
    ├ /en/weekberichten/wekelijkse-update-coronacijfers-7-september
    └ [+77 more paths]
+ First Load JS shared by all                                                                         248 kB
  ├ chunks/framework-bbe16bb72ca1ef54.js                                                              42.6 kB
  ├ chunks/main-5d31c7f85d93bd09.js                                                                   31.5 kB
  ├ chunks/pages/_app-ac18e684796cefb0.js                                                             171 kB
  ├ chunks/webpack-da43fe5215f85b44.js                                                                2.17 kB
  └ css/2fa5746e266317e3.css                                                                          325 B
```