### PR TITLE
Rollback unnecessary changes topical page

### DIFF
--- a/packages/app/src/queries/get-topical-page-data.ts
+++ b/packages/app/src/queries/get-topical-page-data.ts
@@ -43,14 +43,14 @@ export function getTopicalPageData(
 
     const highlightInfo = getHighlightedItemParts(
       content.parts.pageParts,
-      'topical_page_highlights'
+      'topicalPageHighlights'
     );
 
     return {
       content: {
         articles: getArticleParts(
           content.parts.pageParts,
-          'topical_page_articles'
+          'topicalPageArticles'
         ),
         highlights: highlightInfo?.highlights ?? null,
         showWeeklyHighlight: highlightInfo?.showWeeklyHighlight ?? false,

--- a/packages/cms/src/data/data-structure.ts
+++ b/packages/cms/src/data/data-structure.ts
@@ -351,7 +351,7 @@ export const dataStructure = {
       "janssen_not_available",
       "janssen_total",
     ],
-    variants: ["name", "values", "last_value"],
+    variants: ["variant_code", "values", "last_value"],
   },
   vr: {
     g_number: ["g_number"],


### PR DESCRIPTION
## Summary

Rollback of the following, because it did not relate to the scope of snake case and does not provide fix. 
- `topical_page_highlights` to `topicalPageHighlights`
- `topical_page_articles` to `topicalPageArticles`

Update missing property for data-structures