### PR TITLE
feat: added custom validation for image and enabled category validation

### DIFF
--- a/packages/cms/src/lokalize/sync-prd-to-dev.ts
+++ b/packages/cms/src/lokalize/sync-prd-to-dev.ts
@@ -65,8 +65,8 @@ const NO_DRAFTS = '!(_id in path("drafts.**"))';
     documents.forEach((doc) => {
       transaction.patch(doc._id, {
         set: {
-          'text.nl': doc.text.nl,
-          'text.en': doc.text.en,
+          'text.nl': doc?.text?.nl,
+          'text.en': doc?.text?.en,
           should_display_empty: doc.should_display_empty,
           /**
            * Never copy over the key and subject properties! Because these could

--- a/packages/cms/src/schemas/fields/article-fields.ts
+++ b/packages/cms/src/schemas/fields/article-fields.ts
@@ -57,7 +57,7 @@ export const ARTICLE_FIELDS = [
         { title: 'Gedrag', value: 'gedrag' },
       ],
     },
-    // validation: (rule: Rule) => rule.required().min(1),
+    validation: (rule: Rule) => rule.required().min(1),
   },
   {
     title: 'Samenvatting',
@@ -88,7 +88,12 @@ export const ARTICLE_FIELDS = [
         type: 'localeString',
       },
     ],
-    validation: (rule: Rule) => rule.required(),
+    validation: (rule: Rule) =>
+      rule
+        .custom((context: any) => {
+          return context.asset ? true : 'Image required';
+        })
+        .required(),
   },
   {
     title: 'Content',


### PR DESCRIPTION
- Advanced image validation
   - Checking if image itself is empty and ignoring the image text, as the user was able to publish with no image.
- Enabled required category select
- Added optional chaining so command won't break. 