### PR TITLE
Removed unnecessary width for external links

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -324,8 +324,6 @@ function InlineLinkMark(props: { children: ReactNode; mark: InlineLink }) {
   return isAbsoluteUrl(mark.href) ? (
     <ExternalLink
       href={mark.href}
-      width="max-content"
-      display="inline-block"
       underline
     >
       {children}


### PR DESCRIPTION
## Summary

Removed `display: inline-block` and `width`, so the links became flexible again.

