### PR TITLE
feature/COR-1301-graph-toggle-adjustments

### DIFF
--- a/packages/app/src/components/radio-group.tsx
+++ b/packages/app/src/components/radio-group.tsx
@@ -1,9 +1,7 @@
 import { colors } from '@corona-dashboard/common';
-import { css } from '@styled-system/css';
 import { Fragment } from 'react';
 import styled from 'styled-components';
-import { space } from '~/style/theme';
-import { asResponsiveArray } from '~/style/utils';
+import { mediaQueries, radii, space } from '~/style/theme';
 import { useUniqueId } from '~/utils/use-unique-id';
 import { Box } from './base';
 import { InlineText } from './typography';
@@ -13,49 +11,6 @@ export interface RadioGroupItem<T extends string> {
   value: T;
   ariaLabel?: string;
 }
-
-const StyledInput = styled.input(
-  css({
-    position: 'absolute',
-    clip: 'rect(0, 0, 0, 0)',
-    '&:checked + label': {
-      bg: 'blue8',
-      color: 'white',
-      borderColor: 'blue8',
-    },
-    '&:focus-visible + label': {
-      outline: `2px dotted ${colors.magenta3}`,
-    },
-  })
-);
-
-const StyledLabel = styled.label(
-  css({
-    flex: '0 1 auto',
-    color: 'blue8',
-    textAlign: 'center',
-    padding: asResponsiveArray({ _: `${space[1]} ${space[2]}`, xs: `0.3rem ${space[3]}` }),
-    borderRadius: '5px 0 0 5px',
-    border: `1px solid ${colors.gray3}`,
-    borderRightWidth: '0',
-    whiteSpace: 'nowrap',
-    cursor: 'pointer',
-    userSelect: 'none',
-    height: '36px',
-    transition: '0.1s background-color',
-
-    '&:last-child': {
-      borderWidth: '1px 1px 1px 0',
-      borderRadius: '0 5px 5px 0',
-    },
-
-    '&:hover, &:focus': {
-      bg: 'gray1',
-      color: 'blue8',
-      borderColor: 'blue8',
-    },
-  })
-);
 
 interface RadioGroupProps<T extends string> {
   onChange: (value: T) => void;
@@ -67,15 +22,15 @@ interface RadioGroupProps<T extends string> {
  * A radiogroup component that takes an array of radiogroup items and
  * reports its changes using the given onSelect callback.
  */
-export function RadioGroup<T extends string>(props: RadioGroupProps<T>) {
+export const RadioGroup = <T extends string>(props: RadioGroupProps<T>) => {
   const { onChange, items, value } = props;
   const id = useUniqueId();
 
   return (
-    <Box bg="white" display="flex" justifyContent="center" data-cy="radiogroup">
+    <Box backgroundColor={colors.white} display="flex" justifyContent="center" data-cy="radiogroup">
       {items.map((item, index) => (
         <Fragment key={`radiogroup-${id}-input-${index}`}>
-          <StyledInput
+          <Input
             onChange={() => onChange(item.value)}
             id={`radiogroup-${item.value}-${id}-${index}`}
             type="radio"
@@ -84,11 +39,57 @@ export function RadioGroup<T extends string>(props: RadioGroupProps<T>) {
             checked={value === item.value}
             aria-label={value === item.value ? item.ariaLabel : undefined}
           />
-          <StyledLabel htmlFor={`radiogroup-${item.value}-${id}-${index}`}>
+          <Label htmlFor={`radiogroup-${item.value}-${id}-${index}`}>
             <InlineText variant="button2">{item.label}</InlineText>
-          </StyledLabel>
+          </Label>
         </Fragment>
       ))}
     </Box>
   );
-}
+};
+
+const Label = styled.label`
+  border: 1px solid ${colors.gray3};
+  color: ${colors.blue8};
+  cursor: pointer;
+  flex: 0 1 auto;
+  padding: ${space[1]} ${space[2]};
+  text-align: center;
+  user-select: none;
+
+  &:first-of-type {
+    border-radius: ${radii[1]}px 0 0 ${radii[1]}px;
+    border-right-width: 0;
+  }
+
+  &:last-of-type {
+    border-left-width: 0;
+    border-radius: 0 ${radii[1]}px ${radii[1]}px 0;
+  }
+
+  &:focus,
+  &:hover {
+    background: ${colors.gray1};
+    border-color: ${colors.blue8};
+    color: ${colors.blue8};
+  }
+
+  @media ${mediaQueries.xs} {
+    padding: 0.3rem ${space[3]};
+  }
+`;
+
+const Input = styled.input`
+  clip: rect(0, 0, 0, 0);
+  position: absolute;
+
+  &:checked + ${Label} {
+    background: ${colors.blue8};
+    border-color: ${colors.blue8};
+    color: ${colors.white};
+  }
+
+  &:focus-visible + ${Label} {
+    outline: 2px dotted ${colors.magenta3};
+  }
+`;


### PR DESCRIPTION
## Summary

* updated RadioGroup component to adjust styles, resulting in the desired outcome for graph toggles with longer titles;
* updated styles from styled system to styled components;
* further clean up;

### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![COR-1301_before](https://user-images.githubusercontent.com/107395524/217003132-6f901969-3c2f-4fd5-abf9-1c7f0f551d24.png)
</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![COR-1301_after](https://user-images.githubusercontent.com/107395524/217003139-0b83cc65-3edc-4efb-8cd9-2cddf08d517d.png)
</details>