### PR TITLE
task/COR-1370-bed-occupancy-graph-timelines

### DIFF
--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -63,7 +63,7 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
   const { commonTexts } = useIntl();
   const { metadataTexts, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
-  const [selectedAdmissionsPerAgeGroupOverTimeChart, setSelectedAdmissionsPerAgeGroupOverTimeChart] = useState<string>('admissions_per_age_group_over_time_hospital'); // other option is 'admissions_per_age_group_over_time_icu'
+  const [selectedAdmissionsPerAgeGroupOverTimeChart, setSelectedAdmissionsPerAgeGroupOverTimeChart] = useState<string>('admissions_per_age_group_over_time_hospital');
   const [hospitalAdmissionsPerAgeGroupOverTimeTimeframe, setHospitalAdmissionsPerAgeGroupOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const [intensiveCareAdmissionsPerAgeGroupOverTimeTimeframe, setIntensiveCareAdmissionsPerAgeGroupOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
@@ -78,7 +78,7 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
     },
   ];
 
-  const [selectedAdmissionsOverTimeChart, setSelectedAdmissionsOverTimeChart] = useState<string>('admissions_over_time_hospital'); // other option is 'admissions_over_time_icu'
+  const [selectedAdmissionsOverTimeChart, setSelectedAdmissionsOverTimeChart] = useState<string>('admissions_over_time_hospital');
   const [hospitalAdmissionsOverTimeTimeframe, setHospitalAdmissionsOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const [intensiveCareAdmissionsOverTimeTimeframe, setIntensiveCareAdmissionsOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 

--- a/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
@@ -200,6 +200,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                       shortLabel: commonTexts.common.incomplete,
                     },
                   ],
+                  timelineEvents: getTimelineEvents(content.elements.timeSeries, 'hospital_lcps', 'beds_occupied_covid'),
                 }}
               />
             </ChartTile>
@@ -226,16 +227,6 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 values={data.intensive_care_lcps.values}
                 timeframe={intensiveCareBedsTimeframe}
                 forceLegend
-                dataOptions={{
-                  timespanAnnotations: [
-                    {
-                      start: data.intensive_care_lcps.values[0].date_unix,
-                      end: new Date('1 June 2020').getTime() / 1000,
-                      label: textNl.icu.chart_beds_occupied.legend_inaccurate_label,
-                      shortLabel: commonTexts.common.incomplete,
-                    },
-                  ],
-                }}
                 seriesConfig={[
                   {
                     type: 'line',
@@ -252,6 +243,17 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                     color: colors.primary,
                   },
                 ]}
+                dataOptions={{
+                  timespanAnnotations: [
+                    {
+                      start: data.intensive_care_lcps.values[0].date_unix,
+                      end: new Date('1 June 2020').getTime() / 1000,
+                      label: textNl.icu.chart_beds_occupied.legend_inaccurate_label,
+                      shortLabel: commonTexts.common.incomplete,
+                    },
+                  ],
+                  timelineEvents: getTimelineEvents(content.elements.timeSeries, 'intensive_care_lcps', 'beds_occupied_covid'),
+                }}
               />
             </ChartTile>
           )}


### PR DESCRIPTION
## Summary

* updated bed occupancy graphs for both hospitals and ICUs to receive two new (individual) timelines (will only be visible when a timeline actually has timeline events assigned to it or if the metric has a timeline events collection assigned to it);

### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
<img width="800" alt="image" src="https://user-images.githubusercontent.com/107395524/213168766-e37843c8-ac0d-4c9b-b408-5fd1c74ecb66.png">
<img width="800" alt="image" src="https://user-images.githubusercontent.com/107395524/213168856-956c9215-a714-4079-9498-00d647bf04a4.png">
</details>

#### After
Do note that any text used in the after screenshots is there for testing purposes as final texts have not yet been determined.
<details>
<summary>Toggle after screenshots</summary>
<img width="800" alt="image" src="https://user-images.githubusercontent.com/107395524/213168577-7a26a163-575f-43b8-8a57-0e0d8b0c79f1.png">
<img width="800" alt="image" src="https://user-images.githubusercontent.com/107395524/213168509-335251e3-1028-4d51-bf5c-9f8e56fff4d0.png">
</details>

### Sanity
Sanity timelines for the new graphs can be found in the following path inside Sanity studio: `Datagerelateerde content > Elements > nl > hospital_lcps - Grafiek - beds_occupied_covid OR intensive_care_lcps - Grafiek - beds_occupied_covid` (depending on which graph's timeline is relevant). New timelines are called 'Annotaties bedbezetting ziekenhuizen' and 'Annotaties bedbezetting intensive care'. An example is as below.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/107395524/213169805-a545ca37-ba01-49d2-92d9-a24cc2ae4e12.png">