### PR TITLE
feature/COR-1177-added-metadata-to-TopicalTile

### DIFF
--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -67,7 +67,6 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
             })}
           >
             <Box
-              display="block"
               fontSize={{ _: fontSizes[6], xs: fontSizes[7] }}
               paddingLeft={asResponsiveArray({ _: space[3], xs: space[4] })}
               paddingTop={asResponsiveArray({ _: space[3], xs: space[4] })}

--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -17,6 +17,7 @@ import { Cta } from '~/queries/query-types';
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 import { TrendIcon as TrendIconType } from '@corona-dashboard/app/src/domain/topical/types';
 import { mapStringToColors } from '~/components/severity-indicator-tile/logic/map-string-to-colors';
+import { Metadata, MetadataProps } from '~/components/metadata';
 
 interface TopicalTileProps {
   title: string;
@@ -25,9 +26,10 @@ interface TopicalTileProps {
   description: PortableTextEntry[];
   kpiValue: string | null;
   cta: Cta;
+  metadataText: MetadataProps;
 }
 
-export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta }: TopicalTileProps) {
+export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, metadataText }: TopicalTileProps) {
   const { formatNumber } = useIntl();
 
   const formattedKpiValue = typeof kpiValue === 'number' ? formatNumber(kpiValue) : typeof kpiValue === 'string' ? kpiValue : false;
@@ -104,6 +106,7 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
             <Box display="flex" alignItems="center">
               <RichContent blocks={description} elementAlignment="start" />
             </Box>
+            {metadataText && <Metadata {...metadataText} isTileFooter />}
           </Box>
         </Box>
 

--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -25,7 +25,7 @@ interface TopicalTileProps {
   description: PortableTextEntry[];
   kpiValue: string | null;
   cta: Cta;
-  sourceLabel: string;
+  sourceLabel: string | null;
 }
 
 export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, sourceLabel }: TopicalTileProps) {
@@ -119,11 +119,13 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
           </Box>
         </Box>
         <Box>
-          <Box padding={{ _: space[3], xs: space[4] }}>
-            <InlineText color="gray7">{sourceLabel}</InlineText>
-          </Box>
+          {sourceLabel && (
+            <Box padding={{ _: space[3], xs: space[4] }} paddingTop={{ _: space[0], xs: space[0] }}>
+              <InlineText color="gray7">{sourceLabel}</InlineText>
+            </Box>
+          )}
           {cta.title && (
-            <Box display="flex" justifyContent="center" alignItems="center" bg={colors.blue1} color={colors.blue8} padding={3} className="topical-tile-cta">
+            <Box display="flex" justifyContent="center" alignItems="center" backgroundColor={colors.blue1} color={colors.blue8} padding={3} className="topical-tile-cta">
               <TextWithIcon text={cta.title} icon={<ChevronRight />} />
             </Box>
           )}

--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -1,5 +1,5 @@
 import { Box } from '~/components/base';
-import theme, { space } from '~/style/theme';
+import theme, { space, fontSizes } from '~/style/theme';
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import { Heading, InlineText } from '~/components/typography';
@@ -51,7 +51,7 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
       color="black"
       css={css({
         '&:hover .topical-tile-cta': {
-          bg: colors.blue8,
+          backgroundColor: colors.blue8,
           textDecoration: 'underline',
           color: colors.white,
         },
@@ -66,7 +66,12 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
               gap: 2,
             })}
           >
-            <Box display="block" fontSize={{ _: 6, xs: 7 }} pl={asResponsiveArray({ _: 3, xs: 4 })} pt={asResponsiveArray({ _: 3, xs: 4 })}>
+            <Box
+              display="block"
+              fontSize={{ _: fontSizes[6], xs: fontSizes[7] }}
+              paddingLeft={asResponsiveArray({ _: space[3], xs: space[4] })}
+              paddingTop={asResponsiveArray({ _: space[3], xs: space[4] })}
+            >
               <Heading
                 level={3}
                 color={colors.blue8}
@@ -86,7 +91,7 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
                 )}
               </Heading>
               {formattedKpiValue && (
-                <Box display="flex" justifyContent="start" alignItems="center" mt={2}>
+                <Box display="flex" justifyContent="start" alignItems="center" marginTop={space[2]}>
                   <KpiValue color={colors.black} text={formattedKpiValue} />
                   {trendIcon.direction && trendIcon.color && (
                     <TrendIconWrapper color={mapStringToColors(trendIcon.color)}>
@@ -101,21 +106,29 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
               <DynamicIcon name={tileIcon} aria-hidden="true" />
             </TileIcon>
           </Box>
-          <Box display="flex" flexDirection="column" justifyContent="start" textAlign="left" p={{ _: 3, xs: 4 }} pt={formattedKpiValue ? { _: 2, xs: 2 } : undefined}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="start"
+            textAlign="left"
+            padding={{ _: space[3], xs: space[4] }}
+            paddingTop={formattedKpiValue ? { _: space[2], xs: space[2] } : undefined}
+          >
             <Box display="flex" alignItems="center">
               <RichContent blocks={description} elementAlignment="start" />
             </Box>
-            <Box display="inline-block" align-self="flex-end">
-              <InlineText color="gray7">{sourceLabel}</InlineText>
-            </Box>
           </Box>
         </Box>
-
-        {cta.title && (
-          <Box display="flex" justifyContent="center" alignItems="center" bg={colors.blue1} color={colors.blue8} padding={3} className="topical-tile-cta">
-            <TextWithIcon text={cta.title} icon={<ChevronRight />} />
+        <Box>
+          <Box padding={{ _: space[3], xs: space[4] }}>
+            <InlineText color="gray7">{sourceLabel}</InlineText>
           </Box>
-        )}
+          {cta.title && (
+            <Box display="flex" justifyContent="center" alignItems="center" bg={colors.blue1} color={colors.blue8} padding={3} className="topical-tile-cta">
+              <TextWithIcon text={cta.title} icon={<ChevronRight />} />
+            </Box>
+          )}
+        </Box>
       </>
     </Box>
   );

--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -26,10 +26,10 @@ interface TopicalTileProps {
   description: PortableTextEntry[];
   kpiValue: string | null;
   cta: Cta;
-  metadataText: MetadataProps;
+  metadata: MetadataProps;
 }
 
-export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, metadataText }: TopicalTileProps) {
+export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, metadata }: TopicalTileProps) {
   const { formatNumber } = useIntl();
 
   const formattedKpiValue = typeof kpiValue === 'number' ? formatNumber(kpiValue) : typeof kpiValue === 'string' ? kpiValue : false;
@@ -106,7 +106,7 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
             <Box display="flex" alignItems="center">
               <RichContent blocks={description} elementAlignment="start" />
             </Box>
-            {metadataText && <Metadata {...metadataText} isTileFooter />}
+            {metadata && <Metadata {...metadata} isTileFooter />}
           </Box>
         </Box>
 

--- a/packages/app/src/domain/topical/components/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-tile.tsx
@@ -2,7 +2,7 @@ import { Box } from '~/components/base';
 import theme, { space } from '~/style/theme';
 import css from '@styled-system/css';
 import styled from 'styled-components';
-import { Heading } from '~/components/typography';
+import { Heading, InlineText } from '~/components/typography';
 import { TextWithIcon } from '~/components/text-with-icon';
 import { asResponsiveArray } from '~/style/utils';
 import { colors } from '@corona-dashboard/common';
@@ -17,7 +17,6 @@ import { Cta } from '~/queries/query-types';
 import { PortableTextEntry } from '@sanity/block-content-to-react';
 import { TrendIcon as TrendIconType } from '@corona-dashboard/app/src/domain/topical/types';
 import { mapStringToColors } from '~/components/severity-indicator-tile/logic/map-string-to-colors';
-import { Metadata, MetadataProps } from '~/components/metadata';
 
 interface TopicalTileProps {
   title: string;
@@ -26,10 +25,10 @@ interface TopicalTileProps {
   description: PortableTextEntry[];
   kpiValue: string | null;
   cta: Cta;
-  metadata: MetadataProps;
+  sourceLabel: string;
 }
 
-export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, metadata }: TopicalTileProps) {
+export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue, cta, sourceLabel }: TopicalTileProps) {
   const { formatNumber } = useIntl();
 
   const formattedKpiValue = typeof kpiValue === 'number' ? formatNumber(kpiValue) : typeof kpiValue === 'string' ? kpiValue : false;
@@ -106,7 +105,9 @@ export function TopicalTile({ title, tileIcon, trendIcon, description, kpiValue,
             <Box display="flex" alignItems="center">
               <RichContent blocks={description} elementAlignment="start" />
             </Box>
-            {metadata && <Metadata {...metadata} isTileFooter />}
+            <Box display="inline-block" align-self="flex-end">
+              <InlineText color="gray7">{sourceLabel}</InlineText>
+            </Box>
           </Box>
         </Box>
 

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -213,7 +213,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                           cta={themeTile.cta}
                           key={themeTile.title}
                           kpiValue={themeTile.kpiValue}
-                          metadataText={{
+                          metadata={{
                             date: 'Waarde van dinsdag 1 november',
                             source: {
                               text: 'RIVM',

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -213,6 +213,13 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                           cta={themeTile.cta}
                           key={themeTile.title}
                           kpiValue={themeTile.kpiValue}
+                          metadataText={{
+                            date: 'Waarde van dinsdag 1 november',
+                            source: {
+                              text: 'RIVM',
+                              href: '',
+                            },
+                          }}
                         />
                       );
                     })}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -213,7 +213,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                           cta={themeTile.cta}
                           key={themeTile.title}
                           kpiValue={themeTile.kpiValue}
-                          sourceLabel="Waarde van dinsdag 1 november Bron: RIVM"
+                          sourceLabel={themeTile.sourceLabel}
                         />
                       );
                     })}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -213,13 +213,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                           cta={themeTile.cta}
                           key={themeTile.title}
                           kpiValue={themeTile.kpiValue}
