### PR TITLE
force legends for LCPS graphs

### DIFF
--- a/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
+++ b/packages/app/src/pages/landelijk/intensive-care-opnames.tsx
@@ -285,6 +285,7 @@ const IntakeIntensiveCare = (props: StaticProps<typeof getStaticProps>) => {
                 }}
                 values={data.intensive_care_lcps.values}
                 timeframe={timeframe}
+                forceLegend
                 dataOptions={{
                   timespanAnnotations: [
                     {

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -297,6 +297,7 @@ const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
                 }}
                 values={dataHospitalLcps.values}
                 timeframe={timeframe}
+                forceLegend
                 seriesConfig={[
                   {
                     type: 'line',


### PR DESCRIPTION
Forced to have at least one legend in the graphs for LCPS data.

<img width="686" alt="Screenshot 2022-06-08 at 05 32 51" src="https://user-images.githubusercontent.com/93984341/172525965-4441b9ac-8a68-4ce5-a9e4-f3da0d0b71e0.png">
