### PR TITLE
feature/COR-1356-death-rate-page-adjustments

### DIFF
--- a/packages/app/schema/gm/__difference.json
+++ b/packages/app/schema/gm/__difference.json
@@ -15,7 +15,7 @@
     "sewer__average": {
       "$ref": "#/definitions/diff_integer"
     },
-    "deceased_rivm__covid_daily": {
+    "deceased_rivm__covid_daily_archived_20221231": {
       "$ref": "#/definitions/diff_integer"
     }
   },
@@ -23,7 +23,7 @@
     "tested_overall__infected_per_100k_moving_average",
     "tested_overall__infected_moving_average",
     "hospital_nice__admissions_on_date_of_reporting_moving_average",
-    "deceased_rivm__covid_daily"
+    "deceased_rivm__covid_daily_archived_20221231"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/gm/__index.json
+++ b/packages/app/schema/gm/__index.json
@@ -10,7 +10,7 @@
     "code",
     "tested_overall",
     "hospital_nice",
-    "deceased_rivm",
+    "deceased_rivm_archived_20221231",
     "difference",
     "static_values",
     "sewer",
@@ -35,8 +35,8 @@
     "static_values": {
       "$ref": "__static_values.json"
     },
-    "deceased_rivm": {
-      "$ref": "deceased_rivm.json"
+    "deceased_rivm_archived_20221231": {
+      "$ref": "deceased_rivm_archived_20221231.json"
     },
     "difference": {
       "$ref": "__difference.json"

--- a/packages/app/schema/gm/deceased_rivm_archived_20221231.json
+++ b/packages/app/schema/gm/deceased_rivm_archived_20221231.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_deceased_rivm",
+  "title": "gm_deceased_rivm_archived_20221231",
   "type": "object",
   "properties": {
     "values": {
@@ -17,7 +17,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "nl_deceased_rivm_value",
+      "title": "gm_deceased_rivm_archived_20221231_value",
       "type": "object",
       "properties": {
         "covid_daily": {
@@ -36,13 +36,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "covid_daily",
-        "covid_daily_moving_average",
-        "covid_total",
-        "date_unix",
-        "date_of_insertion_unix"
-      ],
+      "required": ["covid_daily", "covid_daily_moving_average", "covid_total", "date_unix", "date_of_insertion_unix"],
       "additionalProperties": false
     }
   }

--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -63,7 +63,7 @@
     "elderly_at_home__positive_tested_daily": {
       "$ref": "#/definitions/diff_integer"
     },
-    "deceased_rivm__covid_daily": {
+    "deceased_rivm__covid_daily_archived_20221231": {
       "$ref": "#/definitions/diff_integer"
     }
   },
@@ -88,7 +88,7 @@
     "disability_care__newly_infected_people",
     "disability_care__infected_locations_total",
     "elderly_at_home__positive_tested_daily",
-    "deceased_rivm__covid_daily"
+    "deceased_rivm__covid_daily_archived_20221231"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -12,8 +12,8 @@
     "corona_melder_app_download",
     "corona_melder_app_warning",
     "deceased_cbs",
-    "deceased_rivm",
-    "deceased_rivm_per_age_group",
+    "deceased_rivm_archived_20221231",
+    "deceased_rivm_per_age_group_archived_20221231",
     "difference",
     "named_difference",
     "disability_care",
@@ -153,11 +153,11 @@
     "behavior_annotations": {
       "$ref": "behavior_annotations.json"
     },
-    "deceased_rivm": {
-      "$ref": "deceased_rivm.json"
+    "deceased_rivm_archived_20221231": {
+      "$ref": "deceased_rivm_archived_20221231.json"
     },
-    "deceased_rivm_per_age_group": {
-      "$ref": "deceased_rivm_per_age_group.json"
+    "deceased_rivm_per_age_group_archived_20221231": {
+      "$ref": "deceased_rivm_per_age_group_archived_20221231.json"
     },
     "deceased_cbs": {
       "$ref": "deceased_cbs.json"

--- a/packages/app/schema/nl/deceased_rivm_archived_20221231.json
+++ b/packages/app/schema/nl/deceased_rivm_archived_20221231.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "gm_deceased_rivm",
+  "title": "nl_deceased_rivm_archived_20221231",
   "type": "object",
   "properties": {
     "values": {
@@ -17,7 +17,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "gm_deceased_rivm_value",
+      "title": "nl_deceased_rivm_archived_20221231_value",
       "type": "object",
       "properties": {
         "covid_daily": {
@@ -36,13 +36,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "covid_daily",
-        "covid_daily_moving_average",
-        "covid_total",
-        "date_unix",
-        "date_of_insertion_unix"
-      ],
+      "required": ["covid_daily", "covid_daily_moving_average", "covid_total", "date_unix", "date_of_insertion_unix"],
       "additionalProperties": false
     }
   }

--- a/packages/app/schema/nl/deceased_rivm_per_age_group_archived_20221231.json
+++ b/packages/app/schema/nl/deceased_rivm_per_age_group_archived_20221231.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_deceased_rivm_per_age_group",
+  "title": "nl_deceased_rivm_per_age_group_archived_20221231",
   "type": "object",
   "required": ["values"],
   "additionalProperties": false,
@@ -14,14 +14,9 @@
   },
   "definitions": {
     "value": {
-      "title": "nl_deceased_rivm_per_age_group_value",
+      "title": "nl_deceased_rivm_per_age_group_archived_20221231_value",
       "type": "object",
-      "required": [
-        "age_group_range",
-        "age_group_percentage",
-        "covid_percentage",
-        "date_of_insertion_unix"
-      ],
+      "required": ["age_group_range", "age_group_percentage", "covid_percentage", "date_of_insertion_unix"],
       "additionalProperties": false,
       "properties": {
         "age_group_range": {

--- a/packages/app/schema/vr/__difference.json
+++ b/packages/app/schema/vr/__difference.json
@@ -39,7 +39,7 @@
     "elderly_at_home__positive_tested_daily": {
       "$ref": "#/definitions/diff_integer"
     },
-    "deceased_rivm__covid_daily": {
+    "deceased_rivm__covid_daily_archived_20221231": {
       "$ref": "#/definitions/diff_integer"
     }
   },
@@ -56,7 +56,7 @@
     "disability_care__newly_infected_people",
     "disability_care__infected_locations_total",
     "elderly_at_home__positive_tested_daily",
-    "deceased_rivm__covid_daily"
+    "deceased_rivm__covid_daily_archived_20221231"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/vr/__index.json
+++ b/packages/app/schema/vr/__index.json
@@ -15,7 +15,7 @@
     "sewer",
     "sewer_per_installation",
     "difference",
-    "deceased_rivm",
+    "deceased_rivm_archived_20221231",
     "deceased_cbs",
     "elderly_at_home",
     "disability_care",
@@ -79,8 +79,8 @@
     "behavior_archived_20221019": {
       "$ref": "behavior_archived_20221019.json"
     },
-    "deceased_rivm": {
-      "$ref": "deceased_rivm.json"
+    "deceased_rivm_archived_20221231": {
+      "$ref": "deceased_rivm_archived_20221231.json"
     },
     "deceased_cbs": {
       "$ref": "deceased_cbs.json"

--- a/packages/app/schema/vr/deceased_rivm_archived_20221231.json
+++ b/packages/app/schema/vr/deceased_rivm_archived_20221231.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "vr_deceased_rivm",
+  "title": "vr_deceased_rivm_archived_20221231",
   "type": "object",
   "properties": {
     "values": {
@@ -17,7 +17,7 @@
   "additionalProperties": false,
   "definitions": {
     "value": {
-      "title": "vr_deceased_rivm_value",
+      "title": "vr_deceased_rivm_archived_20221231_value",
       "type": "object",
       "properties": {
         "covid_daily": {
@@ -40,14 +40,7 @@
           "equalsRootProperty": "code"
         }
       },
-      "required": [
-        "covid_daily", 
-        "covid_daily_moving_average",
-        "covid_total",
-        "date_unix",
-        "date_of_insertion_unix",
-        "vrcode"
-      ],
+      "required": ["covid_daily", "covid_daily_moving_average", "covid_total", "date_unix", "date_of_insertion_unix", "vrcode"],
       "additionalProperties": false
     }
   }

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -65,9 +65,10 @@ export function GmLayout(props: GmLayoutProps) {
     layout: 'gm',
     code: code,
     map: [
-      ['development_of_the_virus', ['sewage_measurement', 'positive_tests', 'mortality']],
+      ['development_of_the_virus', ['sewage_measurement', 'positive_tests']],
       ['consequences_for_healthcare', ['hospital_admissions']],
       ['actions_to_take', ['vaccinations']],
+      ['archived_metrics', ['mortality']],
     ],
   });
 

--- a/packages/app/src/domain/layout/logic/types.ts
+++ b/packages/app/src/domain/layout/logic/types.ts
@@ -1,18 +1,10 @@
 export type Layout = 'nl' | 'vr' | 'gm';
 
-type SharedCategoryKeys =
-  | 'development_of_the_virus'
-  | 'consequences_for_healthcare'
-  | 'actions_to_take';
+type SharedCategoryKeys = 'development_of_the_virus' | 'consequences_for_healthcare' | 'actions_to_take';
 
-export type GmItemKeys =
-  | 'hospital_admissions'
-  | 'mortality'
-  | 'positive_tests'
-  | 'sewage_measurement'
-  | 'vaccinations';
+export type GmItemKeys = 'hospital_admissions' | 'mortality' | 'positive_tests' | 'sewage_measurement' | 'vaccinations';
 
-export type GmCategoryKeys = SharedCategoryKeys;
+export type GmCategoryKeys = SharedCategoryKeys | 'archived_metrics';
 
 export type VrItemKeys =
   | 'compliance'
@@ -50,27 +42,16 @@ export type NlItemKeys =
 
 export type NlCategoryKeys = SharedCategoryKeys | 'archived_metrics';
 
-export type CategoryKeys<T extends Layout> = T extends 'nl'
-  ? NlCategoryKeys
-  : T extends 'vr'
-  ? VrCategoryKeys
-  : GmCategoryKeys;
+export type CategoryKeys<T extends Layout> = T extends 'nl' ? NlCategoryKeys : T extends 'vr' ? VrCategoryKeys : GmCategoryKeys;
 
-export type ItemKeys<T extends Layout> = T extends 'nl'
-  ? NlItemKeys
-  : T extends 'vr'
-  ? VrItemKeys
-  : GmItemKeys;
+export type ItemKeys<T extends Layout> = T extends 'nl' ? NlItemKeys : T extends 'vr' ? VrItemKeys : GmItemKeys;
 
 /**
  * The following types are consumed by the useSidebar hook.
  */
 export type SidebarMap<T extends Layout> = (SidebarElement<T> | ItemKeys<T>)[];
 
-export type SidebarElement<T extends Layout> = [
-  category: CategoryKeys<T>,
-  items: ItemKeys<T>[]
-];
+export type SidebarElement<T extends Layout> = [category: CategoryKeys<T>, items: ItemKeys<T>[]];
 
 /**
  * The following types are returned by the useSidebar hook.
@@ -88,7 +69,4 @@ export type SidebarItem<T extends Layout> = {
   href: string | undefined;
 };
 
-export type ExpandedSidebarMap<T extends Layout> = (
-  | SidebarCategory<T>
-  | SidebarItem<T>
-)[];
+export type ExpandedSidebarMap<T extends Layout> = (SidebarCategory<T> | SidebarItem<T>)[];

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -1,53 +1,27 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
+import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import {
-  KpiValue,
-  KpiTile,
-  ChartTile,
-  PageInformationBlock,
-  Markdown,
-  TimeSeriesChart,
-  TwoKpiSection,
-  TileList,
-} from '~/components';
 import { useState } from 'react';
+import { ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
 import { Text } from '~/components/typography';
-import { Layout, GmLayout } from '~/domain/layout';
+import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetContent,
-  getLastGeneratedDate,
-  getLokalizeTexts,
-  selectGmData,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { replaceVariablesInText } from '~/utils';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
-const pageMetrics = ['deceased_rivm'];
+const pageMetrics = ['deceased_rivm_archived_20221231'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   textGm: siteText.pages.deceased_page.gm,
+  textShared: siteText.pages.deceased_page.shared,
 });
 
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
@@ -55,14 +29,9 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export { getStaticPaths } from '~/static-paths/gm';
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectGmData(
-    'difference.deceased_rivm__covid_daily',
-    'deceased_rivm',
-    'code'
-  ),
+  selectGmData('difference.deceased_rivm__covid_daily_archived_20221231', 'deceased_rivm_archived_20221231', 'code'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
       parts: PagePartQueryResult<ArticleParts>;
@@ -71,39 +40,26 @@ export const getStaticProps = createGetStaticProps(
       const { locale } = context;
       return `{
       "parts": ${getPagePartsQuery('deceased_page')},
-      "elements": ${getElementsQuery('gm', ['deceased_rivm'], locale)}
+      "elements": ${getElementsQuery('gm', ['deceased_rivm_archived_20221231'], locale)}
      }`;
     })(context);
 
     return {
       content: {
-        articles: getArticleParts(
-          content.parts.pageParts,
-          'deceasedPageArticles'
-        ),
+        articles: getArticleParts(content.parts.pageParts, 'deceasedPageArticles'),
         elements: content.elements,
       },
     };
   }
 );
 
-function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    municipalityName,
-    selectedGmData: data,
-    content,
-    lastGenerated,
-  } = props;
+const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
+  const { pageText, municipalityName, selectedGmData: data, content, lastGenerated } = props;
 
-  const [deceasedMunicipalTimeframe, setDeceasedMunicipalTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [deceasedMunicipalTimeframe, setDeceasedMunicipalTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { commonTexts } = useIntl();
-  const { textGm } = useDynamicLokalizeTexts<LokalizeTexts>(
-    pageText,
-    selectLokalizeTexts
-  );
+  const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const metadata = {
     ...commonTexts.gemeente_index.metadata,
@@ -115,6 +71,8 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
     }),
   };
 
+  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
   return (
@@ -122,9 +80,7 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
       <GmLayout code={data.code} municipalityName={municipalityName}>
         <TileList>
           <PageInformationBlock
-            category={
-              commonTexts.sidebar.categories.development_of_the_virus.title
-            }
+            category={commonTexts.sidebar.categories.development_of_the_virus.title}
             title={replaceVariablesInText(textGm.section_deceased_rivm.title, {
               municipalityName,
             })}
@@ -133,7 +89,7 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
             referenceLink={textGm.section_deceased_rivm.reference.href}
             metadata={{
               datumsText: textGm.section_deceased_rivm.datums,
-              dateOrRange: data.deceased_rivm.last_value.date_unix,
+              dateOrRange: data.deceased_rivm_archived_20221231.last_value.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.section_deceased_rivm.bronnen.rivm],
             }}
@@ -142,49 +98,41 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
             warning={textGm.warning}
           />
 
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.notification.message} variant="emphasis" />}
+
           <TwoKpiSection>
             <KpiTile
               title={textGm.section_deceased_rivm.kpi_covid_daily_title}
               metadata={{
-                date: data.deceased_rivm.last_value.date_unix,
+                date: data.deceased_rivm_archived_20221231.last_value.date_unix,
                 source: textGm.section_deceased_rivm.bronnen.rivm,
               }}
             >
               <KpiValue
                 data-cy="covid_daily"
-                absolute={data.deceased_rivm.last_value.covid_daily}
-                difference={data.difference.deceased_rivm__covid_daily}
+                absolute={data.deceased_rivm_archived_20221231.last_value.covid_daily}
+                difference={data.difference.deceased_rivm__covid_daily_archived_20221231}
                 isAmount
               />
-              <Markdown
-                content={
-                  textGm.section_deceased_rivm.kpi_covid_daily_description
-                }
-              />
+              <Markdown content={textGm.section_deceased_rivm.kpi_covid_daily_description} />
             </KpiTile>
+
             <KpiTile
               title={textGm.section_deceased_rivm.kpi_covid_total_title}
               metadata={{
-                date: data.deceased_rivm.last_value.date_unix,
+                date: data.deceased_rivm_archived_20221231.last_value.date_unix,
                 source: textGm.section_deceased_rivm.bronnen.rivm,
               }}
             >
-              <KpiValue
-                data-cy="covid_total"
-                absolute={data.deceased_rivm.last_value.covid_total}
-              />
-              <Text>
-                {textGm.section_deceased_rivm.kpi_covid_total_description}
-              </Text>
+              <KpiValue data-cy="covid_total" absolute={data.deceased_rivm_archived_20221231.last_value.covid_total} />
+              <Text>{textGm.section_deceased_rivm.kpi_covid_total_description}</Text>
             </KpiTile>
           </TwoKpiSection>
 
           <ChartTile
             timeframeOptions={TimeframeOptionsList}
             title={textGm.section_deceased_rivm.line_chart_covid_daily_title}
-            description={
-              textGm.section_deceased_rivm.line_chart_covid_daily_description
-            }
+            description={textGm.section_deceased_rivm.line_chart_covid_daily_description}
             metadata={{ source: textGm.section_deceased_rivm.bronnen.rivm }}
             onSelectTimeframe={setDeceasedMunicipalTimeframe}
           >
@@ -192,37 +140,26 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
               accessibility={{
                 key: 'deceased_over_time_chart',
               }}
-              values={data.deceased_rivm.values}
+              values={data.deceased_rivm_archived_20221231.values}
               timeframe={deceasedMunicipalTimeframe}
               seriesConfig={[
                 {
                   type: 'line',
                   metricProperty: 'covid_daily_moving_average',
-                  label:
-                    textGm.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label_moving_average,
-                  shortLabel:
-                    textGm.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label_moving_average,
+                  label: textGm.section_deceased_rivm.line_chart_covid_daily_legend_trend_label_moving_average,
+                  shortLabel: textGm.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label_moving_average,
                   color: colors.primary,
                 },
                 {
                   type: 'bar',
                   metricProperty: 'covid_daily',
-                  label:
-                    textGm.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label,
-                  shortLabel:
-                    textGm.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label,
+                  label: textGm.section_deceased_rivm.line_chart_covid_daily_legend_trend_label,
+                  shortLabel: textGm.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label,
                   color: colors.primary,
                 },
               ]}
               dataOptions={{
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'deceased_rivm'
-                ),
+                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'deceased_rivm_archived_20221231'),
               }}
             />
           </ChartTile>
@@ -230,6 +167,6 @@ function DeceasedMunicipalPage(props: StaticProps<typeof getStaticProps>) {
       </GmLayout>
     </Layout>
   );
-}
+};
 
 export default DeceasedMunicipalPage;

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -1,6 +1,5 @@
 import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
-import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
@@ -71,7 +70,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
     }),
   };
 
-  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+  const hasActiveWarningTile = !!textShared.notification.message;
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -1,8 +1,9 @@
-import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
-import { useState } from 'react';
+import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
+import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import { TwoKpiSection, TimeSeriesChart, TileList, PageInformationBlock, AgeDemographic, ChartTile, Divider, KpiTile, KpiValue, Markdown } from '~/components';
+import { useState } from 'react';
+import { AgeDemographic, ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
 import { Text } from '~/components/typography';
 import { DeceasedMonitorSection } from '~/domain/deceased';
 import { Layout, NlLayout } from '~/domain/layout';
@@ -10,13 +11,13 @@ import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
 import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
-const pageMetrics = ['deceased_cbs', 'deceased_rivm_per_age_group', 'deceased_rivm'];
+const pageMetrics = ['deceased_cbs', 'deceased_rivm_per_age_group_archived_20221231', 'deceased_rivm_archived_20221231'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -29,7 +30,7 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData('deceased_cbs', 'deceased_rivm_per_age_group', 'deceased_rivm', 'difference.deceased_rivm__covid_daily'),
+  selectNlData('deceased_cbs', 'deceased_rivm_per_age_group_archived_20221231', 'deceased_rivm_archived_20221231', 'difference.deceased_rivm__covid_daily_archived_20221231'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
       parts: PagePartQueryResult<ArticleParts>;
@@ -38,7 +39,7 @@ export const getStaticProps = createGetStaticProps(
       const { locale } = context;
       return `{
       "parts": ${getPagePartsQuery('deceased_page')},
-      "elements": ${getElementsQuery('nl', ['deceased_rivm'], locale)}
+      "elements": ${getElementsQuery('nl', ['deceased_rivm_archived_20221231'], locale)}
      }`;
     })(context);
 
@@ -52,13 +53,15 @@ export const getStaticProps = createGetStaticProps(
   }
 );
 
-function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
-  const [deceasedOverTimeTimeframe, setDeceasedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
-
+const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
   const { pageText, selectedNlData: data, lastGenerated, content } = props;
+
+  const [deceasedOverTimeTimeframe, setDeceasedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [isArchivedContentShown, setIsArchivedContentShown] = useState<boolean>(false);
+
   const dataCbs = data.deceased_cbs;
-  const dataRivm = data.deceased_rivm;
-  const dataDeceasedPerAgeGroup = data.deceased_rivm_per_age_group;
+  const dataRivm = data.deceased_rivm_archived_20221231;
+  const dataDeceasedPerAgeGroup = data.deceased_rivm_per_age_group_archived_20221231;
 
   const { commonTexts, formatPercentage } = useIntl();
   const { metadataTexts, textNl, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
@@ -69,112 +72,14 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
     description: textNl.metadata.description,
   };
 
+  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NlLayout>
         <TileList>
-          <PageInformationBlock
-            category={commonTexts.sidebar.categories.development_of_the_virus.title}
-            title={textNl.section_deceased_rivm.title}
-            icon={<Coronavirus aria-hidden="true" />}
-            description={textNl.section_deceased_rivm.description}
-            referenceLink={textNl.section_deceased_rivm.reference.href}
-            metadata={{
-              datumsText: textNl.section_deceased_rivm.datums,
-              dateOrRange: dataRivm.last_value.date_unix,
-              dateOfInsertionUnix: lastInsertionDateOfPage,
-              dataSources: [textNl.section_deceased_rivm.bronnen.rivm],
-            }}
-            articles={content.mainArticles}
-          />
-
-          <TwoKpiSection>
-            <KpiTile
-              title={textNl.section_deceased_rivm.kpi_covid_daily_title}
-              metadata={{
-                date: dataRivm.last_value.date_unix,
-                source: textNl.section_deceased_rivm.bronnen.rivm,
-              }}
-            >
-              <KpiValue data-cy="covid_daily" absolute={dataRivm.last_value.covid_daily} difference={data.difference.deceased_rivm__covid_daily} isAmount />
-              <Markdown content={textNl.section_deceased_rivm.kpi_covid_daily_description} />
-            </KpiTile>
-            <KpiTile
-              title={textNl.section_deceased_rivm.kpi_covid_total_title}
-              metadata={{
-                date: dataRivm.last_value.date_unix,
-                source: textNl.section_deceased_rivm.bronnen.rivm,
-              }}
-            >
-              <KpiValue data-cy="covid_total" absolute={dataRivm.last_value.covid_total} />
-              <Text>{textNl.section_deceased_rivm.kpi_covid_total_description}</Text>
-            </KpiTile>
-          </TwoKpiSection>
-
-          <ChartTile
-            timeframeOptions={TimeframeOptionsList}
-            title={textNl.section_deceased_rivm.line_chart_covid_daily_title}
-            description={textNl.section_deceased_rivm.line_chart_covid_daily_description}
-            metadata={{
-              source: textNl.section_deceased_rivm.bronnen.rivm,
-            }}
-            onSelectTimeframe={setDeceasedOverTimeTimeframe}
-          >
-            <TimeSeriesChart
-              accessibility={{
-                key: 'deceased_over_time_chart',
-              }}
-              values={dataRivm.values}
-              timeframe={deceasedOverTimeTimeframe}
-              seriesConfig={[
-                {
-                  type: 'line',
-                  metricProperty: 'covid_daily_moving_average',
-                  label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label_moving_average,
-                  shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label_moving_average,
-                  color: colors.primary,
-                },
-                {
-                  type: 'bar',
-                  metricProperty: 'covid_daily',
-                  label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label,
-                  shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label,
-                  color: colors.primary,
-                },
-              ]}
-              dataOptions={{
-                timelineEvents: getTimelineEvents(content.elements.timeSeries, 'deceased_rivm'),
-              }}
-            />
-          </ChartTile>
-
-          <ChartTile
-            title={textShared.age_groups.title}
-            description={textShared.age_groups.description}
-            metadata={{
-              date: dataRivm.last_value.date_unix,
-              source: textShared.age_groups.bronnen.rivm,
-            }}
-          >
-            <AgeDemographic
-              accessibility={{
-                key: 'deceased_per_age_group_over_time_chart',
-              }}
-              data={dataDeceasedPerAgeGroup}
-              rightMetricProperty="covid_percentage"
-              leftMetricProperty="age_group_percentage"
-              rightColor={colors.primary}
-              leftColor={colors.neutral}
-              maxDisplayValue={60}
-              text={textShared.age_groups.graph}
-              formatValue={(a: number) => `${formatPercentage(a * 100)}%`}
-            />
-          </ChartTile>
-
-          <Divider />
-
           <PageInformationBlock
             title={textShared.section_sterftemonitor.title}
             icon={<Coronavirus />}
@@ -192,11 +97,122 @@ function DeceasedNationalPage(props: StaticProps<typeof getStaticProps>) {
             articles={content.monitorArticles}
           />
 
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.notification.message} variant="emphasis" />}
+
           <DeceasedMonitorSection data={dataCbs} text={textShared.section_sterftemonitor} showCauseMessage />
+
+          <PageInformationBlock
+            title={textShared.section_archived.title}
+            description={textShared.section_archived.description}
+            isArchivedHidden={isArchivedContentShown}
+            onToggleArchived={() => setIsArchivedContentShown(!isArchivedContentShown)}
+          />
+
+          {isArchivedContentShown && (
+            <>
+              <PageInformationBlock
+                category={commonTexts.sidebar.categories.development_of_the_virus.title}
+                title={textNl.section_deceased_rivm.title}
+                icon={<Coronavirus aria-hidden="true" />}
+                description={textNl.section_deceased_rivm.description}
+                referenceLink={textNl.section_deceased_rivm.reference.href}
+                metadata={{
+                  datumsText: textNl.section_deceased_rivm.datums,
+                  dateOrRange: dataRivm.last_value.date_unix,
+                  dateOfInsertionUnix: lastInsertionDateOfPage,
+                  dataSources: [textNl.section_deceased_rivm.bronnen.rivm],
+                }}
+                articles={content.mainArticles}
+              />
+
+              <TwoKpiSection>
+                <KpiTile
+                  title={textNl.section_deceased_rivm.kpi_covid_daily_title}
+                  metadata={{
+                    date: dataRivm.last_value.date_unix,
+                    source: textNl.section_deceased_rivm.bronnen.rivm,
+                  }}
+                >
+                  <KpiValue data-cy="covid_daily" absolute={dataRivm.last_value.covid_daily} difference={data.difference.deceased_rivm__covid_daily_archived_20221231} isAmount />
+                  <Markdown content={textNl.section_deceased_rivm.kpi_covid_daily_description} />
+                </KpiTile>
+                <KpiTile
+                  title={textNl.section_deceased_rivm.kpi_covid_total_title}
+                  metadata={{
+                    date: dataRivm.last_value.date_unix,
+                    source: textNl.section_deceased_rivm.bronnen.rivm,
+                  }}
+                >
+                  <KpiValue data-cy="covid_total" absolute={dataRivm.last_value.covid_total} />
+                  <Text>{textNl.section_deceased_rivm.kpi_covid_total_description}</Text>
+                </KpiTile>
+              </TwoKpiSection>
+
+              <ChartTile
+                timeframeOptions={TimeframeOptionsList}
+                title={textNl.section_deceased_rivm.line_chart_covid_daily_title}
+                description={textNl.section_deceased_rivm.line_chart_covid_daily_description}
+                metadata={{
+                  source: textNl.section_deceased_rivm.bronnen.rivm,
+                }}
+                onSelectTimeframe={setDeceasedOverTimeTimeframe}
+              >
+                <TimeSeriesChart
+                  accessibility={{
+                    key: 'deceased_over_time_chart',
+                  }}
+                  values={dataRivm.values}
+                  timeframe={deceasedOverTimeTimeframe}
+                  seriesConfig={[
+                    {
+                      type: 'line',
+                      metricProperty: 'covid_daily_moving_average',
+                      label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label_moving_average,
+                      shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label_moving_average,
+                      color: colors.primary,
+                    },
+                    {
+                      type: 'bar',
+                      metricProperty: 'covid_daily',
+                      label: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_label,
+                      shortLabel: textNl.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label,
+                      color: colors.primary,
+                    },
+                  ]}
+                  dataOptions={{
+                    timelineEvents: getTimelineEvents(content.elements.timeSeries, 'deceased_rivm_archived_20221231'),
+                  }}
+                />
+              </ChartTile>
+
+              <ChartTile
+                title={textShared.age_groups.title}
+                description={textShared.age_groups.description}
+                metadata={{
+                  date: dataRivm.last_value.date_unix,
+                  source: textShared.age_groups.bronnen.rivm,
+                }}
+              >
+                <AgeDemographic
+                  accessibility={{
+                    key: 'deceased_per_age_group_over_time_chart',
+                  }}
+                  data={dataDeceasedPerAgeGroup}
+                  rightMetricProperty="covid_percentage"
+                  leftMetricProperty="age_group_percentage"
+                  rightColor={colors.primary}
+                  leftColor={colors.neutral}
+                  maxDisplayValue={60}
+                  text={textShared.age_groups.graph}
+                  formatValue={(a: number) => `${formatPercentage(a * 100)}%`}
+                />
+              </ChartTile>
+            </>
+          )}
         </TileList>
       </NlLayout>
     </Layout>
   );
-}
+};
 
 export default DeceasedNationalPage;

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -76,6 +76,8 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
+  const lastdeceasedPerAgeGroupInsertionDate = getLastInsertionDateOfPage(data, ['deceased_rivm_per_age_group_archived_20221231']);
+
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NlLayout>
@@ -189,7 +191,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
                 title={textShared.age_groups.title}
                 description={textShared.age_groups.description}
                 metadata={{
-                  date: dataRivm.last_value.date_unix,
+                  date: lastdeceasedPerAgeGroupInsertionDate,
                   source: textShared.age_groups.bronnen.rivm,
                 }}
               >

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -1,6 +1,5 @@
 import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
-import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { AgeDemographic, ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
@@ -72,7 +71,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
     description: textNl.metadata.description,
   };
 
-  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+  const hasActiveWarningTile = !!textShared.notification.message;
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -1,55 +1,27 @@
-import {
-  colors,
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
+import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import {
-  ChartTile,
-  KpiTile,
-  KpiValue,
-  Markdown,
-  PageInformationBlock,
-  TileList,
-  TimeSeriesChart,
-  TwoKpiSection,
-} from '~/components';
 import { useState } from 'react';
+import { ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
 import { Text } from '~/components/typography';
 import { DeceasedMonitorSection } from '~/domain/deceased';
 import { Layout, VrLayout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import {
-  ElementsQueryResult,
-  getElementsQuery,
-  getTimelineEvents,
-} from '~/queries/get-elements-query';
-import {
-  getArticleParts,
-  getPagePartsQuery,
-} from '~/queries/get-page-parts-query';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetContent,
-  getLastGeneratedDate,
-  getLokalizeTexts,
-  selectVrData,
-} from '~/static-props/get-data';
+import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
+import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectVrData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { replaceVariablesInText } from '~/utils';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
-const pageMetrics = ['deceased_cbs', 'deceased_rivm'];
+const pageMetrics = ['deceased_cbs', 'deceased_rivm_archived_20221231'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
-  categoryTexts:
-    siteText.common.sidebar.categories.development_of_the_virus.title,
+  categoryTexts: siteText.common.sidebar.categories.development_of_the_virus.title,
   textVr: siteText.pages.deceased_page.vr,
   textShared: siteText.pages.deceased_page.shared,
 });
@@ -59,14 +31,9 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export { getStaticPaths } from '~/static-paths/vr';
 
 export const getStaticProps = createGetStaticProps(
-  ({ locale }: { locale: keyof Languages }) =>
-    getLokalizeTexts(selectLokalizeTexts, locale),
+  ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectVrData(
-    'deceased_cbs',
-    'deceased_rivm',
-    'difference.deceased_rivm__covid_daily'
-  ),
+  selectVrData('deceased_cbs', 'deceased_rivm_archived_20221231', 'difference.deceased_rivm__covid_daily_archived_20221231'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
       parts: PagePartQueryResult<ArticleParts>;
@@ -75,43 +42,30 @@ export const getStaticProps = createGetStaticProps(
       const { locale } = context;
       return `{
       "parts": ${getPagePartsQuery('deceased_page')},
-      "elements": ${getElementsQuery('vr', ['deceased_rivm'], locale)}
+      "elements": ${getElementsQuery('vr', ['deceased_rivm_archived_20221231'], locale)}
      }`;
     })(context);
 
     return {
       content: {
-        mainArticles: getArticleParts(
-          content.parts.pageParts,
-          'deceasedPageArticles'
-        ),
-        monitorArticles: getArticleParts(
-          content.parts.pageParts,
-          'deceasedMonitorArticles'
-        ),
+        mainArticles: getArticleParts(content.parts.pageParts, 'deceasedPageArticles'),
+        monitorArticles: getArticleParts(content.parts.pageParts, 'deceasedMonitorArticles'),
         elements: content.elements,
       },
     };
   }
 );
 
-function DeceasedRegionalPage(props: StaticProps<typeof getStaticProps>) {
-  const {
-    pageText,
-    selectedVrData: data,
-    vrName,
-    content,
-    lastGenerated,
-  } = props;
+const DeceasedRegionalPage = (props: StaticProps<typeof getStaticProps>) => {
+  const { pageText, selectedVrData: data, vrName, content, lastGenerated } = props;
 
-  const [deceasedMunicipalTimeframe, setDeceasedMunicipalTimeframe] =
-    useState<TimeframeOption>(TimeframeOption.ALL);
+  const [deceasedMunicipalTimeframe, setDeceasedMunicipalTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [isArchivedContentShown, setIsArchivedContentShown] = useState<boolean>(false);
 
-  const { deceased_cbs: dataCbs, deceased_rivm: dataRivm, difference } = data;
+  const { deceased_cbs: dataCbs, deceased_rivm_archived_20221231: dataRivm, difference } = data;
 
   const { commonTexts } = useIntl();
-  const { categoryTexts, textVr, textShared } =
-    useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
+  const { categoryTexts, textVr, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const metadata = {
     ...commonTexts.veiligheidsregio_index.metadata,
@@ -123,118 +77,14 @@ function DeceasedRegionalPage(props: StaticProps<typeof getStaticProps>) {
     }),
   };
 
+  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <VrLayout vrName={vrName}>
         <TileList>
-          <PageInformationBlock
-            category={categoryTexts}
-            title={replaceVariablesInText(textVr.section_deceased_rivm.title, {
-              safetyRegion: vrName,
-            })}
-            icon={<Coronavirus aria-hidden="true" />}
-            description={textVr.section_deceased_rivm.description}
-            referenceLink={textVr.section_deceased_rivm.reference.href}
-            metadata={{
-              datumsText: textVr.section_deceased_rivm.datums,
-              dateOrRange: dataRivm.last_value.date_unix,
-              dateOfInsertionUnix: lastInsertionDateOfPage,
-              dataSources: [textVr.section_deceased_rivm.bronnen.rivm],
-            }}
-            articles={content.mainArticles}
-            vrNameOrGmName={vrName}
-            warning={textVr.warning}
-          />
-
-          <TwoKpiSection>
-            <KpiTile
-              title={textVr.section_deceased_rivm.kpi_covid_daily_title}
-              metadata={{
-                date: dataRivm.last_value.date_unix,
-                source: textVr.section_deceased_rivm.bronnen.rivm,
-              }}
-            >
-              <KpiValue
-                data-cy="covid_daily"
-                absolute={dataRivm.last_value.covid_daily}
-                difference={difference.deceased_rivm__covid_daily}
-                isAmount
-              />
-              <Markdown
-                content={
-                  textVr.section_deceased_rivm.kpi_covid_daily_description
-                }
-              />
-            </KpiTile>
-            <KpiTile
-              title={textVr.section_deceased_rivm.kpi_covid_total_title}
-              metadata={{
-                date: dataRivm.last_value.date_unix,
-                source: textVr.section_deceased_rivm.bronnen.rivm,
-              }}
-            >
-              <KpiValue
-                data-cy="covid_total"
-                absolute={dataRivm.last_value.covid_total}
-              />
-              <Text>
-                {textVr.section_deceased_rivm.kpi_covid_total_description}
-              </Text>
-            </KpiTile>
-          </TwoKpiSection>
-
-          <ChartTile
-            timeframeOptions={TimeframeOptionsList}
-            title={textVr.section_deceased_rivm.line_chart_covid_daily_title}
-            description={
-              textVr.section_deceased_rivm.line_chart_covid_daily_description
-            }
-            metadata={{
-              source: textVr.section_deceased_rivm.bronnen.rivm,
-            }}
-            onSelectTimeframe={setDeceasedMunicipalTimeframe}
-          >
-            <TimeSeriesChart
-              accessibility={{
-                key: 'deceased_over_time_chart',
-              }}
-              values={dataRivm.values}
-              timeframe={deceasedMunicipalTimeframe}
-              seriesConfig={[
-                {
-                  type: 'line',
-                  metricProperty: 'covid_daily_moving_average',
-                  label:
-                    textVr.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label_moving_average,
-                  shortLabel:
-                    textVr.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label_moving_average,
-                  color: colors.primary,
-                },
-                {
-                  type: 'bar',
-                  metricProperty: 'covid_daily',
-                  label:
-                    textVr.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_label,
-                  shortLabel:
-                    textVr.section_deceased_rivm
-                      .line_chart_covid_daily_legend_trend_short_label,
-                  color: colors.primary,
-                },
-              ]}
-              dataOptions={{
-                timelineEvents: getTimelineEvents(
-                  content.elements.timeSeries,
-                  'deceased_rivm'
-                ),
-              }}
-            />
-          </ChartTile>
-
           <PageInformationBlock
             title={textVr.section_sterftemonitor.title}
             icon={<Coronavirus aria-hidden="true" />}
@@ -252,14 +102,104 @@ function DeceasedRegionalPage(props: StaticProps<typeof getStaticProps>) {
             articles={content.monitorArticles}
           />
 
-          <DeceasedMonitorSection
-            text={textShared.section_sterftemonitor}
-            data={dataCbs}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.notification.message} variant="emphasis" />}
+
+          <DeceasedMonitorSection text={textShared.section_sterftemonitor} data={dataCbs} />
+
+          <PageInformationBlock
+            title={textShared.section_archived.title}
+            description={textShared.section_archived.description}
+            isArchivedHidden={isArchivedContentShown}
+            onToggleArchived={() => setIsArchivedContentShown(!isArchivedContentShown)}
           />
+
+          {isArchivedContentShown && (
+            <>
+              <PageInformationBlock
+                category={categoryTexts}
+                title={replaceVariablesInText(textVr.section_deceased_rivm.title, {
+                  safetyRegion: vrName,
+                })}
+                icon={<Coronavirus aria-hidden="true" />}
+                description={textVr.section_deceased_rivm.description}
+                referenceLink={textVr.section_deceased_rivm.reference.href}
+                metadata={{
+                  datumsText: textVr.section_deceased_rivm.datums,
+                  dateOrRange: dataRivm.last_value.date_unix,
+                  dateOfInsertionUnix: lastInsertionDateOfPage,
+                  dataSources: [textVr.section_deceased_rivm.bronnen.rivm],
+                }}
+                articles={content.mainArticles}
+                vrNameOrGmName={vrName}
+                warning={textVr.warning}
+              />
+
+              <TwoKpiSection>
+                <KpiTile
+                  title={textVr.section_deceased_rivm.kpi_covid_daily_title}
+                  metadata={{
+                    date: dataRivm.last_value.date_unix,
+                    source: textVr.section_deceased_rivm.bronnen.rivm,
+                  }}
+                >
+                  <KpiValue data-cy="covid_daily" absolute={dataRivm.last_value.covid_daily} difference={difference.deceased_rivm__covid_daily_archived_20221231} isAmount />
+                  <Markdown content={textVr.section_deceased_rivm.kpi_covid_daily_description} />
+                </KpiTile>
+
+                <KpiTile
+                  title={textVr.section_deceased_rivm.kpi_covid_total_title}
+                  metadata={{
+                    date: dataRivm.last_value.date_unix,
+                    source: textVr.section_deceased_rivm.bronnen.rivm,
+                  }}
+                >
+                  <KpiValue data-cy="covid_total" absolute={dataRivm.last_value.covid_total} />
+                  <Text>{textVr.section_deceased_rivm.kpi_covid_total_description}</Text>
+                </KpiTile>
+              </TwoKpiSection>
+
+              <ChartTile
+                timeframeOptions={TimeframeOptionsList}
+                title={textVr.section_deceased_rivm.line_chart_covid_daily_title}
+                description={textVr.section_deceased_rivm.line_chart_covid_daily_description}
+                metadata={{
+                  source: textVr.section_deceased_rivm.bronnen.rivm,
+                }}
+                onSelectTimeframe={setDeceasedMunicipalTimeframe}
+              >
+                <TimeSeriesChart
+                  accessibility={{
+                    key: 'deceased_over_time_chart',
+                  }}
+                  values={dataRivm.values}
+                  timeframe={deceasedMunicipalTimeframe}
+                  seriesConfig={[
+                    {
+                      type: 'line',
+                      metricProperty: 'covid_daily_moving_average',
+                      label: textVr.section_deceased_rivm.line_chart_covid_daily_legend_trend_label_moving_average,
+                      shortLabel: textVr.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label_moving_average,
+                      color: colors.primary,
+                    },
+                    {
+                      type: 'bar',
+                      metricProperty: 'covid_daily',
+                      label: textVr.section_deceased_rivm.line_chart_covid_daily_legend_trend_label,
+                      shortLabel: textVr.section_deceased_rivm.line_chart_covid_daily_legend_trend_short_label,
+                      color: colors.primary,
+                    },
+                  ]}
+                  dataOptions={{
+                    timelineEvents: getTimelineEvents(content.elements.timeSeries, 'deceased_rivm_archived_20221231'),
+                  }}
+                />
+              </ChartTile>
+            </>
+          )}
         </TileList>
       </VrLayout>
     </Layout>
   );
-}
+};
 
 export default DeceasedRegionalPage;

--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -1,6 +1,5 @@
 import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
 import { Coronavirus } from '@corona-dashboard/icons';
-import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
@@ -77,7 +76,7 @@ const DeceasedRegionalPage = (props: StaticProps<typeof getStaticProps>) => {
     }),
   };
 
-  const hasActiveWarningTile = !!textShared.notification.message && !isEmpty(textShared.notification.message);
+  const hasActiveWarningTile = !!textShared.notification.message;
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 

--- a/packages/cms/src/elements/schemas/shared/index.ts
+++ b/packages/cms/src/elements/schemas/shared/index.ts
@@ -66,7 +66,7 @@ const titleByMetricName: Partial<Record<MetricName, string>> = {
   vaccine_administered_total: 'Totaal gezette prikken',
   nursing_home: 'Verpleeghuizen',
   disability_care: 'Gehandicaptenzorg',
-  deceased_rivm: 'Sterfte (RIVM)',
+  deceased_rivm_archived_20221231: 'Sterfte (RIVM)',
   intensive_care_nice_per_age_group: 'IC-opnames (per leeftijd)',
   hospital_nice_per_age_group: 'Ziekenhuisopnames (per leeftijd)',
   tested_per_age_group: 'Positief getest (per leeftijd)',

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,4 @@
 timestamp,action,key,document_id,move_to
+2023-01-20T17:01:08.974Z,add,pages.deceased_page.shared.section_archived.title,say0BNKaNSuhganBi7SnHD,__
+2023-01-20T17:01:09.936Z,add,pages.deceased_page.shared.section_archived.description,say0BNKaNSuhganBi7Sna7,__
+2023-01-20T17:01:10.959Z,add,pages.deceased_page.shared.notification.message,AE5jpq5sZWNgXeEUcJEy4d,__

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -12,7 +12,7 @@ export interface Gm {
   name: GmCode;
   code: GmCode;
   static_values: GmStaticValues;
-  deceased_rivm: GmDeceasedRivm;
+  deceased_rivm_archived_20221231: GmDeceasedRivmArchived_20221231;
   difference: GmDifference;
   hospital_nice: GmHospitalNice;
   tested_overall: GmTestedOverall;
@@ -26,11 +26,11 @@ export interface Gm {
 export interface GmStaticValues {
   population_count: number;
 }
-export interface GmDeceasedRivm {
-  values: GmDeceasedRivmValue[];
-  last_value: GmDeceasedRivmValue;
+export interface GmDeceasedRivmArchived_20221231 {
+  values: GmDeceasedRivmArchived_20221231Value[];
+  last_value: GmDeceasedRivmArchived_20221231Value;
 }
-export interface GmDeceasedRivmValue {
+export interface GmDeceasedRivmArchived_20221231Value {
   covid_daily: number;
   covid_daily_moving_average: number | null;
   covid_total: number;
@@ -42,7 +42,7 @@ export interface GmDifference {
   tested_overall__infected_moving_average: DifferenceDecimal;
   hospital_nice__admissions_on_date_of_reporting_moving_average: DifferenceDecimal;
   sewer__average?: DifferenceInteger;
-  deceased_rivm__covid_daily: DifferenceInteger;
+  deceased_rivm__covid_daily_archived_20221231: DifferenceInteger;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -250,8 +250,8 @@ export interface Nl {
   behavior_per_age_group?: NlBehaviorPerAgeGroup;
   behavior_get_tested_support_per_age_group?: NlBehaviorGetTestedSupportPerAgeGroup;
   behavior_annotations: NlBehaviorAnnotations;
-  deceased_rivm: NlDeceasedRivm;
-  deceased_rivm_per_age_group: NlDeceasedRivmPerAgeGroup;
+  deceased_rivm_archived_20221231: NlDeceasedRivmArchived_20221231;
+  deceased_rivm_per_age_group_archived_20221231: NlDeceasedRivmPerAgeGroupArchived_20221231;
   deceased_cbs: NlDeceasedCbs;
   elderly_at_home: NlElderlyAtHome;
   vaccine_vaccinated_or_support: NlVaccineVaccinatedOrSupport;
@@ -303,7 +303,7 @@ export interface NlDifference {
   disability_care__newly_infected_people: DifferenceInteger;
   disability_care__infected_locations_total: DifferenceInteger;
   elderly_at_home__positive_tested_daily: DifferenceInteger;
-  deceased_rivm__covid_daily: DifferenceInteger;
+  deceased_rivm__covid_daily_archived_20221231: DifferenceInteger;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -735,21 +735,21 @@ export interface NlBehaviorAnnotations1 {
   date_end_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlDeceasedRivm {
-  values: NlDeceasedRivmValue[];
-  last_value: NlDeceasedRivmValue;
+export interface NlDeceasedRivmArchived_20221231 {
+  values: NlDeceasedRivmArchived_20221231Value[];
+  last_value: NlDeceasedRivmArchived_20221231Value;
 }
-export interface NlDeceasedRivmValue {
+export interface NlDeceasedRivmArchived_20221231Value {
   covid_daily: number;
   covid_daily_moving_average: number | null;
   covid_total: number;
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlDeceasedRivmPerAgeGroup {
-  values: NlDeceasedRivmPerAgeGroupValue[];
+export interface NlDeceasedRivmPerAgeGroupArchived_20221231 {
+  values: NlDeceasedRivmPerAgeGroupArchived_20221231Value[];
 }
-export interface NlDeceasedRivmPerAgeGroupValue {
+export interface NlDeceasedRivmPerAgeGroupArchived_20221231Value {
   age_group_range: string;
   age_group_percentage: number;
   covid_percentage: number;
@@ -1363,7 +1363,7 @@ export interface Vr {
   nursing_home: VrNursingHome;
   disability_care: VrDisabilityCare;
   behavior_archived_20221019: VrBehaviorArchived_20221019;
-  deceased_rivm: VrDeceasedRivm;
+  deceased_rivm_archived_20221231: VrDeceasedRivmArchived_20221231;
   deceased_cbs: VrDeceasedCbs;
   elderly_at_home: VrElderlyAtHome;
   tested_overall_sum: VrTestedOverallSum;
@@ -1390,7 +1390,7 @@ export interface VrDifference {
   disability_care__newly_infected_people: DifferenceInteger;
   disability_care__infected_locations_total: DifferenceInteger;
   elderly_at_home__positive_tested_daily: DifferenceInteger;
-  deceased_rivm__covid_daily: DifferenceInteger;
+  deceased_rivm__covid_daily_archived_20221231: DifferenceInteger;
 }
 export interface DifferenceDecimal {
   old_value: number;
@@ -1570,11 +1570,11 @@ export interface VrBehaviorArchived_20221019Value {
   date_of_insertion_unix: number;
   vrcode: string;
 }
-export interface VrDeceasedRivm {
-  values: VrDeceasedRivmValue[];
-  last_value: VrDeceasedRivmValue;
+export interface VrDeceasedRivmArchived_20221231 {
+  values: VrDeceasedRivmArchived_20221231Value[];
+  last_value: VrDeceasedRivmArchived_20221231Value;
 }
-export interface VrDeceasedRivmValue {
+export interface VrDeceasedRivmArchived_20221231Value {
   covid_daily: number;
   covid_daily_moving_average: number | null;
   covid_total: number;

--- a/packages/e2e/src/integration/gemeente/sterfte.spec.ts
+++ b/packages/e2e/src/integration/gemeente/sterfte.spec.ts
@@ -6,7 +6,7 @@ context('Gemeente - Sterfte', () => {
   });
 
   it('Should show the correct KPI values', function (this: GmContext) {
-    const lastValue = this.municipalData.deceased_rivm.last_value;
+    const lastValue = this.municipalData.deceased_rivm_archived_20221231.last_value;
 
     const kpiTestInfo = {
       covid_daily: cy.formatters.formatNumber(lastValue.covid_daily),

--- a/packages/e2e/src/integration/landelijk/sterfte.spec.ts
+++ b/packages/e2e/src/integration/landelijk/sterfte.spec.ts
@@ -6,7 +6,7 @@ context('Landelijk - Sterfte', () => {
   });
 
   it('Should show the correct KPI values', function (this: NlContext) {
-    const rivmLastValue = this.nationalData.deceased_rivm.last_value;
+    const rivmLastValue = this.nationalData.deceased_rivm_archived_20221231.last_value;
 
     const kpiTestInfo = {
       covid_daily: cy.formatters.formatNumber(rivmLastValue.covid_daily),

--- a/packages/e2e/src/integration/veiligheidsregio/sterfte.spec.ts
+++ b/packages/e2e/src/integration/veiligheidsregio/sterfte.spec.ts
@@ -6,7 +6,7 @@ context('Regionaal - Sterfte', () => {
   });
 
   it('Should show the correct KPI values', function (this: RegionalContext) {
-    const rivmLastValue = this.regionData.deceased_rivm.last_value;
+    const rivmLastValue = this.regionData.deceased_rivm_archived_20221231.last_value;
 
     const kpiTestInfo = {
       covid_daily: cy.formatters.formatNumber(rivmLastValue.covid_daily),


### PR DESCRIPTION
## Summary

* updated 'Sterfte' (or 'Death rate') pages across NL, VR and GM to correctly archive (parts of) the pages
* updated GM layout to enhance the navigational sidebar with an 'Archived pages' section
* updated various JSON schemas to be marked as archived across NL, VR and GM
* generated data types based on new schema updates
* updated Sanity keys

### Screenshots
Any texts in the screenshots are not set in stone.

#### Before
<details>
<summary>Toggle before screenshots</summary>

![COR-1356_before_NL](https://user-images.githubusercontent.com/107395524/214000985-11a4dcd8-c7b3-4b5c-85c3-3f322d859ca0.png)
![COR-1356_before_VR](https://user-images.githubusercontent.com/107395524/214000990-9b16e882-b819-4b88-ac23-a8e764c01b49.png)
![COR-1356_before_GM](https://user-images.githubusercontent.com/107395524/214000999-c68c57c9-fdd7-4e23-b72d-c1f24d885397.png)

</details>

#### After
<details>
<summary>Toggle before screenshots</summary>

![COR-1356_after_NL](https://user-images.githubusercontent.com/107395524/214000918-5905e968-d4cf-461e-be2e-90fc6df8031f.png)
![COR-1356_after_VR](https://user-images.githubusercontent.com/107395524/214000936-dd8a2aea-55fa-47a9-bdc6-bf11dd756539.png)
![COR-1356_after_GM](https://user-images.githubusercontent.com/107395524/214000948-63ffa0f1-c352-48f3-b9c1-5c1e3a4e295c.png)

</details>