### PR TITLE
fix: add missing default timeframe option to charts

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,8 +1,4 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
@@ -26,34 +22,13 @@ import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Layout, GmLayout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetChoroplethData,
-  createGetContent,
-  getLastGeneratedDate,
-  selectGmData,
-  getLokalizeTexts,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectGmData, getLokalizeTexts } from '~/static-props/get-data';
 import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
-import {
-  replaceComponentsInText,
-  replaceVariablesInText,
-  getVrForMunicipalityCode,
-  useReverseRouter,
-} from '~/utils';
+import { replaceComponentsInText, replaceVariablesInText, getVrForMunicipalityCode, useReverseRouter } from '~/utils';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
@@ -69,8 +44,7 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 const pageMetrics = ['tested_overall'];
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
   selectGmData(
     'code',
@@ -98,10 +72,7 @@ export const getStaticProps = createGetStaticProps(
     })(context);
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'positiveTestsPageArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'positiveTestsPageArticles'),
         elements: content.elements,
       },
     } as const;
@@ -109,29 +80,16 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedGmData: data,
-    choropleth,
-    municipalityName,
-    content,
-    lastGenerated,
-  } = props;
-  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const { pageText, selectedGmData: data, choropleth, municipalityName, content, lastGenerated } = props;
+  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
   const reverseRouter = useReverseRouter();
-  const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(
-    pageText,
-    selectLokalizeTexts
-  );
+  const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const lastValue = data.tested_overall.last_value;
   const populationCount = data.static_values.population_count;
   const vrForMunicipality = getVrForMunicipalityCode(data.code);
-  const vrData = choropleth.vr.tested_overall.find(
-    (v) => v.vrcode === vrForMunicipality?.code
-  );
+  const vrData = choropleth.vr.tested_overall.find((v) => v.vrcode === vrForMunicipality?.code);
   const metadata = {
     ...commonTexts.gemeente_index.metadata,
     title: replaceVariablesInText(textGm.metadata.title, {
@@ -149,9 +107,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
       <GmLayout code={data.code} municipalityName={municipalityName}>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.development_of_the_virus.title
-            }
+            category={commonTexts.sidebar.categories.development_of_the_virus.title}
             title={replaceVariablesInText(textGm.titel, {
               municipality: municipalityName,
             })}
@@ -177,44 +133,23 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 source: textGm.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="infected_moving_average"
-                absolute={lastValue.infected_moving_average_rounded}
-                isAmount
-              />
+              <KpiValue data-cy="infected_moving_average" absolute={lastValue.infected_moving_average_rounded} isAmount />
               <Text>
-                {replaceComponentsInText(
-                  commonTexts.gemeente_index.population_count,
-                  {
-                    municipalityName,
-                    populationCount: (
-                      <strong>{formatNumber(populationCount)}</strong>
-                    ),
-                  }
-                )}
+                {replaceComponentsInText(commonTexts.gemeente_index.population_count, {
+                  municipalityName,
+                  populationCount: <strong>{formatNumber(populationCount)}</strong>,
+                })}
               </Text>
               <Markdown content={textGm.infected_kpi.description} />
 
               <Box spacing={3}>
                 <BoldText variant="body2">
-                  {replaceComponentsInText(
-                    textGm.infected_kpi.last_value_text,
-                    {
-                      infected: (
-                        <InlineText color="data.primary">{`${formatNumber(
-                          lastValue.infected
-                        )}`}</InlineText>
-                      ),
-                      dateTo: formatDateFromSeconds(
-                        lastValue.date_unix,
-                        'weekday-medium'
-                      ),
-                    }
-                  )}
+                  {replaceComponentsInText(textGm.infected_kpi.last_value_text, {
+                    infected: <InlineText color="data.primary">{`${formatNumber(lastValue.infected)}`}</InlineText>,
+                    dateTo: formatDateFromSeconds(lastValue.date_unix, 'weekday-medium'),
+                  })}
                 </BoldText>
-                {textGm.infected_kpi.link_cta && (
-                  <Markdown content={textGm.infected_kpi.link_cta} />
-                )}
+                {textGm.infected_kpi.link_cta && <Markdown content={textGm.infected_kpi.link_cta} />}
               </Box>
             </KpiTile>
 
@@ -225,32 +160,15 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 source: textGm.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="infected_per_100k_moving_average"
-                absolute={lastValue.infected_per_100k_moving_average}
-                isAmount
-              />
+              <KpiValue data-cy="infected_per_100k_moving_average" absolute={lastValue.infected_per_100k_moving_average} isAmount />
               <Text>{textGm.barscale_toelichting}</Text>
 
-              <CollapsibleContent
-                label={
-                  commonTexts.gemeente_index.population_count_explanation_title
-                }
-              >
+              <CollapsibleContent label={commonTexts.gemeente_index.population_count_explanation_title}>
                 <Text>
-                  {replaceComponentsInText(
-                    textGm.population_count_explanation,
-                    {
-                      municipalityName: <strong>{municipalityName}</strong>,
-                      value: (
-                        <strong>
-                          {formatNumber(
-                            lastValue.infected_per_100k_moving_average
-                          )}
-                        </strong>
-                      ),
-                    }
-                  )}
+                  {replaceComponentsInText(textGm.population_count_explanation, {
+                    municipalityName: <strong>{municipalityName}</strong>,
+                    value: <strong>{formatNumber(lastValue.infected_per_100k_moving_average)}</strong>,
+                  })}
                 </Text>
               </CollapsibleContent>
             </KpiTile>
@@ -263,6 +181,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               source: textGm.bronnen.rivm,
             }}
             timeframeOptions={TimeframeOptionsList}
