### PR TITLE
feature(CMS): slice first 3 path elements of for the title because they are redundant in the preview

### DIFF
--- a/packages/cms/src/schemas/documents/lokalize-text.ts
+++ b/packages/cms/src/schemas/documents/lokalize-text.ts
@@ -80,8 +80,15 @@ export const lokalizeText = {
        * list, but the path field is cleaner when browsing texts because it
        * avoids a lot of string duplication.
        */
-      title: 'key',
+      key: 'key',
       subtitle: 'text.nl',
+    },
+    prepare({ key, subtitle}: { key: string, subtitle: string}) {
+      const title = key.split('.').slice(3).join('.');
+      return {
+        title,
+        subtitle
+      }
     },
   },
 };


### PR DESCRIPTION
closes: COR-543