### PR TITLE
feature/COR-1284-Improve-readability-Sanity-shrink-or-hide-fields

### DIFF
--- a/packages/cms/src/schemas/topical/theme.ts
+++ b/packages/cms/src/schemas/topical/theme.ts
@@ -5,6 +5,17 @@ export const theme = {
   type: 'document',
   title: 'Thema',
   name: 'theme',
+  fieldsets: [
+    {
+      title: 'Ondertitel',
+      description: 'Klik op het label om de velden te tonen.',
+      name: 'ondertitel',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+  ],
   fields: [
     {
       title: 'Titel',
@@ -16,6 +27,7 @@ export const theme = {
       title: 'Ondertitel',
       name: 'subTitle',
       type: 'localeRichContentBlock',
+      fieldset: 'ondertitel',
     },
     {
       title: 'Thema icoon',

--- a/packages/cms/src/schemas/topical/thermometer.ts
+++ b/packages/cms/src/schemas/topical/thermometer.ts
@@ -10,6 +10,35 @@ export const thermometer = {
   type: 'object',
   title: 'Thermometer',
   name: 'thermometer',
+  fieldsets: [
+    {
+      title: 'De beschrijving boven de thermometer',
+      name: 'description',
+      description: 'Klik op het label om de velden te tonen.',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+    {
+      title: 'Artikel referentie',
+      name: 'artikel-referentie',
+      description: 'Klik op het label om de velden te tonen.',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+    {
+      title: 'Titel van standen informatie',
+      name: 'level-information',
+      description: 'Klik op het label om de velden te tonen.',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+  ],
   fields: [
     {
       title: 'Thermometer icoon',
@@ -28,6 +57,7 @@ export const thermometer = {
       title: 'De beschrijving boven de thermometer',
       name: 'subTitle',
       type: 'localeRichContentBlock',
+      fieldset: 'description',
     },
     {
       title: 'De titel binnen de thermometer tegel',
@@ -73,6 +103,7 @@ export const thermometer = {
       title: 'Artikel referentie',
       name: 'articleReference',
       type: 'localeRichContentBlock',
+      fieldset: 'artikel-referentie',
     },
     {
       title: 'Titel van uitklapbare sectie',
@@ -84,6 +115,7 @@ export const thermometer = {
       title: 'Titel van standen informatie',
       name: 'trendIcon',
       type: 'trendIcon',
+      fieldset: 'level-information',
     },
     {
       title: 'Tijdlijn',


### PR DESCRIPTION
# Summary

This ticket wraps rich text fields for the homepage (Themes) and thermometer sections in sanity in field-sets to make the UX better.

The adjustments are for rich text fields mentioned in the ticket and one additional one, `Artikel Referentie`.

The before and after only shows one instance, but it's the same for all.

### Before
![BEFORE](https://user-images.githubusercontent.com/116002914/207892029-76bf4a59-4c58-4f0e-8b27-6a47cf00afdb.png)

### After
![AFTER](https://user-images.githubusercontent.com/116002914/207892066-99d370ac-f328-49e2-a718-ca30cbea080a.png)