+            timeframeInitialValue={positivelyTestedPeopleTimeframe}
             onSelectTimeframe={setpositivelyTestedPeopleTimeframe}
           >
             <TimeSeriesChart
@@ -287,10 +206,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 },
               ]}
               dataOptions={{
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'tested_overall'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'tested_overall'),
               }}
             />
           </ChartTile>
@@ -305,26 +221,15 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                   <Markdown content={textGm.map_toelichting} />
                   <BoldText variant="body2">
                     {replaceComponentsInText(textGm.map_last_value_text, {
-                      infected_per_100k: (
-                        <InlineText color="data.primary">{`${formatNumber(
-                          lastValue.infected_per_100k
-                        )}`}</InlineText>
-                      ),
+                      infected_per_100k: <InlineText color="data.primary">{`${formatNumber(lastValue.infected_per_100k)}`}</InlineText>,
                       municipality: municipalityName,
                     })}
                   </BoldText>
                   <BoldText variant="body2">
-                    {replaceComponentsInText(
-                      textGm.map_safety_region_last_value_text,
-                      {
-                        infected_per_100k: (
-                          <InlineText color="data.primary">{`${formatNumber(
-                            vrData?.infected_per_100k
-                          )}`}</InlineText>
-                        ),
-                        safetyRegion: vrForMunicipality?.name,
-                      }
-                    )}
+                    {replaceComponentsInText(textGm.map_safety_region_last_value_text, {
+                      infected_per_100k: <InlineText color="data.primary">{`${formatNumber(vrData?.infected_per_100k)}`}</InlineText>,
+                      safetyRegion: vrForMunicipality?.name,
+                    })}
                   </BoldText>
                 </>
               }

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -153,7 +153,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               source: textNl.bronnen.rivm,
             }}
             timeframeOptions={TimeframeOptionsList}
-            timeframeInitialValue={TimeframeOption.SIX_MONTHS}
+            timeframeInitialValue={confirmedCasesSelfTestedTimeframe}
             onSelectTimeframe={setConfirmedCasesSelfTestedTimeframe}
           >
             <TimeSeriesChart
@@ -190,7 +190,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               source: textNl.bronnen.rivm,
             }}
             timeframeOptions={TimeframeOptionsList}
-            timeframeInitialValue={TimeframeOption.SIX_MONTHS}
+            timeframeInitialValue={confirmedCasesInfectedTimeframe}
             onSelectTimeframe={setConfirmedCasesInfectedTimeframe}
           >
             <TimeSeriesChart

