### PR TITLE
feat: COR-1087: Applied a new button design

### DIFF
--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -15,6 +15,8 @@ import { RichContent } from './cms/rich-content';
 import { LinkWithIcon } from './link-with-icon';
 import { PublicationDate } from './publication-date';
 import { useBreakpoints } from '~/utils/use-breakpoints';
+import { colors } from '@corona-dashboard/common';
+import { space } from '~/style/theme';
 interface ArticleDetailProps {
   article: Article;
   text: SiteText['pages']['topical_page']['shared'];
@@ -50,29 +52,17 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
           <RichContent blocks={article.intro} contentWrapper={ContentBlock} />
         </Box>
 
-        <ContentImage
-          node={article.cover}
-          contentWrapper={ContentBlock}
-          sizes={imageSizes}
-        />
+        <ContentImage node={article.cover} contentWrapper={ContentBlock} sizes={imageSizes} />
       </ContentBlock>
       {!breakpoints.xs
         ? article.imageMobile && (
             <Box mt={4}>
-              <ContentImage
-                node={article.imageMobile}
-                contentWrapper={ContentBlock}
-                sizes={imageSizes}
-              />
+              <ContentImage node={article.imageMobile} contentWrapper={ContentBlock} sizes={imageSizes} />
             </Box>
           )
         : article.imageDesktop && (
             <Box mt={4}>
-              <ContentImage
-                node={article.imageDesktop}
-                contentWrapper={ContentBlock}
-                sizes={imageSizes}
-              />
+              <ContentImage node={article.imageDesktop} contentWrapper={ContentBlock} sizes={imageSizes} />
             </Box>
           )}
       {!!article.content?.length && (
@@ -93,9 +83,7 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
       {article.categories && (
         <ContentBlock>
           <Box pb={2} pt={4}>
-            <InlineText color="gray7">
-              {text.secties.artikelen.tags}
-            </InlineText>
+            <InlineText color="gray7">{text.secties.artikelen.tags}</InlineText>
           </Box>
           <Box
             as="ul"
@@ -117,13 +105,7 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
                   }}
                   passHref={true}
                 >
-                  <TagAnchor>
-                    {
-                      text.secties.artikelen.categorie_filters[
-                        item as ArticleCategoryType
-                      ]
-                    }
-                  </TagAnchor>
+                  <TagAnchor>{text.secties.artikelen.categorie_filters[item as ArticleCategoryType]}</TagAnchor>
                 </Link>
               </li>
             ))}
@@ -134,25 +116,25 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
   );
 }
 
-const TagAnchor = styled.a(
-  css({
-    display: 'block',
-    border: '2px solid transparent',
-    mb: 3,
-    px: 3,
-    py: 2,
-    backgroundColor: 'blue3',
-    color: 'blue8',
-    textDecoration: 'none',
-    transition: '0.1s border-color',
+const TagAnchor = styled.a`
+  display: block;
+  border: 2px solid ${colors.gray4};
+  border-radius: 5px;
+  color: ${colors.black};
+  margin-bottom: ${space[3]};
+  padding: ${space[2]} ${space[3]};
 
-    '&:hover': {
-      borderColor: 'blue8',
-    },
+  &:hover {
+    border: 2px solid ${colors.blue8};
+    background: ${colors.blue8};
+    color: ${colors.white};
+    text-shadow: 0.5px 0px 0px #fff, -0.5px 0px 0px #fff;
+  }
 
-    '&:focus': {
-      outline: '2px dotted',
-      outlineColor: 'blue8',
-    },
-  })
-);
+  &:focus {
+    border: 2px solid ${colors.blue8};
+    background: ${colors.blue8};
+    color: ${colors.white};
+    text-shadow: 0.5px 0px 0px #fff, -0.5px 0px 0px #fff;
+  }
+`;

--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ArrowIconLeft } from '~/components/arrow-icon';
 import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
-import { Heading, InlineText, AnchorProps } from '~/components/typography';
+import { Heading, InlineText, Anchor } from '~/components/typography';
 import { ArticleCategoryType } from '~/domain/topical/common/categories';
 import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
@@ -116,23 +116,26 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
   );
 }
 
-const StyledTagAnchor = styled.a<AnchorProps>`
+const StyledTagAnchor = styled(Anchor)`
   border-radius: 5px;
   border: 2px solid ${colors.gray4};
   color: ${colors.black};
   display: block;
   margin-bottom: ${space[3]};
   padding: ${space[2]} ${space[3]};
-  outline-color: ${colors.blue8}!important;
+
+  &:focus:focus-visible {
+    outline: 2px dotted ${colors.blue8};
+  }
 
   &:hover {
     background: ${colors.blue8};
     border: 2px solid ${colors.blue8};
     color: ${colors.white};
     text-shadow: 0.5px 0px 0px ${colors.white}, -0.5px 0px 0px ${colors.white};
-  }
 
