### PR TITLE
Bugfix/lcps double tooltip and legend fix

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/legend.tsx
+++ b/packages/app/src/components/time-series-chart/logic/legend.tsx
@@ -30,6 +30,7 @@ export function useLegendItems<T extends TimestampedValue>(
   return useMemo(() => {
     const legendItems = config
       .filter(isVisible)
+      .filter((configItem) => !configItem?.hideInLegend)
       .map<LegendItem | undefined>((x) => {
         switch (x.type) {
           case 'split-area':

--- a/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
+++ b/packages/app/src/domain/hospital/admissions-per-age-group/series-config.ts
@@ -4,47 +4,38 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'admissions_age_0_19_per_million',
     color: colors.data.multiseries.cyan,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_20_29_per_million',
     color: colors.data.multiseries.turquoise,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_30_39_per_million',
     color: colors.data.multiseries.turquoise_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_40_49_per_million',
     color: colors.data.multiseries.yellow,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_50_59_per_million',
     color: colors.data.multiseries.yellow_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_60_69_per_million',
     color: colors.data.multiseries.orange,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_70_79_per_million',
     color: colors.data.multiseries.orange_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_80_89_per_million',
     color: colors.data.multiseries.magenta,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_age_90_plus_per_million',
     color: colors.data.multiseries.magenta_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'admissions_overall_per_million',

--- a/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
+++ b/packages/app/src/domain/tested/infected-per-age-group/series-config.ts
@@ -4,52 +4,42 @@ export const BASE_SERIES_CONFIG = [
   {
     metricProperty: 'infected_age_0_9_per_100k',
     color: colors.data.multiseries.cyan,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_10_19_per_100k',
     color: colors.data.multiseries.cyan_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_20_29_per_100k',
     color: colors.data.multiseries.turquoise,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_30_39_per_100k',
     color: colors.data.multiseries.turquoise_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_40_49_per_100k',
     color: colors.data.multiseries.yellow,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_50_59_per_100k',
     color: colors.data.multiseries.yellow_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_60_69_per_100k',
     color: colors.data.multiseries.orange,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_70_79_per_100k',
     color: colors.data.multiseries.orange_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_80_89_per_100k',
     color: colors.data.multiseries.magenta,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_age_90_plus_per_100k',
     color: colors.data.multiseries.magenta_dark,
-    hideInLegend: true,
   },
   {
     metricProperty: 'infected_overall_per_100k',

--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -299,6 +299,8 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                   {
                     type: 'line',
                     metricProperty: 'beds_occupied_covid',
+                    nonInteractive: true,
+                    hideInLegend: true,
                     label: textNl.chart_bedbezetting.legend_trend_label,
                     color: colors.data.primary,
                   },

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -301,6 +301,8 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                   {
                     type: 'line',
                     metricProperty: 'beds_occupied_covid',
+                    nonInteractive: true,
+                    hideInLegend: true,
                     label: textNl.chart_bedbezetting.legend_trend_label,
                     color: colors.data.primary,
                   },


### PR DESCRIPTION
The LCPS graph had a double legend and a double tooltip. Thus one had to go.

The following had to be done as well:
- The return of the HideInLegend feature
- Turn off the hideInLegend in old configs in other graphs.

In an other PR there will be the feature for forcing a single legend item. For now it's there but not showing until that feature is added.

![Screenshot 2022-06-07 at 11 58 08](https://user-images.githubusercontent.com/93984341/172352823-bb1e4281-f2a1-4a02-8266-da70d4653adb.png)
 