### PR TITLE
Bugfix/cor 1067 fullscreen modal close button is not aligned properly

### DIFF
--- a/packages/app/src/components/fullscreen-chart-tile.tsx
+++ b/packages/app/src/components/fullscreen-chart-tile.tsx
@@ -1,6 +1,7 @@
+import { colors } from '@corona-dashboard/common';
 import { Close, Expand } from '@corona-dashboard/icons';
-import css from '@styled-system/css';
 import { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
 import { Tile } from '~/components/tile';
 import { useIntl } from '~/intl';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
@@ -12,15 +13,13 @@ import { IconButton } from './icon-button';
 import { Metadata, MetadataProps } from './metadata';
 import { Modal } from './modal';
 
-export function FullscreenChartTile({
-  children,
-  metadata,
-  disabled,
-}: {
+interface FullscreenChartTileProps {
   children: React.ReactNode;
   metadata?: MetadataProps;
   disabled?: boolean;
-}) {
+}
+
+export function FullscreenChartTile({ children, metadata, disabled }: FullscreenChartTileProps) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const wasFullscreen = usePrevious(isFullscreen);
   const breakpoints = useBreakpoints();
@@ -33,22 +32,11 @@ export function FullscreenChartTile({
     }
   }, [wasFullscreen, isFullscreen]);
 
-  const label = replaceVariablesInText(
-    isFullscreen
-      ? commonTexts.common.modal_close
-      : commonTexts.common.modal_open,
-    { subject: commonTexts.common.grafiek_singular }
-  );
+  const label = replaceVariablesInText(isFullscreen ? commonTexts.common.modal_close : commonTexts.common.modal_open, { subject: commonTexts.common.grafiek_singular });
 
   const tile = (
     <Tile hasNoBorder={isFullscreen} height="100%">
-      <Box
-        px={isFullscreen ? { _: 3, sm: 4 } : undefined}
-        py={isFullscreen ? { _: 2, sm: 3 } : undefined}
-        height="100%"
-        display="flex"
-        flexDirection="column"
-      >
+      <Box px={isFullscreen ? { _: 3, sm: 4 } : undefined} py={isFullscreen ? { _: 2, sm: 3 } : undefined} height="100%" display="flex" flexDirection="column">
         {children}
 
         {metadata && (
@@ -59,31 +47,11 @@ export function FullscreenChartTile({
         )}
 
         {!disabled && breakpoints.md && (
-          <div
-            css={css({
-              position: 'absolute',
-              top: '1.85rem',
-              right: isFullscreen ? '10px' : '-10px',
-              color: 'gray3',
-
-              '&:focus': {
-                outlineWidth: '1px',
-                outlineStyle: 'dashed',
-                outlineColor: 'blue8',
-              },
-
-              '&:hover': { color: 'gray5' },
-            })}
-          >
-            <IconButton
-              ref={isFullscreen ? undefined : buttonRef}
-              title={label}
-              onClick={() => setIsFullscreen((x) => !x)}
-              size={16}
-            >
+          <StyledModalCloseButtonWrapper isFullscreen={isFullscreen}>
+            <IconButton ref={isFullscreen ? undefined : buttonRef} title={label} onClick={() => setIsFullscreen((x) => !x)} size={16}>
               {isFullscreen ? <Close /> : <Expand />}
             </IconButton>
-          </div>
+          </StyledModalCloseButtonWrapper>
         )}
       </Box>
     </Tile>
@@ -91,11 +59,7 @@ export function FullscreenChartTile({
 
   if (!disabled && breakpoints.md && isFullscreen) {
     return (
-      <Modal
-        id="chart-tile-container"
-        onClose={() => setIsFullscreen(false)}
-        isFullheight
-      >
+      <Modal id="chart-tile-container" onClose={() => setIsFullscreen(false)} isFullheight>
         {tile}
       </Modal>
     );
@@ -103,3 +67,22 @@ export function FullscreenChartTile({
 
   return <div>{tile}</div>;
 }
+
+interface StyledModalCloseButtonWrapperProps {
+  isFullscreen: boolean;
+}
+
+const StyledModalCloseButtonWrapper = styled.div<StyledModalCloseButtonWrapperProps>`
+  color: ${colors.gray3};
+  position: absolute;
+  right: ${({ isFullscreen }) => (isFullscreen ? '25px' : '0')};
+  top: 25px;
+
+  &:focus {
+    outline: 1px dashed ${colors.blue8};
+  }
+
+  &:hover {
+    color: ${colors.gray5};
+  }
+`;

--- a/packages/app/src/components/icon-button.tsx
+++ b/packages/app/src/components/icon-button.tsx
@@ -1,4 +1,3 @@
-import css from '@styled-system/css';
 import { cloneElement, forwardRef, ReactElement } from 'react';
 import styled from 'styled-components';
 import { VisuallyHidden } from './visually-hidden';
@@ -12,54 +11,33 @@ interface IconButtonProps {
   padding?: number | string;
 }
 
-export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  (
-    {
-      children,
-      size,
-      title,
-      color = 'currentColor',
-      onClick,
-      padding,
-      ...ariaProps
-    },
-    ref
-  ) => {
-    return (
-      <StyledIconButton
-        ref={ref}
-        title={title}
-        type="button"
-        onClick={onClick}
-        size={size}
-        color={color}
-        padding={padding}
-        {...ariaProps}
-      >
-        <VisuallyHidden>{title}</VisuallyHidden>
-        {cloneElement(children, { 'aria-hidden': "true" })}
-      </StyledIconButton>
-    );
-  }
-);
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(({ children, size, title, color = 'currentColor', onClick, padding, ...ariaProps }, ref) => {
+  return (
+    <StyledIconButton ref={ref} title={title} type="button" onClick={onClick} size={size} color={color} padding={padding} {...ariaProps}>
+      <VisuallyHidden>{title}</VisuallyHidden>
+      {cloneElement(children, { 'aria-hidden': 'true' })}
+    </StyledIconButton>
+  );
+});
 
-const StyledIconButton = styled.button<{
+interface StyledIconButtonProps {
   color: string;
   size: number;
   padding?: number | string;
-}>((x) =>
-  css({
-    p: x.padding ?? 0,
-    m: 0,
-    bg: 'transparent',
-    border: 'none',
-    display: 'block',
-    cursor: 'pointer',
-    color: x.color,
-    '& svg': {
-      display: 'block',
-      width: x.size,
-      height: x.size,
-    },
-  })
-);
+}
+
+const StyledIconButton = styled.button<StyledIconButtonProps>`
+  background: transparent;
+  border: none;
+  color: ${({ color }) => color};
+  cursor: pointer;
+  display: block;
+  margin: 0;
+  padding: ${({ padding }) => (padding ? `${padding}px` : '0')};
+
+  & svg {
+    display: block;
+    height: ${({ size }) => size}px;
+    width: ${({ size }) => size}px;
+  }
+`;


### PR DESCRIPTION
### Summary

The fullscreen `expand` button and the `close` button were not aligned properly. This PR addresses that.

Apart from that, this PR also introduces some changes to the code which have been made to align with the updated conventions.

Before - Expand button
![BEFORE - EXPAND](https://user-images.githubusercontent.com/116002914/203548663-edc413c7-da00-4ea1-84a5-23deb1f3a02d.png)

After - Expand button
![AFTER - EXPAND](https://user-images.githubusercontent.com/116002914/203548715-047d9b35-081e-40c9-82df-9b05e951ede7.png)

Before - Close button
![BEFORE - CLOSE](https://user-images.githubusercontent.com/116002914/203548767-349f56fb-4a29-4a1e-bd80-a715f04ff263.png)

After - Close button
![AFTER - CLOSE](https://user-images.githubusercontent.com/116002914/203548787-fb489644-870e-4cce-91e7-1ca338e7cf69.png)

