### PR TITLE
Remove and rename booster data from existing schemas

### DIFF
--- a/packages/app/schema/gm/__index.json
+++ b/packages/app/schema/gm/__index.json
@@ -17,7 +17,7 @@
     "vaccine_coverage_per_age_group",
     "vaccine_coverage_per_age_group_archived",
     "vaccine_coverage_per_age_group_archived_20220908",
-    "booster_coverage"
+    "booster_coverage_archived_20220904"
   ],
   "properties": {
     "last_generated": {
@@ -62,8 +62,8 @@
     "vaccine_coverage_per_age_group_archived_20220908": {
       "$ref": "vaccine_coverage_per_age_group_archived_20220908.json"
     },
-    "booster_coverage": {
-      "$ref": "booster_coverage.json"
+    "booster_coverage_archived_20220904": {
+      "$ref": "booster_coverage_archived_20220904.json"
     }
   },
   "$defs": {

--- a/packages/app/schema/gm/booster_coverage_archived_20220904.json
+++ b/packages/app/schema/gm/booster_coverage_archived_20220904.json
@@ -1,35 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_booster_shot_administered",
+  "title": "gm_booster_coverage_archived_20220904",
   "type": "object",
   "properties": {
     "values": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 1,
+      "maxItems": 2,
       "items": {
         "$ref": "#/definitions/value"
       }
-    },
-    "last_value": {
-      "$ref": "#/definitions/value"
     }
   },
-  "required": ["values", "last_value"],
+  "required": ["values"],
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "nl_booster_shot_administered_value",
+      "title": "gm_booster_coverage_archived_20220904_value",
       "type": "object",
       "properties": {
-        "administered_total": {
+        "age_group": {
+          "type": "string",
+          "enum": ["12+", "18+"]
+        },
+        "percentage": {
           "type": "number"
         },
-        "ggd_administered_total": {
-          "type": "number"
-        },
-        "others_administered_total": {
-          "type": "number"
+        "percentage_label": {
+          "type": ["string", "null"],
+          "pattern": "^([><][=][0-9]{1,2})$"
         },
         "date_unix": {
           "type": "integer"
@@ -39,9 +38,8 @@
         }
       },
       "required": [
-        "administered_total",
-        "ggd_administered_total",
-        "others_administered_total",
+        "percentage",
+        "percentage_label",
         "date_unix",
         "date_of_insertion_unix"
       ],

--- a/packages/app/schema/gm/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm/vaccine_coverage_per_age_group.json
@@ -21,10 +21,8 @@
         "age_group_range",
         "autumn_2022_vaccinated_percentage",
         "fully_vaccinated_percentage",
-        "booster_shot_percentage",
         "autumn_2022_vaccinated_percentage_label",
         "fully_vaccinated_percentage_label",
-        "booster_shot_percentage_label",
         "birthyear_range",
         "date_of_insertion_unix",
         "date_unix"

--- a/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/gm_collection/vaccine_coverage_per_age_group.json
@@ -11,8 +11,6 @@
     "autumn_2022_vaccinated_percentage_label",
     "fully_vaccinated_percentage",
     "fully_vaccinated_percentage_label",
-    "booster_shot_percentage",
-    "booster_shot_percentage_label",
     "date_of_insertion_unix",
     "date_unix"
   ],
@@ -31,9 +29,6 @@
     "fully_vaccinated_percentage": {
       "type": ["integer", "null"]
     },
-    "booster_shot_percentage": {
-      "type": ["integer", "null"]
-    },
     "birthyear_range": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
@@ -43,10 +38,6 @@
       "pattern": "^([><][=][0-9]{1,2})$"
     },
     "fully_vaccinated_percentage_label": {
-      "type": ["string", "null"],
-      "pattern": "^([><][=][0-9]{1,2})$"
-    },
-    "booster_shot_percentage_label": {
       "type": ["string", "null"],
       "pattern": "^([><][=][0-9]{1,2})$"
     },

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -5,9 +5,9 @@
   "required": [
     "behavior",
     "behavior_annotations",
-    "booster_shot_administered",
+    "booster_shot_administered_archived_20220904",
     "repeating_shot_administered",
-    "booster_coverage",
+    "booster_coverage_archived_20220904",
     "code",
     "corona_melder_app_download",
     "corona_melder_app_warning",
@@ -80,14 +80,14 @@
     "named_difference": {
       "$ref": "__named_difference.json"
     },
-    "booster_shot_administered": {
-      "$ref": "booster_shot_administered.json"
+    "booster_shot_administered_archived_20220904": {
+      "$ref": "booster_shot_administered_archived_20220904.json"
     },
     "repeating_shot_administered": {
       "$ref": "repeating_shot_administered.json"
     },
-    "booster_coverage": {
-      "$ref": "booster_coverage.json"
+    "booster_coverage_archived_20220904": {
+      "$ref": "booster_coverage_archived_20220904.json"
     },
     "doctor": {
       "$ref": "doctor.json"

--- a/packages/app/schema/nl/booster_coverage_archived_20220904.json
+++ b/packages/app/schema/nl/booster_coverage_archived_20220904.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_booster_coverage",
+  "title": "nl_booster_coverage_archived_20220904",
   "type": "object",
   "properties": {
     "values": {
@@ -16,7 +16,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "nl_booster_coverage_value",
+      "title": "nl_booster_coverage_archived_20220904_value",
       "type": "object",
       "properties": {
         "age_group": {

--- a/packages/app/schema/nl/booster_shot_administered_archived_20220904.json
+++ b/packages/app/schema/nl/booster_shot_administered_archived_20220904.json
@@ -1,34 +1,35 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "gm_booster_coverage",
+  "title": "nl_booster_shot_administered_archived_20220904",
   "type": "object",
   "properties": {
     "values": {
       "type": "array",
       "minItems": 1,
-      "maxItems": 2,
+      "maxItems": 1,
       "items": {
         "$ref": "#/definitions/value"
       }
+    },
+    "last_value": {
+      "$ref": "#/definitions/value"
     }
   },
-  "required": ["values"],
+  "required": ["values", "last_value"],
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "gm_booster_coverage_value",
+      "title": "nl_booster_shot_administered_archived_20220904_value",
       "type": "object",
       "properties": {
-        "age_group": {
-          "type": "string",
-          "enum": ["12+", "18+"]
-        },
-        "percentage": {
+        "administered_total": {
           "type": "number"
         },
-        "percentage_label": {
-          "type": ["string", "null"],
-          "pattern": "^([><][=][0-9]{1,2})$"
+        "ggd_administered_total": {
+          "type": "number"
+        },
+        "others_administered_total": {
+          "type": "number"
         },
         "date_unix": {
           "type": "integer"
@@ -38,8 +39,9 @@
         }
       },
       "required": [
-        "percentage",
-        "percentage_label",
+        "administered_total",
+        "ggd_administered_total",
+        "others_administered_total",
         "date_unix",
         "date_of_insertion_unix"
       ],

--- a/packages/app/schema/nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/nl/vaccine_coverage_per_age_group.json
@@ -22,10 +22,8 @@
         "age_group_range",
         "age_group_total",
         "autumn_2022_vaccinated",
-        "booster_shot",
         "autumn_2022_vaccinated_percentage",
         "fully_vaccinated_percentage",
-        "booster_shot_percentage",
         "date_of_insertion_unix",
         "date_unix",
         "date_of_report_unix",
@@ -59,17 +57,11 @@
         "fully_vaccinated": {
           "type": "integer"
         },
-        "booster_shot": {
-          "type": ["integer", "null"]
-        },
         "autumn_2022_vaccinated_percentage": {
           "type": ["integer", "null"]
         },
         "fully_vaccinated_percentage": {
           "type": "number"
-        },
-        "booster_shot_percentage": {
-          "type": ["number", "null"]
         },
         "date_unix": {
           "type": "integer"

--- a/packages/app/schema/vr/__index.json
+++ b/packages/app/schema/vr/__index.json
@@ -27,7 +27,7 @@
     "vaccine_coverage_per_age_group",
     "vaccine_coverage_per_age_group_archived",
     "vaccine_coverage_per_age_group_archived_20220908",
-    "booster_coverage"
+    "booster_coverage_archived_20220904"
   ],
   "additionalProperties": false,
   "properties": {
@@ -106,8 +106,8 @@
     "vaccine_coverage_per_age_group_archived_20220908": {
       "$ref": "vaccine_coverage_per_age_group_archived_20220908.json"
     },
-    "booster_coverage": {
-      "$ref": "booster_coverage.json"
+    "booster_coverage_archived_20220904": {
+      "$ref": "booster_coverage_archived_20220904.json"
     }
   },
   "$defs": {

--- a/packages/app/schema/vr/booster_coverage_archived_20220904.json
+++ b/packages/app/schema/vr/booster_coverage_archived_20220904.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "vr_booster_coverage",
+  "title": "vr_booster_coverage_archived_20220904",
   "type": "object",
   "properties": {
     "values": {
@@ -16,7 +16,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "vr_booster_coverage_value",
+      "title": "vr_booster_coverage_archived_20220904_value",
       "type": "object",
       "properties": {
         "age_group": {

--- a/packages/app/schema/vr/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr/vaccine_coverage_per_age_group.json
@@ -21,10 +21,8 @@
         "age_group_range",
         "autumn_2022_vaccinated_percentage",
         "fully_vaccinated_percentage",
-        "booster_shot_percentage",
         "autumn_2022_vaccinated_percentage_label",
         "fully_vaccinated_percentage_label",
-        "booster_shot_percentage_label",
         "birthyear_range",
         "date_of_insertion_unix",
         "date_unix"

--- a/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/vr_collection/vaccine_coverage_per_age_group.json
@@ -11,8 +11,6 @@
     "autumn_2022_vaccinated_percentage_label",
     "fully_vaccinated_percentage_label",
     "fully_vaccinated_percentage",
-    "booster_shot_percentage",
-    "booster_shot_percentage_label",
     "date_of_insertion_unix",
     "date_unix"
   ],
@@ -31,9 +29,6 @@
     "fully_vaccinated_percentage": {
       "type": ["integer", "null"]
     },
-    "booster_shot_percentage": {
-      "type": ["integer", "null"]
-    },
     "birthyear_range": {
       "type": "string",
       "pattern": "^[0-9]{4}-[0-9]{4}$|^-[0-9]{4}$|^[0-9]{4}-$"
@@ -43,10 +38,6 @@
       "pattern": "^([><][=][0-9]{1,2})$"
     },
     "fully_vaccinated_percentage_label": {
-      "type": ["string", "null"],
-      "pattern": "^([><][=][0-9]{1,2})$"
-    },
-    "booster_shot_percentage_label": {
       "type": ["string", "null"],
       "pattern": "^([><][=][0-9]{1,2})$"
     },

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -24,7 +24,7 @@ import { assert, replaceVariablesInText, useReverseRouter, useFormatLokalizePerc
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
-const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage'];
+const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage_archived_20220904'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   textGm: siteText.pages.vaccinations_page.gm,
@@ -39,7 +39,7 @@ export { getStaticPaths } from '~/static-paths/gm';
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectGmData('code', 'vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'vaccine_coverage_per_age_group_archived_20220908', 'booster_coverage'),
+  selectGmData('code', 'vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'vaccine_coverage_per_age_group_archived_20220908', 'booster_coverage_archived_20220904'),
   createGetChoroplethData({
     gm: ({ vaccine_coverage_per_age_group }, ctx) => {
       if (!isDefined(vaccine_coverage_per_age_group)) {
@@ -117,8 +117,8 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
 
   const filteredArchivedAgeGroup12Plus = data.vaccine_coverage_per_age_group_archived_20220908.values.find((x) => x.age_group_range === '12+');
 
-  const boosterCoverage18PlusValue = data.booster_coverage?.values?.find((v) => v.age_group === '18+');
-  const boosterCoverage12PlusValue = data.booster_coverage?.values?.find((v) => v.age_group === '12+');
+  const boosterCoverage18PlusArchivedValue = data.booster_coverage_archived_20220904?.values?.find((v) => v.age_group === '18+');
+  const boosterCoverage12PlusArchivedValue = data.booster_coverage_archived_20220904?.values?.find((v) => v.age_group === '12+');
 
   assert(filteredAgeGroup60Plus, `[${VaccinationsGmPage.name}] Could not find data for the vaccine coverage per age group for the age 60+`);
 
@@ -301,9 +301,9 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
                   birthyear: filteredArchivedAgeGroup18Plus.birthyear_range,
                   fully_vaccinated_label: filteredArchivedAgeGroup18Plus.fully_vaccinated_percentage_label,
                   has_one_shot_label: filteredArchivedAgeGroup18Plus.has_one_shot_percentage_label,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusValue?.percentage}`),
-                  boostered_label: boosterCoverage18PlusValue?.percentage_label,
-                  dateUnixBoostered: boosterCoverage18PlusValue?.date_unix,
+                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusArchivedValue?.percentage}`),
+                  boostered_label: boosterCoverage18PlusArchivedValue?.percentage_label,
+                  dateUnixBoostered: boosterCoverage18PlusArchivedValue?.date_unix,
                 }}
                 age12Plus={{
                   fully_vaccinated: filteredArchivedAgeGroup12Plus.fully_vaccinated_percentage,
@@ -311,9 +311,9 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
                   birthyear: filteredArchivedAgeGroup12Plus.birthyear_range,
                   fully_vaccinated_label: filteredArchivedAgeGroup12Plus.fully_vaccinated_percentage_label,
                   has_one_shot_label: filteredArchivedAgeGroup12Plus.has_one_shot_percentage_label,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusValue?.percentage}`),
-                  boostered_label: boosterCoverage12PlusValue?.percentage_label,
-                  dateUnixBoostered: boosterCoverage12PlusValue?.date_unix,
+                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusArchivedValue?.percentage}`),
+                  boostered_label: boosterCoverage12PlusArchivedValue?.percentage_label,
+                  dateUnixBoostered: boosterCoverage12PlusArchivedValue?.date_unix,
                 }}
                 age12PlusToggleText={textGm.vaccination_grade_toggle_tile.age_12_plus}
                 age18PlusToggleText={textGm.vaccination_grade_toggle_tile.age_18_plus}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -50,8 +50,8 @@ const pageMetrics = [
   'vaccine_coverage_per_age_group_estimated_autumn_2022',
   'vaccine_campaigns',
   'vaccine_planned',
-  'booster_coverage',
-  'booster_shot_administered',
+  'booster_coverage_archived_20220904',
+  'booster_shot_administered_archived_20220904',
   'repeating_shot_administered',
 ];
 
@@ -86,8 +86,8 @@ export const getStaticProps = createGetStaticProps(
     'vaccine_campaigns_archived_20220908',
     'vaccine_planned',
     'vaccine_planned_archived_20220908',
-    'booster_coverage',
-    'booster_shot_administered',
+    'booster_coverage_archived_20220904',
+    'booster_shot_administered_archived_20220904',
     'repeating_shot_administered'
   ),
   () => selectAdministrationData(getNlData().data.vaccine_administered),
@@ -150,13 +150,13 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
   const vaccineCoverageEstimatedArchivedLastValue = data.vaccine_coverage_per_age_group_estimated_archived_20220908.last_value;
 
-  const boosterShotAdministeredLastValue = data.booster_shot_administered.last_value;
+  const boosterShotAdministeredArchivedLastValue = data.booster_shot_administered_archived_20220904.last_value;
 
-  const boosterCoverage18PlusValue = data.booster_coverage.values.find((v) => v.age_group === '18+');
-  const boosterCoverage12PlusValue = data.booster_coverage.values.find((v) => v.age_group === '12+');
+  const boosterCoverage18PlusArchivedValue = data.booster_coverage_archived_20220904.values.find((v) => v.age_group === '18+');
+  const boosterCoverage12PlusArchivedValue = data.booster_coverage_archived_20220904.values.find((v) => v.age_group === '12+');
 
-  assert(boosterCoverage18PlusValue, `[${VaccinationPage.name}] Missing value for booster_coverage 18+`);
-  assert(boosterCoverage12PlusValue, `[${VaccinationPage.name}] Missing value for booster_coverage 12+`);
+  assert(boosterCoverage18PlusArchivedValue, `[${VaccinationPage.name}] Missing value for booster_coverage 18+`);
+  assert(boosterCoverage12PlusArchivedValue, `[${VaccinationPage.name}] Missing value for booster_coverage 12+`);
 
   const repeatingShotAdministeredLastValue = data.repeating_shot_administered?.last_value;
 
@@ -313,16 +313,16 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
                 age18Plus={{
                   fully_vaccinated: vaccineCoverageEstimatedArchivedLastValue.age_18_plus_fully_vaccinated,
                   has_one_shot: vaccineCoverageEstimatedArchivedLastValue.age_18_plus_has_one_shot,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusValue.percentage}`),
+                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusArchivedValue.percentage}`),
                   birthyear: vaccineCoverageEstimatedArchivedLastValue.age_18_plus_birthyear,
-                  dateUnixBoostered: boosterCoverage18PlusValue.date_unix,
+                  dateUnixBoostered: boosterCoverage18PlusArchivedValue.date_unix,
                 }}
                 age12Plus={{
                   fully_vaccinated: vaccineCoverageEstimatedArchivedLastValue.age_12_plus_fully_vaccinated,
                   has_one_shot: vaccineCoverageEstimatedArchivedLastValue.age_12_plus_has_one_shot,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusValue.percentage}`),
+                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusArchivedValue.percentage}`),
                   birthyear: vaccineCoverageEstimatedArchivedLastValue.age_12_plus_birthyear,
-                  dateUnixBoostered: boosterCoverage12PlusValue.date_unix,
+                  dateUnixBoostered: boosterCoverage12PlusArchivedValue.date_unix,
                 }}
                 numFractionDigits={1}
                 age12PlusToggleText={textNl.vaccination_grade_toggle_tile.age_12_plus}
@@ -345,8 +345,8 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               />
               <VaccinationsKpiHeader
                 text={textNl.repeating_shot_information_block}
-                dateUnix={boosterShotAdministeredLastValue.date_unix}
-                dateOfInsertionUnix={boosterShotAdministeredLastValue.date_of_insertion_unix}
+                dateUnix={boosterShotAdministeredArchivedLastValue.date_unix}
+                dateOfInsertionUnix={boosterShotAdministeredArchivedLastValue.date_of_insertion_unix}
               />
 
               <VaccinationsShotKpiSection
@@ -375,34 +375,34 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
               <VaccinationsKpiHeader
                 text={textNl.booster_information_block}
-                dateUnix={boosterShotAdministeredLastValue.date_unix}
-                dateOfInsertionUnix={boosterShotAdministeredLastValue.date_of_insertion_unix}
+                dateUnix={boosterShotAdministeredArchivedLastValue.date_unix}
+                dateOfInsertionUnix={boosterShotAdministeredArchivedLastValue.date_of_insertion_unix}
               />
 
               <VaccineBoosterAdministrationsKpiSection
                 text={textNl.booster_kpi}
-                totalBoosterShots={boosterShotAdministeredLastValue.administered_total}
+                totalBoosterShots={boosterShotAdministeredArchivedLastValue.administered_total}
                 metadateBoosterShots={{
                   datumsText: textNl.booster_kpi.datums,
-                  date: boosterShotAdministeredLastValue.date_unix,
+                  date: boosterShotAdministeredArchivedLastValue.date_unix,
                   source: {
                     href: textNl.booster_kpi.sources.href,
                     text: textNl.booster_kpi.sources.text,
                   },
                 }}
-                boosterGgdValue={boosterShotAdministeredLastValue.ggd_administered_total}
+                boosterGgdValue={boosterShotAdministeredArchivedLastValue.ggd_administered_total}
                 metadateBoosterGgd={{
                   datumsText: textNl.booster_kpi.datums,
-                  date: boosterShotAdministeredLastValue.date_unix,
+                  date: boosterShotAdministeredArchivedLastValue.date_unix,
                   source: {
                     href: textNl.booster_kpi.sources.href,
                     text: textNl.booster_kpi.sources.text,
                   },
                 }}
-                boosterEstimatedValue={boosterShotAdministeredLastValue.others_administered_total}
+                boosterEstimatedValue={boosterShotAdministeredArchivedLastValue.others_administered_total}
                 metadateBoosterEstimated={{
                   datumsText: textNl.booster_kpi.datums,
-                  date: boosterShotAdministeredLastValue.date_unix,
+                  date: boosterShotAdministeredArchivedLastValue.date_unix,
                   source: {
                     href: textNl.booster_kpi.sources.href,
                     text: textNl.booster_kpi.sources.text,

--- a/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/vaccinaties.tsx
@@ -25,7 +25,7 @@ import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts'
 import { BoldText } from '~/components/typography';
 import css from '@styled-system/css';
 
-const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage'];
+const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage_archived_20220904'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   textNl: siteText.pages.vaccinations_page.nl,
@@ -40,7 +40,7 @@ export { getStaticPaths } from '~/static-paths/vr';
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectVrData('vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'vaccine_coverage_per_age_group_archived_20220908', 'booster_coverage'),
+  selectVrData('vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'vaccine_coverage_per_age_group_archived_20220908', 'booster_coverage_archived_20220904'),
   createGetChoroplethData({
     gm: ({ vaccine_coverage_per_age_group }, ctx) => {
       if (!isDefined(vaccine_coverage_per_age_group)) {
@@ -125,8 +125,8 @@ export const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) =>
 
   const filteredAgeGroup12PlusArchived = data.vaccine_coverage_per_age_group_archived_20220908.values.find((item) => item.age_group_range === '12+');
 
-  const boosterCoverage18PlusValue = data.booster_coverage.values.find((v) => v.age_group === '18+');
-  const boosterCoverage12PlusValue = data.booster_coverage.values.find((v) => v.age_group === '12+');
+  const boosterCoverage18PlusArchivedValue = data.booster_coverage_archived_20220904.values.find((v) => v.age_group === '18+');
+  const boosterCoverage12PlusArchivedValue = data.booster_coverage_archived_20220904.values.find((v) => v.age_group === '12+');
 
   assert(filteredAgeGroup60Plus, `[${VaccinationsVrPage.name}] Could not find data for the vaccine coverage per age group for the age 18+`);
 
@@ -305,9 +305,9 @@ export const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) =>
                   birthyear: filteredAgeGroup18PlusArchived.birthyear_range,
                   fully_vaccinated_label: filteredAgeGroup18PlusArchived.fully_vaccinated_percentage_label,
                   has_one_shot_label: filteredAgeGroup18PlusArchived.has_one_shot_percentage_label,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusValue?.percentage}`),
-                  boostered_label: boosterCoverage18PlusValue?.percentage_label,
-                  dateUnixBoostered: boosterCoverage18PlusValue?.date_unix,
+                  boostered: formatPercentageAsNumber(`${boosterCoverage18PlusArchivedValue?.percentage}`),
+                  boostered_label: boosterCoverage18PlusArchivedValue?.percentage_label,
+                  dateUnixBoostered: boosterCoverage18PlusArchivedValue?.date_unix,
                 }}
                 age12Plus={{
                   fully_vaccinated: filteredAgeGroup12PlusArchived.fully_vaccinated_percentage,
@@ -315,9 +315,9 @@ export const VaccinationsVrPage = (props: StaticProps<typeof getStaticProps>) =>
                   birthyear: filteredAgeGroup12PlusArchived.birthyear_range,
                   fully_vaccinated_label: filteredAgeGroup12PlusArchived.fully_vaccinated_percentage_label,
                   has_one_shot_label: filteredAgeGroup12PlusArchived.has_one_shot_percentage_label,
-                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusValue?.percentage}`),
-                  boostered_label: boosterCoverage12PlusValue?.percentage_label,
-                  dateUnixBoostered: boosterCoverage12PlusValue?.date_unix,
+                  boostered: formatPercentageAsNumber(`${boosterCoverage12PlusArchivedValue?.percentage}`),
+                  boostered_label: boosterCoverage12PlusArchivedValue?.percentage_label,
+                  dateUnixBoostered: boosterCoverage12PlusArchivedValue?.date_unix,
                 }}
                 age12PlusToggleText={textVr.vaccination_grade_toggle_tile.age_12_plus}
                 age18PlusToggleText={textVr.vaccination_grade_toggle_tile.age_18_plus}

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -21,7 +21,7 @@ export interface Gm {
   vaccine_coverage_per_age_group: GmVaccineCoveragePerAgeGroup;
   vaccine_coverage_per_age_group_archived: GmVaccineCoveragePerAgeGroupArchived;
   vaccine_coverage_per_age_group_archived_20220908: GmVaccineCoveragePerAgeGroupArchived_20220908;
-  booster_coverage: GmBoosterCoverage;
+  booster_coverage_archived_20220904: GmBoosterCoverageArchived_20220904;
 }
 export interface GmStaticValues {
   population_count: number;
@@ -114,11 +114,11 @@ export interface GmVaccineCoveragePerAgeGroupValue {
   age_group_range: "12+" | "18+" | "60+";
   autumn_2022_vaccinated_percentage: number | null;
   fully_vaccinated_percentage: number | null;
-  booster_shot_percentage: number | null;
+  booster_shot_percentage?: number | null;
   birthyear_range: string;
   autumn_2022_vaccinated_percentage_label: string | null;
   fully_vaccinated_percentage_label: string | null;
-  booster_shot_percentage_label: string | null;
+  booster_shot_percentage_label?: string | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -150,10 +150,10 @@ export interface GmVaccineCoveragePerAgeGroupArchived_20220908Value {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface GmBoosterCoverage {
-  values: GmBoosterCoverageValue[];
+export interface GmBoosterCoverageArchived_20220904 {
+  values: GmBoosterCoverageArchived_20220904Value[];
 }
-export interface GmBoosterCoverageValue {
+export interface GmBoosterCoverageArchived_20220904Value {
   age_group?: "12+" | "18+";
   percentage: number;
   percentage_label: string | null;
@@ -202,11 +202,9 @@ export interface GmCollectionVaccineCoveragePerAgeGroup {
   age_group_range: "12+" | "18+" | "60+";
   autumn_2022_vaccinated_percentage: number | null;
   fully_vaccinated_percentage: number | null;
-  booster_shot_percentage: number | null;
   birthyear_range: string;
   autumn_2022_vaccinated_percentage_label: string | null;
   fully_vaccinated_percentage_label: string | null;
-  booster_shot_percentage_label: string | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -220,9 +218,9 @@ export interface Nl {
   code: NlId;
   difference: NlDifference;
   named_difference: NlNamedDifference;
-  booster_shot_administered: NlBoosterShotAdministered;
+  booster_shot_administered_archived_20220904: NlBoosterShotAdministeredArchived_20220904;
   repeating_shot_administered: NlRepeatingShotAdministered;
-  booster_coverage: NlBoosterCoverage;
+  booster_coverage_archived_20220904: NlBoosterCoverageArchived_20220904;
   doctor: NlDoctor;
   g_number: NlGNumber;
   infectious_people: NlInfectiousPeople;
@@ -343,11 +341,11 @@ export interface NamedDifferenceDecimal {
   old_date_unix: number;
   new_date_unix: number;
 }
-export interface NlBoosterShotAdministered {
-  values: NlBoosterShotAdministeredValue[];
-  last_value: NlBoosterShotAdministeredValue;
+export interface NlBoosterShotAdministeredArchived_20220904 {
+  values: NlBoosterShotAdministeredArchived_20220904Value[];
+  last_value: NlBoosterShotAdministeredArchived_20220904Value;
 }
-export interface NlBoosterShotAdministeredValue {
+export interface NlBoosterShotAdministeredArchived_20220904Value {
   administered_total: number;
   ggd_administered_total: number;
   others_administered_total: number;
@@ -363,10 +361,10 @@ export interface NlRepeatingShotAdministeredValue {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlBoosterCoverage {
-  values: NlBoosterCoverageValue[];
+export interface NlBoosterCoverageArchived_20220904 {
+  values: NlBoosterCoverageArchived_20220904Value[];
 }
-export interface NlBoosterCoverageValue {
+export interface NlBoosterCoverageArchived_20220904Value {
   age_group?: "12+" | "18+";
   percentage: number;
   date_unix: number;
@@ -984,10 +982,8 @@ export interface NlVaccineCoveragePerAgeGroupValue {
   age_group_total: number;
   autumn_2022_vaccinated: number | null;
   fully_vaccinated: number;
-  booster_shot: number | null;
   autumn_2022_vaccinated_percentage: number | null;
   fully_vaccinated_percentage: number;
-  booster_shot_percentage: number | null;
   date_unix: number;
   date_of_insertion_unix: number;
   date_of_report_unix: number;
@@ -1352,7 +1348,7 @@ export interface Vr {
   vaccine_coverage_per_age_group: VrVaccineCoveragePerAgeGroup;
   vaccine_coverage_per_age_group_archived: VrVaccineCoveragePerAgeGroupArchived;
   vaccine_coverage_per_age_group_archived_20220908: VrVaccineCoveragePerAgeGroupArchived_20220908;
-  booster_coverage: VrBoosterCoverage;
+  booster_coverage_archived_20220904: VrBoosterCoverageArchived_20220904;
 }
 export interface VrStaticValues {
   population_count: number;
@@ -1637,11 +1633,11 @@ export interface VrVaccineCoveragePerAgeGroupValue {
   age_group_range: "12+" | "18+" | "60+";
   autumn_2022_vaccinated_percentage: number | null;
   fully_vaccinated_percentage: number | null;
-  booster_shot_percentage: number | null;
+  booster_shot_percentage?: number | null;
   birthyear_range: string;
   autumn_2022_vaccinated_percentage_label: string | null;
   fully_vaccinated_percentage_label: string | null;
-  booster_shot_percentage_label: string | null;
+  booster_shot_percentage_label?: string | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }
@@ -1673,10 +1669,10 @@ export interface VrVaccineCoveragePerAgeGroupArchived_20220908Value {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface VrBoosterCoverage {
-  values: VrBoosterCoverageValue[];
+export interface VrBoosterCoverageArchived_20220904 {
+  values: VrBoosterCoverageArchived_20220904Value[];
 }
-export interface VrBoosterCoverageValue {
+export interface VrBoosterCoverageArchived_20220904Value {
   age_group?: "12+" | "18+";
   percentage: number;
   percentage_label: string | null;
@@ -1814,11 +1810,9 @@ export interface VrCollectionVaccineCoveragePerAgeGroup {
   age_group_range: "12+" | "18+" | "60+";
   autumn_2022_vaccinated_percentage: number | null;
   fully_vaccinated_percentage: number | null;
-  booster_shot_percentage: number | null;
   birthyear_range: string;
   autumn_2022_vaccinated_percentage_label: string | null;
   fully_vaccinated_percentage_label: string | null;
-  booster_shot_percentage_label: string | null;
   date_unix: number;
   date_of_insertion_unix: number;
 }


### PR DESCRIPTION
## Summary

- Archive `booster_coverage` and `booster_shot_administered` in NL | VR | GM
- Remove booster keys from `vaccine_coverage_per_age_group`
- Update with new data types
- Update components with archived naming