### PR TITLE
COR-1027 Remove hover transition from topical-tile

### DIFF
--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -116,9 +116,6 @@ export function TopicalTile({
             color={colors.blue8}
             padding={3}
             className="topical-tile-cta"
-            css={css({
-              transition: 'background .1s ease-in-out',
-            })}
           >
             <TextWithIcon text={cta.label} icon={<ChevronRight />} />
           </Box>


### PR DESCRIPTION
Hovering on a Topical Tile now doesn't use style transforms to be consistent with other hover states on the page.

![Screenshot 2022-10-04 at 15 16 18](https://user-images.githubusercontent.com/97020799/193828987-ddd5e98b-3221-4e04-899a-4d420884d4a8.png)
