### PR TITLE
feature/COR-1275-hospital-icu-pages

### DIFF
--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -135,7 +135,7 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
               datumsText: textNl.datums,
               dateOrRange: lastValueNice.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
-              dataSources: [textNl.sources.nice, textNl.sources.lnaz],
+              dataSources: [textNl.sources.nice],
             }}
             referenceLink={textNl.reference.href}
             pageLinks={content.links}

--- a/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
@@ -1,5 +1,5 @@
 import { colors, getLastFilledValue, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
-import { Ziekenhuis } from '@corona-dashboard/icons';
+import { IntensiveCareOpnames } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { ChartTile } from '~/components/chart-tile';
@@ -124,13 +124,13 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
             category={commonTexts.sidebar.categories.consequences_for_healthcare.title}
             screenReaderCategory={commonTexts.sidebar.metrics.hospitals_and_care.title}
             title={textNl.title}
-            icon={<Ziekenhuis aria-hidden="true" />}
+            icon={<IntensiveCareOpnames aria-hidden="true" />}
             description={textNl.pagina_toelichting}
             metadata={{
               datumsText: textNl.datums,
               dateOrRange: hospitalLastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
-              dataSources: [textNl.sources.nice, textNl.sources.lnaz],
+              dataSources: [textNl.sources.lnaz],
             }}
             referenceLink={textNl.reference.href}
             pageLinks={content.links}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -269,3 +269,9 @@ timestamp,action,key,document_id,move_to
 2023-01-26T14:40:01.873Z,add,pages.behavior_page.shared.basisregels.percentage_bar_column_header,H51WXygmup367lqvWyhYni,__
 2023-01-27T15:36:42.838Z,delete,pages.hospitalPage.nl.extra_uitleg,jF33EuwumlGuwav2FD3XXw,__
 2023-01-27T15:23:55.933Z,add,pages.hospital_page.nl.extra_description,HUrvkI3TfiQn7uqq7z2elF,__
+2023-01-31T13:47:09.959Z,delete,pages.hospitals_and_care_page.nl.sources.nice.download,PKXdxxxKAnTg0F1ZCrJHg3,__
+2023-01-31T13:47:09.966Z,delete,pages.hospitals_and_care_page.nl.sources.nice.href,0iJeil5hiqRr6jTKtaSVMX,__
+2023-01-31T13:47:09.979Z,delete,pages.hospitals_and_care_page.nl.sources.nice.text,PKXdxxxKAnTg0F1ZCrJHmN,__
+2023-01-31T13:47:09.980Z,delete,pages.patients_page.nl.sources.lnaz.download,KoLyCpXIGU95m7jfEOaid7,__
+2023-01-31T13:47:09.981Z,delete,pages.patients_page.nl.sources.lnaz.href,0iJeil5hiqRr6jTKtaSVTH,__
+2023-01-31T13:47:09.981Z,delete,pages.patients_page.nl.sources.lnaz.text,0iJeil5hiqRr6jTKtaSVWx,__


### PR DESCRIPTION
## Summary

* cleaned up unwanted Sanity keys
* adjusted sources for both new pages
  * 'Ziekenhuizen en de zorg' only contains LCPS data (was both)
  * 'Patiënten in beeld' only contains NICE data (was both)
* adjusted icon to be used on the 'Ziekenhuizen en de zorg' page

### Screenshots
Differences might not be too obvious, but basically the sources of both pages weren't completely correct.
#### Before
![COR-1275_before_1](https://user-images.githubusercontent.com/107395524/215788223-aa0bb8ba-13f5-4ee5-a15e-932063970132.png)
![COR-1275_before_2](https://user-images.githubusercontent.com/107395524/215788228-2a9e53da-65aa-481d-9998-0e851158f500.png)

#### After
![COR-1275_after_1](https://user-images.githubusercontent.com/107395524/215788217-4a7141b1-5b99-432c-8eff-c0aacbfb6b31.png)
![COR_1275_after_2](https://user-images.githubusercontent.com/107395524/215788222-c6d6e696-1630-4ecb-982c-b6cdb1c7832b.png)