### PR TITLE
Correct Choropleth responsive size

### DIFF
--- a/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
@@ -38,7 +38,6 @@ export type CanvasChoroplethMapProps = {
   anchorEventHandlers: AnchorEventHandler;
   annotations: AccessibilityAnnotations;
   choroplethFeatures: ChoroplethFeatures;
-  containerRef: MutableRefObject<HTMLDivElement | null>;
   dataOptions: DataOptions;
   featureOutHandler: ChoroplethTooltipHandlers[1];
   featureOverHandler: ChoroplethTooltipHandlers[0];
@@ -64,7 +63,6 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
     anchorEventHandlers,
     annotations,
     choroplethFeatures,
-    containerRef,
     dataOptions,
     featureOutHandler,
     featureOverHandler,
@@ -168,7 +166,6 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
         handleMouseOver={handleMouseOver}
       />
       <div
-        ref={containerRef}
         style={{
           minHeight: height,
           maxHeight: '75vh',

--- a/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
@@ -4,7 +4,6 @@ import Konva from 'konva';
 import {
   memo,
   MouseEvent,
-  MutableRefObject,
   RefObject,
   useCallback,
   useEffect,

--- a/packages/app/src/components/choropleth/components/choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/choropleth-map.tsx
@@ -52,10 +52,6 @@ export const ChoroplethMap: <T extends ChoroplethDataItem>(
     responsiveSizeConfiguration,
   } = props;
 
-  const mapContainerRef = useRef<HTMLDivElement>(null);
-  const mapContainerWidth =
-    mapContainerRef.current?.getBoundingClientRect().width || 0;
-
   const dataConfig = createDataConfig(partialDataConfig);
 
   const mapProjection = isDefined(dataOptions.projection)
@@ -67,7 +63,7 @@ export const ChoroplethMap: <T extends ChoroplethDataItem>(
   const annotations = useAccessibilityAnnotations(accessibility);
   const data = useChoroplethData(originalData, map, dataOptions.selectedCode);
 
-  const [containerRef, { width = mapContainerWidth, height = minHeight }] =
+  const [containerRef, { width = 0, height = minHeight }] =
     useResizeObserver<HTMLDivElement>();
 
   const [mapHeight, padding] = useResponsiveSize(
@@ -125,7 +121,7 @@ export const ChoroplethMap: <T extends ChoroplethDataItem>(
   );
 
   return (
-    <Box ref={mapContainerRef} width="100%" height="100%">
+    <Box ref={containerRef} width="100%" height="100%">
       {!isDefined(choroplethFeatures) ? (
         <img
           src={`/api/choropleth/${map}/${dataConfig.metricName}/${dataConfig.metricProperty}/${minHeight}`}
@@ -135,10 +131,9 @@ export const ChoroplethMap: <T extends ChoroplethDataItem>(
         <>
           {annotations.descriptionElement}
           <CanvasChoroplethMap
-            containerRef={containerRef}
             dataOptions={dataOptions}
-            width={mapContainerWidth}
-            height={mapHeight}
+            width={width}
+            height={height}
             annotations={annotations}
             featureOverHandler={featureOverHandler}
             featureOutHandler={featureOutHandler}

--- a/packages/app/src/components/choropleth/components/choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/choropleth-map.tsx
@@ -1,5 +1,5 @@
 import { geoConicConformal, geoMercator } from 'd3-geo';
-import { FocusEvent, memo, useMemo, useRef } from 'react';
+import { FocusEvent, memo, useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { Box } from '~/components/base';
 import { useAccessibilityAnnotations } from '~/utils/use-accessibility-annotations';


### PR DESCRIPTION
Before:
![Screenshot 2022-03-16 at 16 17 31](https://user-images.githubusercontent.com/97020799/158624634-2881f11d-c7b2-41a4-8d4e-93b154d65cb3.png)

After:
![Screenshot 2022-03-16 at 16 17 21](https://user-images.githubusercontent.com/97020799/158624668-eab31ce1-2a66-48cb-91bc-003936dfb7df.png)

