### PR TITLE
Scroll through list of results with keyboard

### DIFF
--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -45,7 +45,7 @@ type TProps<Option extends TOption> = {
  * />
  * ```
  */
-export function ComboBox<Option extends TOption>(props: TProps<Option>) {
+export const ComboBox = <Option extends TOption>(props: TProps<Option>) => {
   const { options, placeholder, sorter, selectedOption } = props;
 
   const { commonTexts } = useIntl();
@@ -53,7 +53,7 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const router = useRouter();
   const { code } = router.query;
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLUListElement>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const results = useSearchedOptions<Option>(inputValue, options, sorter);
   const breakpoints = useBreakpoints();
@@ -64,34 +64,33 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
    * Allow keyboard interaction to scroll through a list of results.
    */
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!event.isDefaultPrevented()) {
-      const container = containerRef.current;
+    const container = containerRef.current;
 
-      if (container) {
-        window.requestAnimationFrame(() => {
-          const element: HTMLInputElement | null = container.querySelector(
-            '[aria-selected=true]'
-          );
-          if (element) {
-            const top = element.offsetTop - container.scrollTop;
-            const bottom =
-              container.scrollTop +
-              container.clientHeight -
-              (element.offsetTop + element.clientHeight);
+    if (event.isDefaultPrevented() || !container) return;
 
-            if (bottom < 0) container.scrollTop -= bottom;
-            if (top < 0) container.scrollTop += top;
-          }
-        });
+    window.requestAnimationFrame(() => {
+      const element: HTMLInputElement | null = container.querySelector(
+        '[aria-selected=true]'
+      );
+      if (element) {
+        const top = element.offsetTop - container.scrollTop; // Calculate the space between active element and top of the list
+        const bottom =
+          container.scrollTop +
+          container.clientHeight -
+          (element.offsetTop + element.clientHeight); // Calculate the space between active element and bottom of the list
+        if (bottom < 0) container.scrollTop -= bottom;
+        if (top < 0) container.scrollTop += top;
       }
-    }
+    });
   };
 
-  function handleInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
     setInputValue(event.target.value);
-  }
+  };
 
-  function handleSelect(name: string): void {
+  const handleSelect = (name: string): void => {
     if (!name) {
       return;
     }
@@ -113,7 +112,7 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
     setTimeout(() => {
       inputRef.current?.blur();
     }, 1);
-  }
+  };
 
   useEffect(() => {
     if (!inputRef.current?.value && isLargeScreen && !hasRegionSelected) {
@@ -132,7 +131,7 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
         />
         <ComboboxPopover>
           {results.length > 0 ? (
-            <ComboboxList>
+            <ComboboxList ref={containerRef}>
               {results.map((option, index) => (
                 <StyledComboboxOption
                   key={`${index}-${option.name}`}
@@ -149,13 +148,13 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
       <ComboBoxStyles />
     </Box>
   );
-}
+};
 
-function useSearchedOptions<Option extends TOption>(
+const useSearchedOptions = <Option extends TOption>(
   term: string,
   options: Option[],
   sorter?: (a: Option, b: Option) => number
-): Option[] {
+): Option[] => {
   const throttledTerm = useThrottle(term, 100);
 
   return useMemo(
@@ -167,7 +166,7 @@ function useSearchedOptions<Option extends TOption>(
           }),
     [throttledTerm, options, sorter]
   );
-}
+};
 
 const StyledComboboxOption = styled(ComboboxOption)<{
   isSelectedOption: boolean;

--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -78,6 +78,7 @@ export const ComboBox = <Option extends TOption>(props: TProps<Option>) => {
           container.scrollTop +
           container.clientHeight -
           (element.offsetTop + element.clientHeight); // Calculate the space between active element and bottom of the list
+
         if (bottom < 0) container.scrollTop -= bottom;
         if (top < 0) container.scrollTop += top;
       }

--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -63,7 +63,7 @@ export const ComboBox = <Option extends TOption>(props: TProps<Option>) => {
   /**
    * Allow keyboard interaction to scroll through a list of results.
    */
-  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const container = containerRef.current;
 
     if (event.isDefaultPrevented() || !container) return;
@@ -126,7 +126,7 @@ export const ComboBox = <Option extends TOption>(props: TProps<Option>) => {
         <ComboboxInput
           ref={inputRef}
           onChange={handleInputChange}
-          onKeyDown={onKeyDown}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
         />
         <ComboboxPopover>

--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -53,11 +53,39 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
   const router = useRouter();
   const { code } = router.query;
   const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState<string>('');
   const results = useSearchedOptions<Option>(inputValue, options, sorter);
   const breakpoints = useBreakpoints();
   const isLargeScreen = breakpoints.md;
   const hasRegionSelected = !!code;
+
+  /**
+   * Allow keyboard interaction to scroll through a list of results.
+   */
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!event.isDefaultPrevented()) {
+      const container = containerRef.current;
+
+      if (container) {
+        window.requestAnimationFrame(() => {
+          const element: HTMLInputElement | null = container.querySelector(
+            '[aria-selected=true]'
+          );
+          if (element) {
+            const top = element.offsetTop - container.scrollTop;
+            const bottom =
+              container.scrollTop +
+              container.clientHeight -
+              (element.offsetTop + element.clientHeight);
+
+            if (bottom < 0) container.scrollTop -= bottom;
+            if (top < 0) container.scrollTop += top;
+          }
+        });
+      }
+    }
+  };
 
   function handleInputChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setInputValue(event.target.value);
@@ -99,6 +127,7 @@ export function ComboBox<Option extends TOption>(props: TProps<Option>) {
         <ComboboxInput
           ref={inputRef}
           onChange={handleInputChange}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
         />
         <ComboboxPopover>


### PR DESCRIPTION
Fixed the issue where it was not possible to scroll through a list of results in a search bar. The bug was present in the index pages of GM and VR