### PR TITLE
Show topical mini charts when we know the correct breakpoints

### DIFF
--- a/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
+++ b/packages/app/src/domain/topical/mini-tile-selector-layout.tsx
@@ -20,7 +20,7 @@ import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
 import { space } from '~/style/theme';
 import { asResponsiveArray } from '~/style/utils';
-import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useBreakpointsAsync } from '~/utils/use-breakpoints';
 import { useCollapsible } from '~/utils/use-collapsible';
 import { Bar } from '../vaccine/components/bar';
 
@@ -49,7 +49,12 @@ type MiniTileSelectorLayoutProps = {
 
 export function MiniTileSelectorLayout(props: MiniTileSelectorLayoutProps) {
   const { text } = props;
-  const breakpoints = useBreakpoints();
+  const breakpoints = useBreakpointsAsync();
+
+  // Prevents flickering; don't show anything until breakpoints are loaded
+  if (!breakpoints) {
+    return null;
+  }
 
   return (
     <>

--- a/packages/app/src/utils/use-breakpoints.tsx
+++ b/packages/app/src/utils/use-breakpoints.tsx
@@ -69,6 +69,16 @@ export function useBreakpoints(initialValue = false): Breakpoints {
   return value || (initialValue ? breakpointsTrue : breakpointsFalse);
 }
 
+/**
+ * This hook works the same as useBreakpointsAsync but can also return undefined when the app is not mounted completely.
+ * This allows the programmer to make decisons based on the loaded state of the breakpoints.
+ *
+ * @returns
+ */
+export function useBreakpointsAsync(): Breakpoints | undefined {
+  return useContext(breakpointContext);
+}
+
 const breakpointsTrue: Breakpoints = {
   xs: true,
   sm: true,


### PR DESCRIPTION
Page load behaviour:

Before:
<video src="https://user-images.githubusercontent.com/97020799/172611382-66827141-14d7-423a-958e-1921c88ada73.mov"></video>

After:
<video src="https://user-images.githubusercontent.com/97020799/172611798-df9eefc7-74d1-4567-83f3-c966496fc455.mov"></video>




