### PR TITLE
feat: Add new Sanity field for collection title

### DIFF
--- a/packages/app/src/pages/landelijk/geldende-adviezen.tsx
+++ b/packages/app/src/pages/landelijk/geldende-adviezen.tsx
@@ -41,7 +41,8 @@ export const getStaticProps = createGetStaticProps(
             }
           },
         'title':title.${locale},
-        'description': description.${locale}
+        'description': description.${locale},
+        'collectionTitle': collectionTitle.${locale}
       },
     }`;
   })
@@ -70,7 +71,7 @@ const NationalRestrictions = (props: StaticProps<typeof getStaticProps>) => {
             )}
           </Box>
           <Box as="article" spacing={3}>
-            <Heading level={3}>{measures.title}</Heading>
+            <Heading level={3}>{measures.collectionTitle}</Heading>
             <MeasuresTable data={measures} />
           </Box>
         </TileList>

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -174,6 +174,7 @@ export type Measures = {
   icon: string;
   title: string;
   description: RichContentBlock[] | null;
+  collectionTitle: string;
   measuresCollection: MeasuresCollection[];
 };
 declare module 'picosanity' {

--- a/packages/cms/src/schemas/measures/measures.ts
+++ b/packages/cms/src/schemas/measures/measures.ts
@@ -25,6 +25,12 @@ export const measures = {
       type: 'localeRichContentBlock',
     },
     {
+      title: 'Titel van de groepen',
+      name: 'collectionTitle',
+      type: 'localeString',
+      validation: REQUIRED,
+    },
+    {
       title: 'Groepen',
       description: 'De maatregelen zijn onderverdeeld in groepen',
       name: 'measuresCollection',


### PR DESCRIPTION
## Summary

- Add a new Sanity field for the title above the measures list, so it can be edited independently.

**Before**
- Title above measures list (table) was the same as the title of the Measures page.

**After**
- Title above measures list (table) is not the same as the title of the Measures page and can be edited in Sanity as a seperate field.