### PR TITLE
JSON validation: vaccine_coverage_per_age_group should have values

### DIFF
--- a/packages/app/schema/gm/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm/vaccine_coverage_per_age_group.json
@@ -7,6 +7,7 @@
   "properties": {
     "values": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/value"
       }

--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -7,6 +7,7 @@
   "properties": {
     "values": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/value"
       }

--- a/packages/app/schema/vr/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr/vaccine_coverage_per_age_group.json
@@ -7,6 +7,7 @@
   "properties": {
     "values": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/value"
       }


### PR DESCRIPTION
Currently when `vaccine_coverage_per_age_group` is an empty array the frontend doesn't build. We should add this check to the json schemas for nl, vr and gm.