### PR TITLE
Release/2.66.3

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -97,7 +97,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
             warning={textGm.warning}
           />
 
-          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.notification.message} variant="emphasis" />}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textGm.notification.message} variant="informational" />}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -122,7 +122,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             articles={content.articles}
           />
 
-          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="emphasis" />}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="informational" />}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -115,7 +115,7 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
             articles={content.articles}
           />
 
-          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="emphasis" />}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="informational" />}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gehandicaptenzorg.tsx
@@ -121,7 +121,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             warning={textVr.besmette_locaties.warning}
           />
 
-          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="emphasis" />}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="informational" />}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/thuiswonende-ouderen.tsx
@@ -117,7 +117,7 @@ function ElderlyAtHomeRegionalPage(props: StaticProps<typeof getStaticProps>) {
             warning={textVr.warning}
           />
 
-          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="emphasis" />}
+          {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.belangrijk_bericht} variant="informational" />}
 
           <TwoKpiSection>
             <KpiTile

--- a/packages/cms/src/data/data-structure.ts
+++ b/packages/cms/src/data/data-structure.ts
@@ -4,7 +4,7 @@
  */
 export const dataStructure = {
   gm: {
-    deceased_rivm: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
+    deceased_rivm_archived_20221231: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
     hospital_nice: [
       'admissions_on_date_of_admission',
       'admissions_on_date_of_admission_moving_average',
@@ -134,7 +134,7 @@ export const dataStructure = {
       'tested_total_moving_average_rounded',
     ],
     tested_ggd_archived: ['infected_percentage', 'infected_percentage_moving_average'],
-    nursing_home: [
+    nursing_home_archived_20230126: [
       'newly_infected_people',
       'newly_infected_people_moving_average',
       'deceased_daily',
@@ -143,7 +143,8 @@ export const dataStructure = {
       'infected_locations_total',
       'infected_locations_percentage',
     ],
-    disability_care: [
+    vulnerable_nursing_home: ['newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage'],
+    disability_care_archived_20230126: [
       'newly_infected_people',
       'newly_infected_people_moving_average',
       'deceased_daily',
@@ -213,10 +214,16 @@ export const dataStructure = {
     ],
     behavior_get_tested_support_per_age_group: ['percentage_average', 'percentage_70_plus', 'percentage_55_69', 'percentage_40_54', 'percentage_25_39', 'percentage_16_24'],
     behavior_annotations: ['behavior_indicator', 'message_title_nl', 'message_title_en', 'message_desc_nl', 'message_desc_en'],
-    deceased_rivm: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
-    deceased_rivm_per_age_group: ['age_group_range', 'age_group_percentage', 'covid_percentage'],
+    deceased_rivm_archived_20221231: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
+    deceased_rivm_per_age_group_archived_20221231: ['age_group_range', 'age_group_percentage', 'covid_percentage'],
     deceased_cbs: ['registered', 'expected', 'expected_min', 'expected_max'],
-    elderly_at_home: ['positive_tested_daily', 'positive_tested_daily_moving_average', 'positive_tested_daily_per_100k', 'deceased_daily', 'deceased_daily_moving_average'],
+    elderly_at_home_archived_20230126: [
+      'positive_tested_daily',
+      'positive_tested_daily_moving_average',
+      'positive_tested_daily_per_100k',
+      'deceased_daily',
+      'deceased_daily_moving_average',
+    ],
     vaccine_vaccinated_or_support: ['percentage_average', 'percentage_70_plus', 'percentage_55_69', 'percentage_40_54', 'percentage_25_39', 'percentage_16_24'],
     corona_melder_app_download: ['count'],
     corona_melder_app_warning: ['count'],
@@ -294,7 +301,6 @@ export const dataStructure = {
     variants: ['variant_code', 'values', 'last_value'],
     self_test_overall: ['infected_percentage'],
   },
-  topical: {},
   vr: {
     g_number: ['g_number'],
     sewer: ['average', 'data_is_outdated'],
@@ -316,7 +322,8 @@ export const dataStructure = {
       'tested_total_moving_average_rounded',
     ],
     tested_ggd_archived: ['infected_percentage', 'infected_percentage_moving_average'],
-    nursing_home: [
+    vulnerable_nursing_home: ['newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage'],
+    nursing_home_archived_20230126: [
       'newly_infected_people',
       'newly_infected_people_moving_average',
       'newly_infected_locations',
@@ -325,7 +332,7 @@ export const dataStructure = {
       'deceased_daily',
       'deceased_daily_moving_average',
     ],
-    disability_care: [
+    disability_care_archived_20230126: [
       'newly_infected_people',
       'newly_infected_people_moving_average',
       'newly_infected_locations',
@@ -377,9 +384,15 @@ export const dataStructure = {
       'selftest_visit_support',
       'selftest_visit_support_trend',
     ],
-    deceased_rivm: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
+    deceased_rivm_archived_20221231: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
     deceased_cbs: ['registered', 'expected', 'expected_min', 'expected_max'],
-    elderly_at_home: ['positive_tested_daily', 'positive_tested_daily_moving_average', 'positive_tested_daily_per_100k', 'deceased_daily', 'deceased_daily_moving_average'],
+    elderly_at_home_archived_20230126: [
+      'positive_tested_daily',
+      'positive_tested_daily_moving_average',
+      'positive_tested_daily_per_100k',
+      'deceased_daily',
+      'deceased_daily_moving_average',
+    ],
     tested_overall_sum: ['infected_per_100k'],
     hospital_nice_sum: ['admissions_per_1m'],
     situations: [
@@ -432,7 +445,8 @@ export const dataStructure = {
     hospital_nice: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     hospital_nice_choropleth: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     tested_overall: ['infected_per_100k', 'infected'],
-    nursing_home: ['newly_infected_people', 'newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage', 'deceased_daily'],
+    vulnerable_nursing_home: ['newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage'],
+    nursing_home_archived_20230126: ['newly_infected_people', 'newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage', 'deceased_daily'],
     sewer: ['average', 'data_is_outdated'],
     behavior_archived_20221019: [
       'number_of_participants',
@@ -473,8 +487,8 @@ export const dataStructure = {
       'ventilate_home_support',
       'ventilate_home_support_trend',
     ],
-    disability_care: ['newly_infected_people', 'newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage', 'deceased_daily'],
-    elderly_at_home: ['positive_tested_daily', 'positive_tested_daily_per_100k', 'deceased_daily'],
+    disability_care_archived_20230126: ['newly_infected_people', 'newly_infected_locations', 'infected_locations_total', 'infected_locations_percentage', 'deceased_daily'],
+    elderly_at_home_archived_20230126: ['positive_tested_daily', 'positive_tested_daily_per_100k', 'deceased_daily'],
     situations: ['has_sufficient_data', 'home_and_visits', 'work', 'school_and_day_care', 'health_care', 'gathering', 'travel', 'hospitality', 'other'],
     vaccine_coverage_per_age_group: [
       'vaccination_type',

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -35,3 +35,4 @@ timestamp,action,key,document_id,move_to
 2023-01-23T10:07:22.471Z,delete,pages.elderly_at_home_page.shared,tX1MPJIDnGqPfyLRsKwNFp,__
 2023-01-23T10:07:55.358Z,add,pages.disability_care_page.shared.belangrijk_bericht,say0BNKaNSuhganBiQDVwp,__
 2023-01-23T10:07:55.358Z,delete,pages.disability_care_page.shared,cYpVOlvFzO3vMMRPBjW7T2,__
+2023-01-26T11:33:38.841Z,add,pages.deceased_page.gm.notification.message,wvJta9ElXUYLPkPUAs2jA2,__


### PR DESCRIPTION
updated release with:

A PR for a fix for the release

This was based on today's feedback on the staging environment.

Updated the GM page with its own warning possibility.
And updated the yellow messages on archived pages to gray.

Before:
<details>
<summery>Screeshots:</summery>

<img width="1455" alt="Screenshot 2023-01-26 at 13 55 52" src="https://user-images.githubusercontent.com/93984341/214841288-c92bd6bf-45fa-4f4a-8391-34fb310c0d5a.png">
<img width="1484" alt="Screenshot 2023-01-26 at 13 55 59" src="https://user-images.githubusercontent.com/93984341/214841296-50839d86-83fa-44c6-a4d6-b48a44d3f79d.png">
<img width="1379" alt="Screenshot 2023-01-26 at 13 56 03" src="https://user-images.githubusercontent.com/93984341/214841300-05628c34-c971-41c3-bb90-e7acaf648ef8.png">

</details>


After:
<details>
<summery>Screeshots:</summery>

<img width="1363" alt="Screenshot 2023-01-26 at 13 56 35" src="https://user-images.githubusercontent.com/93984341/214841558-1cf65cf5-c1fc-47ae-98a8-c8c8e25e7b9c.png">
<img width="1400" alt="Screenshot 2023-01-26 at 13 56 40" src="https://user-images.githubusercontent.com/93984341/214841564-cf04bb31-f620-4306-b9d6-20a7c54d2527.png">
<img width="1419" alt="Screenshot 2023-01-26 at 13 58 44" src="https://user-images.githubusercontent.com/93984341/214841567-d53bddba-cdab-4ae1-b19c-60352cf6c075.png">

</details>