### PR TITLE
Feature/COR-1088-archive-button-styling

### DIFF
--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -152,23 +152,35 @@ const Button = styled.button<{
   isActive?: boolean;
 }>`
   cursor: pointer;
-  background: ${({ isActive }) => (isActive ? colors.blue8 : colors.white)};
+  background: ${({ isActive }) => (isActive ? colors.blue1 : colors.white)};
   border: ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   border-radius: 5px;
-  color: ${({ isActive }) => (isActive ? colors.white : colors.blue8)};
-  padding: ${space[3]} 12px;
+  color: ${({ isActive }) => (isActive ? colors.blue8 : colors.blue8)};
+  padding: 12px ${space[3]};
   border-style: solid;
   min-height: 36px;
   border-width: 1px;
   transition: 0.1s background-color;
 
   ${({ isActive }) =>
+    isActive &&
+    `
+    '&:focus': {
+      position: 'absolute',
+      outline: '2px dotted white',
+      outlineOffset: '-2px',
+      top: 2,
+      left: 2,
+    }
+  `}
+
+  ${({ isActive }) =>
     !isActive &&
     `
     &:hover {
-      background: ${colors.gray1};
-      color: ${colors.blue8};
-      border-color: ${colors.blue8};
+      background: ${colors.blue8};
+      color: ${colors.white};
+      border-color: ${colors.transparent};
     }
   `}
 `;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -121,9 +121,9 @@ export function PageInformationBlock({
           </Box>
           <Box my={3}>
             {showArchivedToggleButton && (
-              <StyledButton type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
+              <StyledArchiveButton type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
                 {!isArchivedHidden ? commonTexts.common.show_archived : commonTexts.common.hide_archived}
-              </StyledButton>
+              </StyledArchiveButton>
             )}
           </Box>
         </Tile>
@@ -148,9 +148,11 @@ const MetadataBox = styled.div(
   })
 );
 
