### PR TITLE
Added alphabetical sorting

### DIFF
--- a/packages/app/src/domain/variants/static-props/get-variant-chart-data.ts
+++ b/packages/app/src/domain/variants/static-props/get-variant-chart-data.ts
@@ -26,7 +26,7 @@ export function getVariantChartData(variants: NlVariants | undefined) {
     return EMPTY_VALUES;
   }
 
-  const firstOccurences = variants.values.reduce<Record<string, number>>(
+  const firstOccurences = variants.values.sort().reverse().reduce<Record<string, number>>(
     (acc, x) =>
       Object.assign(acc, {
         [x.name]: x.values.find((value) => value.percentage > 0)


### PR DESCRIPTION
The order of variants in the graph is random when they have the same first occurrence. (See Omikron BA.4 & Omikron BA.2.12.1)

Before:
<img width="981" alt="Screenshot 2022-07-08 at 01 16 01" src="https://user-images.githubusercontent.com/93984341/177886770-40aa79da-995b-4f19-a1c6-0f6c8df732ff.png">

After:
<img width="1009" alt="Screenshot 2022-07-08 at 01 15 40" src="https://user-images.githubusercontent.com/93984341/177886953-2e6db0f8-448d-4d82-aedb-db29c3605354.png">

