### PR TITLE
feature/COR-1269-time-series-chart-y-axis-scaling

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/scales.ts
+++ b/packages/app/src/components/time-series-chart/logic/scales.ts
@@ -1,11 +1,4 @@
-import {
-  assert,
-  DateSpanValue,
-  DAY_IN_SECONDS,
-  isDateSeries,
-  isDateSpanSeries,
-  TimestampedValue,
-} from '@corona-dashboard/common';
+import { assert, DateSpanValue, DAY_IN_SECONDS, isDateSeries, isDateSpanSeries, TimestampedValue } from '@corona-dashboard/common';
 import { scaleLinear } from '@visx/scale';
 import { ScaleLinear } from 'd3-scale';
 import { first, isEmpty, last } from 'lodash';
@@ -31,28 +24,14 @@ interface UseScalesResult {
   hasAllZeroValues: boolean;
 }
 
-export function useScales<T extends TimestampedValue>(args: {
-  values: T[];
-  maximumValue: number;
-  minimumValue: number;
-  bounds: Bounds;
-  numTicks: number;
-  minimumRange?: number;
-}): UseScalesResult {
+export function useScales<T extends TimestampedValue>(args: { values: T[]; maximumValue: number; minimumValue: number; bounds: Bounds; numTicks: number }): UseScalesResult {
   const today = useCurrentDate();
-  const {
-    maximumValue,
-    minimumValue,
-    bounds,
-    numTicks,
-    values,
-    minimumRange = 10,
-  } = args;
+  const { maximumValue, minimumValue, bounds, numTicks, values } = args;
 
   return useMemo(() => {
     const [start, end] = getTimeDomain({ values, today, withPadding: true });
     const yMin = Math.min(minimumValue, 0);
-    const yMax = Math.max(maximumValue, minimumRange);
+    const yMax = Math.max(maximumValue, 0);
 
     if (isEmpty(values)) {
       return {
@@ -104,16 +83,7 @@ export function useScales<T extends TimestampedValue>(args: {
     };
 
     return result;
-  }, [
-    values,
-    today,
-    minimumValue,
-    maximumValue,
-    bounds.width,
-    bounds.height,
-    numTicks,
-    minimumRange,
-  ]);
+  }, [values, today, minimumValue, maximumValue, bounds.width, bounds.height, numTicks]);
 }
 
 /**
@@ -126,15 +96,7 @@ export function useScales<T extends TimestampedValue>(args: {
  * series starts and where the last series ends, and that would remove all
  * "empty" space on both ends of the chart.
  */
-export function getTimeDomain<T extends TimestampedValue>({
-  values,
-  today,
-  withPadding,
-}: {
-  values: T[];
-  today: Date;
-  withPadding: boolean;
-}): [start: number, end: number] {
+export function getTimeDomain<T extends TimestampedValue>({ values, today, withPadding }: { values: T[]; today: Date; withPadding: boolean }): [start: number, end: number] {
   /**
    * Return a sensible default when no values fall within the selected timeframe
    */
@@ -150,34 +112,24 @@ export function getTimeDomain<T extends TimestampedValue>({
   if (isDateSeries(values)) {
     const start = first(values)?.date_unix;
     const end = last(values)?.date_unix;
-    assert(
-      isDefined(start) && isDefined(end),
-      `[${getTimeDomain.name}] Missing start or end timestamp in [${start}, ${end}]`
-    );
+    assert(isDefined(start) && isDefined(end), `[${getTimeDomain.name}] Missing start or end timestamp in [${start}, ${end}]`);
 
     /**
      * In cases where we render daily data, it is probably good to add a bit of
      * time scale "padding" so that the markers and their date span fall nicely
      * within the "stretched" domain on both ends of the graph.
      */
-    return withPadding
-      ? [start - DAY_IN_SECONDS / 2, end + DAY_IN_SECONDS / 2]
-      : [start, end];
+    return withPadding ? [start - DAY_IN_SECONDS / 2, end + DAY_IN_SECONDS / 2] : [start, end];
   }
 
   if (isDateSpanSeries(values)) {
     const start = first(values)?.date_start_unix;
     const end = last(values)?.date_end_unix;
-    assert(
-      isDefined(start) && isDefined(end),
-      `[${getTimeDomain.name}] Missing start or end timestamp in [${start}, ${end}]`
-    );
+    assert(isDefined(start) && isDefined(end), `[${getTimeDomain.name}] Missing start or end timestamp in [${start}, ${end}]`);
     return [start, end];
   }
 
-  throw new Error(
-    `Invalid timestamped values, shaped like: ${JSON.stringify(values[0])}`
-  );
+  throw new Error(`Invalid timestamped values, shaped like: ${JSON.stringify(values[0])}`);
 }
 
 /**
@@ -188,22 +140,14 @@ export function getTimeDomain<T extends TimestampedValue>({
  * It also assumes that if we use date_unix it always means one day worth of
  * data.
  */
-function getDateSpanWidth<T extends TimestampedValue>(
-  values: T[],
-  xScale: ScaleLinear<number, number>
-) {
+function getDateSpanWidth<T extends TimestampedValue>(values: T[], xScale: ScaleLinear<number, number>) {
   if (isDateSeries(values)) {
     return xScale(DAY_IN_SECONDS) - xScale(0);
   }
 
   if (isDateSpanSeries(values)) {
-    return (
-      xScale((values[0] as DateSpanValue).date_end_unix) -
-      xScale((values[0] as DateSpanValue).date_start_unix)
-    );
+    return xScale((values[0] as DateSpanValue).date_end_unix) - xScale((values[0] as DateSpanValue).date_start_unix);
   }
 
-  throw new Error(
-    `Invalid timestamped values, shaped like: ${JSON.stringify(values[0])}`
-  );
+  throw new Error(`Invalid timestamped values, shaped like: ${JSON.stringify(values[0])}`);
 }

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -1,10 +1,4 @@
-import {
-  getValuesInTimeframe,
-  isDateSeries,
-  isDateSpanSeries,
-  TimeframeOption,
-  TimestampedValue,
-} from '@corona-dashboard/common';
+import { getValuesInTimeframe, isDateSeries, isDateSpanSeries, TimeframeOption, TimestampedValue } from '@corona-dashboard/common';
 import { Property } from 'csstype';
 import { omit } from 'lodash';
 import { useMemo } from 'react';
@@ -56,10 +50,6 @@ interface SeriesCommonDefinition {
    */
   noMarker?: boolean;
   /**
-   * Specifies a different minimum range than the default for this series.
-   */
-  minimumRange?: number;
-  /**
    * Hide this series in the legend (because it is shown in a custom
    * legend, for example)
    */
@@ -73,8 +63,7 @@ interface SeriesCommonDefinition {
   yAxisExceptionValues?: number[];
 }
 
-export interface GappedLineSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface GappedLineSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'gapped-line';
   metricProperty: keyof T;
   label: string;
@@ -85,8 +74,7 @@ export interface GappedLineSeriesDefinition<T extends TimestampedValue>
   curve?: 'linear' | 'step';
 }
 
-export interface LineSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface LineSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'line';
   metricProperty: keyof T;
   label: string;
@@ -97,8 +85,7 @@ export interface LineSeriesDefinition<T extends TimestampedValue>
   curve?: 'linear' | 'step';
 }
 
-export interface ScatterPlotSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface ScatterPlotSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'scatter-plot';
   metricProperty: keyof T;
   label: string;
@@ -106,8 +93,7 @@ export interface ScatterPlotSeriesDefinition<T extends TimestampedValue>
   color: string;
 }
 
-export interface AreaSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface AreaSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'area';
   metricProperty: keyof T;
   label: string;
@@ -118,8 +104,7 @@ export interface AreaSeriesDefinition<T extends TimestampedValue>
   curve?: 'linear' | 'step';
 }
 
-export interface GappedAreaSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface GappedAreaSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'gapped-area';
   metricProperty: keyof T;
   label: string;
@@ -130,8 +115,7 @@ export interface GappedAreaSeriesDefinition<T extends TimestampedValue>
   curve?: 'linear' | 'step';
 }
 
-export interface BarSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface BarSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'bar';
   metricProperty: keyof T;
   label: string;
@@ -140,8 +124,7 @@ export interface BarSeriesDefinition<T extends TimestampedValue>
   fillOpacity?: number;
 }
 
-export interface BarOutOfBoundsSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface BarOutOfBoundsSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'bar-out-of-bounds';
   metricProperty: keyof T;
   label: string;
@@ -150,8 +133,7 @@ export interface BarOutOfBoundsSeriesDefinition<T extends TimestampedValue>
   outOfBoundsDates?: number[];
 }
 
