### PR TITLE
Replace konva-node with konva

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,7 +43,6 @@
     "http-proxy-middleware": "^2.0.1",
     "intercept-stdout": "^0.1.2",
     "konva": "^7.2.5",
-    "konva-node": "^0.11.2",
     "lodash": "^4.17.21",
     "match-sorter": "^6.3.1",
     "next": "^12.0.4",

--- a/packages/app/src/pages/api/choropleth/[...param].ts
+++ b/packages/app/src/pages/api/choropleth/[...param].ts
@@ -2,7 +2,7 @@ import { assert, vrData } from '@corona-dashboard/common';
 import { geoMercator } from 'd3-geo';
 import fs from 'fs';
 import hash from 'hash-sum';
-import Konva from 'konva-node';
+import Konva from 'konva';
 import { NextApiRequest, NextApiResponse } from 'next/dist/shared/lib/utils';
 import path from 'path';
 import sanitize from 'sanitize-filename';
@@ -193,6 +193,7 @@ async function generateChoroplethImage(
   const featureProps = getFeatureProps(map, fColor, dataOptions, dataConfig);
 
   const stage = new Konva.Stage({
+    container: property,
     width,
     height,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,7 +2630,6 @@ __metadata:
     jsdom: ^18.1.1
     jsdom-global: ^3.0.2
     konva: ^7.2.5
-    konva-node: ^0.11.2
     lint-staged: ^11.2.6
     lodash: ^4.17.21
     lodash-webpack-plugin: ^0.11.6
@@ -3308,25 +3307,6 @@ __metadata:
   version: 1.1.1
   resolution: "@kwsites/promise-deferred@npm:1.1.1"
   checksum: 07455477a0123d9a38afb503739eeff2c5424afa8d3dbdcc7f9502f13604488a4b1d9742fc7288832a52a6422cf1e1c0a1d51f69a39052f14d27c9a0420b6629
-  languageName: node
-  linkType: hard
-
-"@mapbox/node-pre-gyp@npm:^1.0.0":
-  version: 1.0.5
-  resolution: "@mapbox/node-pre-gyp@npm:1.0.5"
-  dependencies:
-    detect-libc: ^1.0.3
-    https-proxy-agent: ^5.0.0
-    make-dir: ^3.1.0
-    node-fetch: ^2.6.1
-    nopt: ^5.0.0
-    npmlog: ^4.1.2
-    rimraf: ^3.0.2
-    semver: ^7.3.4
-    tar: ^6.1.0
-  bin:
-    node-pre-gyp: bin/node-pre-gyp
-  checksum: c1f182a707f5782e47b77a76e9d6a073fb043999cf9ad965bc86732e88db27ad00926d1602918edb7105f05cde67871b84a178ee9844eb742319ade419636675
   languageName: node
   linkType: hard
 
@@ -10637,18 +10617,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:^2.5.0":
-  version: 2.8.0
-  resolution: "canvas@npm:2.8.0"
-  dependencies:
-    "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.14.0
-    node-gyp: latest
-    simple-get: ^3.0.3
-  checksum: 4cc909f63eaf88d22f9164601903745abcc6ccb7f70090b9389dc2cb68cbf139c220dbd75837e6d04602ff122b44a2eb17413bca850f9c6c602f74f1f0f1cc3f
-  languageName: node
-  linkType: hard
-
 "capital-case@npm:^1.0.4":
   version: 1.0.4
   resolution: "capital-case@npm:1.0.4"
@@ -12487,15 +12455,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decompress-response@npm:^4.2.0":
-  version: 4.2.1
-  resolution: "decompress-response@npm:4.2.1"
-  dependencies:
-    mimic-response: ^2.0.0
-  checksum: 4e783ca4dfe9417354d61349750fe05236f565a4415a6ca20983a311be2371debaedd9104c0b0e7b36e5f167aeaae04f84f1a0b3f8be4162f1d7d15598b8fdba
-  languageName: node
-  linkType: hard
-
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -12724,15 +12683,6 @@ __metadata:
   version: 1.0.4
   resolution: "destroy@npm:1.0.4"
   checksum: da9ab4961dc61677c709da0c25ef01733042614453924d65636a7db37308fef8a24cd1e07172e61173d471ca175371295fbc984b0af5b2b4ff47cd57bd784c03
-  languageName: node
-  linkType: hard
-
-"detect-libc@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "detect-libc@npm:1.0.3"
-  bin:
-    detect-libc: ./bin/detect-libc.js
-  checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
   languageName: node
   linkType: hard
 
@@ -17648,17 +17598,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"konva-node@npm:^0.11.2":
-  version: 0.11.2
-  resolution: "konva-node@npm:0.11.2"
-  dependencies:
-    canvas: ^2.5.0
-    konva: ^7
-  checksum: 11d99492c653d6e52c370af5831a4dce60b6cabbf81016806fa58c8563174272db39940b8d638fc29f83f949cf5934471ed7c1d3d1d6c3bad60152450f308fd2
-  languageName: node
-  linkType: hard
-
-"konva@npm:^7, konva@npm:^7.2.5":
+"konva@npm:^7.2.5":
   version: 7.2.5
   resolution: "konva@npm:7.2.5"
   checksum: 795ab73af38307243f867be3dab122ec6a5c37bc7f44a20359baf2bf6e1d5cd8a9ce9d7e3b69b21dd6429615b8f96254858e346e8ccb4b5fff8be6c5b60cd12d
@@ -18785,13 +18725,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "mimic-response@npm:2.1.0"
-  checksum: 014fad6ab936657e5f2f48bd87af62a8e928ebe84472aaf9e14fec4fcb31257a5edff77324d8ac13ddc6685ba5135cf16e381efac324e5f174fb4ddbf902bf07
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
@@ -19034,7 +18967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.12.1, nan@npm:^2.14.0":
+"nan@npm:^2.12.1":
   version: 2.15.0
   resolution: "nan@npm:2.15.0"
   dependencies:
@@ -24439,17 +24372,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-get@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "simple-get@npm:3.1.1"
-  dependencies:
-    decompress-response: ^4.2.0
-    once: ^1.3.1
-    simple-concat: ^1.0.0
-  checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
-  languageName: node
-  linkType: hard
-
 "simple-get@npm:^4.0.0, simple-get@npm:^4.0.1":
   version: 4.0.1
   resolution: "simple-get@npm:4.0.1"
@@ -25610,7 +25532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.1.0, tar@npm:^6.1.2":
+"tar@npm:^6.0.2, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:


### PR DESCRIPTION
This PR was reverted at release do to some warnings in the console. These do not occur anymore in this PR as the value is always present in the `container`

Remove deprecated dependancy `konva-node` and replace it with the one that is supported `konva`
[See full conclusion of this fix](https://logius-prd.jira.odc-noord.nl/browse/COR-805)