### PR TITLE
Feature/cor 615 fix two kpi tiles with one column

### DIFF
--- a/packages/app/src/components/two-kpi-section.tsx
+++ b/packages/app/src/components/two-kpi-section.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Children } from 'react';
 import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
 
@@ -8,11 +8,17 @@ interface TwoKpiSectionProps {
 }
 
 export function TwoKpiSection({ children, spacing }: TwoKpiSectionProps) {
+  const hasOnlyOneChild = Children.toArray(children).length === 1;
+
   return (
     <Box
       display="grid"
-      grid-template-columns={{ _: '1fr', lg: '1fr 1fr' }}
-      column-gap={asResponsiveArray({ _: 0, lg: spacing ?? 10 })}
+      gridTemplateColumns={asResponsiveArray({ _: '1fr', lg: '1fr 1fr' })}
+      gridColumnGap={asResponsiveArray({ _: 0, lg: spacing ?? '10rem' })}
+      gridRowGap={asResponsiveArray({ _: '3rem', lg: spacing ?? '8rem' })}
+      borderTop={hasOnlyOneChild ? 'solid 2px lightGray' : undefined}
+      pt={hasOnlyOneChild ? 4 : undefined}
+      pb={hasOnlyOneChild ? asResponsiveArray({ _: 3, sm: 4 }) : undefined}
     >
       {children}
     </Box>

--- a/packages/app/src/components/two-kpi-section.tsx
+++ b/packages/app/src/components/two-kpi-section.tsx
@@ -1,4 +1,3 @@
-import css from '@styled-system/css';
 import React from 'react';
 import { asResponsiveArray } from '~/style/utils';
 import { Box } from './base';
@@ -11,17 +10,9 @@ interface TwoKpiSectionProps {
 export function TwoKpiSection({ children, spacing }: TwoKpiSectionProps) {
   return (
     <Box
-      display="flex"
-      flexDirection={{ _: 'column', lg: 'row' }}
-      css={css({
-        '& > *': {
-          flex: 1,
-        },
-        '& > *:not(:last-child)': {
-          mr: asResponsiveArray({ _: 0, lg: spacing ?? 5 }),
-          mb: asResponsiveArray({ _: spacing ?? 4, lg: 0 }),
-        },
-      })}
+      display="grid"
+      grid-template-columns={{ _: '1fr', lg: '1fr 1fr' }}
+      column-gap={asResponsiveArray({ _: 0, lg: spacing ?? 10 })}
     >
       {children}
     </Box>

--- a/packages/app/src/domain/vaccine/vaccinations-shot-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccinations-shot-kpi-section.tsx
@@ -34,7 +34,7 @@ export function VaccinationsShotKpiSection({
 
   return (
     <TwoKpiSection>
-      <KpiTile title={text.title}>
+      <KpiTile title={text.title} hasNoBorder>
         <KpiValue text={formatNumber(value)} />
         <Markdown content={text.description} />
         {text.warning && <Message variant="warning">{text.warning}</Message>}

--- a/packages/app/src/domain/vaccine/vaccinations-shot-kpi-section.tsx
+++ b/packages/app/src/domain/vaccine/vaccinations-shot-kpi-section.tsx
@@ -47,7 +47,6 @@ export function VaccinationsShotKpiSection({
           }}
         />
       </KpiTile>
-      <KpiTile />
     </TwoKpiSection>
   );
 }


### PR DESCRIPTION
Fixing empty kpi tile in a two column tile

Before:
<img width="387" alt="Screenshot 2022-05-19 at 00 04 58" src="https://user-images.githubusercontent.com/93984341/169163676-8cf8a6f1-3744-4b39-8361-3d2a256b4827.png">
<img width="956" alt="Screenshot 2022-05-19 at 00 05 33" src="https://user-images.githubusercontent.com/93984341/169163681-001de3c3-0f15-48af-9508-8a731a143394.png">


After:
<img width="382" alt="Screenshot 2022-05-19 at 00 05 16" src="https://user-images.githubusercontent.com/93984341/169163715-8975dd83-b3e8-4c03-8a6d-1a874154db66.png">
<img width="1009" alt="Screenshot 2022-05-19 at 00 05 46" src="https://user-images.githubusercontent.com/93984341/169163720-5d484b1b-357e-4a16-a0ec-b78e1d176675.png">

