### PR TITLE
COR-1037 Sanity language toggle

### DIFF
--- a/packages/app/src/locale/use-lokalize-text.tsx
+++ b/packages/app/src/locale/use-lokalize-text.tsx
@@ -39,14 +39,14 @@ export function useLokalizeText(initialLocale: LanguageKey) {
   const [locale, setLocale] = useState(initialLocale);
   const [text, setText] = useState<SiteText>(languages[locale]);
   const lokalizeTextsRef = useRef<SanityDocument<LokalizeText>[]>([]);
-  const showSanityDebugToggle = enableHotReload || IS_STAGING_ENV;
+  const showSanityDebugToggle = true || enableHotReload || IS_STAGING_ENV;
 
   const [dataset, setDataset] = useState<Dataset>(
     (process.env.NEXT_PUBLIC_SANITY_DATASET as Dataset | undefined) ??
       'development'
   );
 
-  const toggleButton = showSanityDebugToggle ? (
+  const toggleHotReloadButton = showSanityDebugToggle ? (
     <ToggleButton isActive={isActive} onClick={() => setIsActive((x) => !x)}>
       <Toggle values={[...datasets]} onToggle={setDataset} value={dataset} />
       <Toggle
@@ -133,7 +133,7 @@ export function useLokalizeText(initialLocale: LanguageKey) {
     }
   }, [initialLocale, dataset, isActive, locale]);
 
-  return [text, toggleButton, dataset] as const;
+  return { text, toggleHotReloadButton, dataset, locale } as const;
 }
 
 /**

--- a/packages/app/src/locale/use-lokalize-text.tsx
+++ b/packages/app/src/locale/use-lokalize-text.tsx
@@ -39,7 +39,7 @@ export function useLokalizeText(initialLocale: LanguageKey) {
   const [locale, setLocale] = useState(initialLocale);
   const [text, setText] = useState<SiteText>(languages[locale]);
   const lokalizeTextsRef = useRef<SanityDocument<LokalizeText>[]>([]);
-  const showSanityDebugToggle = true || enableHotReload || IS_STAGING_ENV;
+  const showSanityDebugToggle = enableHotReload || IS_STAGING_ENV;
 
   const [dataset, setDataset] = useState<Dataset>(
     (process.env.NEXT_PUBLIC_SANITY_DATASET as Dataset | undefined) ??

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { LazyMotion } from 'framer-motion';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { IntlContext } from '~/intl';
 import { useIntlHelperContext } from '~/intl/hooks/use-intl';
@@ -28,22 +28,25 @@ const loadAnimationFeatures = () =>
 export default function App(props: AppProps) {
   const { Component, pageProps } = props;
   const router = useRouter();
-  const { locale = 'nl' } = router;
+  const [locale, setLocale] = useState((router.locale as LanguageKey) || 'nl');
 
-  const [text, toggleHotReloadButton, dataset] = useLokalizeText(
-    locale as LanguageKey
-  );
+  const {
+    text,
+    toggleHotReloadButton,
+    dataset,
+    locale: debugToggleLocale,
+  } = useLokalizeText(locale);
+
+  useEffect(() => {
+    setLocale(debugToggleLocale);
+  }, [debugToggleLocale]);
 
   assert(
     text,
     `[${loadAnimationFeatures.name}] Encountered unknown language: ${locale}`
   );
 
-  const intlContext = useIntlHelperContext(
-    locale as LanguageKey,
-    text.common,
-    dataset
-  );
+  const intlContext = useIntlHelperContext(locale, text.common, dataset);
 
   useEffect(() => {
     const handleRouteChange = (pathname: string) => {

--- a/packages/app/src/utils/cms/use-dynamic-lokalize-texts.ts
+++ b/packages/app/src/utils/cms/use-dynamic-lokalize-texts.ts
@@ -26,8 +26,8 @@ export const useDynamicLokalizeTexts = <T extends Record<string, unknown>>(
         .then((texts) => mapSiteTextValuesToKeys(texts))
         .then((texts) => setTexts(selector(texts)));
     }
-    // when locale is set to 'en' with the debug toggle we fetch the en texts and show them instead of the default nl texts
-    else if (locale === 'en') {
+    // when selected locale is not the default we fetch the texts again and show those instead
+    else if (locale !== 'nl') {
       fetchLokalizeTexts(environment)
         .catch(handleSanityError)
         .then((texts) => texts[locale] as unknown as SiteText)


### PR DESCRIPTION
Fixes the NL/EN toggle in Sanity Debug UI. It now shows the EN texts correctly when enabled.

Before:
![Screenshot 2022-10-03 at 15 22 42](https://user-images.githubusercontent.com/97020799/193588470-b6a899e7-c19d-4192-bbe6-5696bd633ae0.png)


After:
![Screenshot 2022-10-03 at 13 59 15](https://user-images.githubusercontent.com/97020799/193585963-9ffa267b-a725-4727-9ad5-8555220157c4.png)
