### PR TITLE
bugfix/COR-869-scroll-to-anchors

### DIFF
--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -28,31 +28,29 @@ export const CollapsibleSection = ({
      * Checks the hash part of the URL to see if it matches the id.
      * If so, the collapsible needs to be opened.
      */
-    function handleHashChange() {
+    const handleHashChange = () => {
       if (id && window.location.hash === `#${id}`) {
         const sectionElement = section?.current;
         if (!sectionElement) return;
 
-        let shouldToggle = false;
+        let isElementAtTopOfViewport: boolean;
+        let isElementAtBottomOfViewport: boolean;
         const interval = setInterval(() => {
-          const isElementAtTopOfViewport =
+          isElementAtTopOfViewport =
             sectionElement.getBoundingClientRect().top <= 1;
-          const isElementAtBottomOfViewport =
+          isElementAtBottomOfViewport =
             window.innerHeight + Math.round(window.scrollY) >=
             document.body.scrollHeight;
-          if (isElementAtTopOfViewport || isElementAtBottomOfViewport) {
-            shouldToggle = true;
-          }
 
-          if (shouldToggle) {
+          if (isElementAtTopOfViewport || isElementAtBottomOfViewport) {
             toggle(true);
 
             clearInterval(interval);
             return;
           }
-        }, 250);
+        }, 250); // This value is slightly higher than the animation duration of the collapsible section.
       }
-    }
+    };
 
     handleHashChange();
 

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -1,5 +1,5 @@
 import { css } from '@styled-system/css';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { Box, BoxProps } from '~/components/base';
 import { useCollapsible } from '~/utils/use-collapsible';
@@ -18,6 +18,8 @@ export const CollapsibleSection = ({
   id,
   hideBorder,
 }: CollapsibleSectionProps) => {
+  const section = useRef<HTMLElement>(null);
+
   const collapsible = useCollapsible();
   const { toggle } = collapsible;
 
@@ -28,7 +30,7 @@ export const CollapsibleSection = ({
      */
     function handleHashChange() {
       if (id && window.location.hash === `#${id}`) {
-        const sectionElement = document.getElementById(id);
+        const sectionElement = section?.current;
         if (!sectionElement) return;
 
         let shouldToggle = false;
@@ -64,6 +66,7 @@ export const CollapsibleSection = ({
       borderTop={hideBorder ? undefined : '1px solid'}
       borderTopColor={hideBorder ? undefined : 'lightGray'}
       id={id}
+      ref={section}
     >
       {collapsible.button(
         <Summary>

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -1,5 +1,5 @@
 import { css } from '@styled-system/css';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useEffect } from 'react';
 import styled from 'styled-components';
 import { Box, BoxProps } from '~/components/base';
 import { useCollapsible } from '~/utils/use-collapsible';
@@ -75,7 +75,6 @@ export const CollapsibleSection = ({
                 tabIndex={-1}
                 onClick={(e) => e.stopPropagation()}
                 href={`#${id}`}
-                id={`${id}-anchor`}
               >
                 #
               </StyledAnchor>

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -1,5 +1,5 @@
 import { css } from '@styled-system/css';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { Box, BoxProps } from '~/components/base';
 import { useCollapsible } from '~/utils/use-collapsible';
@@ -28,7 +28,27 @@ export const CollapsibleSection = ({
      */
     function handleHashChange() {
       if (id && window.location.hash === `#${id}`) {
-        toggle(true);
+        const sectionElement = document.getElementById(id);
+        if (!sectionElement) return;
+
+        let shouldToggle = false;
+        const interval = setInterval(() => {
+          const isElementAtTopOfViewport =
+            sectionElement.getBoundingClientRect().top <= 1;
+          const isElementAtBottomOfViewport =
+            window.innerHeight + Math.round(window.scrollY) >=
+            document.body.scrollHeight;
+          if (isElementAtTopOfViewport || isElementAtBottomOfViewport) {
+            shouldToggle = true;
+          }
+
+          if (shouldToggle) {
+            toggle(true);
+
+            clearInterval(interval);
+            return;
+          }
+        }, 250);
       }
     }
 
@@ -55,6 +75,7 @@ export const CollapsibleSection = ({
                 tabIndex={-1}
                 onClick={(e) => e.stopPropagation()}
                 href={`#${id}`}
+                id={`${id}-anchor`}
               >
                 #
               </StyledAnchor>


### PR DESCRIPTION
**Notes**
Refactored `handleHashChange` functionality of the `CollapsibleSection` component to not toggle (open) until said section has properly scrolled into view.