-                          metadata={{
-                            date: 'Waarde van dinsdag 1 november',
-                            source: {
-                              text: 'RIVM',
-                              href: '',
-                            },
-                          }}
+                          sourceLabel="Waarde van dinsdag 1 november Bron: RIVM"
                         />
                       );
                     })}

--- a/packages/app/src/queries/get-topical-structure-query.ts
+++ b/packages/app/src/queries/get-topical-structure-query.ts
@@ -26,6 +26,7 @@ export function getTopicalStructureQuery(locale: string) {
             "description":description.${locale},
             tileIcon,
             "title":title.${locale},
+            "sourceLabel":sourceLabel.${locale},
             'kpiValue': kpiValue.${locale},
             'trendIcon': {
               'color': trendIcon.color,

--- a/packages/app/src/queries/query-types.ts
+++ b/packages/app/src/queries/query-types.ts
@@ -74,6 +74,7 @@ interface BaseTile {
 
 interface TopicalTile extends BaseTile {
   title: string;
+  sourceLabel: string | null;
   kpiValue: string | null;
   cta: Cta;
   trendIcon: TrendIcon;

--- a/packages/cms/src/schemas/topical/theme-tile.ts
+++ b/packages/cms/src/schemas/topical/theme-tile.ts
@@ -31,6 +31,11 @@ export const themeTile = {
       type: 'localeString',
     },
     {
+      title: 'Metadata label',
+      name: 'sourceLabel',
+      type: 'localeString',
+    },
+    {
       title: 'Trend icon',
       name: 'trendIcon',
       type: 'trendIcon',


### PR DESCRIPTION
# Summary

This PR addresses the feature described in COR-1177.

With this feature the source and/or dates can be added to the TopicalTile.

## Before:
![Schermafbeelding 2022-11-07 om 17 28 23](https://user-images.githubusercontent.com/93994194/200362803-a5753114-a474-4ec5-947e-c68bba504d30.png)

## After:
![Schermafbeelding 2022-11-07 om 17 27 22](https://user-images.githubusercontent.com/93994194/200362755-73a32079-e052-44ac-8b40-e51d6040fb0d.png)
![Schermafbeelding 2022-11-07 om 17 27 49](https://user-images.githubusercontent.com/93994194/200362761-f68bf5ce-a0b7-40d1-813d-2c2f6a25bbe9.png)
