### PR TITLE
Add redirects for touch-icon and regio urls

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -107,6 +107,11 @@ const nextConfig = {
         permanent: false,
       },
       {
+        source: '/apple-touch-icon.png',
+        destination: '/images/touch-icon.png',
+        permanent: false,
+      },
+      {
         source: '/apple-touch-icon-120x120-precomposed.png',
         destination: '/images/touch-icon.png',
         permanent: false,
@@ -114,6 +119,26 @@ const nextConfig = {
       {
         source: '/apple-touch-icon-120x120.png',
         destination: '/images/touch-icon.png',
+        permanent: false,
+      },
+      {
+        source: '/apple-touch-icon-152x152-precomposed.png',
+        destination: '/images/touch-icon.png',
+        permanent: false,
+      },
+      {
+        source: '/apple-touch-icon-152x152.png',
+        destination: '/images/touch-icon.png',
+        permanent: false,
+      },
+      {
+        source: '/apple-touch-icon-precomposed.png',
+        destination: '/images/touch-icon.png',
+        permanent: false,
+      },
+      {
+        source: '/regio',
+        destination: '/veiligheidsregio',
         permanent: false,
       },
       {

--- a/packages/app/src/pages/api/data/timeseries/[...param].ts
+++ b/packages/app/src/pages/api/data/timeseries/[...param].ts
@@ -64,6 +64,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
             metricProperty as keyof TimestampedValue
           )
         );
+    } else if (isDefined(data)) {
+      res.status(200).json(data);
     } else {
       res.status(404).end();
     }


### PR DESCRIPTION
- To resolve the most common 404 errors.
- Made api more flexible to no longer requiring a nested `values` property for timeseries endpoint