-  &:hover:focus-visible {
-    outline: 2px dotted ${colors.magenta3}!important;
+    &:focus-visible {
+      outline: 2px dotted ${colors.magenta3};
+    }
   }
 `;

--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ArrowIconLeft } from '~/components/arrow-icon';
 import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
-import { Heading, InlineText } from '~/components/typography';
+import { Heading, InlineText, Anchor } from '~/components/typography';
 import { ArticleCategoryType } from '~/domain/topical/common/categories';
 import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
@@ -105,7 +105,7 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
                   }}
                   passHref={true}
                 >
-                  <TagAnchor>{text.secties.artikelen.categorie_filters[item as ArticleCategoryType]}</TagAnchor>
+                  <StyledTagAnchor>{text.secties.artikelen.categorie_filters[item as ArticleCategoryType]}</StyledTagAnchor>
                 </Link>
               </li>
             ))}
@@ -116,25 +116,25 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
   );
 }
 
-const TagAnchor = styled.a`
-  display: block;
-  border: 2px solid ${colors.gray4};
+const StyledTagAnchor = styled(Anchor)`
   border-radius: 5px;
+  border: 2px solid ${colors.gray4};
   color: ${colors.black};
+  display: block;
   margin-bottom: ${space[3]};
   padding: ${space[2]} ${space[3]};
 
   &:hover {
-    border: 2px solid ${colors.blue8};
     background: ${colors.blue8};
+    border: 2px solid ${colors.blue8};
     color: ${colors.white};
-    text-shadow: 0.5px 0px 0px #fff, -0.5px 0px 0px #fff;
+    text-shadow: 0.5px 0px 0px ${colors.white}, -0.5px 0px 0px ${colors.white};
   }
 
   &:focus {
-    border: 2px solid ${colors.blue8};
     background: ${colors.blue8};
+    border: 2px solid ${colors.blue8};
     color: ${colors.white};
-    text-shadow: 0.5px 0px 0px #fff, -0.5px 0px 0px #fff;
+    text-shadow: 0.5px 0px 0px ${colors.white}, -0.5px 0px 0px ${colors.white};
   }
 `;

--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ArrowIconLeft } from '~/components/arrow-icon';
 import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
-import { Heading, InlineText, Anchor } from '~/components/typography';
+import { Heading, InlineText, AnchorProps } from '~/components/typography';
 import { ArticleCategoryType } from '~/domain/topical/common/categories';
 import { useIntl } from '~/intl';
 import { SiteText } from '~/locale';
@@ -116,7 +116,7 @@ export function ArticleDetail({ article, text }: ArticleDetailProps) {
   );
 }
 
-const StyledTagAnchor = styled(Anchor)`
+const StyledTagAnchor = styled.a<AnchorProps>`
   border-radius: 5px;
   border: 2px solid ${colors.gray4};
   color: ${colors.black};
@@ -131,10 +131,7 @@ const StyledTagAnchor = styled(Anchor)`
     text-shadow: 0.5px 0px 0px ${colors.white}, -0.5px 0px 0px ${colors.white};
   }
 
-  &:focus {
-    background: ${colors.blue8};
-    border: 2px solid ${colors.blue8};
-    color: ${colors.white};
-    text-shadow: 0.5px 0px 0px ${colors.white}, -0.5px 0px 0px ${colors.white};
+  &:hover:focus-visible {
+    outline: 2px dotted ${colors.magenta3};
   }
 `;

--- a/packages/app/src/components/article-detail.tsx
+++ b/packages/app/src/components/article-detail.tsx
@@ -123,6 +123,7 @@ const StyledTagAnchor = styled.a<AnchorProps>`
   display: block;
   margin-bottom: ${space[3]};
   padding: ${space[2]} ${space[3]};
+  outline-color: ${colors.blue8}!important;
 
   &:hover {
     background: ${colors.blue8};
@@ -132,6 +133,6 @@ const StyledTagAnchor = styled.a<AnchorProps>`
   }
 
   &:hover:focus-visible {
-    outline: 2px dotted ${colors.magenta3};
+    outline: 2px dotted ${colors.magenta3}!important;
   }
 `;


### PR DESCRIPTION
## Summary

Changed articled button-link design.


## Detailed design
- Before

Default: <img width="217" alt="Screenshot 2022-11-23 at 14 43 19" src="https://user-images.githubusercontent.com/111750729/203565442-b29d9506-4f25-4066-9490-a363a79c373c.png">

On hover: <img width="187" alt="Screenshot 2022-11-23 at 14 43 27" src="https://user-images.githubusercontent.com/111750729/203565875-d4857124-d232-409d-a64d-6b232f9cccf0.png">

- After

Default:
<img width="192" alt="Screenshot 2022-11-23 at 14 43 39" src="https://user-images.githubusercontent.com/111750729/203566100-40647891-8a35-429b-aea0-fef5547c5ea1.png">

Default on hover:
<img width="201" alt="Screenshot 2022-11-23 at 14 43 44" src="https://user-images.githubusercontent.com/111750729/203566115-88ce0e68-35ec-49fb-b338-86133b3eb115.png">

Default state on focus:
<img width="160" alt="Screenshot 2022-11-29 at 14 04 10" src="https://user-images.githubusercontent.com/111750729/204536465-74837218-ba88-488f-b440-cc5c59affa2f.png">

Default state on hover with focus:
<img width="170" alt="Screenshot 2022-11-30 at 11 52 53" src="https://user-images.githubusercontent.com/111750729/204777627-a5c722ed-1663-442c-8486-b761184fc246.png">

 
