### PR TITLE
Added middelOfDay integration

### DIFF
--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -1,5 +1,6 @@
 import { Bevolking } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
+import { middleOfDayInSeconds } from '@corona-dashboard/common';
 import { useMemo, useRef, useState } from 'react';
 import { Box } from '~/components/base';
 import { Markdown } from '~/components/markdown';
@@ -99,8 +100,8 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
       .map((event) => ({
         title: event[`message_title_${locale}`],
         description: event[`message_desc_${locale}`],
-        start: event.date_start_unix,
-        end: event.date_end_unix,
+        start: middleOfDayInSeconds(event.date_start_unix),
+        end: middleOfDayInSeconds(event.date_end_unix),
       }));
 
     return { currentTimelineEvents };


### PR DESCRIPTION
The input from the JSON files mismatched the timeline scope in some time zones.
The solution is to convert all times to the middle of the day. As this is the value that gets used by other functionality as well.

Before output DateTime:
![Screenshot 2022-12-02 at 14 06 53](https://user-images.githubusercontent.com/93984341/205318386-50e138e8-f0c3-4d19-b589-8bb4ce82c2f9.png)

Current output DateTime:
![Screenshot 2022-12-02 at 14 06 57](https://user-images.githubusercontent.com/93984341/205318441-abc996e1-a7d3-41ba-859d-16901fadf672.png)
