### PR TITLE
bugfix/COR-1233-correct-mobile-icon-size

### DIFF
--- a/packages/app/src/domain/topical/components/topical-theme-header.tsx
+++ b/packages/app/src/domain/topical/components/topical-theme-header.tsx
@@ -18,9 +18,9 @@ export const TopicalThemeHeader = ({ title, subtitle, icon }: TopicalThemeHeader
   return (
     <Box spacing={3}>
       <Box display="flex" justifyContent="start" alignItems="center">
-        <TopicalThemeHeaderIcon>
+        <StyledTopicalThemeHeaderIcon>
           <DynamicIcon name={icon} aria-hidden="true" />
-        </TopicalThemeHeaderIcon>
+        </StyledTopicalThemeHeaderIcon>
         <Heading level={2}>{title}</Heading>
       </Box>
       {subtitle && (
@@ -32,11 +32,11 @@ export const TopicalThemeHeader = ({ title, subtitle, icon }: TopicalThemeHeader
   );
 };
 
-const TopicalThemeHeaderIcon = styled.span`
+const StyledTopicalThemeHeaderIcon = styled.span`
   display: block;
   height: 25px;
   margin-right: 10px;
-  width: 25px;
+  min-width: 25px;
 
   @media ${theme.mediaQueries.sm} {
     height: 30px;


### PR DESCRIPTION
## Summary

Corrected the icon size on mobile by adding min-width.

**Before:**
![mobile_icon_size_before](https://user-images.githubusercontent.com/93994194/204509041-98ef8999-7b1f-4c00-bc0e-ef007801399a.png)

**After**
![mobile_icon_size_after](https://user-images.githubusercontent.com/93994194/204509105-18d835f9-c8cc-4441-8aeb-c6a5ec1ab0fa.png)

