### PR TITLE
Feature/cor 1285 sanity thermometer timeline events

### DIFF
--- a/packages/app/src/components/severity-indicator-tile/components/timeline/components/tooltip-content.tsx
+++ b/packages/app/src/components/severity-indicator-tile/components/timeline/components/tooltip-content.tsx
@@ -73,7 +73,11 @@ export const TimelineTooltipContent = ({ config, hasMultipleEvents, onNext, onPr
           <BoldText>{config.title}</BoldText>
         </Box>
 
-        <Text variant="label1">{config.description}</Text>
+        <Text variant="label1">
+          {replaceVariablesInText(config.description.split('**').join(''), {
+            label: config.title.toLowerCase(),
+          })}
+        </Text>
 
         {currentEstimationLabel && (
           <Box textVariant="label1">

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -98,7 +98,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
   const currentSeverityLevel = thermometer.currentLevel as unknown as SeverityLevels;
   const currentSeverityLevelTexts = thermometer.thermometerLevels.find((thermometerLevel) => thermometerLevel.level === currentSeverityLevel);
 
-  const thermometerEvents = getThermometerEvents(thermometer.timeline.ThermometerTimelineEvents);
+  const thermometerEvents = getThermometerEvents(thermometer.timeline.ThermometerTimelineEvents, thermometer.thermometerLevels);
 
   const { startDate, endDate } = getTimelineRangeDates(thermometerEvents);
 

--- a/packages/app/src/queries/get-topical-structure-query.ts
+++ b/packages/app/src/queries/get-topical-structure-query.ts
@@ -108,17 +108,13 @@ export function getTopicalStructureQuery(locale: string) {
 }
 
 export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent[], thermometerLevels: ThermometerLevel[]) => {
-  // 1. USE thermometerEvent.level TO FIND level IN thermometerLevels
-  // 2. USE level TO REFERENCE level.title AND level.description
-
   return thermometerEvents.map<SeverityIndicatorTimelineEventConfig>((thermometerEvent) => {
-    // STEP 1 GOES HERE
-    const currentLevel = thermometerLevels?.find((thermometerLevel) => thermometerLevel.level === (thermometerEvent.level as SeverityLevel));
+    const levelDetails = thermometerLevels.find((thermometerLevel) => thermometerLevel.level === (thermometerEvent.level as SeverityLevel)) as ThermometerLevel;
 
     return {
-      title: currentLevel?.label ?? thermometerEvent.title, // STEP 2.1 - title
-      description: currentLevel?.description ?? thermometerEvent.description, // STEP 2.2 - description
-      level: thermometerEvent.level,
+      title: levelDetails.label,
+      description: levelDetails.description,
+      level: levelDetails.level,
       start: new Date(thermometerEvent.date).getTime() / 1000,
       end: new Date(thermometerEvent.dateEnd).getTime() / 1000,
     };

--- a/packages/app/src/queries/get-topical-structure-query.ts
+++ b/packages/app/src/queries/get-topical-structure-query.ts
@@ -107,8 +107,8 @@ export function getTopicalStructureQuery(locale: string) {
   return query;
 }
 
-export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent[], thermometerLevels: ThermometerLevel[]) => {
-  return thermometerEvents.map<SeverityIndicatorTimelineEventConfig>((thermometerEvent) => {
+export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent[], thermometerLevels: ThermometerLevel[]) =>
+  thermometerEvents.map<SeverityIndicatorTimelineEventConfig>((thermometerEvent) => {
     const levelDetails = thermometerLevels.find((thermometerLevel) => thermometerLevel.level === (thermometerEvent.level as SeverityLevel)) as ThermometerLevel;
 
     return {
@@ -119,4 +119,3 @@ export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent
       end: new Date(thermometerEvent.dateEnd).getTime() / 1000,
     };
   });
-};

--- a/packages/app/src/queries/get-topical-structure-query.ts
+++ b/packages/app/src/queries/get-topical-structure-query.ts
@@ -1,5 +1,6 @@
-import { ThermometerTimelineEvent } from './query-types';
+import { ThermometerLevel, ThermometerTimelineEvent } from './query-types';
 import { SeverityIndicatorTimelineEventConfig } from '~/components/severity-indicator-tile/components/timeline/timeline';
+import { SeverityLevel } from '~/components/severity-indicator-tile/types';
 
 export function getTopicalStructureQuery(locale: string) {
   const query = `// groq
@@ -106,11 +107,17 @@ export function getTopicalStructureQuery(locale: string) {
   return query;
 }
 
-export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent[]) => {
+export const getThermometerEvents = (thermometerEvents: ThermometerTimelineEvent[], thermometerLevels: ThermometerLevel[]) => {
+  // 1. USE thermometerEvent.level TO FIND level IN thermometerLevels
+  // 2. USE level TO REFERENCE level.title AND level.description
+
   return thermometerEvents.map<SeverityIndicatorTimelineEventConfig>((thermometerEvent) => {
+    // STEP 1 GOES HERE
+    const currentLevel = thermometerLevels?.find((thermometerLevel) => thermometerLevel.level === (thermometerEvent.level as SeverityLevel));
+
     return {
-      title: thermometerEvent.title,
-      description: thermometerEvent.description,
+      title: currentLevel?.label ?? thermometerEvent.title, // STEP 2.1 - title
+      description: currentLevel?.description ?? thermometerEvent.description, // STEP 2.2 - description
       level: thermometerEvent.level,
       start: new Date(thermometerEvent.date).getTime() / 1000,
       end: new Date(thermometerEvent.dateEnd).getTime() / 1000,

--- a/packages/app/src/queries/query-types.ts
+++ b/packages/app/src/queries/query-types.ts
@@ -43,7 +43,7 @@ export interface ThermometerTimelineEvent {
   dateEnd: number;
 }
 
-interface ThermometerLevel {
+export interface ThermometerLevel {
   level: SeverityLevel;
   label: string;
   description: string;

--- a/packages/cms/src/schemas/topical/thermometer-level.ts
+++ b/packages/cms/src/schemas/topical/thermometer-level.ts
@@ -1,7 +1,5 @@
-import { Rule } from '~/sanity';
-import { THERMOMETER_MIN_VALUE, THERMOMETER_MAX_VALUE } from './thermometer';
 import { SEVERITY_LEVELS_LIST } from '@corona-dashboard/app/src/components/severity-indicator-tile/constants';
-import { REQUIRED, REQUIRED_MIN_MAX } from '../../validation';
+import { REQUIRED } from '../../validation';
 import { BsFillFileBarGraphFill } from 'react-icons/bs';
 
 export const thermometerLevel = {
@@ -18,7 +16,7 @@ export const thermometerLevel = {
         list: SEVERITY_LEVELS_LIST,
         layout: 'dropdown',
       },
-      validation: (rule: Rule) => REQUIRED_MIN_MAX(rule, THERMOMETER_MIN_VALUE, THERMOMETER_MAX_VALUE),
+      validation: REQUIRED,
     },
     {
       title: 'Stand naam',

--- a/packages/cms/src/schemas/topical/thermometer-timeline-event.ts
+++ b/packages/cms/src/schemas/topical/thermometer-timeline-event.ts
@@ -40,14 +40,18 @@ export const thermometerTimelineEvent = {
   ],
   preview: {
     select: {
-      title: 'title.nl',
+      title: 'level',
       date: 'date',
       dateEnd: 'dateEnd',
     },
-    prepare(x: { title: string; date: string; dateEnd?: string }) {
+    prepare(selection: { title: number; date: string; dateEnd?: string }) {
+      // Construct a custom start date
+      const day = selection.date.slice(8);
+      const month = selection.date.slice(5, -3);
+
       return {
-        title: x.title,
-        subtitle: [x.date, x.dateEnd].filter(isDefined).join(' tot '),
+        title: `${day}/${month}: level ${selection.title}`,
+        subtitle: [selection.date, selection.dateEnd].filter(isDefined).join(' tot '),
       };
     },
   },

--- a/packages/cms/src/schemas/topical/thermometer-timeline-event.ts
+++ b/packages/cms/src/schemas/topical/thermometer-timeline-event.ts
@@ -1,10 +1,6 @@
+import { SEVERITY_LEVELS_LIST } from '@corona-dashboard/app/src/components/severity-indicator-tile/constants';
 import { isDefined } from 'ts-is-present';
-import { Rule } from '~/sanity';
-import { localeStringValidation } from '../../language/locale-validation';
-
-import { REQUIRED, REQUIRED_MIN_MAX } from '../../validation';
-
-import { THERMOMETER_MIN_VALUE, THERMOMETER_MAX_VALUE } from './thermometer';
+import { REQUIRED } from '../../validation';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -14,22 +10,14 @@ export const thermometerTimelineEvent = {
   title: 'Thermometer tijdlijn gebeurtenis',
   fields: [
     {
-      title: 'Titel',
-      name: 'title',
-      type: 'localeString',
-      validation: localeStringValidation((rule) => rule.required().max(60).error('Titels zijn gelimiteerd tot maximaal 60 tekens')),
-    },
-    {
-      title: 'Omschrijving',
-      name: 'description',
-      type: 'localeText',
-      validation: REQUIRED,
-    },
-    {
       title: 'Level',
       name: 'level',
       type: 'number',
-      validation: (rule: Rule) => REQUIRED_MIN_MAX(rule, THERMOMETER_MIN_VALUE, THERMOMETER_MAX_VALUE),
+      options: {
+        list: SEVERITY_LEVELS_LIST,
+        layout: 'dropdown',
+      },
+      validation: REQUIRED,
     },
     {
       title: 'Datum',

--- a/packages/cms/src/schemas/topical/thermometer-timeline.ts
+++ b/packages/cms/src/schemas/topical/thermometer-timeline.ts
@@ -27,6 +27,7 @@ export const thermometerTimeline = {
     },
     {
       title: 'Tooltip label',
+      description: 'Extra beschrijving voor in de laatste gebeurtenis in de tijdlijn',
       name: 'tooltipCurrentEstimationLabel',
       type: 'localeString',
       validation: REQUIRED,

--- a/packages/cms/src/schemas/topical/thermometer.ts
+++ b/packages/cms/src/schemas/topical/thermometer.ts
@@ -1,10 +1,6 @@
-import { Rule } from '~/sanity';
 import { SEVERITY_LEVELS_LIST } from '@corona-dashboard/app/src/components/severity-indicator-tile/constants';
-import { REQUIRED, REQUIRED_MIN_MAX } from '../../validation';
+import { REQUIRED } from '../../validation';
 import { KpiIconInput } from '../../components/portable-text/kpi-configuration/kpi-icon-input';
-
-export const THERMOMETER_MIN_VALUE = Math.min(...SEVERITY_LEVELS_LIST);
-export const THERMOMETER_MAX_VALUE = Math.max(...SEVERITY_LEVELS_LIST);
 
 export const thermometer = {
   type: 'object',
@@ -42,7 +38,7 @@ export const thermometer = {
         list: SEVERITY_LEVELS_LIST,
         layout: 'dropdown',
       },
-      validation: (rule: Rule) => REQUIRED_MIN_MAX(rule, THERMOMETER_MIN_VALUE, THERMOMETER_MAX_VALUE),
+      validation: REQUIRED,
     },
     {
       title: 'Standen',


### PR DESCRIPTION
## Summary
### DONE
**- Remove the thermometerTimelineEvent's title & description fields from the Sanity schema in Tooltip Label**

*Before:*<img width="1770" alt="sanity_thermometer_tijdlijn_gebeurtenissen" src="https://user-images.githubusercontent.com/111750729/207871131-147d98d1-16f3-45de-b23e-e3113aefe386.png">
*After:* <img width="1690" alt="Screenshot 2022-12-15 at 14 28 37" src="https://user-images.githubusercontent.com/111750729/207871087-217fc3de-4463-4fc4-9673-9e09c412f1ba.png">


**- Added a Description text: 'Extra beschrijving voor in de laatste gebeurtenis in de tijdlijn' to the timeline event;**
<img width="1137" alt="Screenshot 2022-12-15 at 14 41 57" src="https://user-images.githubusercontent.com/111750729/207874113-6b07f8b7-5c83-4edd-8468-9b175b7cf96b.png">

**- Convert 'level' field of 'thermometerTimelineEvent' to a dropdown;**

_Before:_<img width="1777" alt="sanity_thermometer_standen" src="https://user-images.githubusercontent.com/111750729/207872855-31a9c4e4-0bd1-4dc1-b8e1-c9ef932988b2.png">
_After:_<img width="1654" alt="Screenshot 2022-12-15 at 14 33 37" src="https://user-images.githubusercontent.com/111750729/207872873-fb22ea50-3286-48dc-a042-f2bbe6aac638.png">

**-Adjusted connection between thermometerLevel's title & description and a thermometerTimelineEvent's title & description;**
_Before:_
![thermometer-tooltop-en-uitleg-stand](https://user-images.githubusercontent.com/111750729/207873581-7de2a6ec-af51-42c0-80af-2883978c1bc5.png)
_After:_
<img width="827" alt="Screenshot 2022-12-15 at 14 49 35" src="https://user-images.githubusercontent.com/111750729/207875571-a8808f01-d7d5-4f2b-96bf-e343c3a9fb84.png">