### PR TITLE
fix: align max display value with x-axis percentage

### DIFF
--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -221,7 +221,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
               leftMetricProperty="age_group_percentage"
               rightColor={'data.primary'}
               leftColor={'data.neutral'}
-              maxDisplayValue={45}
+              maxDisplayValue={60}
               text={textShared.age_groups.graph}
               formatValue={(a: number) => `${formatPercentage(a * 100)}%`}
             />


### PR DESCRIPTION
- Changed`maxDisplayValue` to max percentage, so it aligns better and shows correct colors on bars