-export interface SplitBarSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface SplitBarSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'split-bar';
   metricProperty: keyof T;
   label: string;
@@ -160,8 +142,7 @@ export interface SplitBarSeriesDefinition<T extends TimestampedValue>
   splitPoints: SplitPoint[];
 }
 
-export interface RangeSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface RangeSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'range';
   metricPropertyLow: keyof T;
   metricPropertyHigh: keyof T;
@@ -172,8 +153,7 @@ export interface RangeSeriesDefinition<T extends TimestampedValue>
   fillOpacity?: number;
 }
 
-export interface StackedAreaSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface StackedAreaSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'stacked-area';
   metricProperty: keyof T;
   label: string;
@@ -185,8 +165,7 @@ export interface StackedAreaSeriesDefinition<T extends TimestampedValue>
   mixBlendMode?: Property.MixBlendMode;
 }
 
-export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'gapped-stacked-area';
   metricProperty: keyof T;
   label: string;
@@ -207,8 +186,7 @@ export interface GappedStackedAreaSeriesDefinition<T extends TimestampedValue>
  * If the amount of changes for the chart are limited we could maybe merge it in
  * completely.
  */
-export interface SplitAreaSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface SplitAreaSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'split-area';
   metricProperty: keyof T;
   label: string;
@@ -227,8 +205,7 @@ export interface SplitAreaSeriesDefinition<T extends TimestampedValue>
  * This can be used for example to show a total count at the bottom, or the
  * percentage counterpart of an absolute value.
  */
