### PR TITLE
fix(axes): can't calculate tickValue without values

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -172,6 +172,10 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
 
   const DateSpanTick = useCallback(
     (dateUnix: number, values: DateSpanValue[], index: number) => {
+      if (values.length === 0) {
+        return '';
+      }
+
       const previousYear = createDateFromUnixTimestamp(
         tickValues[index - 1]
       ).getFullYear();


### PR DESCRIPTION
Prevents a potential runtime error since #4292 by returning empty x-axis labels if the graph has no values.

Before:
![image](https://user-images.githubusercontent.com/98813868/176919078-c2ac9a89-cd2d-4fa1-a484-6ae5d5534deb.png)

After:
![image](https://user-images.githubusercontent.com/98813868/176918932-b510b20a-c4c1-4e04-8b53-424b14d9d6b8.png)