### PR TITLE
Fix Timeseries xAxis alignment

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -203,8 +203,6 @@ export const Axes = memo(function Axes({
     : yScale;
   const numDarkGridLines = allZeroValues ? 1 : numGridLines;
 
-  console.log(xTicks.map((x) => new Date(x * 1000)));
-
   return (
     <g css={css({ pointerEvents: 'none' })} aria-hidden="true">
       <GridRows
@@ -267,7 +265,7 @@ export const Axes = memo(function Axes({
                 : 'middle'
               : 'middle',
         })}
-        // hideTicks
+        hideTicks
       />
 
       <g>

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -64,7 +64,28 @@ type AxesProps = {
   hasAllZeroValues?: boolean;
 };
 
-function createTimeTicks(start: number, end: number, count: number) {
+function tickToDate(tick: number): Date {
+  return new Date(tick * 1000);
+}
+
+function dateToTick(date: Date): number {
+  return date.valueOf() / 1000;
+}
+
+/**
+ * Convert tick timestamp to 12:00 at the given day so that the
+ * xAxis tick labels appear in the center of the dedicated bar
+ */
+function normaliseTick(tick: number): number {
+  const tickDate = tickToDate(tick);
+  tickDate.setHours(12);
+  return dateToTick(tickDate);
+}
+
+function createTimeTicks(startTick: number, endTick: number, count: number) {
+  const start = normaliseTick(startTick);
+  const end = normaliseTick(endTick);
+
   if (count <= 2) {
     return [start, end];
   }
@@ -72,8 +93,10 @@ function createTimeTicks(start: number, end: number, count: number) {
   const ticks: number[] = [];
   const stepCount = count - 1;
   const step = Math.floor((end - start) / stepCount);
+
   for (let i = 0; i < stepCount; i++) {
-    ticks.push(start + i * step);
+    const tick = start + i * step;
+    ticks.push(normaliseTick(tick));
   }
   ticks.push(end);
 
@@ -180,6 +203,8 @@ export const Axes = memo(function Axes({
     : yScale;
   const numDarkGridLines = allZeroValues ? 1 : numGridLines;
 
+  console.log(xTicks.map((x) => new Date(x * 1000)));
+
   return (
     <g css={css({ pointerEvents: 'none' })} aria-hidden="true">
       <GridRows
@@ -242,7 +267,7 @@ export const Axes = memo(function Axes({
                 : 'middle'
               : 'middle',
         })}
-        hideTicks
+        // hideTicks
       />
 
       <g>

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -5,7 +5,11 @@
  * props. It might be easier to just create 2 or 3 different types of axes
  * layouts by forking this component.
  */
-import { colors, TimeframeOption } from '@corona-dashboard/common';
+import {
+  colors,
+  middleOfDayInSeconds,
+  TimeframeOption,
+} from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { AxisBottom, AxisLeft } from '@visx/axis';
 import { GridRows } from '@visx/grid';
@@ -64,27 +68,9 @@ type AxesProps = {
   hasAllZeroValues?: boolean;
 };
 
-function tickToDate(tick: number): Date {
-  return new Date(tick * 1000);
-}
-
-function dateToTick(date: Date): number {
-  return date.valueOf() / 1000;
-}
-
-/**
- * Convert tick timestamp to 12:00 at the given day so that the
- * xAxis tick labels appear in the center of the dedicated bar
- */
-function normaliseTick(tick: number): number {
-  const tickDate = tickToDate(tick);
-  tickDate.setHours(12);
-  return dateToTick(tickDate);
-}
-
 function createTimeTicks(startTick: number, endTick: number, count: number) {
-  const start = normaliseTick(startTick);
-  const end = normaliseTick(endTick);
+  const start = middleOfDayInSeconds(startTick);
+  const end = middleOfDayInSeconds(endTick);
 
   if (count <= 2) {
     return [start, end];
@@ -96,7 +82,7 @@ function createTimeTicks(startTick: number, endTick: number, count: number) {
 
   for (let i = 0; i < stepCount; i++) {
     const tick = start + i * step;
-    ticks.push(normaliseTick(tick));
+    ticks.push(middleOfDayInSeconds(tick));
   }
   ticks.push(end);
 


### PR DESCRIPTION
Normalise every tick to 12:00 so the xAxis label appears always in the center of the bar

Before:

<img width="1009" alt="Screenshot 2022-02-23 at 12 50 32" src="https://user-images.githubusercontent.com/97020799/155314119-17b64839-812a-4e3c-b093-8a5fb02876f9.png">

After:

<img width="1013" alt="Screenshot 2022-02-23 at 12 50 49" src="https://user-images.githubusercontent.com/97020799/155314145-2c17ba46-b96e-41ab-a339-3121fddf352d.png">


(https://coronadashboard.rijksoverheid.nl/landelijk/positief-geteste-mensen "Laatste 5 weken")
