### PR TITLE
NL Booster coverage for 18+ & 12+

### DIFF
--- a/packages/app/schema/nl/booster_coverage.json
+++ b/packages/app/schema/nl/booster_coverage.json
@@ -5,23 +5,27 @@
   "properties": {
     "values": {
       "type": "array",
-      "minItems": 1,
-      "maxItems": 1,
+      "minItems": 2,
+      "maxItems": 2,
       "items": {
         "$ref": "#/definitions/value"
       }
-    },
-    "last_value": {
-      "$ref": "#/definitions/value"
     }
   },
-  "required": ["values", "last_value"],
+  "required": ["values"],
   "additionalProperties": false,
   "definitions": {
     "value": {
       "title": "nl_booster_coverage_value",
       "type": "object",
       "properties": {
+        "age_group": {
+          "type": "string",
+          "enum": [
+            "12+",
+            "18+"
+          ]
+        },
         "percentage": {
           "type": "number"
         },

--- a/packages/app/schema/nl/risk_level.json
+++ b/packages/app/schema/nl/risk_level.json
@@ -6,7 +6,6 @@
     "values": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 1,
       "items": {
         "$ref": "#/definitions/value"
       }

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -62,6 +62,7 @@ import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { trimNullValues } from '~/utils/trim-null-values';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 import { useFormatLokalizePercentage } from '~/utils/use-format-lokalize-percentage';
+import { assert } from '~/utils/assert';
 
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) =>
@@ -161,7 +162,14 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
   const vaccineCoverageEstimatedLastValue =
     data.vaccine_coverage_per_age_group_estimated.last_value;
 
-  const boosterCoverageLastValue = data.booster_coverage?.last_value;
+  const boosterCoverage18PlusValue = data.booster_coverage.values.find(
+    (v) => v.age_group === '18+'
+  );
+
+  assert(
+    boosterCoverage18PlusValue,
+    `[${Home.name}] Missing value for booster_coverage 18+`
+  );
 
   const underReportedRangeIntensiveCare = getBoundaryDateStartUnix(
     data.intensive_care_nice.values,
@@ -580,7 +588,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                             textShared.booster_shots_administered_data_drive_text,
                             {
                               percentage: formatters.formatPercentage(
-                                boosterCoverageLastValue.percentage
+                                boosterCoverage18PlusValue.percentage
                               ),
                             }
                           )}
@@ -602,7 +610,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                     vaccineCoverageEstimatedLastValue.age_18_plus_fully_vaccinated
                   }
                   boosterShotAdministered={formatPercentageAsNumber(
-                    `${boosterCoverageLastValue.percentage}`
+                    `${boosterCoverage18PlusValue.percentage}`
                   )}
                   warning={getWarning(
                     content.elements.warning,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -1,4 +1,5 @@
 import {
+  assert,
   colors,
   NlHospitalVaccineIncidencePerAgeGroupValue,
   NlIntensiveCareVaccinationStatusValue,
@@ -236,7 +237,21 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
   const boosterShotAdministeredLastValue =
     data.booster_shot_administered.last_value;
 
-  const boosterCoverageLastValue = data.booster_coverage?.last_value;
+  const boosterCoverage18PlusValue = data.booster_coverage.values.find(
+    (v) => v.age_group === '18+'
+  );
+  const boosterCoverage12PlusValue = data.booster_coverage.values.find(
+    (v) => v.age_group === '12+'
+  );
+
+  assert(
+    boosterCoverage18PlusValue,
+    `[${VaccinationPage.name}] Missing value for booster_coverage 18+`
+  );
+  assert(
+    boosterCoverage12PlusValue,
+    `[${VaccinationPage.name}] Missing value for booster_coverage 12+`
+  );
 
   const thirdShotAdministeredLastValue =
     data.third_shot_administered.last_value;
@@ -307,7 +322,7 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
               has_one_shot:
                 vaccineCoverageEstimatedLastValue.age_18_plus_has_one_shot,
               boostered: formatPercentageAsNumber(
-                `${boosterCoverageLastValue.percentage}`
+                `${boosterCoverage18PlusValue.percentage}`
               ),
               third_shot: thirdShotAdministeredLastValue.administered_total,
               birthyear:
@@ -318,6 +333,9 @@ const VaccinationPage = (props: StaticProps<typeof getStaticProps>) => {
                 vaccineCoverageEstimatedLastValue.age_12_plus_fully_vaccinated,
               has_one_shot:
                 vaccineCoverageEstimatedLastValue.age_12_plus_has_one_shot,
+              boostered: formatPercentageAsNumber(
+                `${boosterCoverage12PlusValue.percentage}`
+              ),
               birthyear:
                 vaccineCoverageEstimatedLastValue.age_12_plus_birthyear,
             }}

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -438,9 +438,9 @@ export interface NlBoosterShotPerAgeGroupValue {
 }
 export interface NlBoosterCoverage {
   values: NlBoosterCoverageValue[];
-  last_value: NlBoosterCoverageValue;
 }
 export interface NlBoosterCoverageValue {
+  age_group?: "12+" | "18+";
   percentage: number;
   date_unix: number;
   date_of_insertion_unix: number;


### PR DESCRIPTION
**For release of March 24:**

Make sure to set the correct text in Sanity for:
`vaccination_grade_toggle_tile.age_12_plus.description_booster_grade`

Before:
![Screenshot 2022-03-22 at 11 43 35](https://user-images.githubusercontent.com/97020799/159464376-1b8ef7d6-b648-4b57-ae2e-a97f02e36620.png)

After:
![Screenshot 2022-03-22 at 11 43 24](https://user-images.githubusercontent.com/97020799/159464406-7a2eaba8-3fb5-4338-8e8b-124e0f57010e.png)

