### PR TITLE
added a new source key for self_tests

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -150,7 +150,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             title={textNl.linechart_self_test_titel}
             description={textNl.linechart_self_test_toelichting}
             metadata={{
-              source: textNl.bronnen.rivm,
+              source: textNl.bronnen.self_test,
             }}
             timeframeOptions={TimeframeOptionsList}
             timeframeInitialValue={confirmedCasesSelfTestedTimeframe}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -19,3 +19,7 @@ timestamp,action,key,document_id,move_to
 2022-12-21T16:15:20.048Z,add,pages.positive_tests_page.nl.linechart_self_test_titel,PKXdxxxKAnTg0F1ZCghMkN,__
 2022-12-21T16:15:20.949Z,add,pages.positive_tests_page.nl.linechart_self_test_toelichting,PKXdxxxKAnTg0F1ZCghMnz,__
 2022-12-21T16:15:22.001Z,add,pages.positive_tests_page.nl.linechart_self_test_tooltip_label,KoLyCpXIGU95m7jfEHZKIf,__
+2022-12-29T12:39:50.414Z,add,pages.positive_tests_page.nl.bronnen.self_test.aria_text,PKXdxxxKAnTg0F1ZCsSm7v,__
+2022-12-29T12:39:51.337Z,add,pages.positive_tests_page.nl.bronnen.self_test.download,KoLyCpXIGU95m7jfEPMPhh,__
+2022-12-29T12:39:52.357Z,add,pages.positive_tests_page.nl.bronnen.self_test.href,KoLyCpXIGU95m7jfEPMPlH,__
+2022-12-29T12:39:53.419Z,add,pages.positive_tests_page.nl.bronnen.self_test.text,0iJeil5hiqRr6jTKtbFGx7,__


### PR DESCRIPTION
BEFORE:
![Screenshot 2022-12-29 at 13 46 41](https://user-images.githubusercontent.com/93984341/209953113-e1243c34-5176-44f4-ab12-6cc69cf654c9.png)

AFTER:
![Screenshot 2022-12-29 at 13 46 30](https://user-images.githubusercontent.com/93984341/209953136-77bd65ce-60af-4241-8010-ce9daa8fa85c.png)
