### PR TITLE
feature/COR-1347-add-new-variant

### DIFF
--- a/packages/app/schema/nl/__named_difference.json
+++ b/packages/app/schema/nl/__named_difference.json
@@ -42,6 +42,7 @@
             "BQ_1_1",
             "XBB",
             "XBB_1_5",
+            "CH_1_1",
             "other_table",
             "other_graph"
           ]

--- a/packages/app/schema/nl/__named_difference.json
+++ b/packages/app/schema/nl/__named_difference.json
@@ -41,6 +41,7 @@
             "BQ_1",
             "BQ_1_1",
             "XBB",
+            "XBB_1_5",
             "other_table",
             "other_graph"
           ]
@@ -58,13 +59,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "variant_code",
-        "old_value",
-        "difference",
-        "old_date_unix",
-        "new_date_unix"
-      ],
+      "required": ["variant_code", "old_value", "difference", "old_date_unix", "new_date_unix"],
       "additionalProperties": false
     }
   }

--- a/packages/app/schema/nl/variants.json
+++ b/packages/app/schema/nl/variants.json
@@ -43,6 +43,7 @@
             "BQ_1",
             "BQ_1_1",
             "XBB",
+            "XBB_1_5",
             "other_table",
             "other_graph"
           ]

--- a/packages/app/schema/nl/variants.json
+++ b/packages/app/schema/nl/variants.json
@@ -44,6 +44,7 @@
             "BQ_1_1",
             "XBB",
             "XBB_1_5",
+            "CH_1_1",
             "other_table",
             "other_graph"
           ]

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,2 @@
 timestamp,action,key,document_id,move_to
+2023-01-13T10:39:47.079Z,add,common.variant_codes.XBB_1_5,SREtVRJ5tkQiFlHXXWbrVz,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,2 +1,3 @@
 timestamp,action,key,document_id,move_to
 2023-01-13T10:39:47.079Z,add,common.variant_codes.XBB_1_5,SREtVRJ5tkQiFlHXXWbrVz,__
+2023-01-16T09:36:56.180Z,add,common.variant_codes.CH_1_1,SSqv0zg5US7hRiLa8c1PWF,__

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -343,6 +343,7 @@ export interface NamedDifferenceDecimal {
     | 'BQ_1'
     | 'BQ_1_1'
     | 'XBB'
+    | 'XBB_1_5'
     | 'other_table'
     | 'other_graph';
   old_value: number;
@@ -1118,6 +1119,7 @@ export interface NlVariantsVariant {
     | 'BQ_1'
     | 'BQ_1_1'
     | 'XBB'
+    | 'XBB_1_5'
     | 'other_table'
     | 'other_graph';
   values: NlVariantsVariantValue[];

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -344,6 +344,7 @@ export interface NamedDifferenceDecimal {
     | 'BQ_1_1'
     | 'XBB'
     | 'XBB_1_5'
+    | 'CH_1_1'
     | 'other_table'
     | 'other_graph';
   old_value: number;
@@ -1120,6 +1121,7 @@ export interface NlVariantsVariant {
     | 'BQ_1_1'
     | 'XBB'
     | 'XBB_1_5'
+    | 'CH_1_1'
     | 'other_table'
     | 'other_graph';
   values: NlVariantsVariantValue[];


### PR DESCRIPTION
## Summary

* added new XBB.1.5 (XBB_1_5) variant
* added new CH.1.1 (CH_1_1) variant

Due to change of scope (CH.1.1 'suddenly' popping up), I have also included that variant. Basically, this feature now includes the following tickets:

* COR-1347
* COR-1371

### Screenshots
#### Before
![COR-1347_before](https://user-images.githubusercontent.com/107395524/212623398-d97181cd-4c16-4ca0-9cbb-40ebb1891b25.png)

#### After
After screenshots cover a two copied variant data entries and give a visual representation of the the new variants (and their colours) working accordingly. The actual position and colour is to be determined by data once that becomes available.
![COR_1347_after](https://user-images.githubusercontent.com/107395524/212701267-159dc968-1d20-420d-b23f-1add3d2ab313.png)