### PR TITLE
feat: moved text field, applied styling

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -37,7 +37,7 @@ import { ChevronRight, Download, External as ExternalLinkIcon } from '@corona-da
 type ElementAlignment = 'start' | 'center' | 'end' | 'stretch';
 
 interface RichContentProps {
-  blocks: PortableTextEntry[];
+  blocks?: PortableTextEntry[];
   contentWrapper?: FunctionComponent;
   imageSizes?: number[][];
   elementAlignment?: ElementAlignment;

--- a/packages/app/src/domain/topical/components/topical-header.tsx
+++ b/packages/app/src/domain/topical/components/topical-header.tsx
@@ -5,15 +5,15 @@ import { PortableTextEntry } from '@sanity/block-content-to-react';
 import { fontSizes } from '~/style/theme';
 
 interface TopicalHeaderProps {
-  title: string;
-  description: PortableTextEntry[];
+  title?: string;
+  description?: PortableTextEntry[];
 }
 
 export const TopicalHeader = ({ title, description }: TopicalHeaderProps) => {
   return (
     <Box spacing={4}>
       <Heading level={1}>{title}</Heading>
-      <Box spacing={3} fontSize={fontSizes[3]}>
+      <Box spacing={3} fontSize={fontSizes[2]}>
         <RichContent blocks={description} elementAlignment="start" />
       </Box>
     </Box>

--- a/packages/app/src/domain/topical/components/topical-header.tsx
+++ b/packages/app/src/domain/topical/components/topical-header.tsx
@@ -10,12 +10,17 @@ interface TopicalHeaderProps {
 }
 
 export const TopicalHeader = ({ title, description }: TopicalHeaderProps) => {
+  if (!title && !description) {
+    return null;
+  }
   return (
     <Box spacing={4}>
-      <Heading level={1}>{title}</Heading>
-      <Box spacing={3} fontSize={fontSizes[2]}>
-        <RichContent blocks={description} elementAlignment="start" />
-      </Box>
+      {title && <Heading level={1}>{title}</Heading>}
+      {description && (
+        <Box spacing={3} fontSize={fontSizes[2]}>
+          <RichContent blocks={description} elementAlignment="start" />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -112,9 +112,12 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
             paddingX={{ _: space[3], sm: space[4] }}
             maxWidth={TOPICAL_SEVERITY_INDICATOR_TILE_MAX_WIDTH}
           >
-            <TopicalHeader title={topicalConfig.title} description={topicalConfig.description} />
+            <TopicalHeader title={topicalConfig.title} />
           </Box>
           <TopicalWeeklySummaryTile title={weeklySummary.title} summaryItems={weeklySummary.items} level={currentSeverityLevel} label={currentSeverityLevelTexts?.label} />
+          <Box paddingX={{ _: space[3], sm: space[4] }} maxWidth={TOPICAL_SEVERITY_INDICATOR_TILE_MAX_WIDTH}>
+            <TopicalHeader description={topicalConfig.description} />
+          </Box>
           {currentSeverityLevelTexts && (
             <Box marginY={space[5]} paddingX={{ _: space[3], sm: space[4] }} maxWidth={TOPICAL_SEVERITY_INDICATOR_TILE_MAX_WIDTH}>
               <TopicalThemeHeader title={thermometer.title} subtitle={thermometer.subTitle} icon={getFilenameToIconName(thermometer.icon) as TopicalIcon} />


### PR DESCRIPTION
## Summary

- Moved `TopicalHeader(description)`  below  `TopicalWeeklySummaryTile`;
- Added styling `Box` around;

## Detailed design

_**Before**_
<details>
  <summary>Toggle before screenshot</summary>
<img width="902" alt="Screenshot 2023-01-24 at 13 47 31" src="https://user-images.githubusercontent.com/111750729/214295878-bf1fcdeb-8fbb-4f5e-bbcf-91f1ea23e377.png">
</details>

_**After**_
<details>
  <summary>Toggle after screenshot</summary>
<img width="899" alt="Screenshot 2023-01-24 at 13 52 12" src="https://user-images.githubusercontent.com/111750729/214296558-6e495971-d5cb-494b-aeab-843fb3e851b1.png">
</details>
