### PR TITLE
bugfix/COR-1146-choropleth-issues-on-android

### DIFF
--- a/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@corona-dashboard/common';
 import type { GeoProjection } from 'd3-geo';
 import Konva from 'konva';
-import { memo, MouseEvent, MutableRefObject, RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, FocusEvent, MouseEvent, MutableRefObject, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { Group, Layer, Line, Stage } from 'react-konva';
 import { isDefined, isPresent } from 'ts-is-present';
 import { isIOSDevice } from '~/utils/is-ios-device';
@@ -404,6 +404,11 @@ function AreaMap(props: AreaMapProps) {
 
   const isTouch = useIsTouchDevice();
 
+  const handleAreaInteraction = (event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>, geoInfoGroup: GeoInfoGroup) => {
+    anchorEventHandlers.onFocus(event);
+    selectFeature(geoInfoGroup.code as CodeProp, true);
+  };
+
   return (
     <map name={id} tabIndex={isTabInteractive ? 0 : -1} onMouseMove={!isTouch || isIOSDevice() ? handleMouseOver : undefined}>
       {geoInfoGroups.map((geoInfoGroup) =>
@@ -420,10 +425,8 @@ function AreaMap(props: AreaMapProps) {
             shape="poly"
             coords={geoInfoCoordinates.flat().join(',')}
             href={!isTouch && isDefined(getLink) ? getLink(geoInfoGroup.code) : undefined}
-            onFocus={(event) => {
-              anchorEventHandlers.onFocus(event);
-              selectFeature(geoInfoGroup.code as CodeProp, true);
-            }}
+            onClick={(event) => (isTouch ? handleAreaInteraction(event, geoInfoGroup) : undefined)}
+            onFocus={(event) => handleAreaInteraction(event, geoInfoGroup)}
             onBlur={(event) => {
               anchorEventHandlers.onBlur(event);
               selectFeature(undefined, true);

--- a/packages/app/src/components/choropleth/tooltips/tooltip-notification.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip-notification.tsx
@@ -1,6 +1,6 @@
 import { colors } from '@corona-dashboard/common';
 import { VisuallyHidden } from '~/components';
-import { space } from '~/style/theme';
+import { radii, space } from '~/style/theme';
 import styled from 'styled-components';
 
 interface TooltipNotificationProps {
@@ -23,6 +23,7 @@ export const TooltipNotification = (props: TooltipNotificationProps) => {
 // Negative margin is used her to offset the padding from the parent component and to not alter styles for tooltips without a notification.
 const StyledTooltipNotification = styled.div`
   background-color: ${colors.yellow1};
+  border-radius: 0 0 ${radii[1]}px ${radii[1]}px;
   margin: ${space[2]} -${space[3]} -${space[2]};
   padding: ${space[2]} ${space[3]};
 `;

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -87,7 +87,7 @@ const mediaQueries = {
   xl: `screen and (min-width: ${breakpoints[4]})`,
 } as const;
 
-const radii = [0, 5, 10];
+export const radii = [0, 5, 10];
 
 export const shadows = {
   tile: '0px 4px 8px rgba(0, 0, 0, 0.1)',

--- a/packages/app/src/utils/is-touch-device.ts
+++ b/packages/app/src/utils/is-touch-device.ts
@@ -3,8 +3,5 @@
  * @returns boolean
  */
 export function isTouchDevice() {
-  return (
-    typeof window !== 'undefined' &&
-    window.matchMedia('(pointer: coarse)').matches
-  );
+  return typeof window !== 'undefined' && ('ontouchstart' in window || window.navigator.maxTouchPoints > 0 || window.matchMedia('(pointer: coarse)').matches);
 }


### PR DESCRIPTION
## Summary

* added `onClick` event to selected image map areas to properly show tooltips for Android devices;
* adjusted determinators for checking if the current device is a touch device;
* fixed tooltip notification styling issues likely introduced by COR-694

## Notes

Disclaimer: let me start off by saying that I am not entirely sure if any of these changes will actually work 100% of the time, as I was only able to test this on Android emulators, not physical devices. I invite other developers that own Android devices to pull this branch locally and test the bugfix accordingly.

Here is a list of my findings

* I initially noticed that only regions with holes in them (Midden- en West-Brabant), or regions containing detached parts (Fryslân, Groningen, Flevoland, and so on) run into issues with showing the tooltip on Android devices;
* it appears that these regions can not be focussed upon (the `onFocus` event listener does not do anything for those regions), though I am not entirely sure why not;
* iOS devices seem to handle the above just fine;
* I added a new `onClick` on the areas to be handled for touch devices; oddly enough, `onTouchStart` does end up showing the tooltip for broken regions, but also instantly navigates to the pages of the selected region; the same behaviour occurs on iOS devices (both emulated as well as physical);
* before the changes to `packages/app/src/utils/is-touch-device.ts` the Android emulator tends to first recognise a device as non-touch at first; as soon as I use Chrome DevTools to inspect the emulator, it is recognised as a touch device; I am not sure if this is a hiccup of the emulator or something else; testing using physical devices (with and without this change) could help with insights on this;

I personally also believe that this fix also covers COR-51, or that COR-51 is not even applicable anymore. There is no popover as described in the ticket, unless a user long-presses the choropleth map. Long-presses act as 'right mouse clicks' in the context of most touch devices. In case if long-pressing, a popover shows information about an image. This image is used to facilitate the image map areas to make the choropleth interactive and allows for the popup to show and it therefore required. 
