### PR TITLE
fix: Add missing number formatting to Choropleths, legends and KPIs

### DIFF
--- a/packages/app/src/components/choropleth-legenda.tsx
+++ b/packages/app/src/components/choropleth-legenda.tsx
@@ -2,6 +2,7 @@ import { ChoroplethThresholdsValue } from '@corona-dashboard/common';
 import { css, SystemStyleObject } from '@styled-system/css';
 import styled from 'styled-components';
 import { ValueAnnotation } from '~/components/value-annotation';
+import { useIntl } from '~/intl';
 import { useResizeObserver } from '~/utils/use-resize-observer';
 import { Box } from './base';
 import { Text } from './typography';
@@ -19,6 +20,7 @@ export function ChoroplethLegenda({
 }: ChoroplethLegendaProps) {
   const [itemRef, itemSize] = useResizeObserver<HTMLLIElement>();
   const [endLabelRef, endLabelSize] = useResizeObserver<HTMLSpanElement>();
+  const { formatNumber } = useIntl();
 
   return (
     <Box
@@ -33,6 +35,7 @@ export function ChoroplethLegenda({
           const isFirst = index === 0;
           const isLast = index === thresholds.length - 1;
           const displayLabel = (itemSize.width ?? 0) > 35 || index % 2 === 0;
+          const formattedTreshold = formatNumber(threshold);
 
           return (
             <Item
@@ -41,9 +44,9 @@ export function ChoroplethLegenda({
             >
               <LegendaColor color={color} first={isFirst} last={isLast} />
               {isFirst ? (
-                <StartLabel>{label ?? threshold}</StartLabel>
+                <StartLabel>{label ?? formattedTreshold}</StartLabel>
               ) : (
-                displayLabel && <Label>{label ?? threshold}</Label>
+                displayLabel && <Label>{label ?? formattedTreshold}</Label>
               )}
 
               {isLast && endLabel && (

--- a/packages/app/src/components/choropleth/components/choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/choropleth-map.tsx
@@ -27,7 +27,7 @@ export type AnchorEventHandler = {
 
 type ChoroplethMapProps<T extends ChoroplethDataItem> = Omit<
   ChoroplethProps<T>,
-  'formatTooltip' | 'tooltipPlacement'
+  'formatTooltip' | 'tooltipPlacement' | 'dataFormatters'
 > & {
   setTooltip: (tooltip: TooltipSettings<T> | undefined) => void;
   isTabInteractive: boolean;

--- a/packages/app/src/components/choropleth/index.tsx
+++ b/packages/app/src/components/choropleth/index.tsx
@@ -101,6 +101,10 @@ export type OptionalDataConfig<T extends ChoroplethDataItem> = {
    * The width that is used to for the feature outline when the feature is rendered normally.
    */
   areaStrokeWidth?: number;
+  /**
+   * A record containing the keys of T that needs formatting. The values are the formatting functions itself.
+   */
+  dataFormatters?: Partial<Record<keyof T, (input: string | number) => string>>;
 };
 
 export type DataConfig<T extends ChoroplethDataItem> = Required<
@@ -243,6 +247,7 @@ export function Choropleth<T extends ChoroplethDataItem>({
               setTooltip={setTooltip}
               formatTooltip={formatTooltip}
               data={tooltip.data}
+              dataFormatters={props.dataConfig.dataFormatters}
             />
           </div>
         )}

--- a/packages/app/src/components/choropleth/tooltips/tooltip.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip.tsx
@@ -19,6 +19,7 @@ type TTooltipProps<T extends ChoroplethDataItem> = {
   placement?: ChoroplethTooltipPlacement;
   formatTooltip?: TooltipFormatter<T>;
   data: TooltipData<T>;
+  dataFormatters?: Partial<Record<keyof T, (input: string | number) => string>>;
 };
 
 const VIEWPORT_PADDING = 10;
@@ -32,6 +33,7 @@ export function Tooltip<T extends ChoroplethDataItem>({
   top,
   formatTooltip,
   data,
+  dataFormatters,
   placement = 'bottom-right',
 }: TTooltipProps<T>) {
   const viewportSize = useViewport();
@@ -43,7 +45,7 @@ export function Tooltip<T extends ChoroplethDataItem>({
   const content = isDefined(formatTooltip) ? (
     formatTooltip(data)
   ) : (
-    <ChoroplethTooltip data={data} />
+    <ChoroplethTooltip data={data} dataFormatters={dataFormatters} />
   );
 
   if (!content) return null;

--- a/packages/app/src/components/difference-indicator/tile-average-difference.tsx
+++ b/packages/app/src/components/difference-indicator/tile-average-difference.tsx
@@ -72,7 +72,7 @@ export function TileAverageDifference({
         }}
         content={replaceVariablesInText(content, {
           amount: `${formattedDifference}${isPercentage ? '%' : ''}`,
-          totalAverage: old_value,
+          totalAverage: formatNumber(old_value),
         })}
       />
     </Container>

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -314,6 +314,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 dataConfig={{
                   metricName: 'tested_overall',
                   metricProperty: 'infected_per_100k',
+                  dataFormatters: {
+                    infected: formatNumber,
+                    infected_per_100k: formatNumber,
+                  },
                 }}
                 dataOptions={{
                   selectedCode: data.code,

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -83,7 +83,7 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
   const values = data.disability_care.values;
   const underReportedDateStart = getBoundaryDateStartUnix(values, 7);
 
-  const { siteText } = useIntl();
+  const { siteText, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
   const infectedLocationsText = siteText.gehandicaptenzorg_besmette_locaties;
   const positiveTestedPeopleText =
@@ -262,6 +262,9 @@ const DisabilityCare = (props: StaticProps<typeof getStaticProps>) => {
               dataConfig={{
                 metricName: 'disability_care',
                 metricProperty: 'infected_locations_percentage',
+                dataFormatters: {
+                  infected_locations_percentage: formatNumber,
+                },
               }}
               dataOptions={{
                 getLink: reverseRouter.vr.gehandicaptenzorg,

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -306,6 +306,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   dataConfig={{
                     metricName: 'tested_overall',
                     metricProperty: 'infected_per_100k',
+                    dataFormatters: {
+                      infected: formatNumber,
+                      infected_per_100k: formatNumber,
+                    },
                   }}
                   dataOptions={{
                     getLink: reverseRouter.gm.positiefGetesteMensen,
@@ -322,6 +326,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                   dataConfig={{
                     metricName: 'tested_overall',
                     metricProperty: 'infected_per_100k',
+                    dataFormatters: {
+                      infected: formatNumber,
+                      infected_per_100k: formatNumber,
+                    },
                   }}
                   dataOptions={{
                     getLink: reverseRouter.vr.positiefGetesteMensen,

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -54,7 +54,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
-  const { siteText } = useIntl();
+  const { siteText, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
   const { selectedNlData: data, choropleth, content, lastGenerated } = props;
 
@@ -165,6 +165,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 dataConfig={{
                   metricName: 'sewer',
                   metricProperty: 'average',
+                  dataFormatters: {
+                    average: formatNumber,
+                  },
                 }}
                 dataOptions={{
                   getLink: reverseRouter.gm.rioolwater,
@@ -182,6 +185,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
                 dataConfig={{
                   metricName: 'sewer',
                   metricProperty: 'average',
+                  dataFormatters: {
+                    average: formatNumber,
+                  },
                 }}
                 dataOptions={{
                   getLink: reverseRouter.vr.rioolwater,

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -89,7 +89,7 @@ const ElderlyAtHomeNationalPage = (
     7
   );
 
-  const { siteText } = useIntl();
+  const { siteText, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
 
   const text = siteText.thuiswonende_ouderen;
@@ -245,6 +245,9 @@ const ElderlyAtHomeNationalPage = (
               dataConfig={{
                 metricName: 'elderly_at_home',
                 metricProperty: 'positive_tested_daily_per_100k',
+                dataFormatters: {
+                  positive_tested_daily_per_100k: formatNumber,
+                },
               }}
               dataOptions={{
                 getLink: reverseRouter.vr.thuiswonendeOuderen,

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -86,7 +86,7 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
     7
   );
 
-  const { siteText } = useIntl();
+  const { siteText, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
   const infectedLocationsText = siteText.verpleeghuis_besmette_locaties;
   const positiveTestedPeopleText =
@@ -276,6 +276,9 @@ const NursingHomeCare = (props: StaticProps<typeof getStaticProps>) => {
               dataConfig={{
                 metricName: 'nursing_home',
                 metricProperty: 'infected_locations_percentage',
+                dataFormatters: {
+                  infected_locations_percentage: formatNumber,
+                },
               }}
               dataOptions={{
                 isPercentage: true,

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -313,6 +313,10 @@ const PositivelyTestedPeople = (props: StaticProps<typeof getStaticProps>) => {
                 dataConfig={{
                   metricName: 'tested_overall',
                   metricProperty: 'infected_per_100k',
+                  dataFormatters: {
+                    infected: formatNumber,
+                    infected_per_100k: formatNumber,
+                  },
                 }}
                 dataOptions={{
                   getLink: reverseRouter.gm.positiefGetesteMensen,


### PR DESCRIPTION
`dataFormatters` can now be passed to the `<Choropleth />` to format data on property basis