### PR TITLE
Add extra responsive image for articles

### DIFF
--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -14,6 +14,7 @@ import { ContentImage } from './cms/content-image';
 import { RichContent } from './cms/rich-content';
 import { LinkWithIcon } from './link-with-icon';
 import { PublicationDate } from './publication-date';
+import { useBreakpoints } from '~/utils/use-breakpoints';
 interface ArticleDetailProps {
   article: Article;
   text: SiteText['pages']['topical_page']['shared'];
@@ -21,11 +22,12 @@ interface ArticleDetailProps {
 
 const imageSizes = [
   // viewport min-width 700px display images at max. 636px wide
-  [700, 636],
+  [400, 700, 636],
 ];
 
 export function ArticleDetail({ article, text }: ArticleDetailProps) {
   const { commonTexts } = useIntl();
+  const breakpoints = useBreakpoints();
 
   article.intro = mergeAdjacentKpiBlocks(article.intro);
   article.content = mergeAdjacentKpiBlocks(article.content);
@@ -69,7 +71,21 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
           <RichContent blocks={article.content} contentWrapper={ContentBlock} />
         </Box>
       )}
-
+      {!breakpoints.xs
+        ? article.imageMobile && (
+            <ContentImage
+              node={article.imageMobile}
+              contentWrapper={ContentBlock}
+              sizes={imageSizes}
+            />
+          )
+        : article.imageDesktop && (
+            <ContentImage
+              node={article.imageDesktop}
+              contentWrapper={ContentBlock}
+              sizes={imageSizes}
+            />
+          )}
       {article.categories && (
         <ContentBlock>
           <Box pb={2} pt={4}>

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -108,6 +108,8 @@ export interface Article {
   };
   categories?: CategoriesTypes[];
   cover: ImageBlock;
+  imageMobile?: ImageBlock;
+  imageDesktop?: ImageBlock;
   summary: Block;
   intro: RichContentBlock[];
   content: RichContentBlock[];

--- a/packages/cms/src/schemas/fields/article-fields.ts
+++ b/packages/cms/src/schemas/fields/article-fields.ts
@@ -96,6 +96,36 @@ export const ARTICLE_FIELDS = [
         .required(),
   },
   {
+    title: 'Afbeelding voor grote schermen',
+    name: 'imageDesktop',
+    type: 'image',
+    options: {
+      hotspot: true,
+    },
+    fields: [
+      {
+        title: 'Alternatieve tekst (toegankelijkheid)',
+        name: 'alt',
+        type: 'localeString',
+      },
+    ],
+  },
+  {
+    title: 'Afbeelding voor kleine schermen',
+    name: 'imageMobile',
+    type: 'image',
+    options: {
+      hotspot: true,
+    },
+    fields: [
+      {
+        title: 'Alternatieve tekst (toegankelijkheid)',
+        name: 'alt',
+        type: 'localeString',
+      },
+    ],
+  },
+  {
     title: 'Content',
     name: 'content',
     type: 'localeRichContentBlock',


### PR DESCRIPTION
# Summary
- Add extra fields in Sanity for desktop and mobile
- Render uploaded images based on breakpoints