### PR TITLE
Add choropleth autumn options for VR and GM

### DIFF
--- a/packages/app/src/components/choropleth-tile.tsx
+++ b/packages/app/src/components/choropleth-tile.tsx
@@ -23,6 +23,7 @@ type ChoroplethTileProps = DataProps & {
   };
   metadata?: MetadataProps;
   valueAnnotation?: string;
+  hasPadding?: boolean;
 } & (
     | {
         onChartRegionChange: (v: RegionControlOption) => void;
@@ -43,6 +44,7 @@ export function ChoroplethTile({
   children,
   metadata,
   valueAnnotation,
+  hasPadding,
   ...dataProps
 }: ChoroplethTileProps) {
   const breakpoints = useBreakpoints(true);
@@ -104,7 +106,11 @@ export function ChoroplethTile({
           height="100%"
           spacing={3}
         >
-          <Box height="100%" marginTop={4}>
+          <Box
+            height="100%"
+            mt={4}
+            pl={hasPadding && breakpoints.lg ? 4 : undefined}
+          >
             <ErrorBoundary>{children}</ErrorBoundary>
           </Box>
 

--- a/packages/app/src/domain/vaccine/common.ts
+++ b/packages/app/src/domain/vaccine/common.ts
@@ -12,7 +12,12 @@ export const ARCHIVED_COLORS = {
 type FullyVaccinatedAges = '12+' | '18+';
 type Autumn2022Vaccinated = '12+' | '60+';
 
-export type MatchingVaccineCoverageAgeGroupsType = {
+type MatchingVaccineCoverageAgeGroupsType = {
   autumn_2022_vaccinated_percentage: Autumn2022Vaccinated[];
   fully_vaccinated_percentage: FullyVaccinatedAges[];
+};
+
+export const matchingAgeGroups: MatchingVaccineCoverageAgeGroupsType = {
+  autumn_2022_vaccinated_percentage: ['12+', '60+'],
+  fully_vaccinated_percentage: ['12+', '18+'],
 };

--- a/packages/app/src/domain/vaccine/index.ts
+++ b/packages/app/src/domain/vaccine/index.ts
@@ -7,10 +7,10 @@ export { VaccineBoosterAdministrationsKpiSection } from './vaccine-booster-admin
 export { VaccineAdministrationsKpiSection } from './vaccine-administrations-kpi-section';
 export { VaccinationsShotKpiSection } from './vaccinations-shot-kpi-section';
 export { VaccinationsKpiHeader } from './vaccinations-kpi-header';
-export { VaccineCoverageChoroplethPerGm } from './vaccine-coverage-choropleth-per-gm';
+export { VaccineCoverageChoropleth } from './vaccine-coverage-choropleth';
 export { VaccineCoveragePerAgeGroup } from './vaccine-coverage-per-age-group';
 export { VaccineCoverageTile } from './vaccine-coverage-tile/vaccine-coverage-tile';
 export { VaccineCoverageToggleTile } from './vaccine-coverage-toggle-tile';
 export { VaccineDeliveryBarChart } from './vaccine-delivery-bar-chart';
 export { VaccineStockPerSupplierChart } from './vaccine-stock-per-supplier-chart';
-export { ChoroplethTooltip } from './vaccine-coverage-choropleth-per-gm';
+export { ChoroplethTooltip } from './vaccine-coverage-choropleth';

--- a/packages/app/src/domain/vaccine/vaccine-coverage-choropleth.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-choropleth.tsx
@@ -4,7 +4,7 @@ import {
   VrCollectionVaccineCoveragePerAgeGroup,
 } from '@corona-dashboard/common';
 import { SiteText } from '~/locale';
-import { MatchingVaccineCoverageAgeGroupsType } from './common';
+import { matchingAgeGroups } from './common';
 import css from '@styled-system/css';
 import { useState } from 'react';
 import { hasValueAtKey } from 'ts-is-present';
@@ -30,16 +30,16 @@ import {
 } from './components/vaccination-coverage-kind-select';
 import { useVaccineCoveragePercentageFormatter } from './logic/use-vaccine-coverage-percentage-formatter';
 
-interface VaccineCoverageChoroplethPerGmProps {
+interface VaccineCoverageChoroplethProps {
   data: {
     gm: GmCollectionVaccineCoveragePerAgeGroup[];
     vr: VrCollectionVaccineCoveragePerAgeGroup[];
   };
 }
 
-export function VaccineCoverageChoroplethPerGm({
+export const VaccineCoverageChoropleth = ({
   data,
-}: VaccineCoverageChoroplethPerGmProps) {
+}: VaccineCoverageChoroplethProps) => {
   const { commonTexts } = useIntl();
   const [selectedMap, setSelectedMap] = useState<RegionControlOption>('gm');
   const [selectedAgeGroup, setSelectedAgeGroup] = useState<AgeGroup>('18+');
@@ -47,14 +47,14 @@ export function VaccineCoverageChoroplethPerGm({
     useState<CoverageKindProperty>('fully_vaccinated_percentage');
   const reverseRouter = useReverseRouter();
 
+  /**
+   * When changing between coverage kinds where the selected age group isn't available,
+   * the other coverage kind set the non-matching age group to a default one.
+   */
   const setSelectedCoverageKindAndAge = (
     coverageKind: CoverageKindProperty
   ) => {
-    if (coverageKind === selectedCoverageKind) {
-      return;
-    }
-    // When changing between coverage kinds where the selected age group isn't available,
-    // the other coverage kind set the non-matching age group to a default one.
+    if (coverageKind === selectedCoverageKind) return;
     if (selectedAgeGroup !== '12+') {
       setSelectedAgeGroup(selectedAgeGroup === '18+' ? '60+' : '18+');
     }
@@ -72,11 +72,6 @@ export function VaccineCoverageChoroplethPerGm({
     data.vr.filter(hasValueAtKey('age_group_range', selectedAgeGroup));
   const choroplethDataGm: GmCollectionVaccineCoveragePerAgeGroup[] =
     data.gm.filter(hasValueAtKey('age_group_range', selectedAgeGroup));
-
-  const matchingAgeGroups: MatchingVaccineCoverageAgeGroupsType = {
-    autumn_2022_vaccinated_percentage: ['12+', '60+'],
-    fully_vaccinated_percentage: ['12+', '18+'],
-  };
 
   return (
     <ChoroplethTile
@@ -203,7 +198,7 @@ export function VaccineCoverageChoroplethPerGm({
       )}
     </ChoroplethTile>
   );
-}
+};
 
 type VaccineCoverageData =
   | GmCollectionVaccineCoveragePerAgeGroup

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -453,6 +453,7 @@ export const VaccinationsGmPage = (
                 commonTexts.choropleth.vaccination_coverage.shared.bronnen.rivm,
               date: choropleth.gm.vaccine_coverage_per_age_group[0].date_unix,
             }}
+            hasPadding
           >
             <DynamicChoropleth
               accessibility={{ key: 'vaccine_coverage_nl_choropleth' }}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -2,6 +2,7 @@ import {
   colors,
   GmCollectionVaccineCoveragePerAgeGroup,
 } from '@corona-dashboard/common';
+import css from '@styled-system/css';
 import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
@@ -19,10 +20,16 @@ import { thresholds } from '~/components/choropleth/logic';
 import { gmCodesByVrCode, vrCodeByGmCode } from '~/data';
 import { Layout, GmLayout } from '~/domain/layout';
 import { Languages, SiteText } from '~/locale';
+import { BoldText } from '~/components/typography';
+import { matchingAgeGroups } from '~/domain/vaccine/common';
 import {
   AgeGroup,
   AgeGroupSelect,
 } from '~/domain/vaccine/components/age-group-select';
+import {
+  VaccinationCoverageKindSelect,
+  CoverageKindProperty,
+} from '~/domain/vaccine/components/vaccination-coverage-kind-select';
 import {
   selectVaccineCoverageData,
   VaccineCoverageToggleTile,
@@ -139,6 +146,8 @@ export const VaccinationsGmPage = (
   const { commonTexts } = useIntl();
   const reverseRouter = useReverseRouter();
   const [selectedAgeGroup, setSelectedAgeGroup] = useState<AgeGroup>('18+');
+  const [selectedCoverageKind, setSelectedCoverageKind] =
+    useState<CoverageKindProperty>('fully_vaccinated_percentage');
   const { formatPercentageAsNumber } = useFormatLokalizePercentage();
   const [hasHideArchivedCharts, setHideArchivedCharts] =
     useState<boolean>(false);
@@ -159,6 +168,20 @@ export const VaccinationsGmPage = (
   };
 
   const vaccinationsCoverageFeature = useFeature('vaccinationsCoverage');
+
+  /**
+   * When changing between coverage kinds where the selected age group isn't available,
+   * the other coverage kind set the non-matching age group to a default one.
+   */
+  const setSelectedCoverageKindAndAge = (
+    coverageKind: CoverageKindProperty
+  ) => {
+    if (coverageKind === selectedCoverageKind) return;
+    if (selectedAgeGroup !== '12+') {
+      setSelectedAgeGroup(selectedAgeGroup === '18+' ? '60+' : '18+');
+    }
+    setSelectedCoverageKind(coverageKind);
+  };
 
   /**
    * Filter out only the the 12+ and 18+ for the toggle component.
@@ -371,12 +394,51 @@ export const VaccinationsGmPage = (
                   )}
                 />
 
-                <Box maxWidth="20rem">
-                  <AgeGroupSelect
-                    onChange={setSelectedAgeGroup}
-                    initialValue={selectedAgeGroup}
-                    shownAgeGroups={['12+', '18+']}
-                  />
+                <Box
+                  display="flex"
+                  flexDirection="row"
+                  justifyContent="flex-start"
+                  spacingHorizontal={2}
+                  as={'fieldset'}
+                >
+                  <BoldText
+                    as="legend"
+                    css={css({
+                      flexBasis: '100%',
+                      mb: 2,
+                    })}
+                  >
+                    {
+                      commonTexts.choropleth.vaccination_coverage.shared
+                        .dropdowns_title
+                    }
+                  </BoldText>
+
+                  <Box
+                    display="flex"
+                    width="100%"
+                    spacingHorizontal={{ xs: 2 }}
+                    flexWrap="wrap"
+                    flexDirection={{ _: 'column', xs: 'row' }}
+                  >
+                    <Box flex="1">
+                      <VaccinationCoverageKindSelect
+                        onChange={setSelectedCoverageKindAndAge}
+                        initialValue={selectedCoverageKind}
+                      />
+                    </Box>
+                    <Box flex="1">
+                      <Box maxWidth="20rem">
+                        <AgeGroupSelect
+                          onChange={setSelectedAgeGroup}
+                          initialValue={selectedAgeGroup}
+                          shownAgeGroups={
+                            matchingAgeGroups[selectedCoverageKind]
+                          }
+                        />
+                      </Box>
+                    </Box>
+                  </Box>
                 </Box>
               </>
             }
@@ -398,7 +460,7 @@ export const VaccinationsGmPage = (
               data={choroplethData}
               dataConfig={{
                 metricName: 'vaccine_coverage_per_age_group',
-                metricProperty: 'fully_vaccinated_percentage',
+                metricProperty: selectedCoverageKind,
               }}
               dataOptions={{
                 getLink: reverseRouter.gm.vaccinaties,
@@ -414,8 +476,8 @@ export const VaccinationsGmPage = (
                   mapData={choropleth.gm.vaccine_coverage_per_age_group.filter(
                     (singleGm) => singleGm.gmcode === context.code
                   )}
-                  ageGroups={['12+', '18+']}
-                  selectedCoverageKind={'fully_vaccinated_percentage'}
+                  ageGroups={matchingAgeGroups[selectedCoverageKind]}
+                  selectedCoverageKind={selectedCoverageKind}
                 />
               )}
             />

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -20,7 +20,7 @@ import {
   VaccineBoosterAdministrationsKpiSection,
   VaccinationsShotKpiSection,
   VaccinationsKpiHeader,
-  VaccineCoverageChoroplethPerGm,
+  VaccineCoverageChoropleth,
   VaccineCoveragePerAgeGroup,
   VaccineCoverageTile,
   VaccineCoverageToggleTile,
@@ -410,7 +410,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             }}
           />
 
-          <VaccineCoverageChoroplethPerGm data={choropleth} />
+          <VaccineCoverageChoropleth data={choropleth} />
           <Autumn2022ShotCoveragePerAgeGroup
             text={textNl.vaccination_coverage}
             title={textNl.vaccination_coverage.title}

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -451,6 +451,7 @@ export const VaccinationsVrPage = (
                 commonTexts.choropleth.vaccination_coverage.shared.bronnen.rivm,
               date: choropleth.gm.vaccine_coverage_per_age_group[0].date_unix,
             }}
+            hasPadding
           >
             <DynamicChoropleth
               accessibility={{ key: 'vaccine_coverage_nl_choropleth' }}

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -24,6 +24,11 @@ import {
   AgeGroupSelect,
 } from '~/domain/vaccine/components/age-group-select';
 import {
+  VaccinationCoverageKindSelect,
+  CoverageKindProperty,
+} from '~/domain/vaccine/components/vaccination-coverage-kind-select';
+import { matchingAgeGroups } from '~/domain/vaccine/common';
+import {
   selectVaccineCoverageData,
   ChoroplethTooltip,
   VaccineCoveragePerAgeGroup,
@@ -58,6 +63,8 @@ import {
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useFeature } from '~/lib/features';
+import { BoldText } from '~/components/typography';
+import css from '@styled-system/css';
 
 const pageMetrics = [
   'vaccine_coverage_per_age_group',
@@ -137,15 +144,30 @@ export const VaccinationsVrPage = (
   const { formatPercentageAsNumber } = useFormatLokalizePercentage();
   const [hasHideArchivedCharts, setHideArchivedCharts] =
     useState<boolean>(false);
+  const [selectedAgeGroup, setSelectedAgeGroup] = useState<AgeGroup>('18+');
+  const [selectedCoverageKind, setSelectedCoverageKind] =
+    useState<CoverageKindProperty>('fully_vaccinated_percentage');
 
   const vaccinationsCoverageFeature = useFeature('vaccinationsCoverage');
-
-  const [selectedAgeGroup, setSelectedAgeGroup] = useState<AgeGroup>('18+');
 
   const { textNl, textVr, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(
     pageText,
     selectLokalizeTexts
   );
+
+  /**
+   * When changing between coverage kinds where the selected age group isn't available,
+   * the other coverage kind set the non-matching age group to a default one.
+   */
+  const setSelectedCoverageKindAndAge = (
+    coverageKind: CoverageKindProperty
+  ) => {
+    if (coverageKind === selectedCoverageKind) return;
+    if (selectedAgeGroup !== '12+') {
+      setSelectedAgeGroup(selectedAgeGroup === '18+' ? '60+' : '18+');
+    }
+    setSelectedCoverageKind(coverageKind);
+  };
 
   const metadata = {
     ...textVr.metadata,
@@ -160,8 +182,14 @@ export const VaccinationsVrPage = (
   const gmCodes = gmCodesByVrCode[router.query.code as string];
   const selectedGmCode = gmCodes ? gmCodes[0] : undefined;
 
+  const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
+  const choroplethData: GmCollectionVaccineCoveragePerAgeGroup[] =
+    choropleth.gm.vaccine_coverage_per_age_group.filter(
+      hasValueAtKey('age_group_range', selectedAgeGroup)
+    );
+
   /**
-   * Filter out only the the 12+ and 18+ for the toggle component.
+   * Filter out only the 12+ and 18+ for the toggle component.
    */
   const filteredAgeGroup60Plus =
     data.vaccine_coverage_per_age_group.values.find(
@@ -222,12 +250,6 @@ export const VaccinationsVrPage = (
     filteredAgeGroup12PlusArchived,
     `[${VaccinationsVrPage.name}] Could not find archived data for the vaccine coverage per age group for the age 12+`
   );
-
-  const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
-  const choroplethData: GmCollectionVaccineCoveragePerAgeGroup[] =
-    choropleth.gm.vaccine_coverage_per_age_group.filter(
-      hasValueAtKey('age_group_range', selectedAgeGroup)
-    );
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
@@ -370,12 +392,51 @@ export const VaccinationsVrPage = (
                     { safetyRegionName: vrName }
                   )}
                 />
-                <Box maxWidth="20rem">
-                  <AgeGroupSelect
-                    onChange={setSelectedAgeGroup}
-                    initialValue={selectedAgeGroup}
-                    shownAgeGroups={['12+', '18+']}
-                  />
+                <Box
+                  display="flex"
+                  flexDirection="row"
+                  justifyContent="flex-start"
+                  spacingHorizontal={2}
+                  as={'fieldset'}
+                >
+                  <BoldText
+                    as="legend"
+                    css={css({
+                      flexBasis: '100%',
+                      mb: 2,
+                    })}
+                  >
+                    {
+                      commonTexts.choropleth.vaccination_coverage.shared
+                        .dropdowns_title
+                    }
+                  </BoldText>
+
+                  <Box
+                    display="flex"
+                    width="100%"
+                    spacingHorizontal={{ xs: 2 }}
+                    flexWrap="wrap"
+                    flexDirection={{ _: 'column', xs: 'row' }}
+                  >
+                    <Box flex="1">
+                      <VaccinationCoverageKindSelect
+                        onChange={setSelectedCoverageKindAndAge}
+                        initialValue={selectedCoverageKind}
+                      />
+                    </Box>
+                    <Box flex="1">
+                      <Box maxWidth="20rem">
+                        <AgeGroupSelect
+                          onChange={setSelectedAgeGroup}
+                          initialValue={selectedAgeGroup}
+                          shownAgeGroups={
+                            matchingAgeGroups[selectedCoverageKind]
+                          }
+                        />
+                      </Box>
+                    </Box>
+                  </Box>
                 </Box>
               </>
             }
@@ -397,7 +458,7 @@ export const VaccinationsVrPage = (
               data={choroplethData}
               dataConfig={{
                 metricName: 'vaccine_coverage_per_age_group',
-                metricProperty: 'fully_vaccinated_percentage',
+                metricProperty: selectedCoverageKind,
               }}
               dataOptions={{
                 getLink: reverseRouter.gm.vaccinaties,
@@ -412,8 +473,8 @@ export const VaccinationsVrPage = (
                   mapData={choropleth.gm.vaccine_coverage_per_age_group.filter(
                     (singleGm) => singleGm.gmcode === context.code
                   )}
-                  ageGroups={['12+', '18+']}
-                  selectedCoverageKind={'fully_vaccinated_percentage'}
+                  ageGroups={matchingAgeGroups[selectedCoverageKind]}
+                  selectedCoverageKind={selectedCoverageKind}
                 />
               )}
             />


### PR DESCRIPTION
## Summary
- Added autumn dropdown options for VR and GM choropleth maps.
- Added extra space so the choropleth map will not hit the dropdown, only for VR and GM by prop
- Renamed regular choropleth component to a more generic name for NL

----
### **---- Before ----**
<img width="997" alt="Schermafbeelding 2022-10-07 om 13 21 03" src="https://user-images.githubusercontent.com/93981322/194546691-2458471d-bded-4973-bec5-c06343321252.png">


### **---- After ----** 
<img width="993" alt="Schermafbeelding 2022-10-07 om 13 49 00" src="https://user-images.githubusercontent.com/93981322/194546286-da98c968-94ac-45f5-86e1-f4d8b968ca1f.png">
