### PR TITLE
bugfix/COR-1069-inconsistent-link-hover-styles

### DIFF
--- a/packages/app/src/components/typography.tsx
+++ b/packages/app/src/components/typography.tsx
@@ -1,4 +1,4 @@
-import { Color } from '@corona-dashboard/common';
+import { Color, colors } from '@corona-dashboard/common';
 import css, { CSSProperties } from '@styled-system/css';
 import styled, { DefaultTheme } from 'styled-components';
 import { Preset, preset } from '~/style/preset';
@@ -13,20 +13,7 @@ export interface TextProps {
   ariaLabel?: string;
 }
 
-export interface AnchorProps extends TextProps {
-  underline?: boolean | 'hover';
-  hoverColor?: TextProps['color'];
-  display?: string;
-  width?: string | number;
-}
-
-export interface HeadingProps extends TextProps {
-  level: HeadingLevel;
-}
-
-export type HeadingLevel = 1 | 2 | 3 | 4 | 5;
-
-function textStyle(props: TextProps & { as?: string }) {
+export const textStyle = (props: TextProps & { as?: string }) => {
   return css({
     ...(props.as === 'button'
       ? {
@@ -40,16 +27,13 @@ function textStyle(props: TextProps & { as?: string }) {
       : undefined),
 
     ...(props.variant ? preset.typography[props.variant] : undefined),
-
     ...(props.fontWeight ? { fontWeight: props.fontWeight } : undefined),
     ...(props.color ? { color: props.color } : undefined),
-    ...(props.textTransform
-      ? { textTransform: props.textTransform }
-      : undefined),
+    ...(props.textTransform ? { textTransform: props.textTransform } : undefined),
     ...(props.textAlign ? { textAlign: props.textAlign } : undefined),
     ...(props.hyphens ? { hyphens: props.hyphens } : undefined),
   });
-}
+};
 
 export const Text = styled.p<TextProps>(textStyle);
 
@@ -57,40 +41,62 @@ export const InlineText = styled.span<TextProps>(textStyle);
 
 export const BoldText = styled.strong<TextProps>(textStyle);
 
-export const Anchor = styled.a<AnchorProps>(
-  textStyle,
-  (props) =>
-    props.underline &&
-    css({
-      textDecoration: props.underline === 'hover' ? 'none' : 'underline',
-      '&:hover, &:focus': {
-        span: {
-          textDecoration: 'underline',
-        },
-      },
-    }),
-  (props) =>
-    props.hoverColor &&
-    css({
-      '&:hover,&:focus': { color: 'blue8' },
-    }),
-  (props) =>
-    props.display &&
-    css({
-      display: props.display,
-    })
-);
+export interface AnchorProps extends TextProps {
+  underline?: boolean | 'hover';
+  hoverColor?: TextProps['color'];
+  display?: string;
+  width?: string | number;
+}
 
-export const Heading = styled.h1.attrs(
-  (props: HeadingProps & { as?: string }) => ({
-    as: props.as ?? (`h${props.level}` as const),
-    variant: props.variant ?? (`h${props.level}` as const),
-  })
-)<HeadingProps>(textStyle);
+export const Anchor = styled.a<AnchorProps>`
+  ${textStyle}
+  ${({ underline }) =>
+    underline
+      ? `
+          cursor: pointer;
+          text-decoration: ${underline === 'hover' ? 'none' : 'underline'};
 
-export function styledTextVariant(variant: string, as?: string) {
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+
+      span {
+        text-decoration: underline;
+      }
+    }
+  `
+      : undefined}
+  ${({ hoverColor }) =>
+    hoverColor
+      ? `
+    &:hover,
+    &:focus {
+      color: ${colors.blue8};
+    }
+  `
+      : undefined}
+  ${({ display }) =>
+    display
+      ? `
+    display: ${display};
+  `
+      : undefined}
+`;
+
+export interface HeadingProps extends TextProps {
+  level: HeadingLevel;
+}
+
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5;
+
+export const Heading = styled.h1.attrs((props: HeadingProps & { as?: string }) => ({
+  as: props.as ?? (`h${props.level}` as const),
+  variant: props.variant ?? (`h${props.level}` as const),
+}))<HeadingProps>(textStyle);
+
+export const styledTextVariant = (variant: string, as?: string) => {
   return styled.p.attrs(() => ({
     as: as ?? 'p',
     variant,
   }));
-}
+};

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -4,9 +4,10 @@ import { Menu, MenuRenderer } from '~/components/aside/menu';
 import { Box } from '~/components/base';
 import { ErrorBoundary } from '~/components/error-boundary';
 import { AppContent } from '~/components/layout/app-content';
-import { Heading, Text } from '~/components/typography';
+import { Anchor, Heading, Text } from '~/components/typography';
 import { VisuallyHidden } from '~/components/visually-hidden';
 import { useIntl } from '~/intl';
+import { space } from '~/style/theme';
 import { getVrForMunicipalityCode } from '~/utils/get-vr-for-municipality-code';
 import { Link } from '~/utils/link';
 import { useReverseRouter } from '~/utils/use-reverse-router';
@@ -64,10 +65,7 @@ export function GmLayout(props: GmLayoutProps) {
     layout: 'gm',
     code: code,
     map: [
-      [
-        'development_of_the_virus',
-        ['sewage_measurement', 'positive_tests', 'mortality'],
-      ],
+      ['development_of_the_virus', ['sewage_measurement', 'positive_tests', 'mortality']],
       ['consequences_for_healthcare', ['hospital_admissions']],
       ['actions_to_take', ['vaccinations']],
     ],
@@ -76,23 +74,14 @@ export function GmLayout(props: GmLayoutProps) {
   return (
     <>
       <Head>
-        <link
-          key="dc-spatial"
-          rel="dcterms:spatial"
-          href="https://standaarden.overheid.nl/owms/terms/Nederland"
-        />
-        <link
-          key="dc-spatial-title"
-          rel="dcterms:spatial"
-          href="https://standaarden.overheid.nl/owms/terms/Nederland"
-          title="Nederland"
-        />
+        <link key="dc-spatial" rel="dcterms:spatial" href="https://standaarden.overheid.nl/owms/terms/Nederland" />
+        <link key="dc-spatial-title" rel="dcterms:spatial" href="https://standaarden.overheid.nl/owms/terms/Nederland" title="Nederland" />
       </Head>
 
       <AppContent
         hideBackButton={isMainRoute}
         searchComponent={
-          <Box height="100%" maxWidth={{ _: '38rem', md: undefined }} mx="auto">
+          <Box height="100%" maxWidth={{ _: '38rem', md: undefined }} marginX="auto">
             <GmComboBox getLink={getLink} selectedGmCode={code} />
           </Box>
         }
@@ -107,21 +96,19 @@ export function GmLayout(props: GmLayoutProps) {
                 aria-labelledby="sidebar-title"
                 role="navigation"
                 maxWidth={{ _: '38rem', md: undefined }}
-                mx="auto"
+                marginX="auto"
                 spacing={1}
               >
-                <Box px={3} pb={4} spacing={1}>
+                <Box paddingX={space[3]} paddingBottom={space[4]} spacing={1}>
                   <Heading id="sidebar-title" level={2} variant="h3">
-                    <VisuallyHidden as="span">
-                      {commonTexts.gemeente_layout.headings.sidebar}
-                    </VisuallyHidden>
+                    <VisuallyHidden as="span">{commonTexts.gemeente_layout.headings.sidebar}</VisuallyHidden>
                     {municipalityName}
                   </Heading>
                   {vr && (
                     <Text>
                       {commonTexts.common.veiligheidsregio_label}{' '}
                       <Link href={reverseRouter.vr.index(vr.code)}>
-                        <a>{vr.name}</a>
+                        <Anchor underline="hover">{vr.name}</Anchor>
                       </Link>
                     </Text>
                   )}


### PR DESCRIPTION
## Summary

* updated general typography styles to always make anchor elements underlined when associated props are supplied
* rewrote (pars of) the styled components for typography elements

## Notes
The original pull request for bugfix can be found [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4507), yet I opted to close it as it gave the wrong impression about the bug and took a wrong approach to resolve it.

I left a question in said pull request to try and figure out why certain logic was applied to JSX, resulting in complex JSX and a large redundancy of `span` elements in the DOM. However, during testing I realised that these changes were there because of certain sentences being cut off and the fact that we need to group the last word and the arrow icon together. I do still think that this logic should be removed, yet I opted to not pick it up as part of this ticket, mainly due to the fact that this type of logic can be found in multiple places throughout the code base and does not result in inconsistent link styles.

As per agreement with design: all links should get an underline when hovered. The below screenshot only covers the link mentioned in the associated ticket, but all links have been checked. Other links that are covered by this pull request are

* links in the footer
* navigational links on an article page
* navigational links on a GM page

Links that already existed but have a distinct `text-decoration` value of `none` have been left out for now.

As mentioned above: there are some more things to generally fix for the various flavours of links, but I think it makes sense pick this up seperately.

### Screenshots
Both screenshots show a hover state, but no cursor.

#### Before
<img width="568" alt="image" src="https://user-images.githubusercontent.com/107395524/203110231-9d241564-14af-4dbd-b2e3-4c84049b5509.png">

#### After
<img width="562" alt="image" src="https://user-images.githubusercontent.com/107395524/204269357-356ef58c-283a-4d6a-97c4-ebf708210ef9.png">