### PR TITLE
bugfix/COR-1201-vandaag-is-not-positioned-proportionally-to-the-timeline

### DIFF
--- a/packages/app/src/components/severity-indicator-tile/components/timeline/components/timeline-bar-part.tsx
+++ b/packages/app/src/components/severity-indicator-tile/components/timeline/components/timeline-bar-part.tsx
@@ -12,6 +12,10 @@ interface TimelineBarPartsProps {
   isLast?: boolean;
 }
 
+/**
+ * TODO: An improvement would be to divide this bar part further into parts
+ * where each part refers to a day in the date range this bar part represents.
+ */
 export const TimelineBarPart = ({ children, color, size = 10, width, isFirst = false, isLast = false }: TimelineBarPartsProps) => {
   const borderRadius = isFirst ? `${size / 2}px 0 0 ${size / 2}px` : null;
 

--- a/packages/app/src/components/severity-indicator-tile/components/timeline/logic/get-timeline-bar-arrow-offset.ts
+++ b/packages/app/src/components/severity-indicator-tile/components/timeline/logic/get-timeline-bar-arrow-offset.ts
@@ -1,0 +1,17 @@
+import { createDateFromUnixTimestamp } from '~/utils/create-date-from-unix-timestamp';
+
+// Returns the difference betweeen two dates in days.
+const getDifferenceInDays = (start: Date, end: Date): number => {
+  return Math.ceil((end.getTime() - start.getTime()) / (1000 * 3600 * 24));
+};
+
+// Determines where to position the 'Vandaag' label on the timeline.
+export const getTimelineBarArrowOffset = (today: Date, startDate: number, endDate: number): number => {
+  const startOfIntervalDate = createDateFromUnixTimestamp(startDate);
+  const endOfIntervalDate = createDateFromUnixTimestamp(endDate);
+  const noOfDaysInInterval = getDifferenceInDays(startOfIntervalDate, endOfIntervalDate);
+  const noOfDaysFromStartToToday = getDifferenceInDays(startOfIntervalDate, today);
+  const arrowOffset = (noOfDaysFromStartToToday / noOfDaysInInterval) * 100;
+
+  return arrowOffset;
+};

--- a/packages/app/src/components/severity-indicator-tile/components/timeline/timeline.tsx
+++ b/packages/app/src/components/severity-indicator-tile/components/timeline/timeline.tsx
@@ -1,4 +1,4 @@
-import { colors, middleOfDayInSeconds } from '@corona-dashboard/common';
+import { colors } from '@corona-dashboard/common';
 import { ReactNode, useCallback, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useIntl } from '~/intl';
@@ -13,6 +13,7 @@ import { TimelineBar } from './components/timeline-bar';
 import { TimelineBarPart } from './components/timeline-bar-part';
 import { TimelineTooltipContent } from './components/tooltip-content';
 import { getSeverityColor } from '../../logic/get-severity-color';
+import { getTimelineBarArrowOffset } from './logic/get-timeline-bar-arrow-offset';
 import { SeverityLevels } from '../../types';
 
 export interface SeverityIndicatorTimelineEventConfig {
@@ -103,31 +104,22 @@ export const Timeline = ({ labels, startDate, endDate, legendItems, size = 10, t
   );
 };
 
-const getTimelineBarArrowOffset = (today: Date, startDate: number, endDate: number) => {
-  const todayInSeconds = middleOfDayInSeconds(today.getTime() / 1000);
-  return todayInSeconds / (endDate - startDate) / 100;
-};
+const TimelineBarArrow = ({ children, today, startDate, endDate }: { children: ReactNode; today: Date; startDate: number; endDate: number }) => {
+  const arrowLeftOffset = getTimelineBarArrowOffset(today, startDate, endDate) ?? 0;
 
-const TimelineBarArrow = ({ children, today, startDate, endDate }: { children: ReactNode; today: Date; startDate: number; endDate: number }) => (
-  <Box
-    alignItems="center"
-    display="flex"
-    flexDirection="column"
-    left={`${getTimelineBarArrowOffset(today, startDate, endDate) ?? 0}%`}
-    position="absolute"
-    top="-40px"
-    transform="translateX(-50%)"
-  >
-    {children}
-    <Box
-      borderLeft={`${space[2]} solid transparent`}
-      borderRight={`${space[2]} solid transparent`}
-      borderTop={`${space[2]} solid ${colors.black}`}
-      height={space[2]}
-      width={space[2]}
-    />
-  </Box>
-);
+  return (
+    <Box alignItems="center" display="flex" flexDirection="column" left={`${arrowLeftOffset}%`} position="absolute" top="-40px" transform="translateX(-50%)">
+      {children}
+      <Box
+        borderLeft={`${space[2]} solid transparent`}
+        borderRight={`${space[2]} solid transparent`}
+        borderTop={`${space[2]} solid ${colors.black}`}
+        height={space[2]}
+        width={space[2]}
+      />
+    </Box>
+  );
+};
 
 const TimelineHeading = styled(Heading)`
   margin-bottom: ${space[3]};

--- a/packages/cms/src/data/data-structure.ts
+++ b/packages/cms/src/data/data-structure.ts
@@ -176,6 +176,8 @@ export const dataStructure = {
       'ventilate_home_compliance_trend',
       'selftest_visit_compliance',
       'selftest_visit_compliance_trend',
+      'posttest_isolation_compliance',
+      'posttest_isolation_compliance_trend',
       'curfew_support',
       'curfew_support_trend',
       'wash_hands_support',
@@ -202,6 +204,8 @@ export const dataStructure = {
       'ventilate_home_support_trend',
       'selftest_visit_support',
       'selftest_visit_support_trend',
+      'posttest_isolation_support',
+      'posttest_isolation_support_trend',
     ],
     behavior_get_tested_support_per_age_group: ['percentage_average', 'percentage_70_plus', 'percentage_55_69', 'percentage_40_54', 'percentage_25_39', 'percentage_16_24'],
     behavior_annotations: ['behavior_indicator', 'message_title_nl', 'message_title_en', 'message_desc_nl', 'message_desc_en'],
@@ -259,17 +263,8 @@ export const dataStructure = {
       'date_of_report_unix',
       'birthyear_range',
     ],
-    vaccine_coverage_per_age_group_estimated: [
-      'age_60_plus_autumn_2022_vaccinated',
-      'age_60_plus_birthyear',
-      'age_18_plus_fully_vaccinated',
-      'age_18_plus_has_one_shot',
-      'age_18_plus_birthyear',
-      'age_12_plus_autumn_2022_vaccinated',
-      'age_12_plus_fully_vaccinated',
-      'age_12_plus_has_one_shot',
-      'age_12_plus_birthyear',
-    ],
+    vaccine_coverage_per_age_group_estimated_fully_vaccinated: ['age_12_plus_birthyear', 'age_12_plus_vaccinated', 'age_18_plus_birthyear', 'age_18_plus_vaccinated'],
+    vaccine_coverage_per_age_group_estimated_autumn_2022: ['age_12_plus_birthyear', 'age_12_plus_vaccinated', 'age_60_plus_birthyear', 'age_60_plus_vaccinated'],
     vaccine_coverage_per_age_group_estimated_archived_20220908: [
       'age_18_plus_fully_vaccinated',
       'age_18_plus_has_one_shot',
@@ -335,7 +330,7 @@ export const dataStructure = {
       'deceased_daily',
       'deceased_daily_moving_average',
     ],
-    behavior: [
+    behavior_archived_20221019: [
       'number_of_participants',
       'curfew_compliance',
       'curfew_compliance_trend',
@@ -433,7 +428,7 @@ export const dataStructure = {
     tested_overall: ['infected_per_100k', 'infected'],
     nursing_home: ['newly_infected_people', 'newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage', 'deceased_daily'],
     sewer: ['average'],
-    behavior: [
+    behavior_archived_20221019: [
       'number_of_participants',
       'curfew_compliance',
       'curfew_compliance_trend',


### PR DESCRIPTION
# Summary

This PR addresses the issue described in COR-1201.

The fix changes the logic for how the offset for the `vandaag` label is calculated. 

NOTE: In the images below, today refers to the 4th of November 2022.

## Before:
![Screenshot 2022-11-04 at 17 11 44](https://user-images.githubusercontent.com/116002914/200024292-830a7c20-3f26-4bf6-b91c-c74763366069.png)

## After:
![Screenshot 2022-11-04 at 17 15 39](https://user-images.githubusercontent.com/116002914/200024425-a9320f41-a228-4f5e-bd8c-c891800ba3b8.png)

This fix also allows future events to be entered (in case that is a possibility):
![Screenshot 2022-11-04 at 16 48 46](https://user-images.githubusercontent.com/116002914/200024560-09e874a1-6179-4be8-be7d-1ceed88daa73.png)
