### PR TITLE
fix: set icon size for the top menu icons on smaller screens

### DIFF
--- a/packages/app/src/components/layout/components/top-navigation.tsx
+++ b/packages/app/src/components/layout/components/top-navigation.tsx
@@ -32,7 +32,9 @@ export function TopNavigation() {
       >
         {collapsible.button(
           <NavToggle>
-            {collapsible.isOpen ? <CloseThick /> : <Menu />}
+            {collapsible.isOpen
+              ? <CloseThick heigth="36px" width="36px"/>
+              : <Menu  heigth="36px" width="36px"/>}
             <VisuallyHidden>
               {collapsible.isOpen
                 ? commonTexts.nav.menu.close_menu


### PR DESCRIPTION
Before, firefox:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/98813868/170259532-5a819a8f-96bd-4f07-b79e-5a2649df8554.png">
Chrome:
<img width="448" alt="image" src="https://user-images.githubusercontent.com/98813868/170259601-35cc7346-bbb4-4623-bd28-c69104affde8.png">

After, firefox:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/98813868/170259680-913f447b-ba14-40d7-8f59-9b3010c9847b.png">
Chrome:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/98813868/170259781-bdc5d0c0-062d-4a4a-8a29-d0f6eea0bc58.png">
