### PR TITLE
task/COR-1151-safety-region-behaviour-page-archiving

### DIFF
--- a/packages/app/schema/vr/__index.json
+++ b/packages/app/schema/vr/__index.json
@@ -19,7 +19,7 @@
     "deceased_cbs",
     "elderly_at_home",
     "disability_care",
-    "behavior",
+    "behavior_archived_20221019",
     "tested_overall_sum",
     "hospital_nice_sum",
     "g_number",
@@ -76,8 +76,8 @@
     "disability_care": {
       "$ref": "disability_care.json"
     },
-    "behavior": {
-      "$ref": "behavior.json"
+    "behavior_archived_20221019": {
+      "$ref": "behavior_archived_20221019.json"
     },
     "deceased_rivm": {
       "$ref": "deceased_rivm.json"

--- a/packages/app/schema/vr/behavior_archived_20221019.json
+++ b/packages/app/schema/vr/behavior_archived_20221019.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "vr_behavior",
+  "title": "vr_behavior_archived_20221019",
   "type": "object",
   "properties": {
     "values": {
@@ -28,7 +28,7 @@
       ]
     },
     "value": {
-      "title": "vr_behavior_value",
+      "title": "vr_behavior_archived_20221019_value",
       "type": "object",
       "properties": {
         "number_of_participants": {

--- a/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-line-chart-tile.tsx
@@ -1,7 +1,7 @@
 import {
   colors,
   NlBehaviorValue,
-  VrBehaviorValue,
+  VrBehaviorArchived_20221019Value,
 } from '@corona-dashboard/common';
 import { dropRightWhile, dropWhile } from 'lodash';
 import { useMemo } from 'react';
@@ -21,7 +21,7 @@ import {
   behaviorIdentifiers,
 } from './logic/behavior-types';
 
-type ValueType = NlBehaviorValue | VrBehaviorValue;
+type ValueType = NlBehaviorValue | VrBehaviorArchived_20221019Value;
 type ValueKey = keyof ValueType;
 
 interface BehaviorLineChartTileProps {
@@ -45,16 +45,17 @@ export function BehaviorLineChartTile({
   useDatesAsRange,
   text,
 }: BehaviorLineChartTileProps) {
-  const selectedComplianceValueKey =
-    `${currentId}_compliance` as ValueKey;
-  const selectedSupportValueKey =
-    `${currentId}_support` as ValueKey;
+  const selectedComplianceValueKey = `${currentId}_compliance` as ValueKey;
+  const selectedSupportValueKey = `${currentId}_support` as ValueKey;
 
   const complianceValuesHasGap = useDataHasGaps<ValueType>(
     values,
     selectedComplianceValueKey
   );
-  const supportValuesHasGap = useDataHasGaps<ValueType>(values, selectedSupportValueKey);
+  const supportValuesHasGap = useDataHasGaps<ValueType>(
+    values,
+    selectedSupportValueKey
+  );
 
   const breakpoints = useBreakpoints();
 

--- a/packages/app/src/domain/behavior/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-table-tile.tsx
@@ -1,7 +1,7 @@
 import {
   colors,
   NlBehaviorValue,
-  VrBehaviorValue,
+  VrBehaviorArchived_20221019Value,
 } from '@corona-dashboard/common';
 import { ChevronRight } from '@corona-dashboard/icons';
 import css from '@styled-system/css';
@@ -26,7 +26,7 @@ interface BehaviorTableTileProps {
   description: string;
   complianceExplanation: string;
   supportExplanation: string;
-  value: NlBehaviorValue | VrBehaviorValue;
+  value: NlBehaviorValue | VrBehaviorArchived_20221019Value;
   annotation: string;
   setCurrentId: React.Dispatch<React.SetStateAction<BehaviorIdentifier>>;
   scrollRef: { current: HTMLDivElement | null };

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -60,48 +60,24 @@ export function VrLayout(props: VrLayoutProps) {
     layout: 'vr',
     code: code,
     map: [
-      [
-        'development_of_the_virus',
-        ['sewage_measurement', 'positive_tests', 'mortality'],
-      ],
-      [
-        'consequences_for_healthcare',
-        [
-          'hospital_admissions',
-          'nursing_home_care',
-          'disabled_care',
-          'elderly_at_home',
-        ],
-      ],
+      ['development_of_the_virus', ['sewage_measurement', 'positive_tests', 'mortality']],
+      ['consequences_for_healthcare', ['hospital_admissions', 'nursing_home_care', 'disabled_care', 'elderly_at_home']],
       ['actions_to_take', ['vaccinations', 'current_advices']],
-      ['archived_metrics', ['source_investigation', 'compliance']],
+      ['archived_metrics', ['compliance', 'source_investigation']],
     ],
   });
 
   return (
     <>
       <Head>
-        <link
-          key="dc-spatial"
-          rel="dcterms:spatial"
-          href="https://standaarden.overheid.nl/owms/terms/Nederland"
-        />
-        <link
-          key="dc-spatial-title"
-          rel="dcterms:spatial"
-          href="https://standaarden.overheid.nl/owms/terms/Nederland"
-          title="Nederland"
-        />
+        <link key="dc-spatial" rel="dcterms:spatial" href="https://standaarden.overheid.nl/owms/terms/Nederland" />
+        <link key="dc-spatial-title" rel="dcterms:spatial" href="https://standaarden.overheid.nl/owms/terms/Nederland" title="Nederland" />
       </Head>
 
       <AppContent
         hideBackButton={isMainRoute}
         searchComponent={
-          <Box
-            backgroundColor="white"
-            maxWidth={{ _: '38rem', md: undefined }}
-            mx="auto"
-          >
+          <Box backgroundColor="white" maxWidth={{ _: '38rem', md: undefined }} mx="auto">
             <VrComboBox getLink={getLink} selectedVrCode={code} />
           </Box>
         }
@@ -120,9 +96,7 @@ export function VrLayout(props: VrLayoutProps) {
               >
                 <Box px={3}>
                   <Heading id="sidebar-title" level={2} variant="h3">
-                    <VisuallyHidden as="span">
-                      {commonTexts.veiligheidsregio_layout.headings.sidebar}
-                    </VisuallyHidden>
+                    <VisuallyHidden as="span">{commonTexts.veiligheidsregio_layout.headings.sidebar}</VisuallyHidden>
                     {vrName}
                   </Heading>
                 </Box>

--- a/packages/app/src/domain/layout/vr-layout.tsx
+++ b/packages/app/src/domain/layout/vr-layout.tsx
@@ -73,8 +73,8 @@ export function VrLayout(props: VrLayoutProps) {
           'elderly_at_home',
         ],
       ],
-      ['actions_to_take', ['vaccinations', 'current_advices', 'compliance']],
-      ['archived_metrics', ['source_investigation']],
+      ['actions_to_take', ['vaccinations', 'current_advices']],
+      ['archived_metrics', ['source_investigation', 'compliance']],
     ],
   });
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -1,4 +1,4 @@
-import { VrBehaviorValue } from '@corona-dashboard/common';
+import { VrBehaviorArchived_20221019Value } from '@corona-dashboard/common';
 import { Bevolking } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useRef, useState } from 'react';
@@ -53,10 +53,11 @@ export const getStaticProps = createGetStaticProps(
     getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
   (context) => {
-    const data = selectVrData('behavior')(context);
-    const chartBehaviorOptions = getBehaviorChartOptions<VrBehaviorValue>(
-      data.selectedVrData.behavior.values[0]
-    );
+    const data = selectVrData('behavior_archived_20221019')(context);
+    const chartBehaviorOptions =
+      getBehaviorChartOptions<VrBehaviorArchived_20221019Value>(
+        data.selectedVrData.behavior_archived_20221019.values[0]
+      );
 
     return { ...data, chartBehaviorOptions };
   },
@@ -97,7 +98,7 @@ export default function BehaviorPageVr(
     description: text.vr.metadata.description,
   };
 
-  const behaviorLastValue = data.behavior.last_value;
+  const behaviorLastValue = data.behavior_archived_20221019.last_value;
 
   const [currentId, setCurrentId] = useState<BehaviorIdentifier>(
     chartBehaviorOptions[0]
@@ -111,7 +112,7 @@ export default function BehaviorPageVr(
       <VrLayout vrName={vrName}>
         <TileList>
           <PageInformationBlock
-            category={commonTexts.sidebar.categories.actions_to_take.title}
+            category={commonTexts.sidebar.categories.archived_metrics.title}
             title={text.vr.pagina.titel}
             icon={<Bevolking />}
             description={text.vr.pagina.toelichting}
@@ -173,7 +174,7 @@ export default function BehaviorPageVr(
 
           <span ref={scrollToRef} />
           <BehaviorLineChartTile
-            values={data.behavior.values}
+            values={data.behavior_archived_20221019.values}
             metadata={{
               date: [
                 behaviorLastValue.date_start_unix,

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -605,13 +605,17 @@ export interface NlBehaviorValue {
   avoid_crowds_compliance?: number | null;
   avoid_crowds_compliance_trend: ('up' | 'down' | 'equal') | null;
   symptoms_stay_home_if_mandatory_compliance?: number | null;
-  symptoms_stay_home_if_mandatory_compliance_trend?: ('up' | 'down' | 'equal') | null;
+  symptoms_stay_home_if_mandatory_compliance_trend?:
+    | ('up' | 'down' | 'equal')
+    | null;
   symptoms_get_tested_compliance?: number | null;
   symptoms_get_tested_compliance_trend?: ('up' | 'down' | 'equal') | null;
   wear_mask_public_indoors_compliance?: number | null;
   wear_mask_public_indoors_compliance_trend: ('up' | 'down' | 'equal') | null;
   wear_mask_public_transport_compliance?: number | null;
-  wear_mask_public_transport_compliance_trend?: ('up' | 'down' | 'equal') | null;
+  wear_mask_public_transport_compliance_trend?:
+    | ('up' | 'down' | 'equal')
+    | null;
   sneeze_cough_elbow_compliance?: number | null;
   sneeze_cough_elbow_compliance_trend: ('up' | 'down' | 'equal') | null;
   max_visitors_compliance?: number | null;
@@ -631,7 +635,9 @@ export interface NlBehaviorValue {
   avoid_crowds_support?: number | null;
   avoid_crowds_support_trend: ('up' | 'down' | 'equal') | null;
   symptoms_stay_home_if_mandatory_support?: number | null;
-  symptoms_stay_home_if_mandatory_support_trend?: ('up' | 'down' | 'equal') | null;
+  symptoms_stay_home_if_mandatory_support_trend?:
+    | ('up' | 'down' | 'equal')
+    | null;
   symptoms_get_tested_support?: number | null;
   symptoms_get_tested_support_trend?: ('up' | 'down' | 'equal') | null;
   wear_mask_public_indoors_support?: number | null;
@@ -968,7 +974,16 @@ export interface NlVaccineCoveragePerAgeGroup {
   values: NlVaccineCoveragePerAgeGroupValue[];
 }
 export interface NlVaccineCoveragePerAgeGroupValue {
-  age_group_range: '5-11' | '12-17' | '18-29' | '30-39' | '40-49' | '50-59' | '60-69' | '70-79' | '80+';
+  age_group_range:
+    | '5-11'
+    | '12-17'
+    | '18-29'
+    | '30-39'
+    | '40-49'
+    | '50-59'
+    | '60-69'
+    | '70-79'
+    | '80+';
   age_group_percentage: number;
   age_group_total: number;
   autumn_2022_vaccinated: number | null;
@@ -986,7 +1001,16 @@ export interface NlVaccineCoveragePerAgeGroupArchived {
   values: NlVaccineCoveragePerAgeGroupArchivedValue[];
 }
 export interface NlVaccineCoveragePerAgeGroupArchivedValue {
-  age_group_range: '5-11' | '12-17' | '18-30' | '31-40' | '41-50' | '51-60' | '61-70' | '71-80' | '81+';
+  age_group_range:
+    | '5-11'
+    | '12-17'
+    | '18-30'
+    | '31-40'
+    | '41-50'
+    | '51-60'
+    | '61-70'
+    | '71-80'
+    | '81+';
   age_group_percentage: number;
   age_group_total: number;
   fully_vaccinated: number;
@@ -1002,7 +1026,16 @@ export interface NlVaccineCoveragePerAgeGroupArchived_20220908 {
   values: NlVaccineCoveragePerAgeGroupArchived_20220908Value[];
 }
 export interface NlVaccineCoveragePerAgeGroupArchived_20220908Value {
-  age_group_range: '5-11' | '12-17' | '18-29' | '30-39' | '40-49' | '50-59' | '60-69' | '70-79' | '80+';
+  age_group_range:
+    | '5-11'
+    | '12-17'
+    | '18-29'
+    | '30-39'
+    | '40-49'
+    | '50-59'
+    | '60-69'
+    | '70-79'
+    | '80+';
   age_group_percentage: number;
   age_group_total: number;
   fully_vaccinated: number;
@@ -1272,7 +1305,7 @@ export interface TopicalTheme {
 }
 export interface TopicalThemeTile {
   index: number;
-  kpiValue?: number | null | string;
+  kpiValue: number | null | string;
   title: MultilanguageString;
   dynamicDescription: MultilanguageString;
   trendIcon: {
@@ -1320,7 +1353,7 @@ export interface Vr {
   tested_ggd_archived: VrTestedGgdArchived;
   nursing_home: VrNursingHome;
   disability_care: VrDisabilityCare;
-  behavior: VrBehavior;
+  behavior_archived_20221019: VrBehaviorArchived_20221019;
   deceased_rivm: VrDeceasedRivm;
   deceased_cbs: VrDeceasedCbs;
   elderly_at_home: VrElderlyAtHome;
@@ -1476,11 +1509,11 @@ export interface VrDisabilityCareValue {
   date_of_insertion_unix: number;
   vrcode: string;
 }
-export interface VrBehavior {
-  values: VrBehaviorValue[];
-  last_value: VrBehaviorValue;
+export interface VrBehaviorArchived_20221019 {
+  values: VrBehaviorArchived_20221019Value[];
+  last_value: VrBehaviorArchived_20221019Value;
 }
-export interface VrBehaviorValue {
+export interface VrBehaviorArchived_20221019Value {
   number_of_participants: number;
   curfew_compliance?: number | null;
   curfew_compliance_trend: ('up' | 'down' | 'equal') | null;


### PR DESCRIPTION
## Summary

* renamed `behavior.json` to `behavior_archived_20221019.json` (including references inside the schema, schema index and associated files)
* adjusted the menu for VR layouts to archive the behaviour page
* adjusted the page category of the behaviour page

### Screenshots
#### After
![COR-1151_after](https://user-images.githubusercontent.com/107395524/196894148-b0f9e980-03a4-43f8-9e18-d1da5bdece66.png)