-export interface InvisibleSeriesDefinition<T extends TimestampedValue>
-  extends SeriesCommonDefinition {
+export interface InvisibleSeriesDefinition<T extends TimestampedValue> extends SeriesCommonDefinition {
   type: 'invisible';
   metricProperty: keyof T;
   label: string;
@@ -251,34 +228,17 @@ type CutValuesConfig = {
  * present in the chart. This is a reverse type guard that you can use in a
  * filter and TS will understand what comes after is only the others.
  */
-export function isVisible<T extends TimestampedValue>(
-  def: SeriesConfig<T>[number]
-): def is Exclude<typeof def, InvisibleSeriesDefinition<T>> {
+export function isVisible<T extends TimestampedValue>(def: SeriesConfig<T>[number]): def is Exclude<typeof def, InvisibleSeriesDefinition<T>> {
   return def.type !== 'invisible';
 }
 
-export function useSeriesList<T extends TimestampedValue>(
-  values: T[],
-  seriesConfig: SeriesConfig<T>,
-  cutValuesConfig?: CutValuesConfig[],
-  dataOptions?: DataOptions
-) {
-  return useMemo(
-    () => getSeriesList(values, seriesConfig, cutValuesConfig, dataOptions),
-    [values, seriesConfig, cutValuesConfig, dataOptions]
-  );
+export function useSeriesList<T extends TimestampedValue>(values: T[], seriesConfig: SeriesConfig<T>, cutValuesConfig?: CutValuesConfig[], dataOptions?: DataOptions) {
+  return useMemo(() => getSeriesList(values, seriesConfig, cutValuesConfig, dataOptions), [values, seriesConfig, cutValuesConfig, dataOptions]);
 }
 
-export function useValuesInTimeframe<T extends TimestampedValue>(
-  values: T[],
-  timeframe: TimeframeOption,
-  endDate?: Date
-) {
+export function useValuesInTimeframe<T extends TimestampedValue>(values: T[], timeframe: TimeframeOption, endDate?: Date) {
   const today = useCurrentDate();
-  return useMemo(
-    () => getValuesInTimeframe(values, timeframe, endDate ?? today),
-    [values, timeframe, endDate, today]
-  );
+  return useMemo(() => getValuesInTimeframe(values, timeframe, endDate ?? today), [values, timeframe, endDate, today]);
 }
 
 /**
@@ -287,15 +247,8 @@ export function useValuesInTimeframe<T extends TimestampedValue>(
  * render lines, so that the axis scales with whatever key contains the highest
  * values.
  */
-export function calculateSeriesMaximum<T extends TimestampedValue>(
-  seriesList: SeriesList,
-  seriesConfig: SeriesConfig<T>,
-  benchmarkValue = -Infinity
-) {
-  const filterSeries = (
-    seriesConfig: SeriesConfigSingle<T>,
-    series: SeriesValue[]
-  ): SeriesValue[] => {
+export function calculateSeriesMaximum<T extends TimestampedValue>(seriesList: SeriesList, seriesConfig: SeriesConfig<T>, benchmarkValue = -Infinity) {
+  const filterSeries = (seriesConfig: SeriesConfigSingle<T>, series: SeriesValue[]): SeriesValue[] => {
     const yAxisExceptionValues = seriesConfig.yAxisExceptionValues;
     if (!yAxisExceptionValues || yAxisExceptionValues.length === 0) {
       return series;
@@ -309,26 +262,17 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
         // Because the frontend application is serverside rendered, 'the middle of the day' depends on the locale settings of the server.
         // Despite having the actual backend data, we can't reliably know what the middle of the day will be. (don't start on daylight saving time)
         // This is circumvented by only looking at the day itself, ignoring the time-part, and assuming that will not match too broadly.
-        return (
-          new Date(exceptionValue * 1000).toDateString() ===
-          new Date(value.__date_unix * 1000).toDateString()
-        );
+        return new Date(exceptionValue * 1000).toDateString() === new Date(value.__date_unix * 1000).toDateString();
       });
     });
   };
 
-  const filteredSeriesList = seriesList.map((series, index) =>
-    filterSeries(seriesConfig[index], series)
-  );
+  const filteredSeriesList = seriesList.map((series, index) => filterSeries(seriesConfig[index], series));
 
   const values = filteredSeriesList
     .filter((_, index) => isVisible(seriesConfig[index]))
     .flatMap((series) =>
-      series.flatMap((seriesItem: SeriesSingleValue | SeriesDoubleValue) =>
-        isSeriesSingleValue(seriesItem)
-          ? seriesItem.__value
-          : [seriesItem.__value_a, seriesItem.__value_b]
-      )
+      series.flatMap((seriesItem: SeriesSingleValue | SeriesDoubleValue) => (isSeriesSingleValue(seriesItem) ? seriesItem.__value : [seriesItem.__value_a, seriesItem.__value_b]))
     )
     .filter(isDefined);
 
@@ -339,8 +283,7 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
    * sure the signaalwaarde floats in the middle
    */
 
-  const artificialMax =
-    overallMaximum < benchmarkValue ? benchmarkValue * 2 : 0;
+  const artificialMax = overallMaximum < benchmarkValue ? benchmarkValue * 2 : 0;
 
   const maximumValue = Math.max(overallMaximum, artificialMax);
 
@@ -352,26 +295,15 @@ export function calculateSeriesMaximum<T extends TimestampedValue>(
  * scale the y-axis. We need to do this for each of the keys that are used to
  * render lines, so that the axis scales with whatever key contains the lowest.
  */
-export function calculateSeriesMinimum<T extends TimestampedValue>(
-  seriesList: SeriesList,
-  seriesConfig: SeriesConfig<T>,
-  benchmarkValue = -Infinity
-) {
+export function calculateSeriesMinimum<T extends TimestampedValue>(seriesList: SeriesList, seriesConfig: SeriesConfig<T>, benchmarkValue = -Infinity) {
   const values = seriesList
     .filter((_, index) => isVisible(seriesConfig[index]))
-    .flatMap((series) =>
-      series.flatMap((x: SeriesSingleValue | SeriesDoubleValue) =>
-        isSeriesSingleValue(x) ? x.__value : [x.__value_a, x.__value_b]
-      )
-    )
+    .flatMap((series) => series.flatMap((x: SeriesSingleValue | SeriesDoubleValue) => (isSeriesSingleValue(x) ? x.__value : [x.__value_a, x.__value_b])))
     .filter(isDefined);
 
   const overallMinimum = Math.min(...values);
 
-  const artificialMin =
-    overallMinimum > benchmarkValue
-      ? benchmarkValue - Math.abs(benchmarkValue)
-      : 0;
+  const artificialMin = overallMinimum > benchmarkValue ? benchmarkValue - Math.abs(benchmarkValue) : 0;
 
   const minimumValue = Math.max(overallMinimum, artificialMin);
 
@@ -392,21 +324,15 @@ export interface SeriesDoubleValue extends SeriesItem {
   __value_b?: number;
 }
 
-export function isBarOutOfBounds<T extends TimestampedValue>(
-  value: SeriesConfigSingle<T>
-): value is BarOutOfBoundsSeriesDefinition<T> {
+export function isBarOutOfBounds<T extends TimestampedValue>(value: SeriesConfigSingle<T>): value is BarOutOfBoundsSeriesDefinition<T> {
   return isDefined((value as any).outOfBoundsDates);
 }
 
-export function isSeriesSingleValue(
-  value: SeriesValue
-): value is SeriesSingleValue {
+export function isSeriesSingleValue(value: SeriesValue): value is SeriesSingleValue {
   return isDefined((value as any).__value);
 }
 
-export function isSeriesMissingValue(
-  value: SeriesValue
-): value is SeriesMissingValue {
+export function isSeriesMissingValue(value: SeriesValue): value is SeriesMissingValue {
   return isDefined(value) && isDefined((value as any).__hasMissing);
 }
 
@@ -416,34 +342,17 @@ export function isSeriesMissingValue(
  * with TimestampedValue as the LineChart because types got simplified in other
  * places.
  */
-export type SeriesValue =
-  | SeriesSingleValue
-  | SeriesDoubleValue
-  | SeriesMissingValue;
+export type SeriesValue = SeriesSingleValue | SeriesDoubleValue | SeriesMissingValue;
 export type SeriesList = SeriesValue[][];
 
-function getSeriesList<T extends TimestampedValue>(
-  values: T[],
-  seriesConfig: SeriesConfig<T>,
-  cutValuesConfig?: CutValuesConfig[],
-  dataOptions?: DataOptions
-): SeriesList {
+function getSeriesList<T extends TimestampedValue>(values: T[], seriesConfig: SeriesConfig<T>, cutValuesConfig?: CutValuesConfig[], dataOptions?: DataOptions): SeriesList {
   return seriesConfig.filter(isVisible).map((config) =>
     config.type === 'stacked-area'
       ? getStackedAreaSeriesData(values, config.metricProperty, seriesConfig)
       : config.type === 'gapped-stacked-area'
-      ? getGappedStackedAreaSeriesData(
-          values,
-          config.metricProperty,
-          seriesConfig,
-          dataOptions
-        )
+      ? getGappedStackedAreaSeriesData(values, config.metricProperty, seriesConfig, dataOptions)
       : config.type === 'range'
-      ? getRangeSeriesData(
-          values,
-          config.metricPropertyLow,
-          config.metricPropertyHigh
-        )
+      ? getRangeSeriesData(values, config.metricPropertyLow, config.metricPropertyHigh)
       : /**
          * Cutting values based on annotation is only supported for single line series
          */
@@ -451,34 +360,21 @@ function getSeriesList<T extends TimestampedValue>(
   );
 }
 
-function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
-  values: T[],
-  metricProperty: keyof T,
-  seriesConfig: SeriesConfig<T>,
-  dataOptions?: DataOptions
-) {
+function getGappedStackedAreaSeriesData<T extends TimestampedValue>(values: T[], metricProperty: keyof T, seriesConfig: SeriesConfig<T>, dataOptions?: DataOptions) {
   /**
    * Stacked area series are rendered from top to bottom. The sum of a Y-value
    * of all series below the current series equals the low value of a current
    * series's Y-value.
    */
-  const stackedAreaDefinitions = seriesConfig.filter(
-    hasValueAtKey('type', 'gapped-stacked-area' as const)
-  );
+  const stackedAreaDefinitions = seriesConfig.filter(hasValueAtKey('type', 'gapped-stacked-area' as const));
 
-  const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(
-    stackedAreaDefinitions,
-    metricProperty
-  );
+  const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(stackedAreaDefinitions, metricProperty);
 
   const seriesHigh = getSeriesData(values, metricProperty);
   const seriesLow = getSeriesData(values, metricProperty);
 
   seriesLow.forEach((seriesSingleValue, index) => {
-    if (
-      !dataOptions?.renderNullAsZero &&
-      !isPresent(seriesSingleValue.__value)
-    ) {
+    if (!dataOptions?.renderNullAsZero && !isPresent(seriesSingleValue.__value)) {
       return;
     }
 
@@ -487,20 +383,12 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
      * current series, we will sum up all values of the
      * `seriesBelowCurrentSeries`.
      */
-    seriesSingleValue.__value = sumSeriesValues(
-      seriesBelowCurrentSeries,
-      values,
-      index
-    );
+    seriesSingleValue.__value = sumSeriesValues(seriesBelowCurrentSeries, values, index);
   });
 
   return seriesLow.map((low, index) => {
     const valueLow = low.__value;
-    const valueHigh = isDefined(valueLow)
-      ? valueLow + (seriesHigh[index].__value ?? 0)
-      : dataOptions?.renderNullAsZero
-      ? 0
-      : undefined;
+    const valueHigh = isDefined(valueLow) ? valueLow + (seriesHigh[index].__value ?? 0) : dataOptions?.renderNullAsZero ? 0 : undefined;
 
     return {
       __date_unix: low.__date_unix,
@@ -510,11 +398,7 @@ function getGappedStackedAreaSeriesData<T extends TimestampedValue>(
   });
 }
 
-function sumSeriesValues<T extends TimestampedValue>(
-  seriesBelowCurrentSeries: { metricProperty: keyof T }[],
-  values: T[],
-  index: number
-): number | undefined {
+function sumSeriesValues<T extends TimestampedValue>(seriesBelowCurrentSeries: { metricProperty: keyof T }[], values: T[], index: number): number | undefined {
   return (
     seriesBelowCurrentSeries
       // for each serie we'll get the value of the current index
@@ -524,24 +408,15 @@ function sumSeriesValues<T extends TimestampedValue>(
   );
 }
 
-function getStackedAreaSeriesData<T extends TimestampedValue>(
-  values: T[],
-  metricProperty: keyof T,
-  seriesConfig: SeriesConfig<T>
-) {
+function getStackedAreaSeriesData<T extends TimestampedValue>(values: T[], metricProperty: keyof T, seriesConfig: SeriesConfig<T>) {
   /**
    * Stacked area series are rendered from top to bottom. The sum of a Y-value
    * of all series below the current series equals the low value of a current
    * series's Y-value.
    */
-  const stackedAreaDefinitions = seriesConfig.filter(
-    hasValueAtKey('type', 'stacked-area' as const)
-  );
+  const stackedAreaDefinitions = seriesConfig.filter(hasValueAtKey('type', 'stacked-area' as const));
 
-  const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(
-    stackedAreaDefinitions,
-    metricProperty
-  );
+  const seriesBelowCurrentSeries = getSeriesBelowCurrentSeries(stackedAreaDefinitions, metricProperty);
 
   const seriesHigh = getSeriesData(values, metricProperty);
   const seriesLow = getSeriesData(values, metricProperty);
@@ -552,11 +427,7 @@ function getStackedAreaSeriesData<T extends TimestampedValue>(
      * current series, we will sum up all values of the
      * `seriesBelowCurrentSeries`.
      */
-    seriesSingleValue.__value = sumSeriesValues(
-      seriesBelowCurrentSeries,
-      values,
-      index
-    );
+    seriesSingleValue.__value = sumSeriesValues(seriesBelowCurrentSeries, values, index);
   });
 
   return seriesLow.map((low, index) => {
@@ -571,20 +442,11 @@ function getStackedAreaSeriesData<T extends TimestampedValue>(
   });
 }
 
-function getSeriesBelowCurrentSeries<T extends TimestampedValue>(
-  definitions: { metricProperty: keyof T }[],
-  metricProperty: keyof T
-) {
-  return definitions.slice(
-    definitions.findIndex((x) => x.metricProperty === metricProperty) + 1
-  );
+function getSeriesBelowCurrentSeries<T extends TimestampedValue>(definitions: { metricProperty: keyof T }[], metricProperty: keyof T) {
+  return definitions.slice(definitions.findIndex((x) => x.metricProperty === metricProperty) + 1);
 }
 
-function getRangeSeriesData<T extends TimestampedValue>(
-  values: T[],
-  metricPropertyLow: keyof T,
-  metricPropertyHigh: keyof T
-): SeriesDoubleValue[] {
+function getRangeSeriesData<T extends TimestampedValue>(values: T[], metricPropertyLow: keyof T, metricPropertyHigh: keyof T): SeriesDoubleValue[] {
   const seriesLow = getSeriesData(values, metricPropertyLow);
   const seriesHigh = getSeriesData(values, metricPropertyHigh);
 
@@ -595,11 +457,7 @@ function getRangeSeriesData<T extends TimestampedValue>(
   }));
 }
 
-function getSeriesData<T extends TimestampedValue>(
-  values: T[],
-  metricProperty: keyof T,
-  cutValuesConfig?: CutValuesConfig[]
-): SeriesSingleValue[] {
+function getSeriesData<T extends TimestampedValue>(values: T[], metricProperty: keyof T, cutValuesConfig?: CutValuesConfig[]): SeriesSingleValue[] {
   if (values.length === 0) {
     /**
      * It could happen that you are using an old dataset and select last week as
@@ -609,9 +467,7 @@ function getSeriesData<T extends TimestampedValue>(
     return [];
   }
 
-  const activeCuts = cutValuesConfig?.filter((x) =>
-    x.metricProperties.includes(metricProperty as string)
-  );
+  const activeCuts = cutValuesConfig?.filter((x) => x.metricProperties.includes(metricProperty as string));
 
   if (isDateSeries(values)) {
     const uncutValues = values.map((x) => ({
@@ -651,21 +507,14 @@ function getSeriesData<T extends TimestampedValue>(
  * Cutting values means setting series item.__value to undefined. We still want
  * them to be fully qualified series items.
  */
-function cutValues(
-  values: SeriesSingleValue[],
-  cuts: { start: number; end: number }[]
-): SeriesSingleValue[] {
+function cutValues(values: SeriesSingleValue[], cuts: { start: number; end: number }[]): SeriesSingleValue[] {
   const result = [...values]; // clone because we will mutate this.
 
   for (const cut of cuts) {
     /**
      * By passing result as the values, we incrementally mutate the input array
      */
-    const [startIndex, endIndex] = getCutIndexStartEnd(
-      result,
-      cut.start,
-      cut.end
-    );
+    const [startIndex, endIndex] = getCutIndexStartEnd(result, cut.start, cut.end);
 
     clearValues(result, startIndex, endIndex);
   }
@@ -677,14 +526,8 @@ function cutValues(
  * Figure out the position and length of the cut to be applied to the values
  * array, based on start/end timestamps
  */
-function getCutIndexStartEnd(
-  values: SeriesSingleValue[],
-  start: number,
-  end: number
-) {
-  const startIndex = values.findIndex(
-    (x) => x.__date_unix >= start && x.__date_unix < end
-  );
+function getCutIndexStartEnd(values: SeriesSingleValue[], start: number, end: number) {
+  const startIndex = values.findIndex((x) => x.__date_unix >= start && x.__date_unix < end);
 
   if (startIndex === -1) {
     /**
@@ -713,9 +556,7 @@ function getCutIndexStartEnd(
  * We could just pass down the full annotations type but that would create a bit
  * of an odd dependency between two mostly independent concepts.
  */
-export function extractCutValuesConfig(
-  timespanAnnotations?: TimespanAnnotationConfig[]
-) {
+export function extractCutValuesConfig(timespanAnnotations?: TimespanAnnotationConfig[]) {
   return timespanAnnotations
     ?.map((x) =>
       x.cutValuesForMetricProperties
@@ -729,11 +570,7 @@ export function extractCutValuesConfig(
     .filter(isDefined);
 }
 
-function clearValues(
-  values: SeriesSingleValue[],
-  startIndex: number,
-  endIndex: number
-) {
+function clearValues(values: SeriesSingleValue[], startIndex: number, endIndex: number) {
   for (let index = startIndex; index <= endIndex; ++index) {
     const originalValue = values[index];
 
@@ -744,10 +581,7 @@ function clearValues(
   }
 }
 
-export function omitValuePropertiesForAnnotation<T extends TimestampedValue>(
-  value: T,
-  timespan: TimespanAnnotationConfig
-) {
+export function omitValuePropertiesForAnnotation<T extends TimestampedValue>(value: T, timespan: TimespanAnnotationConfig) {
   if (timespan.cutValuesForMetricProperties) {
     return omit(value, timespan.cutValuesForMetricProperties) as T;
   } else {

--- a/packages/app/src/components/time-series-chart/time-series-chart.tsx
+++ b/packages/app/src/components/time-series-chart/time-series-chart.tsx
@@ -11,10 +11,7 @@ import { Legend } from '~/components/legend';
 import { ValueAnnotation } from '~/components/value-annotation';
 import { useIntl } from '~/intl';
 import { useCurrentDate } from '~/utils/current-date-context';
-import {
-  AccessibilityDefinition,
-  addAccessibilityFeatures,
-} from '~/utils/use-accessibility-annotations';
+import { AccessibilityDefinition, addAccessibilityFeatures } from '~/utils/use-accessibility-annotations';
 import { useOnClickOutside } from '~/utils/use-on-click-outside';
 import { useResponsiveContainer } from '~/utils/use-responsive-container';
 import { useTabInteractiveButton } from '~/utils/use-tab-interactive-button';
@@ -82,10 +79,7 @@ export type { SeriesConfig } from './logic';
  * to see if we can use the date_unix timestamps from the data directly
  * everywhere without unnecessary conversion to and from Date objects.
  */
-export type TimeSeriesChartProps<
-  T extends TimestampedValue,
-  C extends SeriesConfig<T>
-> = {
+export type TimeSeriesChartProps<T extends TimestampedValue, C extends SeriesConfig<T>> = {
   /**
    * The mandatory AccessibilityDefinition provides a reference to annotate the
    * graph with a label and description.
@@ -154,10 +148,7 @@ export type TimeSeriesChartProps<
   isYAxisCollapsed?: boolean;
 };
 
-export function TimeSeriesChart<
-  T extends TimestampedValue,
-  C extends SeriesConfig<T>
->({
+export function TimeSeriesChart<T extends TimestampedValue, C extends SeriesConfig<T>>({
   accessibility,
   values: allValues,
   endDate,
@@ -183,34 +174,14 @@ export function TimeSeriesChart<
 }: TimeSeriesChartProps<T, C>) {
   const { commonTexts } = useIntl();
 
-  const {
-    tooltipData,
-    tooltipLeft = 0,
-    tooltipTop = 0,
-    showTooltip,
-    hideTooltip,
-    tooltipOpen,
-  } = useTooltip<TooltipData<T>>();
+  const { tooltipData, tooltipLeft = 0, tooltipTop = 0, showTooltip, hideTooltip, tooltipOpen } = useTooltip<TooltipData<T>>();
 
   const today = useCurrentDate();
   const chartId = useUniqueId();
 
-  const {
-    valueAnnotation,
-    isPercentage,
-    forcedMaximumValue,
-    benchmark,
-    timespanAnnotations,
-    timeAnnotations,
-    timelineEvents,
-  } = dataOptions || {};
+  const { valueAnnotation, isPercentage, forcedMaximumValue, benchmark, timespanAnnotations, timeAnnotations, timelineEvents } = dataOptions || {};
 
-  const {
-    ResponsiveContainer,
-    ref: containerRef,
-    width,
-    height,
-  } = useResponsiveContainer(initialWidth, minHeight);
+  const { ResponsiveContainer, ref: containerRef, width, height } = useResponsiveContainer(initialWidth, minHeight);
 
   const { padding, bounds, leftPaddingRef } = useDimensions({
     width,
@@ -221,62 +192,29 @@ export function TimeSeriesChart<
 
   const values = useValuesInTimeframe(allValues, timeframe, endDate);
 
-  const cutValuesConfig = useMemo(
-    () => extractCutValuesConfig(timespanAnnotations),
-    [timespanAnnotations]
-  );
+  const cutValuesConfig = useMemo(() => extractCutValuesConfig(timespanAnnotations), [timespanAnnotations]);
 
-  const seriesList = useSeriesList(
-    values,
-    seriesConfig,
-    cutValuesConfig,
-    dataOptions
-  );
+  const seriesList = useSeriesList(values, seriesConfig, cutValuesConfig, dataOptions);
 
   /**
    * The maximum is calculated over all values, because you don't want the
    * y-axis scaling to change when toggling the timeframe setting.
    */
   const [calculatedSeriesMin, calculatedSeriesMax] = useMemo(
-    () => [
-      calculateSeriesMinimum(seriesList, seriesConfig, benchmark?.value),
-      calculateSeriesMaximum(seriesList, seriesConfig, benchmark?.value),
-    ],
+    () => [calculateSeriesMinimum(seriesList, seriesConfig, benchmark?.value), calculateSeriesMaximum(seriesList, seriesConfig, benchmark?.value)],
     [seriesList, seriesConfig, benchmark?.value]
   );
 
-  const calculatedForcedMaximumValue = isFunction(forcedMaximumValue)
-    ? forcedMaximumValue(calculatedSeriesMax)
-    : forcedMaximumValue;
+  const calculatedForcedMaximumValue = isFunction(forcedMaximumValue) ? forcedMaximumValue(calculatedSeriesMax) : forcedMaximumValue;
 
-  const seriesMax =
-    typeof calculatedForcedMaximumValue === 'number'
-      ? Math.min(calculatedForcedMaximumValue, calculatedSeriesMax)
-      : calculatedSeriesMax;
+  const seriesMax = typeof calculatedForcedMaximumValue === 'number' ? Math.min(calculatedForcedMaximumValue, calculatedSeriesMax) : calculatedSeriesMax;
 
-  const minimumRanges = seriesConfig
-    .map((c) => c.minimumRange)
-    .filter(isDefined);
-  const minimumRange = minimumRanges.length
-    ? Math.max(...minimumRanges)
-    : undefined;
-
-  const {
-    xScale,
-    yScale,
-    getX,
-    getY,
-    getY0,
-    getY1,
-    dateSpanWidth,
-    hasAllZeroValues,
-  } = useScales({
+  const { xScale, yScale, getX, getY, getY0, getY1, dateSpanWidth, hasAllZeroValues } = useScales({
     values,
     maximumValue: yTickValues?.[yTickValues.length - 1] || seriesMax,
     minimumValue: calculatedSeriesMin,
     bounds,
     numTicks: yTickValues?.length || numGridLines,
-    minimumRange,
   });
 
   const { legendItems, splitLegendGroups } = useLegendItems(
@@ -287,18 +225,9 @@ export function TimeSeriesChart<
     forceLegend
   );
 
-  const timeDomain = useMemo(
-    () =>
-      getTimeDomain({ values, today: endDate ?? today, withPadding: false }),
-    [values, endDate, today]
-  );
+  const timeDomain = useMemo(() => getTimeDomain({ values, today: endDate ?? today, withPadding: false }), [values, endDate, today]);
 
-  const {
-    isTabInteractive,
-    tabInteractiveButton,
-    anchorEventHandlers,
-    setIsTabInteractive,
-  } = useTabInteractiveButton(commonTexts.accessibility.tab_navigatie_button);
+  const { isTabInteractive, tabInteractiveButton, anchorEventHandlers, setIsTabInteractive } = useTabInteractiveButton(commonTexts.accessibility.tab_navigatie_button);
 
   const timelineState = useTimelineState(timelineEvents, xScale);
   const [hoverState, chartEventHandlers] = useHoverState({
@@ -315,26 +244,13 @@ export function TimeSeriesChart<
     setIsTabInteractive,
   });
 
-  const metricPropertyFormatters = useMetricPropertyFormatters(
-    seriesConfig,
-    values
-  );
+  const metricPropertyFormatters = useMetricPropertyFormatters(seriesConfig, values);
 
-  const valueMinWidth = useValueWidth(
-    values,
-    seriesConfig,
-    isPercentage,
-    metricPropertyFormatters
-  );
+  const valueMinWidth = useValueWidth(values, seriesConfig, isPercentage, metricPropertyFormatters);
 
   useEffect(() => {
     if (hoverState) {
-      const {
-        nearestPoint,
-        valuesIndex,
-        timespanAnnotationIndex,
-        timelineEventIndex,
-      } = hoverState;
+      const { nearestPoint, valuesIndex, timespanAnnotationIndex, timelineEventIndex } = hoverState;
 
       showTooltip({
         tooltipData: {
@@ -349,10 +265,7 @@ export function TimeSeriesChart<
            */
           value:
             timespanAnnotations && isDefined(timespanAnnotationIndex)
-              ? omitValuePropertiesForAnnotation(
-                  values[valuesIndex],
-                  timespanAnnotations[timespanAnnotationIndex]
-                )
+              ? omitValuePropertiesForAnnotation(values[valuesIndex], timespanAnnotations[timespanAnnotationIndex])
               : values[valuesIndex],
           config: seriesConfig,
           configIndex: nearestPoint.seriesConfigIndex,
@@ -364,22 +277,13 @@ export function TimeSeriesChart<
            * dataOptions is already being passed, but it's cumbersome to have to
            * dig up the annotation from the array in the tooltip logic.
            */
-          timespanAnnotation:
-            timespanAnnotations && isDefined(timespanAnnotationIndex)
-              ? timespanAnnotations[timespanAnnotationIndex]
-              : undefined,
-          timelineEvent: isDefined(timelineEventIndex)
-            ? timelineState.events[timelineEventIndex]
-            : undefined,
+          timespanAnnotation: timespanAnnotations && isDefined(timespanAnnotationIndex) ? timespanAnnotations[timespanAnnotationIndex] : undefined,
+          timelineEvent: isDefined(timelineEventIndex) ? timelineState.events[timelineEventIndex] : undefined,
 
           valueMinWidth,
           metricPropertyFormatters,
           seriesMax,
-          isOutOfBounds: dataOptions?.outOfBoundsConfig?.checkIsOutofBounds(
-            values[valuesIndex],
-            seriesMax,
-            timeDomain
-          ),
+          isOutOfBounds: dataOptions?.outOfBoundsConfig?.checkIsOutofBounds(values[valuesIndex], seriesMax, timeDomain),
         },
         tooltipLeft: nearestPoint.x,
         tooltipTop: nearestPoint.y,
@@ -413,15 +317,10 @@ export function TimeSeriesChart<
     }
   }, [onSeriesClick, seriesConfig, tooltipData]);
 
-  const isYAxisCollapsed =
-    defaultIsYAxisCollapsed ?? width < COLLAPSE_Y_AXIS_THRESHOLD;
-  const timeSeriesAccessibility = addAccessibilityFeatures(accessibility, [
-    'keyboard_time_series_chart',
-  ]);
+  const isYAxisCollapsed = defaultIsYAxisCollapsed ?? width < COLLAPSE_Y_AXIS_THRESHOLD;
+  const timeSeriesAccessibility = addAccessibilityFeatures(accessibility, ['keyboard_time_series_chart']);
 
-  const highlightZero =
-    (first(yScale.domain()) as number) < 0 &&
-    (last(yScale.domain()) as number) > 0;
+  const highlightZero = (first(yScale.domain()) as number) < 0 && (last(yScale.domain()) as number) > 0;
 
   return (
     <>
@@ -496,24 +395,9 @@ export function TimeSeriesChart<
              * Highlight 0 on the y-axis when there are positive and
              * negative values
              */}
-            {highlightZero && (
-              <rect
-                x={0}
-                y={yScale(0)}
-                width={bounds.width}
-                height={1}
-                fill="black"
-              />
-            )}
+            {highlightZero && <rect x={0} y={yScale(0)} width={bounds.width} height={1} fill="black" />}
 
-            {benchmark && (
-              <Benchmark
-                value={benchmark.value}
-                label={benchmark.label}
-                top={yScale(benchmark.value)}
-                width={bounds.width}
-              />
-            )}
+            {benchmark && <Benchmark value={benchmark.value} label={benchmark.label} top={yScale(benchmark.value)} width={bounds.width} />}
 
             {/**
              * Timespan annotations are rendered on top of the chart. It is
@@ -522,50 +406,22 @@ export function TimeSeriesChart<
             {timespanAnnotations
               ?.filter((x) => x.fill !== 'none')
               .map((x, index) => (
-                <TimespanAnnotation
-                  key={index}
-                  domain={xScale.domain() as [number, number]}
-                  getX={getX}
-                  height={bounds.height}
-                  config={x}
-                  bounds={bounds}
-                  series={seriesList[0]}
-                />
+                <TimespanAnnotation key={index} domain={xScale.domain() as [number, number]} getX={getX} height={bounds.height} config={x} bounds={bounds} series={seriesList[0]} />
               ))}
             {timeAnnotations?.map((x, index) => (
-              <TimeAnnotation
-                key={index}
-                domain={xScale.domain() as [number, number]}
-                getX={getX}
-                height={bounds.height}
-                config={x}
-              />
+              <TimeAnnotation key={index} domain={xScale.domain() as [number, number]} getX={getX} height={bounds.height} config={x} />
             ))}
 
-            <TimelineEventHighlight
-              height={bounds.height}
-              timelineState={timelineState}
-            />
+            <TimelineEventHighlight height={bounds.height} timelineState={timelineState} />
           </ChartContainer>
 
           {tooltipOpen && tooltipData && (
-            <Tooltip
-              title={tooltipTitle}
-              data={tooltipData}
-              left={tooltipLeft}
-              top={tooltipTop}
-              formatTooltip={formatTooltip}
-              bounds={bounds}
-              padding={padding}
-            />
+            <Tooltip title={tooltipTitle} data={tooltipData} left={tooltipLeft} top={tooltipTop} formatTooltip={formatTooltip} bounds={bounds} padding={padding} />
           )}
 
           {hoverState && (
             <Overlay bounds={bounds} padding={padding}>
-              <DateSpanMarker
-                width={dateSpanWidth}
-                point={hoverState.nearestPoint}
-              />
+              <DateSpanMarker width={dateSpanWidth} point={hoverState.nearestPoint} />
 
               <DateLineMarker
                 point={hoverState.nearestPoint}
@@ -574,9 +430,7 @@ export function TimeSeriesChart<
                    * Only display a line when we have range- or line-points.
                    * Bar-series have no markers, which defeats the need of a line.
                    */
-                  hoverState.rangePoints.length || hoverState.linePoints.length
-                    ? 'gray7'
-                    : 'transparent'
+                  hoverState.rangePoints.length || hoverState.linePoints.length ? 'gray7' : 'transparent'
                 }
                 value={values[hoverState.valuesIndex]}
               />
@@ -601,14 +455,7 @@ export function TimeSeriesChart<
       {!disableLegend && splitLegendGroups && (
         <>
           {splitLegendGroups.map((x) => (
-            <Box
-              key={x.label}
-              pl={paddingLeft}
-              display="flex"
-              flexDirection={['column', 'row']}
-              alignItems="baseline"
-              spacingHorizontal={3}
-            >
+            <Box key={x.label} pl={paddingLeft} display="flex" flexDirection={['column', 'row']} alignItems="baseline" spacingHorizontal={3}>
               {x.label && <InlineText>{x.label}:</InlineText>}
               <Legend items={x.items} />
             </Box>

--- a/packages/app/src/domain/tested/reproduction-chart-tile.tsx
+++ b/packages/app/src/domain/tested/reproduction-chart-tile.tsx
@@ -6,7 +6,6 @@ import { ChartTile } from '~/components/chart-tile';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
 import { SiteText } from '~/locale';
-import { metricConfigs } from '~/metric-config';
 
 interface ReproductionChartTileProps {
   data: NlReproduction;
@@ -62,7 +61,6 @@ export const ReproductionChartTile = ({
             label: text.linechart_legend_label,
             shortLabel: text.linechart_tooltip_label,
             color: colors.primary,
-            minimumRange: metricConfigs?.nl?.reproduction?.index_average?.minimumRange,
           },
         ]}
         dataOptions={{

--- a/packages/app/src/metric-config/common.ts
+++ b/packages/app/src/metric-config/common.ts
@@ -1,8 +1,4 @@
-import {
-  DataScope,
-  MetricKeys,
-  MetricProperty,
-} from '@corona-dashboard/common';
+import { DataScope, MetricKeys, MetricProperty } from '@corona-dashboard/common';
 
 /**
  * These types are placed here to avoid a circular dependency. The nl/vr/gm
@@ -19,7 +15,6 @@ export type BarScaleConfig = {
 
 export type MetricConfig = {
   barScale?: BarScaleConfig;
-  minimumRange?: number;
 };
 
 /**

--- a/packages/app/src/metric-config/nl.ts
+++ b/packages/app/src/metric-config/nl.ts
@@ -37,15 +37,4 @@ export const nl: ScopedMetricConfigs<Nl> = {
       },
     },
   },
-  reproduction: {
-    index_low: {
-      minimumRange: 1,
-    },
-    index_average: {
-      minimumRange: 1,
-    },
-    index_high: {
-      minimumRange: 1,
-    },
-  },
 };


### PR DESCRIPTION
## Summary

* reverted (some, not all) changes from pull request #3765 as it did not introduce any logic that did not already work but instead caused certain graphs on certain pages to not scale properly; removing the minimumRange prop will now facilitate automatic scaling on the y-axis of all time series charts

### Motivation

The aforementioned pull request introduced a new `minimumRange` property to all time series charts default to a value of `10`, yet also took the chart representing the R-number into account (which should hopefully never come anywhere near 10). However, this same pull request does not take charts into account in certain (possibly less visited) pages around the dashboard. Examples of these charts are in the list below. Rather than adding an override for `minimumRange` to all these pages/charts, I opted to investigate if we could revert the introduction of `minimumRange`. After this revert, and as such before the merge of the above pull request, all time series charts will use their OOTB logic to dynamically scale its y-axis based on the highest value inside the range of the series, meaning `minimumRange` can be completely omitted.

Examples of pages/charts that are affected by the introduction of `minimumRange` include but are not limited to:
* https://coronadashboard.rijksoverheid.nl/landelijk/gehandicaptenzorg
* https://coronadashboard.rijksoverheid.nl/veiligheidsregio/VR11/gehandicaptenzorg
* https://coronadashboard.rijksoverheid.nl/veiligheidsregio/VR11/verpleeghuiszorg
* https://coronadashboard.rijksoverheid.nl/veiligheidsregio/VR11/thuiswonende-ouderen
* https://coronadashboard.rijksoverheid.nl/gemeente/GM0852/ziekenhuis-opnames
* https://coronadashboard.rijksoverheid.nl/gemeente/GM0852/sterfte 