### PR TITLE
Fixing of hidden map when selecting already selected CoverageKind

### DIFF
--- a/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-choropleth-per-gm.tsx
@@ -50,6 +50,9 @@ export function VaccineCoverageChoroplethPerGm({
   const setSelectedCoverageKindAndAge = (
     coverageKind: CoverageKindProperty
   ) => {
+    if (coverageKind === selectedCoverageKind) {
+      return;
+    }
     // When changing between coverage kinds where the selected age group isn't available,
     // the other coverage kind set the non-matching age group to a default one.
     if (selectedAgeGroup !== '12+') {


### PR DESCRIPTION
When selecting an option that already was selected, the map disappeared. That's been fixed in this PR.