### PR TITLE
Proper metric property disabling

### DIFF
--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -168,8 +168,9 @@ export const features: Feature[] = [
   {
     name: 'nlTestedOverallTopicalPage',
     isEnabled: false,
-    dataScopes: ['nl'],
+    dataScopes: ['nl', 'vr', 'gm'],
     metricName: 'tested_overall',
+    metricProperties: ['infected_moving_average'],
   },
   {
     name: 'nlVaccinationsBoosterInformationBlock',


### PR DESCRIPTION
## Summary

As the title states. Metric properties that were defined in a feature falg were not properly set to non-required in their corresponding schema during validation.
