### PR TITLE
Solved NL bug with last 7 day data

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -114,8 +114,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
     [options]
   );
 
-  const timeframeOptionsVrOrGm = TimeframeOptionsList.filter((timeframeOption) => timeframeOption !== TimeframeOption.ONE_WEEK);
-  const timeframeOptions = vrNameOrGmName ? timeframeOptionsVrOrGm : TimeframeOptionsList;
+  const timeframeOptions = TimeframeOptionsList.filter((timeframeOption) => timeframeOption !== TimeframeOption.ONE_WEEK);
 
   return (
     <ChartTile


### PR DESCRIPTION
This removed the 7-day possibility from NL as well. As [this PR](https://github.com/minvws/nl-covid19-data-dashboard/pull/4534) only did it for GM and VR. (The ticket said only VR and GM, but it now happens on NL as well.)

BEFORE:
![Screenshot 2022-12-29 at 14 29 33](https://user-images.githubusercontent.com/93984341/209960377-d6035bc9-c260-4681-bdae-d6d1434098d3.png)

AFTER:
![Screenshot 2022-12-29 at 14 29 15](https://user-images.githubusercontent.com/93984341/209960412-9c7fddfd-639d-403e-a12f-6fadf40a15a1.png)
