### PR TITLE
Sidebar and content improvements

### DIFF
--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -70,7 +70,7 @@ function NarrowMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
   /**
    * Extra filter for feature flag
    */
-  const filteredChildren = children.filter(x => x !== false);
+  const filteredChildren = children.filter((x) => x !== false);
 
   return (
     <>
@@ -175,10 +175,10 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
   /**
    * Extra filter for feature flag
    */
-  const filteredChildren = children.filter(x => x !== false);
+  const filteredChildren = children.filter((x) => x !== false);
 
   return (
-    <Box display="grid" gridTemplateColumns="24% 1fr" minHeight={265}>
+    <Box display="grid" gridTemplateColumns="30% 1fr" minHeight={265}>
       <Box borderRight="1px" borderRightStyle="solid" borderRightColor="border">
         <ul>
           {menuItems.map((item, index) => (
@@ -259,7 +259,7 @@ function WideMiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
           }
         </>
       </Box>
-      <Box pl={5}>{filteredChildren[selectedIndex]}</Box>
+      <Box pl={4}>{filteredChildren[selectedIndex]}</Box>
     </Box>
   );
 }

--- a/packages/app/src/domain/topical/mini-tile.tsx
+++ b/packages/app/src/domain/topical/mini-tile.tsx
@@ -12,14 +12,13 @@ export type MiniTileProps = {
   text: ReactNode;
   warning?: string;
   children: ReactNode;
-  hideLeftMargin?: boolean;
 };
 
 export function MiniTile(props: MiniTileProps) {
-  const { icon, text, title, warning, children, hideLeftMargin } = props;
+  const { icon, text, title, warning, children } = props;
 
   return (
-    <Box ml={ !hideLeftMargin ? { _: undefined, md: 3 }: undefined} spacing={3}>
+    <Box spacing={3}>
       <Box spacing={2}>
         <Heading level={3} as="h2">
           <Box as="span" fontWeight="bold" display="flex" alignItems="center">

--- a/packages/app/src/domain/topical/mini-trend-tile.tsx
+++ b/packages/app/src/domain/topical/mini-trend-tile.tsx
@@ -16,7 +16,6 @@ type MiniTrendTileProps<T extends TimestampedValue = TimestampedValue> = {
   seriesConfig: SeriesConfig<T>;
   dataOptions?: DataOptions;
   values: T[];
-  hideLeftMargin?: boolean
 } & Omit<MiniTileProps, 'children'>;
 
 export function MiniTrendTile<T extends TimestampedValue>(
@@ -28,12 +27,11 @@ export function MiniTrendTile<T extends TimestampedValue>(
     values,
     seriesConfig,
     dataOptions,
-    hideLeftMargin,
     ...tileProps
   } = props;
 
   return (
-    <MiniTile {...tileProps} hideLeftMargin={hideLeftMargin}>
+    <MiniTile {...tileProps}>
       <div>
         <ErrorBoundary>
           <MiniTrendChart

--- a/packages/app/src/domain/topical/mini-vaccination-coverage-tile.tsx
+++ b/packages/app/src/domain/topical/mini-vaccination-coverage-tile.tsx
@@ -14,7 +14,6 @@ type MiniVaccinationCoverageTileProps = {
   fullyVaccinatedPercentageLabel?: string | null;
   oneShotBarLabel: string;
   fullyVaccinatedBarLabel: string;
-  hideLeftMargin?: boolean
 } & Omit<MiniTileProps, 'children'>;
 
 export function MiniVaccinationCoverageTile(
@@ -27,12 +26,11 @@ export function MiniVaccinationCoverageTile(
     fullyVaccinatedPercentageLabel,
     oneShotBarLabel,
     fullyVaccinatedBarLabel,
-    hideLeftMargin,
     ...tileProps
   } = props;
 
   return (
-    <MiniTile {...tileProps} hideLeftMargin={hideLeftMargin}>
+    <MiniTile {...tileProps}>
       <Box display="flex" flexDirection="column" spacing={3}>
         <LabeledBar
           value={oneShotPercentage}

--- a/packages/app/src/pages/actueel/gemeente/[code].tsx
+++ b/packages/app/src/pages/actueel/gemeente/[code].tsx
@@ -183,7 +183,7 @@ const TopicalMunicipality = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <Box bg="white">
         <MaxWidth id="content">
-          <Box spacing={{ _: 4, md: 5 }} px={{ _: 3, sm: 5 }}>
+          <Box spacing={{ _: 4, md: 5 }} px={{ _: 3, sm: 4 }}>
             <Box spacing={3}>
               <TopicalSectionHeader
                 showBackLink

--- a/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
+++ b/packages/app/src/pages/actueel/veiligheidsregio/[code].tsx
@@ -169,7 +169,7 @@ const TopicalVr = (props: StaticProps<typeof getStaticProps>) => {
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <Box bg="white">
         <MaxWidth id="content">
-          <Box spacing={{ _: 4, md: 5 }} px={{ _: 3, sm: 5 }}>
+          <Box spacing={{ _: 4, md: 5 }} px={{ _: 3, sm: 4 }}>
             <Box spacing={3}>
               <TopicalSectionHeader
                 showBackLink

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -353,7 +353,6 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     content.elements.warning,
                     'intensive_care_nice'
                   )}
-                  hideLeftMargin={true}
                 />
 
                 <MiniTrendTile


### PR DESCRIPTION
* Resize sidebar width back to 30%
* Reduce spacing of tile and sidebar
* Align styling changes to all sub pages
* Remove redundant logic as this applies for all sub pages on homepage