### PR TITLE
bugfix/COR-1242-labels-overlapping-on-smaller-screen-sizes-for-deaths-chart

### DIFF
--- a/packages/app/src/components/time-series-chart/components/axes.tsx
+++ b/packages/app/src/components/time-series-chart/components/axes.tsx
@@ -121,7 +121,7 @@ export const Axes = memo(function Axes<T extends TimestampedValue>({
   const formatYAxisPercentage: TickFormatter<NumberValue> = useCallback((y: NumberValue) => `${formatPercentage(y as number)}%`, [formatPercentage]);
 
   if (!isPresent(xTickNumber)) {
-    const preferredDateTicks: number = breakpoints.sm ? (timeframe === 'all' ? (hasDatesAsRange ? 6 : 4) : hasDatesAsRange ? 5 : 3) : hasDatesAsRange ? 3 : 2;
+    const preferredDateTicks: number = breakpoints.sm ? (timeframe === 'all' ? (hasDatesAsRange ? 4 : 6) : hasDatesAsRange ? 3 : 5) : hasDatesAsRange ? 2 : 3;
     const fullDaysInDomain = Math.floor((endUnix - startUnix) / 86400);
     xTickNumber = Math.max(Math.min(fullDaysInDomain, preferredDateTicks), 2);
   }


### PR DESCRIPTION
## Summary

* updated `preferredDateTicks` logic to present less ticks when date ranges are used, essentially flipping the amount of ticks to be presented based on the existing `hasDatesAsRange` boolean value

### Motivation
In my opinion, it does not make sense to present _more_ ticks for the TimeSeriesChart's `Axes` component when the values have date ranges. Date ranges, essentially, are longer because they include two dates, two months and optionally one or two years. Showing more ticks while there is theoretically less space, does not work well. Now, the conditions are inverted to only show more ticks where there is actually space for them.

### Screenshot
#### Before
<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208452899-f8819d24-3dbc-4578-b930-dfe12e86ee79.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208453307-60351cc3-0a5c-4692-b597-1d01219d0d53.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208453374-a5a81b63-29b5-4ded-b215-f484adce2f11.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208483086-1b85df10-f85a-46f2-8b3b-979eb1f3236c.png">


#### After
<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208453604-7b869086-bd5e-4bdf-867c-f3df40bb4c0e.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208453736-e7ab3e12-25ca-43d2-b4e8-5a6b6d3effb9.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208453877-d358268b-4475-44f1-aa24-0e25cbf11531.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208483012-8ae669c3-ef0f-410e-8314-df446e39cce1.png">

<img width="650" alt="image" src="https://user-images.githubusercontent.com/107395524/208483187-efe4d527-3e34-467b-ad7c-22234fefc377.png">