### PR TITLE
Add timeline events to legend when relevant

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -27,6 +27,7 @@ export function useLegendItems<T extends TimestampedValue>(
   return useMemo(() => {
     const legendItems = config
       .filter(isVisible)
+      .filter((x) => !x.noLegend)
       .map<LegendItem | undefined>((x) => {
         switch (x.type) {
           case 'split-area':

--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -27,7 +27,7 @@ export function useLegendItems<T extends TimestampedValue>(
   return useMemo(() => {
     const legendItems = config
       .filter(isVisible)
-      .filter((x) => !x.noLegend)
+      .filter((x) => !x.hideInLegend)
       .map<LegendItem | undefined>((x) => {
         switch (x.type) {
           case 'split-area':

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -52,10 +52,10 @@ interface SeriesCommonDefinition {
    */
   minimumRange?: number;
   /**
-   * Does not show this series in the legend (because it is shown in a custom
+   * Hide this series in the legend (because it is shown in a custom
    * legend, for example)
    */
-  noLegend?: boolean;
+  hideInLegend?: boolean;
 }
 
 export interface GappedLineSeriesDefinition<T extends TimestampedValue>

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -35,7 +35,7 @@ interface SeriesCommonDefinition {
    */
   shortLabel?: string;
   /**
-   * Hide in tooltip means the series will not show up visually as part of the
+   * nonInteractive means the series will not show up visually as part of the
    * tooltip (only hidden). Sometimes we want to render a series as a backdrop
    * to give context to another interactive series, like in the sewer chart when
    * a location is selected.
@@ -51,6 +51,11 @@ interface SeriesCommonDefinition {
    * Specifies a different minimum range than the default for this series.
    */
   minimumRange?: number;
+  /**
+   * Does not show this series in the legend (because it is shown in a custom
+   * legend, for example)
+   */
+  noLegend?: boolean;
 }
 
 export interface GappedLineSeriesDefinition<T extends TimestampedValue>

--- a/packages/app/src/domain/hospital/admissions-per-age-group/admissions-per-age-group.tsx
+++ b/packages/app/src/domain/hospital/admissions-per-age-group/admissions-per-age-group.tsx
@@ -1,5 +1,4 @@
 import {
-  colors,
   NlHospitalNicePerAgeGroupValue,
   NlIntensiveCareNicePerAgeGroupValue,
 } from '@corona-dashboard/common';
@@ -9,9 +8,7 @@ import {
   InteractiveLegend,
   SelectOption,
 } from '~/components/interactive-legend';
-import { Legend, LegendItem } from '~/components/legend';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { SeriesIcon } from '~/components/time-series-chart/components/series-icon';
 import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
 import { LineSeriesDefinition } from '~/components/time-series-chart/logic';
@@ -82,22 +79,6 @@ export function AdmissionsPerAgeGroup({
     (item) => !alwaysEnabled.includes(item.metricProperty)
   );
 
-  /* Static legend contains always enabled items and the under reported item */
-  const staticLegendItems = seriesConfig
-    .filter((item) => alwaysEnabled.includes(item.metricProperty))
-    .map<LegendItem>((item) => ({
-      label: item.label,
-      shape: 'custom' as const,
-      shapeComponent: <SeriesIcon config={item} />,
-    }))
-    .concat([
-      {
-        shape: 'square' as const,
-        color: colors.data.underReported,
-        label: text.line_chart_legend_inaccurate_label,
-      },
-    ]);
-
   /* Conditionally let tooltip span over multiple columns */
   const hasTwoColumns = list.length === 0 || list.length > 4;
 
@@ -117,7 +98,6 @@ export function AdmissionsPerAgeGroup({
         timeframe={timeframe}
         seriesConfig={chartConfig}
         minHeight={breakpoints.md ? 300 : 250}
-        disableLegend
         formatTooltip={(data) => (
           <TooltipSeriesList data={data} hasTwoColumns={hasTwoColumns} />
         )}
@@ -133,7 +113,6 @@ export function AdmissionsPerAgeGroup({
           timelineEvents,
         }}
       />
-      <Legend items={staticLegendItems} />
     </ErrorBoundary>
   );
 }

--- a/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
+++ b/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
@@ -4,47 +4,47 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'admissions_age_0_19_per_million',
     color: colors.data.multiseries.cyan,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_20_29_per_million',
     color: colors.data.multiseries.turquoise,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_30_39_per_million',
     color: colors.data.multiseries.turquoise_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_40_49_per_million',
     color: colors.data.multiseries.yellow,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_50_59_per_million',
     color: colors.data.multiseries.yellow_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_60_69_per_million',
     color: colors.data.multiseries.orange,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_70_79_per_million',
     color: colors.data.multiseries.orange_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_80_89_per_million',
     color: colors.data.multiseries.magenta,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_90_plus_per_million',
     color: colors.data.multiseries.magenta_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_overall_per_million',

--- a/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
+++ b/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
@@ -4,38 +4,47 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'admissions_age_0_19_per_million',
     color: colors.data.multiseries.cyan,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_20_29_per_million',
     color: colors.data.multiseries.turquoise,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_30_39_per_million',
     color: colors.data.multiseries.turquoise_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_40_49_per_million',
     color: colors.data.multiseries.yellow,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_50_59_per_million',
     color: colors.data.multiseries.yellow_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_60_69_per_million',
     color: colors.data.multiseries.orange,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_70_79_per_million',
     color: colors.data.multiseries.orange_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_80_89_per_million',
     color: colors.data.multiseries.magenta,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_age_90_plus_per_million',
     color: colors.data.multiseries.magenta_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'admissions_overall_per_million',

--- a/packages/app/src/domain/situations/situations-over-time-chart.tsx
+++ b/packages/app/src/domain/situations/situations-over-time-chart.tsx
@@ -8,7 +8,10 @@ import { ErrorBoundary } from '~/components/error-boundary';
 import { InteractiveLegend } from '~/components/interactive-legend';
 import { Legend, LegendItem } from '~/components/legend';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
+import {
+  TimelineEventConfig,
+  TimelineMarker,
+} from '~/components/time-series-chart/components/timeline';
 import { GappedLineSeriesDefinition } from '~/components/time-series-chart/logic';
 import { useGappedLineAnnotations } from '~/components/time-series-chart/logic/use-gapped-line-annotations';
 import { useIntl } from '~/intl';
@@ -39,6 +42,14 @@ export function SituationsOverTimeChart({
       label: text.legenda.onvoldoende_gegevens,
     },
   ];
+
+  if (timelineEvents && timelineEvents.length > 0) {
+    staticLegendItems.push({
+      label: siteText.charts.timeline.legend_label,
+      shape: 'custom',
+      shapeComponent: <TimelineMarker size={10} />,
+    });
+  }
 
   const timespanAnnotations = useGappedLineAnnotations(
     values,

--- a/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
+++ b/packages/app/src/domain/tested/infected-per-age-group/infected-per-age-group.tsx
@@ -1,13 +1,11 @@
-import { colors, NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
+import { NlTestedPerAgeGroupValue } from '@corona-dashboard/common';
 import { Spacer } from '~/components/base';
 import { ErrorBoundary } from '~/components/error-boundary';
 import {
   InteractiveLegend,
   SelectOption,
 } from '~/components/interactive-legend';
-import { Legend, LegendItem } from '~/components/legend';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { SeriesIcon } from '~/components/time-series-chart/components/series-icon';
 import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
 import { LineSeriesDefinition } from '~/components/time-series-chart/logic';
@@ -74,22 +72,6 @@ export function InfectedPerAgeGroup({
     (item) => !alwaysEnabled.includes(item.metricProperty)
   );
 
-  /* Static legend contains always enabled items and the under reported item */
-  const staticLegendItems = seriesConfig
-    .filter((item) => alwaysEnabled.includes(item.metricProperty))
-    .map<LegendItem>((item) => ({
-      label: item.label,
-      shape: 'custom' as const,
-      shapeComponent: <SeriesIcon config={item} />,
-    }))
-    .concat([
-      {
-        shape: 'square' as const,
-        color: colors.data.underReported,
-        label: text.line_chart_legend_inaccurate_label,
-      },
-    ]);
-
   /* Conditionally let tooltip span over multiple columns */
   const hasTwoColumns = list.length === 0 || list.length > 4;
 
@@ -109,7 +91,6 @@ export function InfectedPerAgeGroup({
         timeframe={timeframe}
         seriesConfig={chartConfig}
         minHeight={breakpoints.md ? 300 : 250}
-        disableLegend
         formatTooltip={(data) => (
           <TooltipSeriesList data={data} hasTwoColumns={hasTwoColumns} />
         )}
@@ -126,7 +107,6 @@ export function InfectedPerAgeGroup({
           timelineEvents,
         }}
       />
-      <Legend items={staticLegendItems} />
     </ErrorBoundary>
   );
 }

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -4,52 +4,52 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'infected_age_0_9_per_100k',
     color: colors.data.multiseries.cyan,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_10_19_per_100k',
     color: colors.data.multiseries.cyan_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_20_29_per_100k',
     color: colors.data.multiseries.turquoise,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_30_39_per_100k',
     color: colors.data.multiseries.turquoise_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_40_49_per_100k',
     color: colors.data.multiseries.yellow,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_50_59_per_100k',
     color: colors.data.multiseries.yellow_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_60_69_per_100k',
     color: colors.data.multiseries.orange,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_70_79_per_100k',
     color: colors.data.multiseries.orange_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_80_89_per_100k',
     color: colors.data.multiseries.magenta,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_90_plus_per_100k',
     color: colors.data.multiseries.magenta_dark,
-    noLegend: true,
+    hideInLegend: true,
   },
   {
     metricProperty: 'infected_overall_per_100k',

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -4,42 +4,52 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'infected_age_0_9_per_100k',
     color: colors.data.multiseries.cyan,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_10_19_per_100k',
     color: colors.data.multiseries.cyan_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_20_29_per_100k',
     color: colors.data.multiseries.turquoise,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_30_39_per_100k',
     color: colors.data.multiseries.turquoise_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_40_49_per_100k',
     color: colors.data.multiseries.yellow,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_50_59_per_100k',
     color: colors.data.multiseries.yellow_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_60_69_per_100k',
     color: colors.data.multiseries.orange,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_70_79_per_100k',
     color: colors.data.multiseries.orange_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_80_89_per_100k',
     color: colors.data.multiseries.magenta,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_age_90_plus_per_100k',
     color: colors.data.multiseries.magenta_dark,
+    noLegend: true,
   },
   {
     metricProperty: 'infected_overall_per_100k',


### PR DESCRIPTION
Some graphs were missing the timeline events in their legend because they used a custom legend.

I decided to add an option to hide a certain time series from the legend so we can use the normal legend for some of these graphs. Otherwise we would need to copy quite some logic to determine if there are visible timeline events to other places.