### PR TITLE
Fix util import on windows installations

### DIFF
--- a/packages/common/src/intl/create-formatting.ts
+++ b/packages/common/src/intl/create-formatting.ts
@@ -3,7 +3,7 @@ import isToday from 'date-fns/isToday';
 import isYesterday from 'date-fns/isYesterday';
 import subDays from 'date-fns/subDays';
 import { isDefined } from 'ts-is-present';
-import { assert } from '~/utils';
+import { assert } from '../utils';
 // TypeScript is missing some types for `Intl.DateTimeFormat`.
 // https://github.com/microsoft/TypeScript/issues/35865
 export interface DateTimeFormatOptions extends Intl.DateTimeFormatOptions {


### PR DESCRIPTION
## Summary

Running ``yarn dev`` on windows leads to a build error. This PR fixes that.
See also the screenshot below:
![image](https://user-images.githubusercontent.com/23526707/185389492-504b3cb6-8c36-46a2-8146-e49e88df7cac.png)

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
