### PR TITLE
fix/COR-1263-fix-incorrect-dates

### DIFF
--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -174,7 +174,7 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
             text={textShared}
             metadata={{
               datumsText: textNl.datums,
-              date: data.behavior.values[0].date_end_unix,
+              date: data.behavior.last_value.date_start_unix,
               source: textNl.bronnen.rivm,
             }}
           />
@@ -203,7 +203,7 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
               text={text}
               metadata={{
                 datumsText: textNl.datums,
-                date: data.behavior_per_age_group.date_end_unix,
+                date: data.behavior_per_age_group.date_start_unix,
                 source: textNl.bronnen.rivm,
               }}
             />

--- a/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
+++ b/packages/app/src/pages/veiligheidsregio/[code]/gedrag.tsx
@@ -129,7 +129,7 @@ const BehaviorPageVr = (props: StaticProps<typeof getStaticProps>) => {
             text={text.shared}
             metadata={{
               datumsText: text.vr.datums,
-              date: data.behavior_archived_20221019.values[0].date_end_unix,
+              date: data.behavior_archived_20221019.last_value.date_start_unix,
               source: text.vr.bronnen.rivm,
             }}
           />


### PR DESCRIPTION
## Summary

The two adjusted tables on the behavior page (NL and VR) had the wrong date values. This has been fixed in this PR.