### PR TITLE
bugfix: expand the functionality of getLastInsertionDateOfPage so it covers all scenario's

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -54,8 +54,6 @@ export { getStaticPaths } from '~/static-paths/gm';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
 const pageMetrics = [
-  'code',
-  'static_values.population_count',
   'tested_overall',
 ];
 

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -38,9 +38,7 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 
 const pageMetrics = [
   'sewer_per_installation',
-  'static_values.population_count',
   'sewer',
-  'code',
 ];
 
 export { getStaticPaths } from '~/static-paths/gm';

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -39,7 +39,7 @@ import { replaceVariablesInText } from '~/utils';
 
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
-const pageMetrics = ['deceased_rivm', 'code'];
+const pageMetrics = ['deceased_rivm'];
 
 export { getStaticPaths } from '~/static-paths/gm';
 

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -56,7 +56,6 @@ import {
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
 const pageMetrics = [
-  'code',
   'vaccine_coverage_per_age_group',
   'vaccine_coverage_per_age_group_archived',
   'booster_coverage',

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -54,7 +54,7 @@ import {
 
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
-const pageMetrics = ['hospital_nice', 'code'];
+const pageMetrics = ['hospital_nice'];
 
 export { getStaticPaths } from '~/static-paths/gm';
 

--- a/packages/app/src/utils/__tests__/get-last-insertion-date-of-page.spec.ts
+++ b/packages/app/src/utils/__tests__/get-last-insertion-date-of-page.spec.ts
@@ -2,14 +2,14 @@ import { suite } from 'uvu';
 import * as assert from 'uvu/assert';
 import { getLastInsertionDateOfPage } from '../get-last-insertion-date-of-page';
 
-const GetLastInsertionDateOfPage = suite('getLastInsertionDateOfPage');
+const GetLastDateOfInsertion = suite('getLastInsertionDateOfPage');
 
-GetLastInsertionDateOfPage('returns zero when data is empty', () => {
+GetLastDateOfInsertion('returns zero when data is empty', () => {
   const result = getLastInsertionDateOfPage({}, ['key1']);
   assert.is(result, 0);
 });
 
-GetLastInsertionDateOfPage('returns zero when metrics are empty', () => {
+GetLastDateOfInsertion('returns zero when metrics are empty', () => {
   const result = getLastInsertionDateOfPage(
     { key1: { last_value: { date_of_insertion_unix: 123 } } },
     []
@@ -17,7 +17,7 @@ GetLastInsertionDateOfPage('returns zero when metrics are empty', () => {
   assert.is(result, 0);
 });
 
-GetLastInsertionDateOfPage('returns the max date_of_insertion_unix', () => {
+GetLastDateOfInsertion('returns the max date_of_insertion_unix', () => {
   const result = getLastInsertionDateOfPage(
     {
       key1: { last_value: { date_of_insertion_unix: 123 } },
@@ -28,55 +28,37 @@ GetLastInsertionDateOfPage('returns the max date_of_insertion_unix', () => {
   assert.is(result, 12345);
 });
 
-GetLastInsertionDateOfPage(
-  'ignores missing date_of_insertion_unix properties',
-  () => {
-    const result = getLastInsertionDateOfPage(
-      {
-        key1: { last_value: { date_of_insertion_unix: 9 } },
-        key3: { last_value: {} },
-        key2: { last_value: { date_of_insertion_unix: 6 } },
-      },
-      ['key1', 'key2', 'key3']
-    );
-    assert.is(result, 9);
-  }
-);
+GetLastDateOfInsertion('returns the max date_of_insertion_unix without last_value', () => {
+  const result = getLastInsertionDateOfPage(
+    {
+      key1: { values: [{ date_of_insertion_unix: 123 }, { date_of_insertion_unix: 12345 }] },
+    },
+    ['key1']
+  );
+  assert.is(result, 12345);
+});
 
-GetLastInsertionDateOfPage(
-  'works with paths and keys as given pageMetrics',
-  () => {
+GetLastDateOfInsertion('works with nested values', () => {
     const result = getLastInsertionDateOfPage(
       {
         key1: { last_value: { date_of_insertion_unix: 1 } },
-        level1: {
-          level2: {
-            last_value: {
-              date_of_insertion_unix: 9999,
-            },
-          },
-        },
+        key2: { values: [{last_value: { date_of_insertion_unix: 123 }}]},
       },
-      ['key1', 'level1.level2']
-    );
-    assert.is(result, 9999);
-  }
-);
-
-GetLastInsertionDateOfPage(
-  'works with a direct path instead of date_of_insertion_unix when given',
-  () => {
-    const result = getLastInsertionDateOfPage(
-      {
-        key1: { last_value: { date_of_insertion_unix: 1 } },
-        level1: {
-          level2: 123,
-        },
-      },
-      ['key1', 'level1.level2']
+      ['key1', 'key2']
     );
     assert.is(result, 123);
   }
 );
 
-GetLastInsertionDateOfPage.run();
+GetLastDateOfInsertion('works with a direct date_of_insertion_unix', () => {
+    const result = getLastInsertionDateOfPage(
+      {
+        key1: { date_of_insertion_unix: 123 }
+      },
+      ['key1']
+    );
+    assert.is(result, 123);
+  }
+);
+
+GetLastDateOfInsertion.run();

--- a/packages/app/src/utils/get-last-insertion-date-of-page.ts
+++ b/packages/app/src/utils/get-last-insertion-date-of-page.ts
@@ -1,21 +1,68 @@
 import { get } from 'lodash';
-/**
- * This method gets the most recent insertion date from the metrics used in a page
- *
- */
+
+//functions for checking type of metric
+function hasLastValue(metric: any): boolean {
+  return typeof metric?.last_value?.date_of_insertion_unix !== 'undefined';
+}
+
+function hasValues(metric: any): boolean {
+  return Array.isArray(metric?.values) &&
+    typeof metric?.values[metric?.values.length - 1]?.date_of_insertion_unix !== 'undefined';
+}
+
+function hasInsertionDate(metric: any): boolean {
+  return typeof metric?.date_of_insertion_unix !== 'undefined';
+}
+
+function hasNestedLastValue(metric: any): boolean {
+  return Array.isArray(metric?.values) &&
+    typeof metric?.values[0]?.last_value?.date_of_insertion_unix !== 'undefined';
+}
+
+// functions for getting values
+function getDateFromLastValue(metric: any): number {
+  return metric?.last_value?.date_of_insertion_unix;
+}
+
+function getDateFromValues(metric: any): number {
+  return metric?.values[metric.values.length - 1]?.date_of_insertion_unix;
+}
+
+function getDateFromInsertionDate(metric: any): number {
+  return metric?.date_of_insertion_unix;
+}
+
+function getDateFromNestedLastValue(metric: any): number {
+  return metric?.values.reduce((lastDate :number, innerValue: any) => {
+    const metricDate = getMetricDate(innerValue);
+    return Math.max(metricDate, lastDate);
+  }, 0);
+}
+
+function getMetricDate(metricOrUnixDate: any): number {
+  if (hasLastValue(metricOrUnixDate)) {
+    return getDateFromLastValue(metricOrUnixDate);
+  }
+  if (hasValues(metricOrUnixDate)) {
+    return getDateFromValues(metricOrUnixDate);
+  }
+  if (hasInsertionDate(metricOrUnixDate)) {
+    return getDateFromInsertionDate(metricOrUnixDate);
+  }
+  if (hasNestedLastValue(metricOrUnixDate)) {
+    return getDateFromNestedLastValue(metricOrUnixDate);
+  }
+  return 0;
+}
 
 export function getLastInsertionDateOfPage(
   data: unknown,
   pageMetrics: string[]
 ) {
   return pageMetrics.reduce((lastDate, metricProperty) => {
-    const metricOrUnixDate = get(data, metricProperty);
-
-    const metricDate =
-      typeof metricOrUnixDate === 'number'
-        ? metricOrUnixDate
-        : metricOrUnixDate?.last_value?.date_of_insertion_unix || 0;
-
-    return metricDate > lastDate ? metricDate : lastDate;
+    const metric: any = get(data, metricProperty);
+    const metricDate = getMetricDate(metric);
+    
+    return Math.max(metricDate, lastDate);
   }, 0);
-}
+};


### PR DESCRIPTION
removes occasional January 1st 1970 from the pages.
Also removed some entries as 'pageMetrics' that are backend data, but no page metrics, e.g. 'code' and 'static_values.<anything>'