### PR TITLE
bugfix/COR-1241-Age-demographic-chart-labels-are-not-sizing-correctly-on-EN-dashboard

### DIFF
--- a/packages/app/src/components/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic-chart.tsx
@@ -1,5 +1,4 @@
 import { Color, colors } from '@corona-dashboard/common';
-import css from '@styled-system/css';
 import { AxisBottom, TickRendererProps } from '@visx/axis';
 import { GridColumns } from '@visx/grid';
 import { Group } from '@visx/group';
@@ -10,16 +9,22 @@ import { KeyboardEvent, MouseEvent } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
 import { Text } from '~/components/typography';
+import { fontSizes, fontWeights, space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils';
-import {
-  AccessibilityDefinition,
-  useAccessibilityAnnotations,
-} from '~/utils/use-accessibility-annotations';
+import { AccessibilityDefinition, useAccessibilityAnnotations } from '~/utils/use-accessibility-annotations';
 import { AgeDemographicCoordinates } from './age-demographic-coordinates';
 import { AgeDemographicChartText, AgeDemographicDefaultValue } from './types';
 import { formatAgeGroupRange } from './utils';
 
 export const AGE_GROUP_TOOLTIP_WIDTH = 340;
+
+const TickValue = ({ x, y, formattedValue }: TickRendererProps) => {
+  return (
+    <VisxText x={x} y={y} fill={colors.gray7} fontSize={fontSizes[2]} textAnchor="middle">
+      {formattedValue}
+    </VisxText>
+  );
+};
 
 interface AgeDemographicChartProps<T extends AgeDemographicDefaultValue> {
   /**
@@ -34,25 +39,11 @@ interface AgeDemographicChartProps<T extends AgeDemographicDefaultValue> {
   onKeyInput: (event: KeyboardEvent<SVGElement>) => void;
   rightMetricProperty: keyof T;
   leftMetricProperty: keyof T;
-  rightColor: Color;
-  leftColor: Color;
+  rightColor: Color | string;
+  leftColor: Color | string;
   maxDisplayValue?: number;
   formatValue: (n: number) => string;
 }
-
-const TickValue = ({ x, y, formattedValue }: TickRendererProps) => {
-  return (
-    <VisxText
-      x={x}
-      y={y}
-      fill={colors.gray7}
-      fontSize="1rem"
-      textAnchor="middle"
-    >
-      {formattedValue}
-    </VisxText>
-  );
-};
 
 export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
   accessibility,
@@ -68,23 +59,8 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
   maxDisplayValue,
   formatValue,
 }: AgeDemographicChartProps<T>) {
-  const {
-    width,
-    height,
-    singleBarHeight,
-    numTicks,
-    xMax,
-    yMax,
-    axisWidth,
-    leftScale,
-    leftPoint,
-    rightScale,
-    rightPoint,
-    ageGroupRangePoint,
-    ageGroupRange,
-    margin,
-    values,
-  } = coordinates;
+  const { width, height, singleBarHeight, numTicks, xMax, yMax, axisWidth, leftScale, leftPoint, rightScale, rightPoint, ageGroupRangePoint, ageGroupRange, margin, values } =
+    coordinates;
 
   const annotations = useAccessibilityAnnotations(accessibility);
 
@@ -94,44 +70,21 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
   };
 
   const hasClippedValue = !!values.find(
-    (value) =>
-      getIsClipped(
-        getNumberValue(value, leftMetricProperty),
-        maxDisplayValue
-      ) ||
-      getIsClipped(getNumberValue(value, rightMetricProperty), maxDisplayValue)
+    (value) => getIsClipped(getNumberValue(value, leftMetricProperty), maxDisplayValue) || getIsClipped(getNumberValue(value, rightMetricProperty), maxDisplayValue)
   );
 
   return (
     <Box>
       {annotations.descriptionElement}
-      <svg
-        {...annotations.props}
-        width={width}
-        viewBox={`0 0 ${width} ${height}`}
-        role="img"
-        tabIndex={0}
-        onKeyUp={(event) => onKeyInput(event)}
-        css={css({
-          width: '100%',
-          overflow: 'visible',
-          '&:focus': {
-            outline: 'none',
-          },
-          // For the bottom axes, the tickLabelProps or labelProps won't change the fontSize
-          '.visx-axis-bottom tspan': {
-            fontSize: 12,
-          },
-        })}
-      >
+      <StyledSVG {...annotations.props} width={width} viewBox={`0 0 ${width} ${height}`} role="img" tabIndex={0} onKeyUp={(event) => onKeyInput(event)}>
         <VisxText
           textAnchor="end"
           verticalAnchor="start"
           y={0}
           x={width / 2 - axisWidth / 2}
-          fill="black"
-          fontWeight="bold"
-          fontSize="1rem"
+          fill={colors.black}
+          fontWeight={fontWeights.bold}
+          fontSize={fontSizes[2]}
           width={xMax - 10}
         >
           {text.left_title}
@@ -141,118 +94,67 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
           verticalAnchor="start"
           y={0}
           x={width / 2 + axisWidth / 2}
-          fill="black"
-          fontWeight="bold"
-          fontSize="1rem"
+          fill={colors.black}
+          fontWeight={fontWeights.bold}
+          fontSize={fontSizes[2]}
           width={xMax - 10}
         >
           {text.right_title}
         </VisxText>
 
         {/* Vertical lines */}
-        <GridColumns
-          scale={leftScale}
-          width={xMax}
-          height={yMax}
-          left={margin.left}
-          top={margin.top}
-          numTicks={numTicks}
-          stroke={colors.gray3}
-        />
+        <GridColumns scale={leftScale} width={xMax} height={yMax} left={margin.left} top={margin.top} numTicks={numTicks} stroke={colors.gray3} />
 
-        <GridColumns
-          scale={rightScale}
-          width={xMax}
-          height={yMax}
-          left={width / 2 + axisWidth / 2}
-          top={margin.top}
-          numTicks={numTicks}
-          stroke={colors.gray3}
-        />
+        <GridColumns scale={rightScale} width={xMax} height={yMax} left={width / 2 + axisWidth / 2} top={margin.top} numTicks={numTicks} stroke={colors.gray3} />
 
-        <StyledPatternLines
-          id="is-clipped-pattern-left"
-          height={6}
-          width={6}
-          stroke={leftColor}
-          strokeWidth={2}
-          orientation={['diagonalRightToLeft']}
-        />
+        <StyledPatternLines id="is-clipped-pattern-left" height={6} width={6} stroke={leftColor} strokeWidth={2} orientation={['diagonalRightToLeft']} />
 
-        <StyledPatternLines
-          id="is-clipped-pattern-right"
-          height={6}
-          width={6}
-          stroke={rightColor}
-          strokeWidth={2}
-          orientation={['diagonal']}
-        />
+        <StyledPatternLines id="is-clipped-pattern-right" height={6} width={6} stroke={rightColor} strokeWidth={2} orientation={['diagonal']} />
 
         {values.map((value, index) => {
           const leftBarWidth = xMax - leftPoint(value);
           const rightBarWidth = rightPoint(value);
 
-          const isClippedLeftGroup = getIsClipped(
-            getNumberValue(value, leftMetricProperty),
-            maxDisplayValue
-          );
+          const isClippedLeftGroup = getIsClipped(getNumberValue(value, leftMetricProperty), maxDisplayValue);
 
-          const isClippedRightGroup = getIsClipped(
-            getNumberValue(value, rightMetricProperty),
-            maxDisplayValue
-          );
+          const isClippedRightGroup = getIsClipped(getNumberValue(value, rightMetricProperty), maxDisplayValue);
 
           const isClippedValue = isClippedLeftGroup || isClippedRightGroup;
 
           return (
-            <StyledGroup
-              key={index}
-              onMouseMove={(event) => onMouseMoveBar(value, event)}
-              onMouseLeave={onMouseLeaveBar}
-            >
+            <StyledGroup key={index} onMouseMove={(event) => onMouseMoveBar(value, event)} onMouseLeave={onMouseLeaveBar}>
               {/* This bar takes all width to display the background color on hover */}
-              <StyledHoverBar
-                x={margin.left}
-                y={ageGroupRangePoint(value)}
-                height={singleBarHeight}
-                width={width - margin.left - margin.right}
-              />
-              <Bar
+              <StyledHoverBar x={margin.left} y={ageGroupRangePoint(value)} height={singleBarHeight} width={width - margin.left - margin.right} />
+              <StyledBar
                 x={width / 2 - axisWidth / 2 - leftBarWidth}
                 y={ageGroupRangePoint(value)}
                 height={singleBarHeight}
                 width={leftBarWidth}
-                css={css({
-                  fill: isClippedLeftGroup
-                    ? `url(#is-clipped-pattern-left)`
-                    : leftColor,
-                })}
+                color={leftColor}
+                isClipped={isClippedLeftGroup}
+                isClippedPattern="is-clipped-pattern-left"
               />
               <VisxText
                 textAnchor="middle"
                 verticalAnchor="middle"
-                fontSize="12"
-                fontWeight="bold"
+                fontSize={fontSizes[0]}
+                fontWeight={fontWeights.bold}
                 y={ageGroupRangePoint(value) + singleBarHeight / 2}
                 x={width / 2}
-                fill="black"
+                fill={colors.black}
               >
                 {replaceVariablesInText(text.age_group_range_tooltip, {
-                  ageGroupRange:
-                    formatAgeGroupRange(ageGroupRange(value)) +
-                    (isClippedValue ? ' *' : ''),
+                  ageGroupRange: formatAgeGroupRange(ageGroupRange(value)) + (isClippedValue ? ' *' : ''),
                 })}
               </VisxText>
-              <Bar
+              <StyledBar
                 x={width / 2 + axisWidth / 2}
                 y={ageGroupRangePoint(value)}
                 height={singleBarHeight}
                 width={rightBarWidth}
-                css={css({
-                  fill: isClippedRightGroup
-                    ? `url(#is-clipped-pattern-right)`
-                    : rightColor,
-                })}
+                color={rightColor}
+                isClipped={isClippedRightGroup}
+                isClippedPattern="is-clipped-pattern-right"
               />
             </StyledGroup>
           );
@@ -264,10 +166,10 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
           left={margin.left}
           top={height - margin.bottom}
           numTicks={numTicks}
-          hideTicks={true}
-          hideAxisLine={true}
           tickFormat={formatValue}
           tickComponent={TickValue}
+          hideTicks
+          hideAxisLine
         />
 
         <AxisBottom
@@ -275,15 +177,15 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
           left={width / 2 + axisWidth / 2}
           top={height - margin.bottom}
           numTicks={numTicks}
-          hideTicks={true}
-          hideAxisLine={true}
           tickFormat={formatValue}
           tickComponent={TickValue}
+          hideTicks
+          hideAxisLine
         />
-      </svg>
+      </StyledSVG>
 
       {hasClippedValue && (
-        <Box mt={2}>
+        <Box marginTop={space[2]}>
           <Text variant="label1" color="gray7">
             {text.clipped_value_message}
           </Text>
@@ -293,23 +195,48 @@ export function AgeDemographicChart<T extends AgeDemographicDefaultValue>({
   );
 }
 
-const StyledPatternLines = styled(PatternLines)<{ stroke: Color }>((p) =>
-  css({ stroke: p.stroke })
-);
+const StyledSVG = styled.svg`
+  overflow: visible;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+
+  // For the bottom axes, the tickLabelProps or labelProps won't change the fontSize
+  .visx-axis-bottom tspan {
+    font-size: ${fontSizes[0]};
+  }
+`;
+
+interface StyledPatternLinesProps {
+  stroke: Color | string;
+}
+
+const StyledPatternLines = styled(PatternLines)<StyledPatternLinesProps>`
+  stroke: ${({ stroke }) => stroke};
+`;
 
 const StyledGroup = styled(Group)({});
-const StyledHoverBar = styled(Bar)(
-  css({
-    fill: 'transparent',
-    // transparent stroke is to capture mouse movements in between bars for the tooltip
-    stroke: 'transparent',
-    strokeWidth: 12,
+const StyledHoverBar = styled(Bar)`
+  fill: transparent;
+  stroke: transparent;
+  stroke-width: 12px;
 
-    [`${StyledGroup}:hover &`]: {
-      fill: colors.blue1,
-    },
-  })
-);
+  ${StyledGroup}:hover & {
+    fill: ${colors.blue1};
+  }
+`;
+
+interface StyledBarProps {
+  color: Color | string;
+  isClipped: boolean;
+  isClippedPattern: string;
+}
+
+const StyledBar = styled(Bar)<StyledBarProps>`
+  fill: ${({ color, isClipped, isClippedPattern }) => (isClipped ? `url(#${isClippedPattern})` : color)};
+`;
 
 function getIsClipped(value: number, maxValue: number | undefined) {
   if (!maxValue) return false;

--- a/packages/app/src/components/age-demographic/age-demographic-chart.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic-chart.tsx
@@ -219,8 +219,8 @@ const StyledPatternLines = styled(PatternLines)<StyledPatternLinesProps>`
 
 const StyledGroup = styled(Group)({});
 const StyledHoverBar = styled(Bar)`
-  fill: transparent;
-  stroke: transparent;
+  fill: ${colors.transparent};
+  stroke: ${colors.transparent};
   stroke-width: 12px;
 
   ${StyledGroup}:hover & {

--- a/packages/app/src/components/age-demographic/age-demographic-coordinates.ts
+++ b/packages/app/src/components/age-demographic/age-demographic-coordinates.ts
@@ -1,18 +1,13 @@
 import { localPoint } from '@visx/event';
 import { scaleBand, scaleLinear, ScaleTypeToD3Scale } from '@visx/scale';
 import { MouseEvent, useMemo } from 'react';
-import {
-  GetTooltipCoordinates,
-  TooltipCoordinates,
-} from '~/components/tooltip';
+import { GetTooltipCoordinates, TooltipCoordinates } from '~/components/tooltip';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useResizeObserver } from '~/utils/use-resize-observer';
 import { AGE_GROUP_TOOLTIP_WIDTH } from './age-demographic-chart';
 import { AgeDemographicDefaultValue } from './types';
 
-export interface AgeDemographicCoordinates<
-  T extends AgeDemographicDefaultValue
-> {
+export interface AgeDemographicCoordinates<T extends AgeDemographicDefaultValue> {
   width: number;
   height: number;
   singleBarHeight: number;
@@ -37,9 +32,7 @@ export interface AgeDemographicCoordinates<
   axisWidth: number;
 }
 
-export function useAgeDemographicCoordinates<
-  T extends AgeDemographicDefaultValue
->(
+export function useAgeDemographicCoordinates<T extends AgeDemographicDefaultValue>(
   data: { values: T[] },
   rightMetricProperty: keyof T,
   leftMetricProperty: keyof T,
@@ -52,31 +45,13 @@ export function useAgeDemographicCoordinates<
   const isExtraSmallScreen = xs;
 
   const coordinates = useMemo(() => {
-    return calculateAgeDemographicCoordinates(
-      data,
-      rightMetricProperty,
-      leftMetricProperty,
-      isSmallScreen,
-      width,
-      isExtraSmallScreen,
-      maxDisplayValue
-    );
-  }, [
-    data,
-    rightMetricProperty,
-    leftMetricProperty,
-    isSmallScreen,
-    width,
-    isExtraSmallScreen,
-    maxDisplayValue,
-  ]);
+    return calculateAgeDemographicCoordinates(data, rightMetricProperty, leftMetricProperty, isSmallScreen, width, isExtraSmallScreen, maxDisplayValue);
+  }, [data, rightMetricProperty, leftMetricProperty, isSmallScreen, width, isExtraSmallScreen, maxDisplayValue]);
 
   return [ref, coordinates] as const;
 }
 
-function calculateAgeDemographicCoordinates<
-  T extends AgeDemographicDefaultValue
->(
+function calculateAgeDemographicCoordinates<T extends AgeDemographicDefaultValue>(
   data: { values: T[] },
   rightMetricProperty: keyof T,
   leftMetricProperty: keyof T,
@@ -93,15 +68,15 @@ function calculateAgeDemographicCoordinates<
   const singleBarHeight = 25;
 
   // Define the graph dimensions and margins
-  const axisWidth = isSmallScreen ? 60 : 100;
+  const axisWidth = 100;
   const width = parentWidth;
 
   // Height and top margin are higher for small screens to fit the heading texts
   const isNarrowScreen = parentWidth < 400;
   // Set height height according to amount of bars in chart.
-  const height = isNarrowScreen
-    ? 234 + singleBarHeight * barCount
-    : 214 + singleBarHeight * barCount;
+  const narrowScreenHeight = 234 + singleBarHeight * barCount;
+  const normalScreenHeight = 214 + singleBarHeight * barCount;
+  const height = isNarrowScreen ? narrowScreenHeight : normalScreenHeight;
   const marginX = isSmallScreen ? 10 : 40;
   const margin = {
     top: isNarrowScreen ? 55 : 35,
@@ -130,14 +105,7 @@ function calculateAgeDemographicCoordinates<
   // Scales to map between values and coordinates
 
   // The scales for bar sizing will use the same domain
-  const domainValues = [
-    0,
-    Math.max(
-      ...values.map((value) =>
-        Math.max(getLeftValue(value), getRightValue(value))
-      )
-    ),
-  ];
+  const domainValues = [0, Math.max(...values.map((value) => Math.max(getLeftValue(value), getRightValue(value))))];
 
   /**
    * If there's a `displayMaxPercentage`-prop we'll clip the domain to that value
@@ -171,18 +139,14 @@ function calculateAgeDemographicCoordinates<
 
   // Compose together the scale and accessor functions to get point functions
   // The any/any is needed as typing would be a-flexible; and without it Typescript would complain
-  const createPoint = (scale: any, accessor: any) => (value: T) =>
-    scale(accessor(value));
+  const createPoint = (scale: any, accessor: any) => (value: T) => scale(accessor(value));
   const leftPoint = createPoint(leftScale, getLeftValue);
   const rightPoint = createPoint(rightScale, getRightValue);
   const ageGroupRangePoint = createPoint(ageGroupRangeScale, ageGroupRange);
 
   // Method for the tooltip to retrieve coordinates based on
   // The event and/or the value
-  const getTooltipCoordinates: GetTooltipCoordinates<T> = (
-    value: T,
-    event?: MouseEvent<any>
-  ): TooltipCoordinates => {
+  const getTooltipCoordinates: GetTooltipCoordinates<T> = (value: T, event?: MouseEvent<any>): TooltipCoordinates => {
     const point = event ? localPoint(event) || { x: width } : { x: 0 };
 
     // On small screens and when using keyboard
@@ -198,11 +162,7 @@ function calculateAgeDemographicCoordinates<
         left = width / 2 + axisWidth / 2 + rightPoint(value) / 2;
       } else {
         // Align the top right of the tooltip with the middle of the age group percentage bar
-        left =
-          width / 2 -
-          axisWidth / 2 -
-          (xMax - leftPoint(value)) / 2 -
-          AGE_GROUP_TOOLTIP_WIDTH;
+        left = width / 2 - axisWidth / 2 - (xMax - leftPoint(value)) / 2 - AGE_GROUP_TOOLTIP_WIDTH;
       }
     }
 

--- a/packages/app/src/components/age-demographic/age-demographic-tooltip-content.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic-tooltip-content.tsx
@@ -1,27 +1,23 @@
-import type { Color } from '@corona-dashboard/common';
-import css from '@styled-system/css';
+import { Color, colors } from '@corona-dashboard/common';
 import styled from 'styled-components';
 import { BoldText } from '~/components/typography';
+import { space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { Box } from '../base';
 import { AgeDemographicChartText, AgeDemographicDefaultValue } from './types';
 import { formatAgeGroupRange } from './utils';
 
-interface AgeDemographicTooltipContentProps<
-  T extends AgeDemographicDefaultValue
-> {
+interface AgeDemographicTooltipContentProps<T extends AgeDemographicDefaultValue> {
   value: T;
   rightMetricProperty: keyof T;
   leftMetricProperty: keyof T;
-  rightColor: Color;
-  leftColor: Color;
+  rightColor: Color | string;
+  leftColor: Color | string;
   text: AgeDemographicChartText;
   formatValue: (n: number) => string;
 }
 
-export function AgeDemographicTooltipContent<
-  T extends AgeDemographicDefaultValue
->({
+export function AgeDemographicTooltipContent<T extends AgeDemographicDefaultValue>({
   value,
   rightMetricProperty,
   leftMetricProperty,
@@ -31,15 +27,14 @@ export function AgeDemographicTooltipContent<
   formatValue,
 }: AgeDemographicTooltipContentProps<T>) {
   const valueRight = value[rightMetricProperty];
-  const rightMetricPropertyValue =
-    typeof valueRight === 'number' ? valueRight : 0;
+  const rightMetricPropertyValue = typeof valueRight === 'number' ? valueRight : 0;
 
   const valueLeft = value[leftMetricProperty];
   const leftMetricPropertyValue = typeof valueLeft === 'number' ? valueLeft : 0;
 
   return (
     <>
-      <Box px={3} py={2}>
+      <Box paddingX={space[3]} paddingY={space[2]}>
         <BoldText variant="h3">
           {replaceVariablesInText(text.age_group_range_tooltip, {
             ageGroupRange: formatAgeGroupRange(value.age_group_range),
@@ -64,33 +59,30 @@ export function AgeDemographicTooltipContent<
   );
 }
 
-const Legend = styled.ul(
-  css({
-    borderTop: '1px solid',
-    borderTopColor: 'gray2',
-    m: 0,
-    px: 0,
-    py: 2,
-  })
-);
+const Legend = styled.ul`
+  border-top: 1px solid ${colors.gray2};
+  margin: 0;
+  padding: ${space[2]} 0;
+`;
 
-const LegendItem = styled.li<{ color: string }>((x) =>
-  css({
-    listStyle: 'none',
-    m: 0,
-    pl: '2.75rem',
-    pr: 3,
-    py: 1,
-    position: 'relative',
-    '&:before': {
-      content: '""',
-      display: 'block',
-      width: '1rem',
-      height: '1rem',
-      backgroundColor: x.color,
-      position: 'absolute',
-      left: 3,
-      top: '0.5rem',
-    },
-  })
-);
+interface LegendItemProps {
+  color: string;
+}
+
+const LegendItem = styled.li<LegendItemProps>`
+  list-style: none;
+  margin: 0;
+  padding: ${space[1]} ${space[3]} ${space[1]} 2.75rem;
+  position: relative;
+
+  &:before {
+    background-color: ${({ color }) => color};
+    content: '';
+    display: block;
+    height: ${space[3]};
+    left: ${space[3]};
+    position: absolute;
+    top: ${space[2]};
+    width: ${space[3]};
+  }
+`;

--- a/packages/app/src/components/age-demographic/age-demographic.tsx
+++ b/packages/app/src/components/age-demographic/age-demographic.tsx
@@ -2,14 +2,8 @@ import type { Color } from '@corona-dashboard/common';
 import { Box } from '~/components/base';
 import { ErrorBoundary } from '~/components/error-boundary';
 import { Tooltip, useTooltip } from '~/components/tooltip';
-import {
-  AccessibilityDefinition,
-  addAccessibilityFeatures,
-} from '~/utils/use-accessibility-annotations';
-import {
-  AgeDemographicChart,
-  AGE_GROUP_TOOLTIP_WIDTH,
-} from './age-demographic-chart';
+import { AccessibilityDefinition, addAccessibilityFeatures } from '~/utils/use-accessibility-annotations';
+import { AgeDemographicChart, AGE_GROUP_TOOLTIP_WIDTH } from './age-demographic-chart';
 import { useAgeDemographicCoordinates } from './age-demographic-coordinates';
 import { AgeDemographicTooltipContent } from './age-demographic-tooltip-content';
 import { AgeDemographicChartText, AgeDemographicDefaultValue } from './types';
@@ -18,8 +12,8 @@ export interface AgeDemographicProps<T extends AgeDemographicDefaultValue> {
   data: { values: T[] };
   rightMetricProperty: keyof T;
   leftMetricProperty: keyof T;
-  rightColor: Color;
-  leftColor: Color;
+  rightColor: Color | string;
+  leftColor: Color | string;
   /**
    * The mandatory AccessibilityDefinition provides a reference to annotate the
    * graph with a label and description.
@@ -41,23 +35,15 @@ export function AgeDemographic<T extends AgeDemographicDefaultValue>({
   maxDisplayValue,
   text,
 }: AgeDemographicProps<T>) {
-  const [ref, coordinates] = useAgeDemographicCoordinates(
-    data,
-    rightMetricProperty,
-    leftMetricProperty,
-    maxDisplayValue
-  );
+  const [ref, coordinates] = useAgeDemographicCoordinates(data, rightMetricProperty, leftMetricProperty, maxDisplayValue);
 
   // Generate tooltip event handlers and state based on values and tooltip coordinates callback
-  const { openTooltip, closeTooltip, keyboardNavigateTooltip, tooltipState } =
-    useTooltip<T>({
-      values: coordinates.values,
-      getTooltipCoordinates: coordinates.getTooltipCoordinates,
-    });
+  const { openTooltip, closeTooltip, keyboardNavigateTooltip, tooltipState } = useTooltip<T>({
+    values: coordinates.values,
+    getTooltipCoordinates: coordinates.getTooltipCoordinates,
+  });
 
-  const ageDemographicAccessibility = addAccessibilityFeatures(accessibility, [
-    'keyboard_time_series_chart',
-  ]);
+  const ageDemographicAccessibility = addAccessibilityFeatures(accessibility, ['keyboard_time_series_chart']);
 
   return (
     <Box position="relative">

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -1,56 +1,22 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { Coronavirus } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
-import {
-  TwoKpiSection,
-  TimeSeriesChart,
-  TileList,
-  PageInformationBlock,
-  AgeDemographic,
-  ChartTile,
-  Divider,
-  KpiTile,
-  KpiValue,
-  Markdown,
-} from '~/components';
+import { TwoKpiSection, TimeSeriesChart, TileList, PageInformationBlock, AgeDemographic, ChartTile, Divider, KpiTile, KpiValue, Markdown } from '~/components';
 import { Text } from '~/components/typography';
 import { DeceasedMonitorSection } from '~/domain/deceased';
 import { Layout, NlLayout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetContent,
-  getLastGeneratedDate,
-  getLokalizeTexts,
-  selectNlData,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
-const pageMetrics = [
-  'deceased_cbs',
-  'deceased_rivm_per_age_group',
-  'deceased_rivm',
-];
+const pageMetrics = ['deceased_cbs', 'deceased_rivm_per_age_group', 'deceased_rivm'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -61,15 +27,9 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData(
-    'deceased_cbs',
-    'deceased_rivm_per_age_group',
-    'deceased_rivm',
-    'difference.deceased_rivm__covid_daily'
-  ),
+  selectNlData('deceased_cbs', 'deceased_rivm_per_age_group', 'deceased_rivm', 'difference.deceased_rivm__covid_daily'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
       parts: PagePartQueryResult<ArticleParts>;
@@ -84,14 +44,8 @@ export const getStaticProps = createGetStaticProps(
 
     return {
       content: {
-        mainArticles: getArticleParts(
-          content.parts.pageParts,
-          'deceasedPageArticles'
-        ),
-        monitorArticles: getArticleParts(
-          content.parts.pageParts,
-          'deceasedMonitorArticles'
-        ),
+        mainArticles: getArticleParts(content.parts.pageParts, 'deceasedPageArticles'),
+        monitorArticles: getArticleParts(content.parts.pageParts, 'deceasedMonitorArticles'),
         elements: content.elements,
       },
     };
@@ -99,8 +53,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
-  const [deceasedOverTimeTimeframe, setDeceasedOverTimeTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [deceasedOverTimeTimeframe, setDeceasedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { pageText, selectedNlData: data, lastGenerated, content } = props;
   const dataCbs = data.deceased_cbs;
@@ -108,8 +61,7 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
   const dataDeceasedPerAgeGroup = data.deceased_rivm_per_age_group;
 
   const { commonTexts, formatPercentage } = useIntl();
-  const { metadataTexts, textNl, textShared } =
-    useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
+  const { metadataTexts, textNl, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const metadata = {
     ...metadataTexts,
@@ -124,9 +76,7 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
       <NlLayout>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.development_of_the_virus.title
-            }
+            category={commonTexts.sidebar.categories.development_of_the_virus.title}
             title={textNl.section_deceased_rivm.title}
             icon={<Coronavirus aria-hidden="true" />}
             description={textNl.section_deceased_rivm.description}
@@ -148,17 +98,8 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.section_deceased_rivm.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="covid_daily"
-                absolute={dataRivm.last_value.covid_daily}
-                difference={data.difference.deceased_rivm__covid_daily}
-                isAmount
-              />
-              <Markdown
-                content={
-                  textNl.section_deceased_rivm.kpi_covid_daily_description
-                }
-              />
+              <KpiValue data-cy="covid_daily" absolute={dataRivm.last_value.covid_daily} difference={data.difference.deceased_rivm__covid_daily} isAmount />
+              <Markdown content={textNl.section_deceased_rivm.kpi_covid_daily_description} />
             </KpiTile>
             <KpiTile
               title={textNl.section_deceased_rivm.kpi_covid_total_title}
@@ -167,22 +108,15 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
                 source: textNl.section_deceased_rivm.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="covid_total"
-                absolute={dataRivm.last_value.covid_total}
-              />
-              <Text>
-                {textNl.section_deceased_rivm.kpi_covid_total_description}
-              </Text>
+              <KpiValue data-cy="covid_total" absolute={dataRivm.last_value.covid_total} />
+              <Text>{textNl.section_deceased_rivm.kpi_covid_total_description}</Text>
             </KpiTile>
           </TwoKpiSection>
 
           <ChartTile
             timeframeOptions={TimeframeOptionsList}
             title={textNl.section_deceased_rivm.line_chart_covid_daily_title}
-            description={
-              textNl.section_deceased_rivm.line_chart_covid_daily_description
-            }
+            description={textNl.section_deceased_rivm.line_chart_covid_daily_description}
             metadata={{
               source: textNl.section_deceased_rivm.bronnen.rivm,
             }}
@@ -198,31 +132,20 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
                 {
                   type: 'line',
                   metricProperty: 'covid_daily_moving_average',
-                  label:
-                    textNl.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label_moving_average,
-                  shortLabel:
-                    textNl.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label_moving_average,
+                  label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label_moving_average,
+                  shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label_moving_average,
                   color: colors.primary,
                 },
                 {
                   type: 'bar',
                   metricProperty: 'covid_daily',
-                  label:
-                    textNl.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label,
-                  shortLabel:
-                    textNl.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label,
+                  label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label,
+                  shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label,
                   color: colors.primary,
                 },
               ]}
               dataOptions={{
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'deceased_rivm'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'deceased_rivm'),
               }}
             />
           </ChartTile>
@@ -242,8 +165,8 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
               data={dataDeceasedPerAgeGroup}
               rightMetricProperty="covid_percentage"
               leftMetricProperty="age_group_percentage"
-              rightColor={'primary'}
-              leftColor={'neutral'}
+              rightColor={colors.primary}
+              leftColor={colors.neutral}
               maxDisplayValue={60}
               text={textShared.age_groups.graph}
               formatValue={(a: number) => `${formatPercentage(a * 100)}%`}
@@ -269,11 +192,7 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
             articles={content.monitorArticles}
           />
 
-          <DeceasedMonitorSection
-            data={dataCbs}
-            text={textShared.section_sterftemonitor}
-            showCauseMessage
-          />
+          <DeceasedMonitorSection data={dataCbs} text={textShared.section_sterftemonitor} showCauseMessage />
         </TileList>
       </NlLayout>
     </Layout>


### PR DESCRIPTION
# Summary

The bug in this ticket was regarding labels being cut off in the age demographic chart. This PR fixes that issue and also refactors some stuff and adjusts styling based on updated conventions.

### Before
![BEFORE](https://user-images.githubusercontent.com/116002914/208100877-35bfacf5-4cba-484c-982f-d70d21d7c75f.png)

### After
![AFTER](https://user-images.githubusercontent.com/116002914/208100898-99edad89-3a9f-420a-a4e0-fba78638d2f6.png)
