### PR TITLE
bugfix/COR-1005-undefined-time-series-chart-values

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
@@ -19,12 +19,12 @@ export function useFormatSeriesValue<T extends TimestampedValue>(
       const formatter =
         metricPropertyFormatters[metricProperty] || intl.formatNumber;
       const numberValue = value[metricProperty];
+      if (!isPresent(numberValue)) return '-';
+
       const formattedValue =
         isPresent(numberValue) && typeof numberValue === 'number'
           ? formatter(numberValue)
-          : isPresent(numberValue)
-          ? String(numberValue)
-          : '-';
+          : String(numberValue);
 
       return isPresent(formattedValue)
         ? isPercentage

--- a/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
@@ -1,6 +1,6 @@
 import { TimestampedValue } from '@corona-dashboard/common';
 import { useMemo } from 'react';
-import { isPresent } from 'ts-is-present';
+import { isDefined, isFilled, isPresent } from 'ts-is-present';
 import { useIntl } from '~/intl';
 import { SeriesConfig } from './series';
 import { MetricPropertyFormatters } from './use-metric-property-formatters';
@@ -22,7 +22,9 @@ export function useFormatSeriesValue<T extends TimestampedValue>(
       const formattedValue =
         isPresent(numberValue) && typeof numberValue === 'number'
           ? formatter(numberValue)
-          : String(numberValue);
+          : isDefined(numberValue) && isFilled(numberValue)
+          ? String(numberValue)
+          : '-';
 
       return isPresent(formattedValue)
         ? isPercentage

--- a/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
+++ b/packages/app/src/components/time-series-chart/logic/use-format-series-value.ts
@@ -1,6 +1,6 @@
 import { TimestampedValue } from '@corona-dashboard/common';
 import { useMemo } from 'react';
-import { isDefined, isFilled, isPresent } from 'ts-is-present';
+import { isPresent } from 'ts-is-present';
 import { useIntl } from '~/intl';
 import { SeriesConfig } from './series';
 import { MetricPropertyFormatters } from './use-metric-property-formatters';
@@ -22,7 +22,7 @@ export function useFormatSeriesValue<T extends TimestampedValue>(
       const formattedValue =
         isPresent(numberValue) && typeof numberValue === 'number'
           ? formatter(numberValue)
-          : isDefined(numberValue) && isFilled(numberValue)
+          : isPresent(numberValue)
           ? String(numberValue)
           : '-';
 

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -120,7 +120,6 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
-  console.log("Test");
   const {
     pageText,
     selectedNlData: data,

--- a/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuis-opnames.tsx
@@ -120,6 +120,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const IntakeHospital = (props: StaticProps<typeof getStaticProps>) => {
+  console.log("Test");
   const {
     pageText,
     selectedNlData: data,


### PR DESCRIPTION
## Summary

* updated `getValueString` method in `useFormatSeriesValue` hook to correctly fall back to '-' when a value is either `null` or `undefined`

### Screenshots
Screenshots cover visualisations before and after changes, in which two scenarios are covered (data entries where a value is either `null` or `undefined`). It is important to note that these screenshots only cover the 'Number of confirmed cases among over-70s living at home over time' visualisation as both scenarios are applicable here, but the fix covers all other time series charts where either of the different scenarios occur.

#### Before
![before_null_instance](https://user-images.githubusercontent.com/107395524/186118833-cca5c90f-5d5f-4240-a8cf-fda81f541f53.png)
Notice how the value is `null`.

![before_undefined_instance](https://user-images.githubusercontent.com/107395524/186118932-2cc0fe3e-6049-4229-bb1b-2b725cd10b9c.png)
Notice how the value is `undefined`.

#### After
![after_null_instance](https://user-images.githubusercontent.com/107395524/186119061-6425d213-b95f-4ad2-b3a0-ee99ff733a85.png)
Notice how the previous `null` value is now marked as '-'.

![after_undefined_instance](https://user-images.githubusercontent.com/107395524/186119118-42ee77c1-6f6f-40de-8c6c-0919ed89dae5.png)
Notice how the previous `undefined` value is now marked as '-'.
