### PR TITLE
Feature/grey areas in timeseries correcton

### DIFF
--- a/packages/app/src/components/time-series-chart/components/timespan-annotation.tsx
+++ b/packages/app/src/components/time-series-chart/components/timespan-annotation.tsx
@@ -1,7 +1,9 @@
 import { colors } from '@corona-dashboard/common';
 import { Bar } from '@visx/shape';
+import { scaleBand } from '@visx/scale';
 import { useUniqueId } from '~/utils/use-unique-id';
-import { GetX, TimespanAnnotationConfig } from '../logic';
+import { GetX, TimespanAnnotationConfig, Bounds, SeriesSingleValue } from '../logic';
+import { useMemo } from 'react';
 
 const DEFAULT_COLOR = colors.data.underReported;
 
@@ -10,11 +12,15 @@ export function TimespanAnnotation({
   getX,
   height,
   config,
+  bounds,
+  series
 }: {
   domain: [number, number];
   height: number;
   getX: GetX;
   config: TimespanAnnotationConfig;
+  bounds: Bounds;
+  series: SeriesSingleValue[];
 }) {
   const [min, max] = domain;
   const { start, end } = config;
@@ -23,13 +29,32 @@ export function TimespanAnnotation({
   const patternId = `${id}_annotation_pattern`;
 
   /**
+   * Calculate the width of one bar, for offset to cover the whole bar on the edge of the timespan.
+   */
+
+  const bandPadding = 0.2;
+
+  const xScale = useMemo(
+    () =>
+      scaleBand<number>({
+        range: [0, bounds.width],
+        round: true,
+        domain: series.map(getX),
+        padding: bandPadding,
+      }),
+    [bounds, getX, series, bandPadding]
+  );
+
+  const halfBarWidth = Math.max(xScale.bandwidth(), 1) / 2;
+
+  /**
    * Clip the start / end dates to the domain of the x-axis, so that we can
    * conveniently pass in things like Infinity for end date.
    */
   const clippedStart = Math.max(start, min);
   const clippedEnd = Math.min(end, max);
 
-  const x0 = getX({ __date_unix: clippedStart });
+  const x0 = getX({ __date_unix: clippedStart }) - halfBarWidth;
   const x1 = getX({ __date_unix: clippedEnd });
 
   /**

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -498,6 +498,8 @@ export function TimeSeriesChart<
                   getX={getX}
                   height={bounds.height}
                   config={x}
+                  bounds={bounds}
+                  series={seriesList[0]}
                 />
               ))}
             {timeAnnotations?.map((x, index) => (


### PR DESCRIPTION
Cover the whole first bar-instance of the time-series-chart instead of 50%.