### PR TITLE
fix/safety-region-not-filled-in-in-page-title

### DIFF
--- a/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/sterfte.tsx
@@ -97,7 +97,9 @@ const DeceasedRegionalPage = (props: StaticProps<typeof getStaticProps>) => {
         <TileList>
           <PageInformationBlock
             category={commonTexts.sidebar.categories.development_of_the_virus.title}
-            title={textVr.section_sterftemonitor.title}
+            title={replaceVariablesInText(textVr.section_sterftemonitor.title, {
+              safetyRegion: vrName,
+            })}
             icon={<Coronavirus aria-hidden="true" />}
             description={textVr.section_sterftemonitor.description}
             referenceLink={textVr.section_sterftemonitor.reference.href}


### PR DESCRIPTION
## Summary

* add variable to text of _Sterfte_ pages on VR level

### Screenshots
#### Before
![hotfix_before](https://user-images.githubusercontent.com/107395524/215042393-0d3cc558-fe7a-490f-9651-231899149145.png)

#### After
![hotfix_after](https://user-images.githubusercontent.com/107395524/215042406-6e0db132-98da-4d0a-a159-53be5cb4ff7d.png)