### PR TITLE
bugfix/COR-1259-sewer-station-remained-selected-when-switching-municipality

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -1,5 +1,6 @@
 import { colors, NlSewer, SewerPerInstallationData, TimeframeOption, TimeframeOptionsList, VrSewer } from '@corona-dashboard/common';
-import { useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
 import { isPresent } from 'ts-is-present';
 import { Warning } from '@corona-dashboard/icons';
 import { Box } from '~/components/base';
@@ -73,6 +74,14 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
         ],
       } as SewerPerInstallationData)
   );
+
+  const router = useRouter();
+
+  useEffect(() => {
+    const routeChangeHandler = () => onChange(undefined);
+    router.events.on('routeChangeStart', routeChangeHandler);
+    return () => router.events.off('routeChangeStart', routeChangeHandler);
+  }, [onChange, router.events]);
 
   const [sewerTimeframe, setSewerTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 


### PR DESCRIPTION
bugfix(sewer station selection): station remained selected after switching municipality

This caused an error because the selected station could not be found in the new municipality.

_Example from selecting station_ **Assen** _in municipality_ **Aa en Hunze** _and then switching to_ **Breda**_:_
![Screenshot 2023-01-20 at 18 03 23](https://user-images.githubusercontent.com/98813868/213760496-d78789e5-e7c4-42a7-a576-55edc8afa31e.png)

Fixes: COR-1259