### PR TITLE
bugfix/COR-1050-removed-timeframeOption-one-week-safety-region-municipality

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -12,6 +12,7 @@ import { LocationTooltip } from './components/location-tooltip';
 import { WarningTile } from '~/components/warning-tile';
 import { mergeData, useSewerStationSelectPropsSimplified } from './logic';
 import { useIntl } from '~/intl';
+import { space } from '~/style/theme';
 import { useScopedWarning } from '~/utils/use-scoped-warning';
 import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
 
@@ -103,7 +104,7 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
         .map((option) => ({
           ...option,
           content: (
-            <Box pr={2}>
+            <Box paddingRight={space[2]}>
               <Text>{option.label}</Text>
             </Box>
           ),
@@ -127,7 +128,7 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
       onSelectTimeframe={setSewerTimeframe}
     >
       {dataPerInstallation && (
-        <Box alignSelf="flex-start" mb={3} minWidth={207}>
+        <Box alignSelf="flex-start" marginBottom={space[3]} minWidth={207}>
           <RichContentSelect
             label={text.selectPlaceholder}
             visuallyHiddenLabel
@@ -138,7 +139,7 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
         </Box>
       )}
       {scopedWarning && scopedGmName.toUpperCase() === selectedInstallation && (
-        <Box mt={2} mb={4}>
+        <Box marginTop={space[2]} marginBottom={space[4]}>
           <WarningTile variant="emphasis" message={scopedWarning} icon={Warning} isFullWidth />
         </Box>
       )}

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -113,13 +113,12 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
     [options]
   );
 
-  const timeframeOptionsWithoutOneWeek = TimeframeOptionsList.filter((option) => option !== TimeframeOption.ONE_WEEK);
-
-  const timeframeOptionsToUse = !vrNameOrGmName ? TimeframeOptionsList : timeframeOptionsWithoutOneWeek;
+  const timeframeOptionsVrOrGm = TimeframeOptionsList.filter((timeframeOption) => timeframeOption !== TimeframeOption.ONE_WEEK);
+  const timeframeOptions = vrNameOrGmName ? timeframeOptionsVrOrGm : TimeframeOptionsList;
 
   return (
     <ChartTile
-      timeframeOptions={timeframeOptionsToUse}
+      timeframeOptions={timeframeOptions}
       title={text.title}
       metadata={{
         source: text.source,

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -1,11 +1,4 @@
-import {
-  colors,
-  NlSewer,
-  SewerPerInstallationData,
-  TimeframeOption,
-  TimeframeOptionsList,
-  VrSewer,
-} from '@corona-dashboard/common';
+import { colors, NlSewer, SewerPerInstallationData, TimeframeOption, TimeframeOptionsList, VrSewer } from '@corona-dashboard/common';
 import { useMemo, useState } from 'react';
 import { isPresent } from 'ts-is-present';
 import { Warning } from '@corona-dashboard/icons';
@@ -58,16 +51,7 @@ type SewerChartProps = {
   timelineEvents?: TimelineEventConfig[];
 };
 
-export function SewerChart({
-  accessibility,
-  dataAverages,
-  dataPerInstallation,
-  text,
-  vrNameOrGmName,
-  incompleteDatesAndTexts,
-  warning,
-  timelineEvents,
-}: SewerChartProps) {
+export function SewerChart({ accessibility, dataAverages, dataPerInstallation, text, vrNameOrGmName, incompleteDatesAndTexts, warning, timelineEvents }: SewerChartProps) {
   const {
     options,
     value: selectedInstallation,
@@ -88,9 +72,7 @@ export function SewerChart({
       } as SewerPerInstallationData)
   );
 
-  const [sewerTimeframe, setSewerTimeframe] = useState<TimeframeOption>(
-    TimeframeOption.ALL
-  );
+  const [sewerTimeframe, setSewerTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { commonTexts } = useIntl();
   const scopedGmName = commonTexts.gemeente_index.municipality_warning;
@@ -103,12 +85,8 @@ export function SewerChart({
           valueAnnotation: text.valueAnnotation,
           timespanAnnotations: [
             {
-              start: parseInt(
-                incompleteDatesAndTexts.zeewolde_date_start_in_unix_time
-              ),
-              end: parseInt(
-                incompleteDatesAndTexts.zeewolde_date_end_in_unix_time
-              ),
+              start: parseInt(incompleteDatesAndTexts.zeewolde_date_start_in_unix_time),
+              end: parseInt(incompleteDatesAndTexts.zeewolde_date_end_in_unix_time),
               label: incompleteDatesAndTexts.zeewolde_label,
               shortLabel: incompleteDatesAndTexts.zeewolde_short_label,
             },
@@ -134,9 +112,13 @@ export function SewerChart({
     [options]
   );
 
+  const timeframeOptionsWithoutOneWeek = TimeframeOptionsList.filter((option) => option !== TimeframeOption.ONE_WEEK);
+
+  const timeframeOptionsToUse = !vrNameOrGmName ? TimeframeOptionsList : timeframeOptionsWithoutOneWeek;
+
   return (
     <ChartTile
-      timeframeOptions={TimeframeOptionsList}
+      timeframeOptions={timeframeOptionsToUse}
       title={text.title}
       metadata={{
         source: text.source,
@@ -157,12 +139,7 @@ export function SewerChart({
       )}
       {scopedWarning && scopedGmName.toUpperCase() === selectedInstallation && (
         <Box mt={2} mb={4}>
-          <WarningTile
-            variant="emphasis"
-            message={scopedWarning}
-            icon={Warning}
-            isFullWidth
-          />
+          <WarningTile variant="emphasis" message={scopedWarning} icon={Warning} isFullWidth />
         </Box>
       )}
       {
@@ -173,11 +150,7 @@ export function SewerChart({
         dataPerInstallation && selectedInstallation ? (
           <TimeSeriesChart
             accessibility={accessibility}
-            values={mergeData(
-              dataAverages,
-              dataPerInstallation,
-              selectedInstallation
-            )}
+            values={mergeData(dataAverages, dataPerInstallation, selectedInstallation)}
             timeframe={sewerTimeframe}
             seriesConfig={[
               {


### PR DESCRIPTION
## Summary

Removed timeframeOption for Last 7 days on the Safety Region and Municipality pages the dropdown function.

**Before**
National level
![before_national](https://user-images.githubusercontent.com/93994194/207580414-c98af8d5-d246-4988-8c2f-e8484f295414.png)

Safety region
![before_safety_region](https://user-images.githubusercontent.com/93994194/207580467-bd334de3-e495-4e44-bd60-95cc617819aa.png)

Municipality
![before_municipality](https://user-images.githubusercontent.com/93994194/207580486-9d2e24bc-1b06-4843-8c0c-78c3fbca53eb.png)


**After**
National level
![after_national](https://user-images.githubusercontent.com/93994194/207579684-8fd368c5-40f8-4b7a-9484-8c23d9416108.png)

Safety region 
![after_safety_region](https://user-images.githubusercontent.com/93994194/207579723-27bc2a42-fd84-4c26-b6ed-a88679a882a9.png)

Municipality
![after_municipality](https://user-images.githubusercontent.com/93994194/207579750-e89b3ca9-96bf-45d0-8a0b-a1697e991a00.png)