### PR TITLE
Cor-1235: make some fields larger, so long texts will be readable

### DIFF
--- a/packages/cms/src/schemas/topical/thermometer-timeline.ts
+++ b/packages/cms/src/schemas/topical/thermometer-timeline.ts
@@ -28,7 +28,7 @@ export const thermometerTimeline = {
     {
       title: 'Tooltip label',
       name: 'tooltipCurrentEstimationLabel',
-      type: 'localeString',
+      type: 'localeText',
       validation: REQUIRED,
     },
     {

--- a/packages/cms/src/schemas/topical/thermometer.ts
+++ b/packages/cms/src/schemas/topical/thermometer.ts
@@ -58,8 +58,8 @@ export const thermometer = {
       type: 'localeString',
     },
     {
-      title: 'Huidige stand omschrijvig',
-      description: 'De omschrijving spcifiek voor de huidige thermometer stand bij de trendIcon',
+      title: 'Huidige stand omschrijving',
+      description: 'De omschrijving specifiek voor de huidige thermometer stand bij de trendIcon',
       name: 'levelDescription',
       type: 'localeText',
       validation: REQUIRED,

--- a/packages/cms/src/schemas/topical/thermometer.ts
+++ b/packages/cms/src/schemas/topical/thermometer.ts
@@ -59,9 +59,9 @@ export const thermometer = {
     },
     {
       title: 'Huidige stand omschrijvig',
-      description: 'De omschrijving spcifiek voor de huidige themrmometer stand bij de trendIcon',
+      description: 'De omschrijving spcifiek voor de huidige thermometer stand bij de trendIcon',
       name: 'levelDescription',
-      type: 'localeString',
+      type: 'localeText',
       validation: REQUIRED,
     },
     {

--- a/packages/cms/src/schemas/topical/weekly-summary-item.ts
+++ b/packages/cms/src/schemas/topical/weekly-summary-item.ts
@@ -16,7 +16,7 @@ export const weeklySummaryItem = {
     {
       title: 'Omschrijving',
       name: 'description',
-      type: 'localeString',
+      type: 'localeText',
       validation: REQUIRED,
     },
     {


### PR DESCRIPTION
## Summary

Some texts were not readable in Sanity, because the text field was too small and not sizing.

- Changed `localString` fields to `localeText` fields, so it becomes a field with more rows.

#### Before

<img width="672" alt="Schermafbeelding 2022-12-15 om 11 34 38" src="https://user-images.githubusercontent.com/93981322/207837325-33c64bab-bb13-4335-913a-13cbd8445b2b.png">


#### After
<img width="658" alt="Schermafbeelding 2022-12-15 om 11 34 00" src="https://user-images.githubusercontent.com/93981322/207837357-88a625aa-a96c-42e1-b050-06e6b5ef016d.png">