-const StyledButton = styled.button<{
+interface StyledArchiveButtonProps {
   isActive?: boolean;
-}>`
+}
+
+const StyledArchiveButton = styled.button<StyledArchiveButtonProps>`
   background: ${({ isActive }) => (isActive ? colors.blue1 : colors.white)};
   border: ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   border-radius: 5px;
@@ -168,7 +170,7 @@ const StyledButton = styled.button<{
     border-color: ${colors.transparent};
   }
 
-  &:focus {
-    outline: 2px dotted ${colors.white};
+  &:hover:focus-visible {
+    outline: 2px dotted ${colors.magenta3};
   }
 `;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -169,6 +169,6 @@ const StyledButton = styled.button<{
   }
 
   &:focus {
-    outline: 2px dotted white;
+    outline: 2px dotted ${colors.white};
   }
 `;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -162,25 +162,15 @@ const Button = styled.button<{
   border-width: 1px;
   transition: 0.1s background-color;
 
-  ${({ isActive }) =>
-    isActive &&
-    `
-    '&:focus': {
-      position: 'absolute',
-      outline: '2px dotted white',
-      outlineOffset: '-2px',
-      top: 2,
-      left: 2,
-    }
-  `}
+  &:hover {
+    background: ${colors.blue8};
+    color: ${colors.white};
+    border-color: ${colors.transparent};
+  }
 
-  ${({ isActive }) =>
-    !isActive &&
-    `
-    &:hover {
-      background: ${colors.blue8};
-      color: ${colors.white};
-      border-color: ${colors.transparent};
-    }
-  `}
+  &:focus {
+    outline: 2px dotted white;
+    top: 2;
+    left: 2;
+  }
 `;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -16,6 +16,8 @@ import { PageLinks } from './components/page-links';
 import { WarningTile } from '~/components/warning-tile';
 import { useScopedWarning } from '~/utils/use-scoped-warning';
 import { useIntl } from '~/intl';
+import { colors } from '@corona-dashboard/common';
+import { space } from '~/style/theme';
 
 interface InformationBlockProps {
   title?: string;
@@ -57,18 +59,12 @@ export function PageInformationBlock({
   onToggleArchived,
 }: InformationBlockProps) {
   const scopedWarning = useScopedWarning(vrNameOrGmName || '', warning || '');
-  const showArchivedToggleButton =
-    typeof isArchivedHidden !== 'undefined' &&
-    typeof onToggleArchived !== 'undefined';
+  const showArchivedToggleButton = typeof isArchivedHidden !== 'undefined' && typeof onToggleArchived !== 'undefined';
   const { commonTexts } = useIntl();
 
   const MetaDataBlock = metadata ? (
     <MetadataBox>
-      <Metadata
-        {...metadata}
-        accessibilitySubject={title}
-        referenceLink={referenceLink}
-      />
+      <Metadata {...metadata} accessibilitySubject={title} referenceLink={referenceLink} />
     </MetadataBox>
   ) : null;
 
@@ -86,22 +82,8 @@ export function PageInformationBlock({
 
   return (
     <Box as="header" id={id} spacing={{ _: 3, md: 4 }}>
-      {title && (
-        <Header
-          icon={icon}
-          title={title}
-          category={category}
-          screenReaderCategory={screenReaderCategory}
-        />
-      )}
-      {scopedWarning && (
-        <WarningTile
-          variant="emphasis"
-          message={scopedWarning}
-          icon={Warning}
-          isFullWidth
-        />
-      )}
+      {title && <Header icon={icon} title={title} category={category} screenReaderCategory={screenReaderCategory} />}
+      {scopedWarning && <WarningTile variant="emphasis" message={scopedWarning} icon={Warning} isFullWidth />}
 
       {description && (
         <Tile hasTitle={!!title}>
@@ -139,14 +121,8 @@ export function PageInformationBlock({
           </Box>
           <Box my={3}>
             {showArchivedToggleButton && (
-              <Button
-                type="button"
-                onClick={onToggleArchived}
-                isActive={isArchivedHidden}
-              >
-                {!isArchivedHidden
-                  ? commonTexts.common.show_archived
-                  : commonTexts.common.hide_archived}
+              <Button type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
+                {!isArchivedHidden ? commonTexts.common.show_archived : commonTexts.common.hide_archived}
               </Button>
             )}
           </Box>
@@ -172,14 +148,27 @@ const MetadataBox = styled.div(
   })
 );
 
-const Button = styled.button<{ isActive?: boolean }>(({ isActive }) =>
-  css({
-    bg: !isActive ? 'blue8' : 'transparent',
-    border: 'none',
-    borderRadius: '5px',
-    color: !isActive ? 'white' : 'blue8',
-    px: !isActive ? 3 : 0,
-    py: !isActive ? 12 : 0,
-    cursor: 'pointer',
-  })
-);
+const Button = styled.button<{
+  isActive?: boolean;
+}>`
+  cursor: pointer;
+  background: ${({ isActive }) => (isActive ? colors.blue8 : colors.white)};
+  border: ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
+  border-radius: 5px;
+  color: ${({ isActive }) => (isActive ? colors.white : colors.blue8)};
+  padding: ${space[3]} 12px;
+  border-style: solid;
+  min-height: 36px;
+  border-width: 1px;
+  transition: 0.1s background-color;
+
+  ${({ isActive }) =>
+    !isActive &&
+    `
+    &:hover {
+      background: ${colors.gray1};
+      color: ${colors.blue8};
+      border-color: ${colors.blue8};
+    }
+  `}
+`;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -162,7 +162,6 @@ const StyledArchiveButton = styled.button<StyledArchiveButtonProps>`
   cursor: pointer;
   min-height: 36px;
   padding: 12px ${space[3]};
-  transition: 0.1s background-color;
 
   &:hover {
     background: ${colors.blue8};

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -121,9 +121,9 @@ export function PageInformationBlock({
           </Box>
           <Box my={3}>
             {showArchivedToggleButton && (
-              <Button type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
+              <StyledButton type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
                 {!isArchivedHidden ? commonTexts.common.show_archived : commonTexts.common.hide_archived}
-              </Button>
+              </StyledButton>
             )}
           </Box>
         </Tile>
@@ -148,18 +148,18 @@ const MetadataBox = styled.div(
   })
 );
 
-const Button = styled.button<{
+const StyledButton = styled.button<{
   isActive?: boolean;
 }>`
-  cursor: pointer;
   background: ${({ isActive }) => (isActive ? colors.blue1 : colors.white)};
   border: ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   border-radius: 5px;
-  color: ${({ isActive }) => (isActive ? colors.blue8 : colors.blue8)};
-  padding: 12px ${space[3]};
   border-style: solid;
-  min-height: 36px;
   border-width: 1px;
+  color: ${({ isActive }) => (isActive ? colors.blue8 : colors.blue8)};
+  cursor: pointer;
+  min-height: 36px;
+  padding: 12px ${space[3]};
   transition: 0.1s background-color;
 
   &:hover {
@@ -170,7 +170,5 @@ const Button = styled.button<{
 
   &:focus {
     outline: 2px dotted white;
-    top: 2;
-    left: 2;
   }
 `;


### PR DESCRIPTION
## Summary

This PR addresses the changes described in COR-1088.
In this PR, the styling of the archived graphs button has been changed.

**Before**

_Default state_
<img width="524" alt="Schermafbeelding 2022-11-22 om 15 56 49" src="https://user-images.githubusercontent.com/93994194/203346404-ef34253f-afc8-401e-89d9-93c281078d8d.png">

_Active state_
<img width="471" alt="Schermafbeelding 2022-11-22 om 15 56 54" src="https://user-images.githubusercontent.com/93994194/203346408-b9b4eaaa-373d-4dd7-809e-07b0975e0e3e.png">

_Active state on focus_

![old_archived_button_active_focus](https://user-images.githubusercontent.com/93994194/203492575-9c5c394e-5736-497b-babf-5b7448913585.png)

**After:**

_Default state_
<img width="473" alt="Schermafbeelding 2022-11-22 om 15 57 30" src="https://user-images.githubusercontent.com/93994194/203346627-ba39a247-e3eb-4f08-9ce1-1252ba187093.png">

_Default state on hover_
<img width="506" alt="Schermafbeelding 2022-11-22 om 15 57 34" src="https://user-images.githubusercontent.com/93994194/203346678-47075b2d-642e-4111-b3ef-95beabdc2df7.png">

_Default state on focus_

![archived_button_default_focus](https://user-images.githubusercontent.com/93994194/203492259-12c7a49a-6f4c-4931-bd61-4948a32df8c0.png)

_Default state on hover with focus_
![archived_button_default_hover_focus](https://user-images.githubusercontent.com/93994194/203558703-71cc9031-739e-4dbc-8049-9b71adf9feee.png)


_Active state_
<img width="510" alt="Schermafbeelding 2022-11-22 om 15 57 39" src="https://user-images.githubusercontent.com/93994194/203346730-24068f4c-1aaf-4623-ba3c-1e37d5b95eb7.png">

_Active state on hover_
<img width="484" alt="Schermafbeelding 2022-11-22 om 15 57 42" src="https://user-images.githubusercontent.com/93994194/203346764-e2f2d88a-f47e-483f-997b-9cfa9c809b10.png">

_Active state on focus_
![archived_button_active_focus](https://user-images.githubusercontent.com/93994194/203492450-1bf9b062-1be5-499f-a190-5e7a646d03c8.png)

_Active state on hover with focus_
![archived_button_active_hover_focus](https://user-images.githubusercontent.com/93994194/203558640-22c6d513-53c9-4776-b6aa-3877447a45e7.png)


