### PR TITLE
Revert to old download command

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -162,7 +162,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --pretty --noEmit",
     "trace": "tsc --pretty --noEmit --generateTrace \"trace-$(date +%Y%m%d%H%M)\" --composite false --incremental false",
-    "download": "npx rimraf ./public/json/* && node ./infra/download.js",
+    "download": "node ./infra/download.js",
     "clean": "npx rimraf .next",
     "nuke": "yarn clean && npx rimraf node_modules"
   },

--- a/packages/cms/src/data/data-structure.ts
+++ b/packages/cms/src/data/data-structure.ts
@@ -74,7 +74,7 @@ export const dataStructure = {
       "birthyear_range",
       "age_group_total",
     ],
-    booster_coverage: ["age_group", "percentage"],
+    booster_coverage: ["percentage"],
     third_shot_administered: ["administered_total"],
     doctor: ["covid_symptoms_per_100k", "covid_symptoms"],
     g_number: ["g_number"],
@@ -266,7 +266,6 @@ export const dataStructure = {
       "percentage_25_39",
       "percentage_16_24",
     ],
-    behavior_annotations: ["source_type", "behaviour_type"],
     deceased_rivm: ["covid_daily", "covid_daily_moving_average", "covid_total"],
     deceased_rivm_per_age_group: [
       "age_group_range",
@@ -318,7 +317,6 @@ export const dataStructure = {
       "cure_vac",
       "janssen",
       "sanofi",
-      "novavax",
       "total",
     ],
     vaccine_administered_estimate: [

--- a/packages/cms/src/data/data-structure.ts
+++ b/packages/cms/src/data/data-structure.ts
@@ -74,7 +74,7 @@ export const dataStructure = {
       "birthyear_range",
       "age_group_total",
     ],
-    booster_coverage: ["percentage"],
+    booster_coverage: ["age_group", "percentage"],
     third_shot_administered: ["administered_total"],
     doctor: ["covid_symptoms_per_100k", "covid_symptoms"],
     g_number: ["g_number"],
@@ -266,6 +266,7 @@ export const dataStructure = {
       "percentage_25_39",
       "percentage_16_24",
     ],
+    behavior_annotations: ["source_type", "behaviour_type"],
     deceased_rivm: ["covid_daily", "covid_daily_moving_average", "covid_total"],
     deceased_rivm_per_age_group: [
       "age_group_range",
@@ -317,6 +318,7 @@ export const dataStructure = {
       "cure_vac",
       "janssen",
       "sanofi",
+      "novavax",
       "total",
     ],
     vaccine_administered_estimate: [


### PR DESCRIPTION
Due to that the pipeline does not recognise the public folder and not needing to remove the contents of the public folder, but instead of doing that, overriding all its contents like it was before.