### PR TITLE
bugfix(main page): rely on focus state of the browser

### DIFF
--- a/packages/app/src/components/link-with-icon.tsx
+++ b/packages/app/src/components/link-with-icon.tsx
@@ -164,9 +164,6 @@ const ButtonBox = styled.span((x: buttonBoxProps) =>
               backgroundColor: colors.blue,
               color: colors.offWhite,
             },
-            '&:focus': {
-              outline: '#000000 dotted 2px',
-            },
             '&:hover, &:focus': {
               textDecoration: 'underline',
             },

--- a/packages/app/src/domain/topical/components/subjects-list.tsx
+++ b/packages/app/src/domain/topical/components/subjects-list.tsx
@@ -55,7 +55,6 @@ export const SubjectsList = ({ moreLinks }: SubjectsListProps) => {
       </Text>
       <ul
         aria-labelledby={labelledById}
-        tabIndex={0}
         css={css({
           display: 'flex',
           flexDirection: asResponsiveArray({ _: 'column', sm: 'row' }),


### PR DESCRIPTION
Also remove the tab-index of the ul-element because the list doesn't need its own tab-index

Fixes COR-1026


Before, unneeded tab-index:
![image](https://user-images.githubusercontent.com/98813868/189640968-02be4b36-f657-4b2c-abfd-b9d29d0501aa.png)
![image](https://user-images.githubusercontent.com/98813868/189641472-9f2d2e88-d61a-4fbc-8be2-7ebef2b41528.png)

Before, focus on click:
![image](https://user-images.githubusercontent.com/98813868/189640902-20d1686e-da90-447c-ad5c-6637c53e77ac.png)


After, focus on click:
![image](https://user-images.githubusercontent.com/98813868/189641138-43529294-5bfb-434a-b7bf-78c719f43ae3.png)

After, focus with keyboard navigation (unchanged):
![image](https://user-images.githubusercontent.com/98813868/189641908-125142c7-380e-4724-ae7d-dd88b9ca6c67.png)