### PR TITLE
bugfix: use correct key for the stap_1-horeca_pertafel.svg icon

### DIFF
--- a/packages/app/src/domain/restrictions/restriction-icons.ts
+++ b/packages/app/src/domain/restrictions/restriction-icons.ts
@@ -35,7 +35,7 @@ export const restrictionIcons: Record<string, string | null> = {
   geenWedstrijden: 'geen-wedstrijden.svg',
   sporterMetZweetband: 'sporter-met-zweetband.svg',
   'stap_1-horeca_max': 'stap_1-horeca_max.svg',
-  'stap-1_horeca_per_tafel': 'stap_1-horeca_pertafel.svg',
+  'stap_1-horeca_per_tafel': 'stap_1-horeca_pertafel.svg',
   'stap_1-horeca_reserveren': 'stap_1-horeca_reserveren.svg',
   'stap_1-horeca_sportaccomodaties': 'stap_1-horeca_sportaccomodaties.svg',
   'stap_1-horeca_terras': 'stap_1-horeca_terras.svg',


### PR DESCRIPTION
Icon doesn't show without this fix.
Before:
![image](https://user-images.githubusercontent.com/98813868/154306539-d2f53342-eecd-46a2-a97f-4dcb372a4ba2.png)
After:
![image](https://user-images.githubusercontent.com/98813868/154306775-fdeef82c-8ea5-454f-b526-20afd7af3b3b.png)
