### PR TITLE
fix: Remove feature flag and replace with fallback data

### DIFF
--- a/packages/app/src/domain/vaccine/vaccinations-booster-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccinations-booster-kpi-section.tsx
@@ -27,7 +27,7 @@ export function VaccinationsBoosterKpiSection({
       <KpiTile title={text.booster_last_7_days.title}>
         <KpiValue text={formatNumber(dataBoosterShotAdministered)} />
         <Markdown content={text.booster_last_7_days.description} />
-        <Metadata {...metadataBoosterShotAdministered} isTileFooter />
+        <Metadata {...metadataBoosterShotAdministered} />
       </KpiTile>
       <KpiTile title={text.booster_planned_7_days.title}>
         <KpiValue text={formatNumber(dataBoosterShotPlanned)} />

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -139,7 +139,6 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
   const testedOverallTopicalPageFeature = useFeature(
     'nlTestedOverallTopicalPage'
   );
-  const boosterCoverageFeature = useFeature('nlBoostersTemporary');
 
   const metadata = {
     ...siteText.nationaal_metadata,
@@ -563,7 +562,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                               .booster_shots_administered_data_drive_text,
                             {
                               percentage: formatPercentage(
-                                boosterCoverageFeature.isEnabled
+                                boosterCoverageEstimatedLastValue.received_booster_percentage
                                   ? boosterCoverageEstimatedLastValue.received_booster_percentage
                                   : boosterCoverageLastValue.percentage
                               ),
@@ -587,7 +586,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     vaccineCoverageEstimatedLastValue.age_18_plus_fully_vaccinated
                   }
                   boosterShotAdministered={formatPercentageAsNumber(
-                    boosterCoverageFeature.isEnabled
+                    boosterCoverageEstimatedLastValue.received_booster_percentage
                       ? `${boosterCoverageEstimatedLastValue.received_booster_percentage}`
                       : `${boosterCoverageLastValue.percentage}`
                   )}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -219,9 +219,6 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
     'nlVaccinationBoosterShotsPerAgeGroup'
   );
 
-  const boosterCoverageFeature = useFeature('nlBoostersTemporary');
-  const boosterDateGgdFeature = useFeature('nlBoostersTemporary');
-
   const metadata = {
     ...siteText.nationaal_metadata,
     title: textNl.metadata.title,
@@ -306,7 +303,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               has_one_shot:
                 vaccineCoverageEstimatedLastValue.age_18_plus_has_one_shot,
               boostered: formatPercentageAsNumber(
-                boosterCoverageFeature.isEnabled
+                boosterCoverageEstimatedLastValue.received_booster_percentage
                   ? `${boosterCoverageEstimatedLastValue.received_booster_percentage}`
                   : `${boosterCoverageLastValue.percentage}`
               ),
@@ -563,7 +560,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               boosterCoverageEstimatedLastValue.administered_total
             }
             percentageBoosterAndThirdShots={
-              boosterCoverageFeature.isEnabled
+              boosterCoverageEstimatedLastValue.received_booster_percentage
                 ? boosterCoverageEstimatedLastValue.received_booster_percentage
                 : boosterCoverageLastValue.percentage
             }
@@ -580,7 +577,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             }
             metadateBoosterGgd={{
               datumsText: textNl.booster_and_third_kpi.datums,
-              date: boosterDateGgdFeature.isEnabled
+              date: boosterShotAdministeredLastValue.date_unix
                 ? boosterShotAdministeredLastValue.date_unix
                 : boosterShotAdministeredLastValue.date_end_unix,
               source: {
@@ -593,7 +590,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             }
             metadateBoosterEstimated={{
               datumsText: textNl.booster_and_third_kpi.datums,
-              date: boosterDateGgdFeature.isEnabled
+              date: boosterShotAdministeredLastValue.date_unix
                 ? boosterShotAdministeredLastValue.date_unix
                 : boosterShotAdministeredLastValue.date_end_unix,
               source: {
@@ -626,7 +623,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
             }}
             metadataBoosterShotAdministered={{
               datumsText: textNl.booster_ggd_kpi_section.datums,
-              date: boosterDateGgdFeature.isEnabled
+              date: boosterShotAdministeredLastValue.date_unix
                 ? boosterShotAdministeredLastValue.date_unix
                 : [
                     boosterShotAdministeredLastValue.date_start_unix,

--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -137,13 +137,6 @@ export const features: Feature[] = [
     metricName: 'booster_shot_planned',
   },
   /**
-   * Temporary for the boosters
-   */
-  {
-    name: 'nlBoostersTemporary',
-    isEnabled: true,
-  },
-  /**
    * These flags are only here that the schemas will not be required when validating.
    * But the features can be seen once toggled on with dummy data and have a seperate flag.
    */


### PR DESCRIPTION
Safer approach for showing new data when old data has been removed by BE, so no `NaN` will be shown on the DB.