### PR TITLE
feat: add lines to graphs and add legends

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -185,13 +185,14 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
             timeframe={sewerTimeframe}
             seriesConfig={[
               {
-                type: 'area',
+                type: 'line',
                 metricProperty: 'average',
                 label: text.averagesDataLabel,
                 color: colors.scale.blue[3],
               },
             ]}
             dataOptions={dataOptions}
+            forceLegend
           />
         )
       }

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -161,7 +161,7 @@ export function SewerChart({ accessibility, dataAverages, dataPerInstallation, t
                 style: 'dashed',
               },
               {
-                type: 'area',
+                type: 'line',
                 metricProperty: 'average',
                 label: text.averagesDataLabel,
                 color: colors.scale.blue[3],

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -1,10 +1,4 @@
-import {
-  colors,
-  NlReproduction,
-  NlReproductionValue,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, NlReproduction, NlReproductionValue, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { last } from 'lodash';
 import { isPresent } from 'ts-is-present';
@@ -35,8 +29,7 @@ export function ReproductionChartTile({
    * display in the chart
    */
 
-  const [reproductionTimeframe, setReproductionTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [reproductionTimeframe, setReproductionTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const values = data.values.slice(
     0,
@@ -68,14 +61,14 @@ export function ReproductionChartTile({
             metricProperty: 'index_average',
             label: text.lineLegendLabel,
             color: colors.primary,
-            minimumRange:
-              metricConfigs?.nl?.reproduction?.index_average?.minimumRange,
+            minimumRange: metricConfigs?.nl?.reproduction?.index_average?.minimumRange,
           },
         ]}
         dataOptions={{
           timelineEvents,
         }}
         numGridLines={reproductionTimeframe === TimeframeOption.ALL ? 4 : 3}
+        forceLegend
       />
     </ChartTile>
   );

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -1,13 +1,5 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
-import {
-  Coronavirus,
-  Gehandicaptenzorg,
-  Location,
-} from '@corona-dashboard/icons';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
+import { Coronavirus, Gehandicaptenzorg, Location } from '@corona-dashboard/icons';
 import { useState } from 'react';
 import { GetStaticPropsContext } from 'next';
 import { ChartTile } from '~/components/chart-tile';
@@ -26,26 +18,10 @@ import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetChoroplethData,
-  createGetContent,
-  getLastGeneratedDate,
-  selectNlData,
-  getLokalizeTexts,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { useReverseRouter } from '~/utils/use-reverse-router';
@@ -56,8 +32,7 @@ const pageMetrics = ['disability_care'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   caterogyTexts: {
-    category:
-      siteText.common.sidebar.categories.consequences_for_healthcare.title,
+    category: siteText.common.sidebar.categories.consequences_for_healthcare.title,
     screenReaderCategory: siteText.common.sidebar.metrics.disabled_care.title,
   },
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -67,14 +42,9 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData(
-    'difference.disability_care__newly_infected_people',
-    'difference.disability_care__infected_locations_total',
-    'disability_care'
-  ),
+  selectNlData('difference.disability_care__newly_infected_people', 'difference.disability_care__infected_locations_total', 'disability_care'),
   createGetChoroplethData({
     vr: ({ disability_care }) => ({ disability_care }),
   }),
@@ -92,10 +62,7 @@ export const getStaticProps = createGetStaticProps(
 
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'disabilityCarePageArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'disabilityCarePageArticles'),
         elements: content.elements,
       },
     };
@@ -103,26 +70,13 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedNlData: data,
-    choropleth,
-    lastGenerated,
-    content,
-  } = props;
+  const { pageText, selectedNlData: data, choropleth, lastGenerated, content } = props;
 
-  const [
-    disabilityCareConfirmedCasesTimeframe,
-    setDisabilityCareConfirmedCasesTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [disabilityCareConfirmedCasesTimeframe, setDisabilityCareConfirmedCasesTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    disabilityCareInfectedLocationsTimeframe,
-    setDisabilityCareInfectedLocationsTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [disabilityCareInfectedLocationsTimeframe, setDisabilityCareInfectedLocationsTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [disabilityCareDeceasedTimeframe, setDisabilityCareDeceasedTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [disabilityCareDeceasedTimeframe, setDisabilityCareDeceasedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const lastValue = data.disability_care.last_value;
   const values = data.disability_care.values;
@@ -130,8 +84,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
 
   const { commonTexts, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
-  const { caterogyTexts, metadataTexts, textNl } =
-    useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
+  const { caterogyTexts, metadataTexts, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const metadata = {
     ...metadataTexts,
@@ -170,14 +123,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.positief_geteste_personen.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="newly_infected_people"
-                absolute={lastValue.newly_infected_people}
-                difference={
-                  data.difference.disability_care__newly_infected_people
-                }
-                isAmount
-              />
+              <KpiValue data-cy="newly_infected_people" absolute={lastValue.newly_infected_people} difference={data.difference.disability_care__newly_infected_people} isAmount />
             </KpiTile>
           </TwoKpiSection>
 
@@ -199,19 +145,13 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                   type: 'line',
                   metricProperty: 'newly_infected_people_moving_average',
                   color: colors.primary,
-                  label:
-                    textNl.positief_geteste_personen
-                      .line_chart_newly_infected_people_moving_average,
-                  shortLabel:
-                    textNl.positief_geteste_personen
-                      .line_chart_newly_infected_people_moving_average_short_label,
+                  label: textNl.positief_geteste_personen.line_chart_newly_infected_people_moving_average,
+                  shortLabel: textNl.positief_geteste_personen.line_chart_newly_infected_people_moving_average_short_label,
                 },
                 {
                   type: 'bar',
                   metricProperty: 'newly_infected_people',
-                  label:
-                    textNl.positief_geteste_personen
-                      .line_chart_legend_trend_label,
+                  label: textNl.positief_geteste_personen.line_chart_legend_trend_label,
                   color: colors.primary,
                 },
               ]}
@@ -220,20 +160,12 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                   {
                     start: underReportedDateStart,
                     end: Infinity,
-                    label:
-                      textNl.positief_geteste_personen
-                        .line_chart_legend_inaccurate_label,
+                    label: textNl.positief_geteste_personen.line_chart_legend_inaccurate_label,
                     shortLabel: commonTexts.common.incomplete,
-                    cutValuesForMetricProperties: [
-                      'newly_infected_people_moving_average',
-                    ],
+                    cutValuesForMetricProperties: ['newly_infected_people_moving_average'],
                   },
                 ],
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'disability_care',
-                  'newly_infected_people'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'disability_care', 'newly_infected_people'),
               }}
             />
           </ChartTile>
@@ -266,9 +198,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 data-cy="infected_locations_total"
                 absolute={lastValue.infected_locations_total}
                 percentage={lastValue.infected_locations_percentage}
-                difference={
-                  data.difference.disability_care__infected_locations_total
-                }
+                difference={data.difference.disability_care__infected_locations_total}
                 isAmount
               />
               <Text>{textNl.besmette_locaties.kpi_toelichting}</Text>
@@ -281,10 +211,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.besmette_locaties.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="newly_infected_locations"
-                absolute={lastValue.newly_infected_locations}
-              />
+              <KpiValue data-cy="newly_infected_locations" absolute={lastValue.newly_infected_locations} />
               <Text>{textNl.besmette_locaties.barscale_toelichting}</Text>
             </KpiTile>
           </TwoKpiSection>
@@ -337,12 +264,13 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
               timeframe={disabilityCareInfectedLocationsTimeframe}
               seriesConfig={[
                 {
-                  type: 'area',
+                  type: 'line',
                   metricProperty: 'infected_locations_total',
                   label: textNl.besmette_locaties.linechart_metric_label,
                   color: colors.primary,
                 },
               ]}
+              forceLegend
             />
           </ChartTile>
 
@@ -371,10 +299,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.oversterfte.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="deceased_daily"
-                absolute={lastValue.deceased_daily}
-              />
+              <KpiValue data-cy="deceased_daily" absolute={lastValue.deceased_daily} />
             </KpiTile>
           </TwoKpiSection>
 
@@ -395,11 +320,8 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 {
                   type: 'line',
                   metricProperty: 'deceased_daily_moving_average',
-                  label:
-                    textNl.oversterfte.line_chart_deceased_daily_moving_average,
-                  shortLabel:
-                    textNl.oversterfte
-                      .line_chart_deceased_daily_moving_average_short_label,
+                  label: textNl.oversterfte.line_chart_deceased_daily_moving_average,
+                  shortLabel: textNl.oversterfte.line_chart_deceased_daily_moving_average_short_label,
                   color: colors.primary,
                 },
                 {
@@ -414,12 +336,9 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                   {
                     start: underReportedDateStart,
                     end: Infinity,
-                    label:
-                      textNl.oversterfte.line_chart_legend_inaccurate_label,
+                    label: textNl.oversterfte.line_chart_legend_inaccurate_label,
                     shortLabel: commonTexts.common.incomplete,
-                    cutValuesForMetricProperties: [
-                      'deceased_daily_moving_average',
-                    ],
+                    cutValuesForMetricProperties: ['deceased_daily_moving_average'],
                   },
                 ],
               }}

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -1,9 +1,4 @@
-import {
-  colors,
-  NlTestedOverallValue,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, NlTestedOverallValue, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { GgdTesten } from '@corona-dashboard/icons';
 import { css } from '@styled-system/css';
@@ -12,57 +7,22 @@ import { Box } from '~/components/base';
 import { RadioGroup } from '~/components/radio-group';
 import { BoldText } from '~/components/typography';
 import { RegionControlOption } from '~/components/chart-region-controls';
-import {
-  TimeSeriesChart,
-  TileList,
-  PageInformationBlock,
-  ChartTile,
-  DynamicChoropleth,
-  ChoroplethTile,
-  Divider,
-  InView,
-  Markdown,
-} from '~/components';
+import { TimeSeriesChart, TileList, PageInformationBlock, ChartTile, DynamicChoropleth, ChoroplethTile, Divider, InView, Markdown } from '~/components';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Layout, NlLayout } from '~/domain/layout';
 import { GNumberBarChartTile, InfectedPerAgeGroup } from '~/domain/tested';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetChoroplethData,
-  createGetContent,
-  getLastGeneratedDate,
-  selectNlData,
-  getLokalizeTexts,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
-import {
-  replaceComponentsInText,
-  replaceVariablesInText,
-  useReverseRouter,
-} from '~/utils';
+import { replaceComponentsInText, replaceVariablesInText, useReverseRouter } from '~/utils';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
-const pageMetrics = [
-  'g_number',
-  'tested_ggd',
-  'tested_overall',
-  'tested_per_age_group',
-];
+const pageMetrics = ['g_number', 'tested_ggd', 'tested_overall', 'tested_per_age_group'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -73,8 +33,7 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
   selectNlData(
     'difference.tested_ggd__infected_percentage_moving_average',
@@ -98,36 +57,20 @@ export const getStaticProps = createGetStaticProps(
       const { locale } = context;
       return `{
        "parts": ${getPagePartsQuery('positive_tests_page')},
-       "elements": ${getElementsQuery(
-         'nl',
-         ['tested_overall', 'tested_ggd', 'tested_per_age_group'],
-         locale
-       )}
+       "elements": ${getElementsQuery('nl', ['tested_overall', 'tested_ggd', 'tested_per_age_group'], locale)}
       }`;
     })(context);
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'positiveTestsPageArticles'
-        ),
-        ggdArticles: getArticleParts(
-          content.parts.pageParts,
-          'positiveTestsGGDArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'positiveTestsPageArticles'),
+        ggdArticles: getArticleParts(content.parts.pageParts, 'positiveTestsGGDArticles'),
         elements: content.elements,
       },
     };
   }
 );
 
-const GgdGraphToggle = ({
-  selectedGgdGraph,
-  onChange,
-}: {
-  selectedGgdGraph: string;
-  onChange: (value: string) => void;
-}) => {
+const GgdGraphToggle = ({ selectedGgdGraph, onChange }: { selectedGgdGraph: string; onChange: (value: string) => void }) => {
   return (
     <Box css={css({ '& div': { justifyContent: 'flex-start' } })} mb={3}>
       <RadioGroup
@@ -149,44 +92,24 @@ const GgdGraphToggle = ({
 };
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedNlData: data,
-    choropleth,
-    content,
-    lastGenerated,
-  } = props;
+  const { pageText, selectedNlData: data, choropleth, content, lastGenerated } = props;
 
-  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    confirmedCasesInfectedPercentageTimeframe,
-    setConfirmedCasesInfectedPercentageTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesInfectedPercentageTimeframe, setConfirmedCasesInfectedPercentageTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    confirmedCasesTestedOverTimeTimeframe,
-    setConfirmedCasesTestedOverTimeTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesTestedOverTimeTimeframe, setConfirmedCasesTestedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    confirmedCasesInfectedPerAgeTimeframe,
-    setConfirmedCasesInfectedPerAgeTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesInfectedPerAgeTimeframe, setConfirmedCasesInfectedPerAgeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
   const reverseRouter = useReverseRouter();
-  const [hasHideArchivedCharts, setHideArchivedCharts] =
-    useState<boolean>(false);
+  const [hasHideArchivedCharts, setHideArchivedCharts] = useState<boolean>(false);
 
-  const { metadataTexts, textNl, textShared } =
-    useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
+  const { metadataTexts, textNl, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const [selectedMap, setSelectedMap] = useState<RegionControlOption>('gm');
-  const [selectedGgdGraph, setSelectedGgdGraph] = useState<string>(
-    'GGD_infected_percentage_over_time_chart'
-  );
+  const [selectedGgdGraph, setSelectedGgdGraph] = useState<string>('GGD_infected_percentage_over_time_chart');
 
   const dataOverallLastValue = data.tested_overall.last_value;
   const dataGgdLastValue = data.tested_ggd.last_value;
@@ -204,12 +127,8 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
       <NlLayout>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.development_of_the_virus.title
-            }
-            screenReaderCategory={
-              commonTexts.sidebar.metrics.positive_tests.title
-            }
+            category={commonTexts.sidebar.categories.development_of_the_virus.title}
+            screenReaderCategory={commonTexts.sidebar.metrics.positive_tests.title}
             title={textNl.titel}
             icon={<GgdTesten aria-hidden="true" />}
             description={textNl.pagina_toelichting}
@@ -226,14 +145,9 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
           <ChartTile
             title={textNl.linechart_titel}
             description={replaceVariablesInText(textNl.linechart_toelichting, {
-              date: formatDateFromSeconds(
-                dataOverallLastValue.date_unix,
-                'weekday-medium'
-              ),
+              date: formatDateFromSeconds(dataOverallLastValue.date_unix, 'weekday-medium'),
               administered_total: formatNumber(dataOverallLastValue.infected),
-              infected_total: formatNumber(
-                dataOverallLastValue.infected_moving_average_rounded
-              ),
+              infected_total: formatNumber(dataOverallLastValue.infected_moving_average_rounded),
             })}
             metadata={{
               source: textNl.bronnen.rivm,
@@ -266,13 +180,9 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 outOfBoundsConfig: {
                   label: textShared.labels.infected_out_of_bounds,
                   tooltipLabel: textShared.tooltip_labels.annotations,
-                  checkIsOutofBounds: (x: NlTestedOverallValue, max: number) =>
-                    x.infected > max,
+                  checkIsOutofBounds: (x: NlTestedOverallValue, max: number) => x.infected > max,
                 },
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'tested_overall'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'tested_overall'),
               }}
             />
           </ChartTile>
@@ -282,17 +192,11 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               <ChartTile
                 timeframeOptions={TimeframeOptionsList}
                 title={textNl.ggd.linechart_percentage_titel}
-                description={replaceVariablesInText(
-                  textNl.ggd.linechart_percentage_toelichting,
-                  {
-                    date: formatDateFromSeconds(
-                      dataGgdLastValue.date_unix,
-                      'weekday-medium'
-                    ),
-                    tested_total: formatNumber(dataGgdLastValue.tested_total),
-                    infected_total: formatNumber(dataGgdLastValue.infected),
-                  }
-                )}
+                description={replaceVariablesInText(textNl.ggd.linechart_percentage_toelichting, {
+                  date: formatDateFromSeconds(dataGgdLastValue.date_unix, 'weekday-medium'),
+                  tested_total: formatNumber(dataGgdLastValue.tested_total),
+                  infected_total: formatNumber(dataGgdLastValue.infected),
+                })}
                 metadata={{
                   date: getLastInsertionDateOfPage(data, ['tested_ggd']),
                   source: textNl.ggd.bronnen.rivm,
@@ -300,10 +204,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 onSelectTimeframe={setConfirmedCasesInfectedPercentageTimeframe}
               >
                 <>
-                  <GgdGraphToggle
-                    selectedGgdGraph={selectedGgdGraph}
-                    onChange={(value) => setSelectedGgdGraph(value)}
-                  />
+                  <GgdGraphToggle selectedGgdGraph={selectedGgdGraph} onChange={(value) => setSelectedGgdGraph(value)} />
                   <TimeSeriesChart
                     accessibility={{
                       key: 'confirmed_cases_infected_percentage_over_time_chart',
@@ -317,9 +218,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                         metricProperty: 'infected_percentage_moving_average',
                         color: colors.primary,
                         label: textNl.ggd.linechart_percentage_legend_label,
-                        shortLabel:
-                          textShared.tooltip_labels
-                            .ggd_infected_percentage_moving_average,
+                        shortLabel: textShared.tooltip_labels.ggd_infected_percentage_moving_average,
                       },
                     ]}
                     dataOptions={{
@@ -333,17 +232,11 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               <ChartTile
                 timeframeOptions={TimeframeOptionsList}
                 title={textNl.ggd.linechart_totaltests_titel}
-                description={replaceVariablesInText(
-                  textNl.ggd.linechart_totaltests_toelichting,
-                  {
-                    date: formatDateFromSeconds(
-                      dataGgdLastValue.date_unix,
-                      'weekday-medium'
-                    ),
-                    tested_total: formatNumber(dataGgdLastValue.tested_total),
-                    infected_total: formatNumber(dataGgdLastValue.infected),
-                  }
-                )}
+                description={replaceVariablesInText(textNl.ggd.linechart_totaltests_toelichting, {
+                  date: formatDateFromSeconds(dataGgdLastValue.date_unix, 'weekday-medium'),
+                  tested_total: formatNumber(dataGgdLastValue.tested_total),
+                  infected_total: formatNumber(dataGgdLastValue.infected),
+                })}
                 metadata={{
                   source: textNl.ggd.bronnen.rivm,
                   date: getLastInsertionDateOfPage(data, ['tested_ggd']),
@@ -351,10 +244,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 onSelectTimeframe={setConfirmedCasesTestedOverTimeTimeframe}
               >
                 <>
-                  <GgdGraphToggle
-                    selectedGgdGraph={selectedGgdGraph}
-                    onChange={(value) => setSelectedGgdGraph(value)}
-                  />
+                  <GgdGraphToggle selectedGgdGraph={selectedGgdGraph} onChange={(value) => setSelectedGgdGraph(value)} />
                   <TimeSeriesChart
                     accessibility={{
                       key: 'confirmed_cases_tested_over_time_chart',
@@ -366,22 +256,15 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                         type: 'line',
                         metricProperty: 'tested_total_moving_average',
                         color: colors.secondary,
-                        label:
-                          textNl.ggd
-                            .linechart_totaltests_legend_label_moving_average,
-                        shortLabel:
-                          textShared.tooltip_labels
-                            .ggd_tested_total_moving_average,
+                        label: textNl.ggd.linechart_totaltests_legend_label_moving_average,
+                        shortLabel: textShared.tooltip_labels.ggd_tested_total_moving_average,
                       },
                       {
                         type: 'line',
                         metricProperty: 'infected_moving_average',
                         color: colors.primary,
-                        label:
-                          textNl.ggd
-                            .linechart_positivetests_legend_label_moving_average,
-                        shortLabel:
-                          textShared.tooltip_labels.infected_moving_average,
+                        label: textNl.ggd.linechart_positivetests_legend_label_moving_average,
+                        shortLabel: textShared.tooltip_labels.infected_moving_average,
                       },
                     ]}
                   />
@@ -406,10 +289,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 }}
                 values={data.tested_per_age_group.values}
                 timeframe={confirmedCasesInfectedPerAgeTimeframe}
-                timelineEvents={getTimelineEvents(
-                  content.elements.timeSeries,
-                  'tested_per_age_group'
-                )}
+                timelineEvents={getTimelineEvents(content.elements.timeSeries, 'tested_per_age_group')}
                 text={textShared}
               />
             </ChartTile>
@@ -427,15 +307,8 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 <>
                   <Markdown content={textNl.map_toelichting} />
                   {replaceComponentsInText(textNl.map_last_value_text, {
-                    infected_per_100k: (
-                      <BoldText>{`${formatNumber(
-                        dataOverallLastValue.infected_per_100k
-                      )}`}</BoldText>
-                    ),
-                    dateTo: formatDateFromSeconds(
-                      dataOverallLastValue.date_unix,
-                      'weekday-medium'
-                    ),
+                    infected_per_100k: <BoldText>{`${formatNumber(dataOverallLastValue.infected_per_100k)}`}</BoldText>,
+                    dateTo: formatDateFromSeconds(dataOverallLastValue.date_unix, 'weekday-medium'),
                   })}
                 </>
               }
@@ -506,9 +379,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
-            onToggleArchived={() =>
-              setHideArchivedCharts(!hasHideArchivedCharts)
-            }
+            onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
           />
 
           {hasHideArchivedCharts && (

--- a/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
+++ b/packages/app/src/pages/landelijk/verpleeghuiszorg.tsx
@@ -1,8 +1,4 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { Coronavirus, Location, Verpleeghuis } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
@@ -23,26 +19,10 @@ import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { Languages, SiteText } from '~/locale';
 import { useIntl } from '~/intl';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetChoroplethData,
-  createGetContent,
-  getLastGeneratedDate,
-  getLokalizeTexts,
-  selectNlData,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { useReverseRouter } from '~/utils/use-reverse-router';
@@ -60,14 +40,9 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData(
-    'difference.nursing_home__infected_locations_total',
-    'difference.nursing_home__newly_infected_people',
-    'nursing_home'
-  ),
+  selectNlData('difference.nursing_home__infected_locations_total', 'difference.nursing_home__newly_infected_people', 'nursing_home'),
   createGetChoroplethData({
     vr: ({ nursing_home }) => ({ nursing_home }),
   }),
@@ -85,10 +60,7 @@ export const getStaticProps = createGetStaticProps(
 
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'nursingHomePageArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'nursingHomePageArticles'),
         elements: content.elements,
       },
     };
@@ -96,40 +68,22 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedNlData: data,
-    choropleth,
-    lastGenerated,
-    content,
-  } = props;
+  const { pageText, selectedNlData: data, choropleth, lastGenerated, content } = props;
 
-  const [
-    nursingHomeConfirmedCasesTimeframe,
-    setNursingHomeConfirmedCasesTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [nursingHomeConfirmedCasesTimeframe, setNursingHomeConfirmedCasesTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    nursingHomeInfectedLocationsTimeframe,
-    setNursingHomeInfectedLocationsTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [nursingHomeInfectedLocationsTimeframe, setNursingHomeInfectedLocationsTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [nursingHomeDeceasedTimeframe, setNursingHomeDeceasedTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [nursingHomeDeceasedTimeframe, setNursingHomeDeceasedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const nursinghomeDataLastValue = data.nursing_home.last_value;
-  const underReportedDateStart = getBoundaryDateStartUnix(
-    data.nursing_home.values,
-    7
-  );
+  const underReportedDateStart = getBoundaryDateStartUnix(data.nursing_home.values, 7);
 
   const { commonTexts, formatNumber } = useIntl();
   const reverseRouter = useReverseRouter();
-  const { metadataTexts, textNl, textShared } =
-    useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
+  const { metadataTexts, textNl, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
   const infectedLocationsText = textShared.verpleeghuis_besmette_locaties;
-  const positiveTestedPeopleText =
-    textNl.verpleeghuis_positief_geteste_personen;
+  const positiveTestedPeopleText = textNl.verpleeghuis_positief_geteste_personen;
 
   const metadata = {
     ...metadataTexts,
@@ -144,17 +98,11 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
       <NlLayout>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.consequences_for_healthcare.title
-            }
-            screenReaderCategory={
-              commonTexts.sidebar.metrics.nursing_home_care.title
-            }
+            category={commonTexts.sidebar.categories.consequences_for_healthcare.title}
+            screenReaderCategory={commonTexts.sidebar.metrics.nursing_home_care.title}
             title={positiveTestedPeopleText.titel}
             icon={<Verpleeghuis aria-hidden="true" />}
-            description={
-              <Markdown content={positiveTestedPeopleText.pagina_toelichting} />
-            }
+            description={<Markdown content={positiveTestedPeopleText.pagina_toelichting} />}
             metadata={{
               datumsText: positiveTestedPeopleText.datums,
               dateOrRange: nursinghomeDataLastValue.date_unix,
@@ -201,20 +149,15 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                   type: 'line',
                   metricProperty: 'newly_infected_people_moving_average',
                   color: colors.primary,
-                  label:
-                    positiveTestedPeopleText.line_chart_legend_trend_moving_average_label,
-                  shortLabel:
-                    positiveTestedPeopleText.tooltip_labels
-                      .newly_infected_people_moving_average,
+                  label: positiveTestedPeopleText.line_chart_legend_trend_moving_average_label,
+                  shortLabel: positiveTestedPeopleText.tooltip_labels.newly_infected_people_moving_average,
                 },
                 {
                   type: 'bar',
                   metricProperty: 'newly_infected_people',
                   color: colors.primary,
                   label: positiveTestedPeopleText.line_chart_legend_trend_label,
-                  shortLabel:
-                    positiveTestedPeopleText.tooltip_labels
-                      .newly_infected_people,
+                  shortLabel: positiveTestedPeopleText.tooltip_labels.newly_infected_people,
                 },
               ]}
               dataOptions={{
@@ -222,20 +165,12 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                   {
                     start: underReportedDateStart,
                     end: Infinity,
-                    label:
-                      positiveTestedPeopleText.line_chart_legend_inaccurate_label,
-                    shortLabel:
-                      positiveTestedPeopleText.tooltip_labels.inaccurate,
-                    cutValuesForMetricProperties: [
-                      'newly_infected_people_moving_average',
-                    ],
+                    label: positiveTestedPeopleText.line_chart_legend_inaccurate_label,
+                    shortLabel: positiveTestedPeopleText.tooltip_labels.inaccurate,
+                    cutValuesForMetricProperties: ['newly_infected_people_moving_average'],
                   },
                 ],
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'nursing_home',
-                  'newly_infected_people'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'nursing_home', 'newly_infected_people'),
               }}
             />
           </ChartTile>
@@ -250,8 +185,7 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
             metadata={{
               datumsText: infectedLocationsText.datums,
               dateOrRange: nursinghomeDataLastValue.date_unix,
-              dateOfInsertionUnix:
-                nursinghomeDataLastValue.date_of_insertion_unix,
+              dateOfInsertionUnix: nursinghomeDataLastValue.date_of_insertion_unix,
               dataSources: [infectedLocationsText.bronnen.rivm],
             }}
             referenceLink={infectedLocationsText.reference.href}
@@ -268,12 +202,8 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
               <KpiValue
                 data-cy="infected_locations_total"
                 absolute={nursinghomeDataLastValue.infected_locations_total}
-                percentage={
-                  nursinghomeDataLastValue.infected_locations_percentage
-                }
-                difference={
-                  data.difference.nursing_home__infected_locations_total
-                }
+                percentage={nursinghomeDataLastValue.infected_locations_percentage}
+                difference={data.difference.nursing_home__infected_locations_total}
                 isAmount
               />
               <Text>{infectedLocationsText.kpi_toelichting}</Text>
@@ -286,10 +216,7 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                 source: infectedLocationsText.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="newly_infected_locations"
-                absolute={nursinghomeDataLastValue.newly_infected_locations}
-              />
+              <KpiValue data-cy="newly_infected_locations" absolute={nursinghomeDataLastValue.newly_infected_locations} />
               <Text>{infectedLocationsText.barscale_toelichting}</Text>
             </KpiTile>
           </TwoKpiSection>
@@ -341,14 +268,13 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
               timeframe={nursingHomeInfectedLocationsTimeframe}
               seriesConfig={[
                 {
-                  type: 'area',
+                  type: 'line',
                   metricProperty: 'infected_locations_total',
-                  label:
-                    textShared.verpleeghuis_besmette_locaties
-                      .linechart_tooltip_label,
+                  label: textShared.verpleeghuis_besmette_locaties.linechart_tooltip_label,
                   color: colors.primary,
                 },
               ]}
+              forceLegend
             />
           </ChartTile>
 
@@ -362,8 +288,7 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
             metadata={{
               datumsText: textNl.datums,
               dateOrRange: nursinghomeDataLastValue.date_unix,
-              dateOfInsertionUnix:
-                nursinghomeDataLastValue.date_of_insertion_unix,
+              dateOfInsertionUnix: nursinghomeDataLastValue.date_of_insertion_unix,
               dataSources: [textNl.bronnen.rivm],
             }}
             referenceLink={textNl.reference.href}
@@ -378,10 +303,7 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="deceased_daily"
-                absolute={nursinghomeDataLastValue.deceased_daily}
-              />
+              <KpiValue data-cy="deceased_daily" absolute={nursinghomeDataLastValue.deceased_daily} />
             </KpiTile>
           </TwoKpiSection>
 
@@ -403,8 +325,7 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                   type: 'line',
                   metricProperty: 'deceased_daily_moving_average',
                   label: textNl.line_chart_legend_trend_moving_average_label,
-                  shortLabel:
-                    textNl.tooltip_labels.deceased_daily_moving_average,
+                  shortLabel: textNl.tooltip_labels.deceased_daily_moving_average,
                   color: colors.primary,
                 },
                 {
@@ -422,16 +343,10 @@ function NursingHomeCare(props: StaticProps<typeof getStaticProps>) {
                     end: Infinity,
                     label: textNl.line_chart_legend_inaccurate_label,
                     shortLabel: textNl.tooltip_labels.inaccurate,
-                    cutValuesForMetricProperties: [
-                      'deceased_daily_moving_average',
-                    ],
+                    cutValuesForMetricProperties: ['deceased_daily_moving_average'],
                   },
                 ],
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'nursing_home',
-                  'deceased_daily'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'nursing_home', 'deceased_daily'),
               }}
             />
           </ChartTile>


### PR DESCRIPTION
## Summary

Currently, four charts are missing legends and/or need to remove the fill below the line.

- Added `forceLegend` prop to force a legend to be shown, even if it has one data point for the legend.
- Change area charts to line charts