### PR TITLE
bugfix/COR-1239-adjust-choropleth-tooltip-width

### DIFF
--- a/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
+++ b/packages/app/src/components/choropleth/tooltips/tooltip-content.tsx
@@ -3,7 +3,7 @@ import { ChevronRight, Location } from '@corona-dashboard/icons';
 import { MouseEventHandler, ReactNode } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
-import { InlineText, Text } from '~/components/typography';
+import { Text } from '~/components/typography';
 import { space } from '~/style/theme';
 import { useIsTouchDevice } from '~/utils/use-is-touch-device';
 
@@ -19,12 +19,8 @@ export const TooltipContent = ({ title, link, children }: TooltipContentProps) =
   return (
     <StyledTooltipContent as={link ? 'a' : 'div'} href={link ? link : undefined} isInteractive={isTouch} aria-live="polite">
       <StyledTooltipHeader>
-        <Text variant="choroplethTooltipHeader">
-          <StyledLocationIcon>
-            <Location />
-          </StyledLocationIcon>
-          {title}
-        </Text>
+        <LocationIcon />
+        <Text variant="choroplethTooltipHeader">{title}</Text>
         {link && <StyledChevronRight />}
       </StyledTooltipHeader>
 
@@ -52,7 +48,6 @@ const StyledTooltipHeader = styled(Box)`
   display: flex;
   justify-content: space-between;
   padding: ${space[2]} ${space[3]};
-  white-space: nowrap;
 `;
 
 const StyledChevronRight = styled(ChevronRight)`
@@ -66,14 +61,9 @@ const StyledTooltipInfo = styled(Box)`
   padding: ${space[2]} ${space[3]};
 `;
 
-const StyledLocationIcon = styled(InlineText)`
-  color: ${colors.black};
-  margin-right: ${space[2]};
-  white-space: nowrap;
-
-  svg {
-    height: 18px;
-    padding-top: 3px;
-    width: 18px;
-  }
+const LocationIcon = styled(Location)`
+  fill: ${colors.black};
+  height: 18px;
+  max-width: 18px;
+  min-width: 18px;
 `;

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -114,8 +114,7 @@ export const nestedHtml = {
    * Apply some special margin styles to "stick" headings to their content.
    */
   'h1, h2, h3, h4, h5, h6': {
-    marginTop: space[4],
-    marginBottom: -space[2],
+    margin: `${space[4]} 0 ${-space[2]}`,
   },
 };
 

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -106,8 +106,8 @@ export const nestedHtml = {
 
   strong: { fontWeight: fontWeights.bold },
   em: { fontStyle: 'italic' },
-  ul: { ml: space[4] },
-  ol: { ml: space[4] },
+  ul: { marginLeft: space[4] },
+  ol: { marginLeft: space[4] },
   a: { textDecoration: 'underline' },
 
   /**

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -115,7 +115,7 @@ export const nestedHtml = {
    */
   'h1, h2, h3, h4, h5, h6': {
     mt: space[4],
-    mb: -2,
+    mb: -space[2],
   },
 };
 

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -1,5 +1,6 @@
+import { colors } from '@corona-dashboard/common';
 import { spacingStyle } from './functions/spacing';
-import { space } from './theme';
+import { fontSizes, fontWeights, lineHeights, space } from './theme';
 import { asResponsiveArray } from './utils';
 
 export type Preset = typeof preset;
@@ -7,88 +8,88 @@ export type Preset = typeof preset;
 export const preset = {
   typography: {
     h1: {
-      fontSize: asResponsiveArray({ _: 8, md: 9 }),
-      lineHeight: 0,
-      fontWeight: 'bold',
+      fontSize: asResponsiveArray({ _: fontSizes[8], md: fontSizes[9] }),
+      lineHeight: lineHeights[0],
+      fontWeight: fontWeights.bold,
     },
     h2: {
-      fontSize: asResponsiveArray({ _: 6, md: 7 }),
-      lineHeight: 1,
-      fontWeight: 'bold',
+      fontSize: asResponsiveArray({ _: fontSizes[6], md: fontSizes[7] }),
+      lineHeight: lineHeights[1],
+      fontWeight: fontWeights.bold,
     },
     h3: {
-      fontSize: asResponsiveArray({ _: 5, md: 6 }),
-      lineHeight: 1,
-      fontWeight: 'bold',
+      fontSize: asResponsiveArray({ _: fontSizes[5], md: fontSizes[6] }),
+      lineHeight: lineHeights[1],
+      fontWeight: fontWeights.bold,
     },
     h4: {
-      fontSize: asResponsiveArray({ _: 3, md: 4 }),
-      lineHeight: 1,
-      fontWeight: 'bold',
+      fontSize: asResponsiveArray({ _: fontSizes[3], md: fontSizes[4] }),
+      lineHeight: lineHeights[1],
+      fontWeight: fontWeights.bold,
     },
     h5: {
-      fontSize: 2,
-      lineHeight: 1,
-      fontWeight: 'bold',
+      fontSize: fontSizes[2],
+      lineHeight: lineHeights[1],
+      fontWeight: fontWeights.bold,
     },
     subtitle1: {
-      fontSize: 2,
-      lineHeight: 2,
-      fontWeight: 'bold',
+      fontSize: fontSizes[2],
+      lineHeight: lineHeights[2],
+      fontWeight: fontWeights.bold,
     },
     subtitle2: {
-      fontSize: 2,
-      lineHeight: 2,
-      fontWeight: 'bold',
-      color: 'gray6',
+      fontSize: fontSizes[2],
+      lineHeight: lineHeights[2],
+      fontWeight: fontWeights.bold,
+      color: colors.gray6,
     },
     body1: {
-      fontSize: 3,
+      fontSize: fontSizes[3],
     },
     body2: {
       /** body2 is the default body styling */
-      fontSize: 2,
-      lineHeight: 2,
+      fontSize: fontSizes[2],
+      lineHeight: lineHeights[2],
     },
     button1: {
-      fontSize: 3,
+      fontSize: fontSizes[3],
     },
     button2: {
-      fontSize: 2,
+      fontSize: fontSizes[2],
     },
     button3: {
-      fontSize: 1,
+      fontSize: fontSizes[1],
     },
     overline1: {
-      fontSize: asResponsiveArray({ _: 3, md: 6 }),
+      fontSize: asResponsiveArray({ _: fontSizes[3], md: fontSizes[6] }),
     },
     overline2: {
-      fontSize: 0,
-      fontWeight: 'bold',
+      fontSize: fontSizes[0],
+      fontWeight: fontWeights.bold,
       textTransform: 'uppercase',
       letterSpacing: '0.05em',
     },
     label1: {
-      fontSize: 1,
-      lineHeight: 1,
+      fontSize: fontSizes[1],
+      lineHeight: lineHeights[1],
     },
     label2: {
-      fontSize: 0,
-      lineHeight: 1,
+      fontSize: fontSizes[0],
+      lineHeight: lineHeights[1],
     },
     datadriven: {
-      fontSize: asResponsiveArray({ _: 3, md: 5 }),
+      fontSize: asResponsiveArray({ _: fontSizes[3], md: fontSizes[5] }),
     },
     choroplethTooltipHeader: {
       flex: 1,
-      fontSize: asResponsiveArray({ _: 5, md: 6 }),
-      lineHeight: 1,
-      fontWeight: 'bold',
+      fontSize: asResponsiveArray({ _: fontSizes[5], md: fontSizes[6] }),
+      lineHeight: lineHeights[1],
+      fontWeight: fontWeights.bold,
       marginInline: space[2],
       overflow: 'hidden',
     },
     loaderText: {
-      lineHeight: 1,
+      lineHeight: lineHeights[1],
     },
   },
 } as const;
@@ -103,17 +104,17 @@ export const nestedHtml = {
   h4: preset.typography.h4,
   h5: preset.typography.h5,
 
-  strong: { fontWeight: 'bold' },
+  strong: { fontWeight: fontWeights.bold },
   em: { fontStyle: 'italic' },
-  ul: { ml: 4 },
-  ol: { ml: 4 },
+  ul: { ml: space[4] },
+  ol: { ml: space[4] },
   a: { textDecoration: 'underline' },
 
   /**
    * Apply some special margin styles to "stick" headings to their content.
    */
   'h1, h2, h3, h4, h5, h6': {
-    mt: 4,
+    mt: space[4],
     mb: -2,
   },
 };

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -1,4 +1,5 @@
 import { spacingStyle } from './functions/spacing';
+import { space } from './theme';
 import { asResponsiveArray } from './utils';
 
 export type Preset = typeof preset;
@@ -79,12 +80,12 @@ export const preset = {
       fontSize: asResponsiveArray({ _: 3, md: 5 }),
     },
     choroplethTooltipHeader: {
+      flex: 1,
       fontSize: asResponsiveArray({ _: 5, md: 6 }),
       lineHeight: 1,
       fontWeight: 'bold',
+      marginInline: space[2],
       overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      mt: 0,
     },
     loaderText: {
       lineHeight: 1,

--- a/packages/app/src/style/preset.ts
+++ b/packages/app/src/style/preset.ts
@@ -114,8 +114,8 @@ export const nestedHtml = {
    * Apply some special margin styles to "stick" headings to their content.
    */
   'h1, h2, h3, h4, h5, h6': {
-    mt: space[4],
-    mb: -space[2],
+    marginTop: space[4],
+    marginBottom: -space[2],
   },
 };
 

--- a/packages/app/src/style/theme.ts
+++ b/packages/app/src/style/theme.ts
@@ -47,7 +47,7 @@ export const fontWeights = {
   heavy: 700,
 } as const;
 
-const lineHeights = [1.2, 1.3, 1.5] as const;
+export const lineHeights = [1.2, 1.3, 1.5] as const;
 
 /**
  * Breakpoints used in original code and their em equivalent


### PR DESCRIPTION
# Summary

This ticket is regarding an issue with Choropleth tooltips. Certain safety regions and municipalities have names which are longer than others, thereby causing the tooltip for that area to be wider than names which are shorter. This created a visual inconsistency which has been fixed in this PR along with some minor refactoring.

Note: This PR addresses the issue in COR-1239, however the fix also covers the issue described in COR-1276. 

### Before - Regular Choropleth, Municipality
![image](https://user-images.githubusercontent.com/116002914/208622181-d2d7261c-a0a3-47d2-b6dc-1e6c32a29ecf.png)

### After - Regular Choropleth, Municipality
![image](https://user-images.githubusercontent.com/116002914/208622540-65e5adb8-d5bc-431f-8fa8-93879ee3ed07.png)

### Before - Regular Choropleth, Safety Region
![image](https://user-images.githubusercontent.com/116002914/208622405-af6f723e-1037-4df6-98a9-de669170dc2e.png)

### After - Regular Choropleth, Safety Region
![image](https://user-images.githubusercontent.com/116002914/208622688-edb9042a-83a8-4d32-84aa-d2b8ad3f2c59.png)

### Before - Municipality selection Choropleth
![image](https://user-images.githubusercontent.com/116002914/208622836-7a90289c-9d6f-4e09-a846-c4490a9f5837.png)

### After - Municipality selection Choropleth
![image](https://user-images.githubusercontent.com/116002914/208622911-2c954399-036d-4fe8-a7a6-5532c931b5ff.png)

### Before - Safety region selection Choropleth
![image](https://user-images.githubusercontent.com/116002914/208623016-a28f5c96-da40-45f4-8770-dd93c43e6ee3.png)

### After - Safety region selection Choropleth
![image](https://user-images.githubusercontent.com/116002914/208623167-20226801-793f-47d5-952b-c01c720c5948.png)