--- a/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/positief-geteste-mensen.tsx
@@ -1,8 +1,4 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { GgdTesten } from '@corona-dashboard/icons';
 import { css } from '@styled-system/css';
 import { GetStaticPropsContext } from 'next';
@@ -12,48 +8,18 @@ import { Box } from '~/components/base';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { RadioGroup } from '~/components/radio-group';
 import { BoldText, InlineText } from '~/components/typography';
-import {
-  ChartTile,
-  TimeSeriesChart,
-  TileList,
-  DynamicChoropleth,
-  ChoroplethTile,
-  Divider,
-  InView,
-  Markdown,
-  PageInformationBlock,
-} from '~/components';
+import { ChartTile, TimeSeriesChart, TileList, DynamicChoropleth, ChoroplethTile, Divider, InView, Markdown, PageInformationBlock } from '~/components';
 import { gmCodesByVrCode } from '~/data';
 import { Layout, VrLayout } from '~/domain/layout';
 import { GNumberBarChartTile } from '~/domain/tested';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetChoroplethData,
-  createGetContent,
-  getLastGeneratedDate,
-  selectVrData,
-  getLokalizeTexts,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectVrData, getLokalizeTexts } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
-import {
-  replaceComponentsInText,
-  replaceVariablesInText,
-  useReverseRouter,
-} from '~/utils';
+import { replaceComponentsInText, replaceVariablesInText, useReverseRouter } from '~/utils';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
@@ -69,8 +35,7 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export { getStaticPaths } from '~/static-paths/vr';
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
   selectVrData(
     'difference.tested_ggd__infected_percentage_moving_average',
@@ -92,36 +57,20 @@ export const getStaticProps = createGetStaticProps(
       const { locale } = context;
       return `{
        "parts": ${getPagePartsQuery('positive_tests_page')},
-       "elements": ${getElementsQuery(
-         'vr',
-         ['tested_overall', 'tested_ggd'],
-         locale
-       )}
+       "elements": ${getElementsQuery('vr', ['tested_overall', 'tested_ggd'], locale)}
       }`;
     })(context);
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'positiveTestsPageArticles'
-        ),
-        ggdArticles: getArticleParts(
-          content.parts.pageParts,
-          'positiveTestsGGDArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'positiveTestsPageArticles'),
+        ggdArticles: getArticleParts(content.parts.pageParts, 'positiveTestsGGDArticles'),
         elements: content.elements,
       },
     };
   }
 );
 
