### PR TITLE
bugfix/COR-1240-Timeseries-chart-label-goes-off-screen-on-mobile

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -14,6 +14,7 @@ import { NumberValue, ScaleBand, ScaleLinear } from 'd3-scale';
 import { memo, Ref, useCallback, useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { useIntl } from '~/intl';
+import { fontSizes } from '~/style/theme';
 import { createDateFromUnixTimestamp } from '~/utils/create-date-from-unix-timestamp';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { Bounds } from '../logic';
@@ -197,10 +198,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
 
   /**
    * Using anchor middle the line marker label will fall nicely on top
-   * of the axis label.
-   *
-   * The only times at which we can not use middle is if we are
-   * rendering a year in the label, because it becomes too long.
+   * of the axis label. This will only happen for labels which are not the first or last label.
    */
   const getAnchor = (x: NumberValue) => {
     return x === tickValues[0] && isLongStartLabel ? (tickValues.length === 1 ? 'middle' : 'start') : x === tickValues[tickValues.length - 1] ? 'end' : 'middle';
@@ -241,7 +239,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
         rangePadding={xRangePadding}
         tickLabelProps={(x) => ({
           fill: colors.gray6,
-          fontSize: 12,
+          fontSize: fontSizes[0],
           /**
            * Applying a dx of -50%, when there's only a single tick value, prevents
            * the tick to go out of bounds and centers the tick value relative to the graph.
@@ -274,7 +272,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
               tickFormat={formatYTickValue ? formatYTickValue : isPercentage ? formatYAxisPercentage : formatYAxis}
               tickLabelProps={() => ({
                 fill: colors.gray6,
-                fontSize: 12,
+                fontSize: fontSizes[0],
                 textAnchor: 'end',
                 verticalAnchor: 'middle',
               })}
@@ -300,7 +298,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
             tickFormat={formatYTickValue ? formatYTickValue : isPercentage ? formatYAxisPercentage : formatYAxis}
             tickLabelProps={() => ({
               fill: colors.gray6,
-              fontSize: 12,
+              fontSize: fontSizes[0],
               textAnchor: 'start',
               // position the label above the chart
               dx: 10,

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -121,7 +121,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
   const formatYAxisPercentage: TickFormatter<NumberValue> = useCallback((y: NumberValue) => `${formatPercentage(y as number)}%`, [formatPercentage]);
 
   if (!isPresent(xTickNumber)) {
-    const preferredDateTicks = breakpoints.sm ? (timeframe === 'all' ? (hasDatesAsRange ? 6 : 4) : hasDatesAsRange ? 5 : 3) : hasDatesAsRange ? 3 : 2;
+    const preferredDateTicks: number = breakpoints.sm ? (timeframe === 'all' ? (hasDatesAsRange ? 6 : 4) : hasDatesAsRange ? 5 : 3) : hasDatesAsRange ? 3 : 2;
     const fullDaysInDomain = Math.floor((endUnix - startUnix) / 86400);
     xTickNumber = Math.max(Math.min(fullDaysInDomain, preferredDateTicks), 2);
   }
@@ -176,13 +176,6 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
   );
 
   /**
-   * Long labels (like the ones including a year, are too long to be positioned
-   * centered on the x-axis tick. Usually a short date has a 2 digit number plus
-   * a space plus a three character month, which makes 6.
-   */
-  const isLongStartLabel = xTicks[0].length > 6;
-
-  /**
    * We make an exception for the situation where all the values in the chart are zero.
    * In that case the top range has been set to zero, but we want to draw exactly
    * two gridlines in this case (at the top and bottom of the chart). So therefore we
@@ -201,7 +194,19 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
    * of the axis label. This will only happen for labels which are not the first or last label.
    */
   const getAnchor = (x: NumberValue) => {
-    return x === tickValues[0] && isLongStartLabel ? (tickValues.length === 1 ? 'middle' : 'start') : x === tickValues[tickValues.length - 1] ? 'end' : 'middle';
+    const isLongStartLabel = xTicks[0].length > 6;
+    const isFirstTick = x === tickValues[0];
+    const isLastTick = x === tickValues[tickValues.length - 1];
+
+    if (isFirstTick && isLongStartLabel && tickValues.length !== 1) {
+      return 'start';
+    }
+
+    if (isLastTick) {
+      return 'end';
+    }
+
+    return 'middle';
   };
 
   return (

--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -5,13 +5,7 @@
  * props. It might be easier to just create 2 or 3 different types of axes
  * layouts by forking this component.
  */
-import {
-  colors,
-  middleOfDayInSeconds,
-  TimeframeOption,
-  TimestampedValue,
-  DateSpanValue,
-} from '@corona-dashboard/common';
+import { colors, middleOfDayInSeconds, TimeframeOption, TimestampedValue, DateSpanValue } from '@corona-dashboard/common';
 import css from '@styled-system/css';
 import { AxisBottom, AxisLeft, TickFormatter } from '@visx/axis';
 import { GridRows } from '@visx/grid';
@@ -71,12 +65,7 @@ export type AxesProps<T extends TimestampedValue> = {
   hasAllZeroValues?: boolean;
 };
 
-function createTimeTicks(
-  startTick: number,
-  endTick: number,
-  count: number,
-  valuesCount: number | undefined
-) {
+function createTimeTicks(startTick: number, endTick: number, count: number, valuesCount: number | undefined) {
   const start = middleOfDayInSeconds(startTick);
   const end = middleOfDayInSeconds(endTick);
 
@@ -85,8 +74,7 @@ function createTimeTicks(
   }
 
   const ticks: number[] = [];
-  const stepCount =
-    (valuesCount && valuesCount <= count ? valuesCount : count) - 1;
+  const stepCount = (valuesCount && valuesCount <= count ? valuesCount : count) - 1;
   const step = Math.floor((end - start) / stepCount);
 
   for (let i = 0; i < stepCount; i++) {
@@ -119,65 +107,30 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
   const [startUnix, endUnix] = timeDomain;
   const startYear = createDateFromUnixTimestamp(startUnix).getFullYear();
   const endYear = createDateFromUnixTimestamp(endUnix).getFullYear();
-
   const breakpoints = useBreakpoints();
 
-  const isDateSpanValue = (value: any): value is DateSpanValue =>
-    value.date_start_unix !== undefined && value.date_end_unix !== undefined;
-  const isDateSpanValues = useCallback(
-    (values: any): values is DateSpanValue[] =>
-      values.every((x: DateSpanValue) => isDateSpanValue(x)),
-    []
-  );
+  const isDateSpanValue = (value: any): value is DateSpanValue => value.date_start_unix !== undefined && value.date_end_unix !== undefined;
+  const isDateSpanValues = useCallback((values: any): values is DateSpanValue[] => values.every((x: DateSpanValue) => isDateSpanValue(x)), []);
   const hasDatesAsRange = isDateSpanValues(values);
 
   const { formatDateFromSeconds, formatNumber, formatPercentage } = useIntl();
 
-  const formatYAxis: TickFormatter<NumberValue> = useCallback(
-    (y: NumberValue) => formatNumber(y as number),
-    [formatNumber]
-  );
+  const formatYAxis: TickFormatter<NumberValue> = useCallback((y: NumberValue) => formatNumber(y as number), [formatNumber]);
 
-  const formatYAxisPercentage: TickFormatter<NumberValue> = useCallback(
-    (y: NumberValue) => `${formatPercentage(y as number)}%`,
-    [formatPercentage]
-  );
+  const formatYAxisPercentage: TickFormatter<NumberValue> = useCallback((y: NumberValue) => `${formatPercentage(y as number)}%`, [formatPercentage]);
 
   if (!isPresent(xTickNumber)) {
-    const preferredDateTicks = breakpoints.sm
-      ? timeframe === 'all'
-        ? hasDatesAsRange
-          ? 6
-          : 4
-        : hasDatesAsRange
-        ? 5
-        : 3
-      : hasDatesAsRange
-      ? 3
-      : 2;
+    const preferredDateTicks = breakpoints.sm ? (timeframe === 'all' ? (hasDatesAsRange ? 6 : 4) : hasDatesAsRange ? 5 : 3) : hasDatesAsRange ? 3 : 2;
     const fullDaysInDomain = Math.floor((endUnix - startUnix) / 86400);
     xTickNumber = Math.max(Math.min(fullDaysInDomain, preferredDateTicks), 2);
   }
 
-  const getSmallestDiff = (start: number, end: number, current: number) =>
-    Math.min(Math.abs(start - current), Math.abs(end - current));
+  const getSmallestDiff = (start: number, end: number, current: number) => Math.min(Math.abs(start - current), Math.abs(end - current));
 
-  const getXTickStyle = (
-    isFirstOrLast: boolean,
-    startYear: number,
-    endYear: number,
-    previousYear: number,
-    currentYear: number
-  ) =>
-    (isFirstOrLast && startYear !== endYear) || previousYear !== currentYear
-      ? 'axis-with-year'
-      : 'axis';
-  const tickValues = createTimeTicks(
-    startUnix,
-    endUnix,
-    xTickNumber,
-    values?.length
-  );
+  const getXTickStyle = (isFirstOrLast: boolean, startYear: number, endYear: number, previousYear: number, currentYear: number) =>
+    (isFirstOrLast && startYear !== endYear) || previousYear !== currentYear ? 'axis-with-year' : 'axis';
+
+  const tickValues = createTimeTicks(startUnix, endUnix, xTickNumber, values?.length);
 
   const DateSpanTick = useCallback(
     (dateUnix: number, values: DateSpanValue[], index: number) => {
@@ -185,64 +138,31 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
         return '';
       }
 
-      const previousYear = createDateFromUnixTimestamp(
-        tickValues[index - 1]
-      ).getFullYear();
+      const previousYear = createDateFromUnixTimestamp(tickValues[index - 1]).getFullYear();
 
       const currentYear = createDateFromUnixTimestamp(dateUnix).getFullYear();
       const tickValue = values.reduce((acc, value) => {
-        const smallestDifferenceAcc = getSmallestDiff(
-          acc.date_start_unix,
-          acc.date_end_unix,
-          dateUnix
-        );
-        const smallestDifferenceVal = getSmallestDiff(
-          value.date_start_unix,
-          value.date_end_unix,
-          dateUnix
-        );
+        const smallestDifferenceAcc = getSmallestDiff(acc.date_start_unix, acc.date_end_unix, dateUnix);
+        const smallestDifferenceVal = getSmallestDiff(value.date_start_unix, value.date_end_unix, dateUnix);
 
-        return (value.date_start_unix <= dateUnix &&
-          value.date_end_unix >= dateUnix) ||
-          smallestDifferenceVal < smallestDifferenceAcc
-          ? value
-          : acc;
+        return (value.date_start_unix <= dateUnix && value.date_end_unix >= dateUnix) || smallestDifferenceVal < smallestDifferenceAcc ? value : acc;
       });
 
-      const isFirstOrLast =
-        startUnix === tickValue.date_start_unix ||
-        endUnix === tickValue.date_end_unix;
-      const style = getXTickStyle(
-        isFirstOrLast,
-        startYear,
-        endYear,
-        previousYear,
-        currentYear
-      );
+      const isFirstOrLast = startUnix === tickValue.date_start_unix || endUnix === tickValue.date_end_unix;
+      const style = getXTickStyle(isFirstOrLast, startYear, endYear, previousYear, currentYear);
 
-      return `${formatDateFromSeconds(
-        tickValue.date_start_unix,
-        'axis'
-      )} - ${formatDateFromSeconds(tickValue.date_end_unix, style)}`;
+      return `${formatDateFromSeconds(tickValue.date_start_unix, 'axis')} - ${formatDateFromSeconds(tickValue.date_end_unix, style)}`;
     },
     [endUnix, endYear, formatDateFromSeconds, startUnix, startYear, tickValues]
   );
 
   const TimeStampTick = useCallback(
     (tickValue: number, index: number) => {
-      const previousYear = createDateFromUnixTimestamp(
-        tickValues[index - 1]
-      ).getFullYear();
+      const previousYear = createDateFromUnixTimestamp(tickValues[index - 1]).getFullYear();
       const currentYear = createDateFromUnixTimestamp(tickValue).getFullYear();
 
       const isFirstOrLast = [startUnix, endUnix].includes(tickValue);
-      const style = getXTickStyle(
-        isFirstOrLast,
-        startYear,
-        endYear,
-        previousYear,
-        currentYear
-      );
+      const style = getXTickStyle(isFirstOrLast, startYear, endYear, previousYear, currentYear);
 
       return formatDateFromSeconds(tickValue, style);
     },
@@ -250,12 +170,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
   );
 
   const xTicks = useMemo(
-    () =>
-      tickValues.map((tickValue, index) =>
-        isDateSpanValues(values)
-          ? DateSpanTick(tickValue, values, index)
-          : TimeStampTick(tickValue, index)
-      ),
+    () => tickValues.map((tickValue, index) => (isDateSpanValues(values) ? DateSpanTick(tickValue, values, index) : TimeStampTick(tickValue, index))),
     [values, DateSpanTick, TimeStampTick, isDateSpanValues, tickValues]
   );
 
@@ -265,7 +180,6 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
    * a space plus a three character month, which makes 6.
    */
   const isLongStartLabel = xTicks[0].length > 6;
-  const isLongEndLabel = xTicks[xTicks.length - 1].length > 6;
 
   /**
    * We make an exception for the situation where all the values in the chart are zero.
@@ -289,13 +203,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
    * rendering a year in the label, because it becomes too long.
    */
   const getAnchor = (x: NumberValue) => {
-    return x === tickValues[0] && isLongStartLabel
-      ? tickValues.length === 1
-        ? 'middle'
-        : 'start'
-      : x === tickValues[tickValues.length - 1] && isLongEndLabel
-      ? 'end'
-      : 'middle';
+    return x === tickValues[0] && isLongStartLabel ? (tickValues.length === 1 ? 'middle' : 'start') : x === tickValues[tickValues.length - 1] ? 'end' : 'middle';
   };
 
   return (
@@ -322,14 +230,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
         stroke={colors.gray3}
       />
 
-      {showWeekNumbers && (
-        <WeekNumbers
-          startUnix={startUnix}
-          endUnix={endUnix}
-          bounds={bounds}
-          xScale={xScale}
-        />
-      )}
+      {showWeekNumbers && <WeekNumbers startUnix={startUnix} endUnix={endUnix} bounds={bounds} xScale={xScale} />}
 
       <AxisBottom
         scale={xScale}
@@ -370,13 +271,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
               hideTicks
               hideAxisLine
               stroke={colors.gray3}
-              tickFormat={
-                formatYTickValue
-                  ? formatYTickValue
-                  : isPercentage
-                  ? formatYAxisPercentage
-                  : formatYAxis
-              }
+              tickFormat={formatYTickValue ? formatYTickValue : isPercentage ? formatYAxisPercentage : formatYAxis}
               tickLabelProps={() => ({
                 fill: colors.gray6,
                 fontSize: 12,
@@ -402,13 +297,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
             hideTicks
             hideAxisLine
             stroke={colors.gray3}
-            tickFormat={
-              formatYTickValue
-                ? formatYTickValue
-                : isPercentage
-                ? formatYAxisPercentage
-                : formatYAxis
-            }
+            tickFormat={formatYTickValue ? formatYTickValue : isPercentage ? formatYAxisPercentage : formatYAxis}
             tickLabelProps={() => ({
               fill: colors.gray6,
               fontSize: 12,


### PR DESCRIPTION
# Summary

This PR fixes the issue where x-axis end labels were falling outside of the viewport on mobile AND falling out of grid on desktop. The issue was caused due to the end label being `centered` when it is a short label (without year). Because of this, the label exceeded the grid. This has been changed so that end labels are always aligned to the `end` which means to the left of the `tick`.

### BEFORE
![BEFORE](https://user-images.githubusercontent.com/116002914/207659025-b065e4c5-367d-4b8f-989e-f9d9326adb8e.png)

### AFTER
![AFTER](https://user-images.githubusercontent.com/116002914/207659060-5d5875e4-ed92-4f7e-91df-323912307cce.png)
