### PR TITLE
bugfix/COR-973-time-series-chart-duplicate-x-axis-ticks

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -75,7 +75,7 @@ function createTimeTicks(
   startTick: number,
   endTick: number,
   count: number,
-  valueCount: number | undefined
+  valuesCount: number | undefined
 ) {
   const start = middleOfDayInSeconds(startTick);
   const end = middleOfDayInSeconds(endTick);
@@ -86,7 +86,7 @@ function createTimeTicks(
 
   const ticks: number[] = [];
   const stepCount =
-    (valueCount && valueCount <= count ? valueCount : count) - 1;
+    (valuesCount && valuesCount <= count ? valuesCount : count) - 1;
   const step = Math.floor((end - start) / stepCount);
 
   for (let i = 0; i < stepCount; i++) {

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -71,7 +71,12 @@ export type AxesProps<T extends TimestampedValue> = {
   hasAllZeroValues?: boolean;
 };
 
-function createTimeTicks(startTick: number, endTick: number, count: number) {
+function createTimeTicks(
+  startTick: number,
+  endTick: number,
+  count: number,
+  valueCount: number | undefined
+) {
   const start = middleOfDayInSeconds(startTick);
   const end = middleOfDayInSeconds(endTick);
 
@@ -80,7 +85,8 @@ function createTimeTicks(startTick: number, endTick: number, count: number) {
   }
 
   const ticks: number[] = [];
-  const stepCount = count - 1;
+  const stepCount =
+    valueCount && valueCount <= count ? valueCount - 1 : count - 1;
   const step = Math.floor((end - start) / stepCount);
 
   for (let i = 0; i < stepCount; i++) {
@@ -166,7 +172,12 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
     (isFirstOrLast && startYear !== endYear) || previousYear !== currentYear
       ? 'axis-with-year'
       : 'axis';
-  const tickValues = createTimeTicks(startUnix, endUnix, xTickNumber);
+  const tickValues = createTimeTicks(
+    startUnix,
+    endUnix,
+    xTickNumber,
+    values?.length
+  );
 
   const DateSpanTick = useCallback(
     (dateUnix: number, values: DateSpanValue[], index: number) => {
@@ -240,10 +251,10 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
 
   const xTicks = useMemo(
     () =>
-      tickValues.map((x, i) =>
+      tickValues.map((tickValue, index) =>
         isDateSpanValues(values)
-          ? DateSpanTick(x, values, i)
-          : TimeStampTick(x, i)
+          ? DateSpanTick(tickValue, values, index)
+          : TimeStampTick(tickValue, index)
       ),
     [values, DateSpanTick, TimeStampTick, isDateSpanValues, tickValues]
   );

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -86,7 +86,7 @@ function createTimeTicks(
 
   const ticks: number[] = [];
   const stepCount =
-    valueCount && valueCount <= count ? valueCount - 1 : count - 1;
+    (valueCount && valueCount <= count ? valueCount : count) - 1;
   const step = Math.floor((end - start) / stepCount);
 
   for (let i = 0; i < stepCount; i++) {


### PR DESCRIPTION
## Summary

* updated `createTimeTicks` method in Axes component to now also take a `valueCount` param into account, this prevents rendering too many or duplicate ticks in certain cases;

#### Before
Notice the triple ticks for range '25 - 31 jul' on desktop and the three ticks (despite having only two data points) on mobile. 
<img width="767" alt="before_desktop_7-days" src="https://user-images.githubusercontent.com/107395524/183639866-3f0dfe96-90e2-4851-a788-a021becf0f4c.png">

<img width="361" alt="before_mobile_7-days" src="https://user-images.githubusercontent.com/107395524/183639873-d962d085-1924-4793-943b-ff98e96b2ab0.png">

#### After
<img width="365" alt="after_mobile_7-days" src="https://user-images.githubusercontent.com/107395524/183639900-58c80d15-4b28-4c74-a81d-440d66b65bcd.png">
<img width="769" alt="after_desktop_7-days" src="https://user-images.githubusercontent.com/107395524/183639908-a82c5298-5b16-4726-bcd4-4c3f1a00941c.png">

