### PR TITLE
feat: Added booster coverage for 12+

### DIFF
--- a/packages/app/schema/gm/booster_coverage.json
+++ b/packages/app/schema/gm/booster_coverage.json
@@ -20,6 +20,10 @@
       "title": "gm_booster_coverage_value",
       "type": "object",
       "properties": {
+        "age_group": {
+          "type": "string",
+          "enum": ["12+", "18+"]
+        },
         "percentage": {
           "type": "number"
         },
@@ -35,6 +39,7 @@
         }
       },
       "required": [
+        "age_group",
         "percentage",
         "percentage_label",
         "date_unix",

--- a/packages/app/schema/vr/booster_coverage.json
+++ b/packages/app/schema/vr/booster_coverage.json
@@ -20,6 +20,10 @@
       "title": "vr_booster_coverage_value",
       "type": "object",
       "properties": {
+        "age_group": {
+          "type": "string",
+          "enum": ["12+", "18+"]
+        },
         "percentage": {
           "type": "number"
         },
@@ -35,6 +39,7 @@
         }
       },
       "required": [
+        "age_group",
         "percentage",
         "percentage_label",
         "date_unix",

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -131,8 +131,6 @@ export const VaccinationsGmPage = (
     }),
   };
 
-  const boosterCoverageLastValue = data.booster_coverage?.last_value;
-
   /**
    * Filter out only the the 12+ and 18+ for the toggle component.
    */
@@ -145,6 +143,13 @@ export const VaccinationsGmPage = (
     data.vaccine_coverage_per_age_group.values.find(
       (x) => x.age_group_range === '12+'
     );
+
+  const boosterCoverage18PlusValue =
+    data.booster_coverage.values.find((v) => v.age_group === '18+') ||
+    data.booster_coverage.last_value;
+  const boosterCoverage12PlusValue =
+    data.booster_coverage.values.find((v) => v.age_group === '12+') ||
+    undefined;
 
   assert(
     filteredAgeGroup18Plus,
@@ -198,10 +203,10 @@ export const VaccinationsGmPage = (
               has_one_shot_label:
                 filteredAgeGroup18Plus.has_one_shot_percentage_label,
               boostered: formatPercentageAsNumber(
-                `${boosterCoverageLastValue.percentage}`
+                `${boosterCoverage18PlusValue?.percentage}`
               ),
-              boostered_label: boosterCoverageLastValue.percentage_label,
-              dateUnixBoostered: boosterCoverageLastValue.date_unix,
+              boostered_label: boosterCoverage18PlusValue?.percentage_label,
+              dateUnixBoostered: boosterCoverage18PlusValue?.date_unix,
             }}
             age12Plus={{
               fully_vaccinated:
@@ -212,6 +217,11 @@ export const VaccinationsGmPage = (
                 filteredAgeGroup12Plus.fully_vaccinated_percentage_label,
               has_one_shot_label:
                 filteredAgeGroup12Plus.has_one_shot_percentage_label,
+              boostered: formatPercentageAsNumber(
+                `${boosterCoverage12PlusValue?.percentage}`
+              ),
+              boostered_label: boosterCoverage12PlusValue?.percentage_label,
+              dateUnixBoostered: boosterCoverage12PlusValue?.date_unix,
             }}
             age12PlusToggleText={
               textGm.vaccination_grade_toggle_tile.age_12_plus

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -133,8 +133,6 @@ export const VaccinationsVrPage = (
   const gmCodes = gmCodesByVrCode[router.query.code as string];
   const selectedGmCode = gmCodes ? gmCodes[0] : undefined;
 
-  const boosterCoverageLastValue = data.booster_coverage?.last_value;
-
   /**
    * Filter out only the the 12+ and 18+ for the toggle component.
    */
@@ -147,6 +145,13 @@ export const VaccinationsVrPage = (
     data.vaccine_coverage_per_age_group.values.find(
       (item) => item.age_group_range === '12+'
     );
+
+  const boosterCoverage18PlusValue =
+    data.booster_coverage.values.find((v) => v.age_group === '18+') ||
+    data.booster_coverage.last_value;
+  const boosterCoverage12PlusValue =
+    data.booster_coverage.values.find((v) => v.age_group === '12+') ||
+    undefined;
 
   assert(
     filteredAgeGroup18Plus,
@@ -200,10 +205,10 @@ export const VaccinationsVrPage = (
               has_one_shot_label:
                 filteredAgeGroup18Plus.has_one_shot_percentage_label,
               boostered: formatPercentageAsNumber(
-                `${boosterCoverageLastValue.percentage}`
+                `${boosterCoverage18PlusValue?.percentage}`
               ),
-              boostered_label: boosterCoverageLastValue.percentage_label,
-              dateUnixBoostered: boosterCoverageLastValue.date_unix,
+              boostered_label: boosterCoverage18PlusValue?.percentage_label,
+              dateUnixBoostered: boosterCoverage18PlusValue?.date_unix,
             }}
             age12Plus={{
               fully_vaccinated:
@@ -214,6 +219,11 @@ export const VaccinationsVrPage = (
                 filteredAgeGroup12Plus.fully_vaccinated_percentage_label,
               has_one_shot_label:
                 filteredAgeGroup12Plus.has_one_shot_percentage_label,
+              boostered: formatPercentageAsNumber(
+                `${boosterCoverage12PlusValue?.percentage}`
+              ),
+              boostered_label: boosterCoverage12PlusValue?.percentage_label,
+              dateUnixBoostered: boosterCoverage12PlusValue?.date_unix,
             }}
             age12PlusToggleText={
               textVr.vaccination_grade_toggle_tile.age_12_plus

--- a/packages/common/src/feature-flags/features.ts
+++ b/packages/common/src/feature-flags/features.ts
@@ -185,6 +185,13 @@ export const features: Feature[] = [
     metricName: 'booster_coverage',
   },
   {
+    name: 'boosterCoverageAgeGroup',
+    isEnabled: false,
+    dataScopes: ['vr', 'gm'],
+    metricName: 'booster_coverage',
+    metricProperties: ['age_group'],
+  },
+  {
     name: 'riskLevel',
     isEnabled: false,
     dataScopes: ['nl'],

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -145,6 +145,7 @@ export interface GmBoosterCoverage {
   last_value: GmBoosterCoverageValue;
 }
 export interface GmBoosterCoverageValue {
+  age_group: "12+" | "18+";
   percentage: number;
   percentage_label: string | null;
   date_unix: number;
@@ -1426,6 +1427,7 @@ export interface VrBoosterCoverage {
   last_value: VrBoosterCoverageValue;
 }
 export interface VrBoosterCoverageValue {
+  age_group: "12+" | "18+";
   percentage: number;
   percentage_label: string | null;
   date_unix: number;


### PR DESCRIPTION
- Updated schemas for VR and GM booster coverage
- Added feature flag to ignore validation of new property
- Added new data to the corresponding pages