-const GgdGraphToggle = ({
-  selectedGgdGraph,
-  onChange,
-}: {
-  selectedGgdGraph: string;
-  onChange: (value: string) => void;
-}) => {
+const GgdGraphToggle = ({ selectedGgdGraph, onChange }: { selectedGgdGraph: string; onChange: (value: string) => void }) => {
   return (
     <Box css={css({ '& div': { justifyContent: 'flex-start' } })} mb={3}>
       <RadioGroup
@@ -143,42 +92,22 @@ const GgdGraphToggle = ({
 };
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedVrData: data,
-    choropleth,
-    vrName,
-    content,
-    lastGenerated,
-  } = props;
+  const { pageText, selectedVrData: data, choropleth, vrName, content, lastGenerated } = props;
 
-  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
 
-  const [
-    confirmedCasesInfectedPercentageTimeframe,
-    setConfirmedCasesInfectedPercentageTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesInfectedPercentageTimeframe, setConfirmedCasesInfectedPercentageTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
-  const [
-    confirmedCasesTestedOverTimeTimeframe,
-    setConfirmedCasesTestedOverTimeTimeframe,
-  ] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [confirmedCasesTestedOverTimeTimeframe, setConfirmedCasesTestedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
 
   const reverseRouter = useReverseRouter();
   const router = useRouter();
-  const [hasHideArchivedCharts, setHideArchivedCharts] =
-    useState<boolean>(false);
-  const [selectedGgdGraph, setSelectedGgdGraph] = useState<string>(
-    'GGD_infected_percentage_over_time_chart'
-  );
+  const [hasHideArchivedCharts, setHideArchivedCharts] = useState<boolean>(false);
+  const [selectedGgdGraph, setSelectedGgdGraph] = useState<string>('GGD_infected_percentage_over_time_chart');
 
-  const { textVr, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(
-    pageText,
-    selectLokalizeTexts
-  );
+  const { textVr, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const dataOverallLastValue = data.tested_overall.last_value;
   const dataGgdLastValue = data.tested_ggd.last_value;
@@ -203,12 +132,8 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
       <VrLayout vrName={vrName}>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.development_of_the_virus.title
-            }
-            screenReaderCategory={
-              commonTexts.sidebar.metrics.positive_tests.title
-            }
+            category={commonTexts.sidebar.categories.development_of_the_virus.title}
+            screenReaderCategory={commonTexts.sidebar.metrics.positive_tests.title}
             title={replaceVariablesInText(textVr.titel, {
               safetyRegion: vrName,
             })}
@@ -229,19 +154,15 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
           <ChartTile
             title={textVr.linechart_titel}
             description={replaceVariablesInText(textVr.linechart_toelichting, {
-              date: formatDateFromSeconds(
-                dataOverallLastValue.date_unix,
-                'weekday-medium'
-              ),
+              date: formatDateFromSeconds(dataOverallLastValue.date_unix, 'weekday-medium'),
               administered_total: formatNumber(dataOverallLastValue.infected),
-              infected_total: formatNumber(
-                dataOverallLastValue.infected_moving_average_rounded
-              ),
+              infected_total: formatNumber(dataOverallLastValue.infected_moving_average_rounded),
             })}
             metadata={{
               source: textVr.bronnen.rivm,
             }}
             timeframeOptions={TimeframeOptionsList}
+            timeframeInitialValue={confirmedCasesInfectedTimeframe}
             onSelectTimeframe={setConfirmedCasesInfectedTimeframe}
           >
             <TimeSeriesChart
@@ -266,10 +187,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 },
               ]}
               dataOptions={{
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'tested_overall'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'tested_overall'),
               }}
             />
           </ChartTile>
@@ -279,17 +197,11 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               <ChartTile
                 timeframeOptions={TimeframeOptionsList}
                 title={textVr.ggd.linechart_percentage_titel}
-                description={replaceVariablesInText(
-                  textVr.ggd.linechart_percentage_toelichting,
-                  {
-                    date: formatDateFromSeconds(
-                      dataGgdLastValue.date_unix,
-                      'weekday-medium'
-                    ),
-                    tested_total: formatNumber(dataGgdLastValue.tested_total),
-                    infected_total: formatNumber(dataGgdLastValue.infected),
-                  }
-                )}
+                description={replaceVariablesInText(textVr.ggd.linechart_percentage_toelichting, {
+                  date: formatDateFromSeconds(dataGgdLastValue.date_unix, 'weekday-medium'),
+                  tested_total: formatNumber(dataGgdLastValue.tested_total),
+                  infected_total: formatNumber(dataGgdLastValue.infected),
+                })}
                 metadata={{
                   date: getLastInsertionDateOfPage(data, ['tested_ggd']),
                   source: textVr.ggd.bronnen.rivm,
@@ -297,10 +209,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 onSelectTimeframe={setConfirmedCasesInfectedPercentageTimeframe}
               >
                 <>
-                  <GgdGraphToggle
-                    selectedGgdGraph={selectedGgdGraph}
-                    onChange={(value) => setSelectedGgdGraph(value)}
-                  />
+                  <GgdGraphToggle selectedGgdGraph={selectedGgdGraph} onChange={(value) => setSelectedGgdGraph(value)} />
                   <TimeSeriesChart
                     accessibility={{
                       key: 'confirmed_cases_infected_percentage_over_time_chart',
@@ -314,9 +223,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                         metricProperty: 'infected_percentage_moving_average',
                         color: colors.primary,
                         label: textVr.ggd.linechart_percentage_legend_label,
-                        shortLabel:
-                          textShared.tooltip_labels
-                            .ggd_infected_percentage_moving_average,
+                        shortLabel: textShared.tooltip_labels.ggd_infected_percentage_moving_average,
                       },
                     ]}
                     dataOptions={{
@@ -330,17 +237,11 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               <ChartTile
                 timeframeOptions={TimeframeOptionsList}
                 title={textVr.ggd.linechart_totaltests_titel}
-                description={replaceVariablesInText(
-                  textVr.ggd.linechart_totaltests_toelichting,
-                  {
-                    date: formatDateFromSeconds(
-                      dataGgdLastValue.date_unix,
-                      'weekday-medium'
-                    ),
-                    tested_total: formatNumber(dataGgdLastValue.tested_total),
-                    infected_total: formatNumber(dataGgdLastValue.infected),
-                  }
-                )}
+                description={replaceVariablesInText(textVr.ggd.linechart_totaltests_toelichting, {
+                  date: formatDateFromSeconds(dataGgdLastValue.date_unix, 'weekday-medium'),
+                  tested_total: formatNumber(dataGgdLastValue.tested_total),
+                  infected_total: formatNumber(dataGgdLastValue.infected),
+                })}
                 metadata={{
                   source: textVr.ggd.bronnen.rivm,
                   date: getLastInsertionDateOfPage(data, ['tested_ggd']),
@@ -348,10 +249,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 onSelectTimeframe={setConfirmedCasesTestedOverTimeTimeframe}
               >
                 <>
-                  <GgdGraphToggle
-                    selectedGgdGraph={selectedGgdGraph}
-                    onChange={(value) => setSelectedGgdGraph(value)}
-                  />
+                  <GgdGraphToggle selectedGgdGraph={selectedGgdGraph} onChange={(value) => setSelectedGgdGraph(value)} />
                   <TimeSeriesChart
                     accessibility={{
                       key: 'confirmed_cases_tested_total_over_time_chart',
@@ -363,22 +261,15 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                         type: 'line',
                         metricProperty: 'tested_total_moving_average',
                         color: colors.secondary,
-                        label:
-                          textVr.ggd
-                            .linechart_totaltests_legend_label_moving_average,
-                        shortLabel:
-                          textShared.tooltip_labels
-                            .ggd_tested_total_moving_average,
+                        label: textVr.ggd.linechart_totaltests_legend_label_moving_average,
+                        shortLabel: textShared.tooltip_labels.ggd_tested_total_moving_average,
                       },
                       {
                         type: 'line',
                         metricProperty: 'infected_moving_average',
                         color: colors.primary,
-                        label:
-                          textVr.ggd
-                            .linechart_positivetests_legend_label_moving_average,
-                        shortLabel:
-                          textShared.tooltip_labels.infected_moving_average,
+                        label: textVr.ggd.linechart_positivetests_legend_label_moving_average,
+                        shortLabel: textShared.tooltip_labels.infected_moving_average,
                       },
                     ]}
                   />
@@ -401,15 +292,8 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                   <Markdown content={textVr.map_toelichting} />
                   <BoldText variant="body2">
                     {replaceComponentsInText(textVr.map_last_value_text, {
-                      infected_per_100k: (
-                        <InlineText color="data.primary">{`${formatNumber(
-                          dataOverallLastValue.infected_per_100k
-                        )}`}</InlineText>
-                      ),
-                      dateTo: formatDateFromSeconds(
-                        dataOverallLastValue.date_unix,
-                        'weekday-medium'
-                      ),
+                      infected_per_100k: <InlineText color="data.primary">{`${formatNumber(dataOverallLastValue.infected_per_100k)}`}</InlineText>,
+                      dateTo: formatDateFromSeconds(dataOverallLastValue.date_unix, 'weekday-medium'),
                       safetyRegion: vrName,
                     })}
                   </BoldText>
@@ -448,9 +332,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             title={textVr.section_archived.title}
             description={textVr.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
-            onToggleArchived={() =>
-              setHideArchivedCharts(!hasHideArchivedCharts)
-            }
+            onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
           />
 
           {hasHideArchivedCharts && (


### PR DESCRIPTION
## Summary

- Add the missing default timeframe option of "six months" to the charts