### PR TITLE
feature/COR-1411-hospital-icu-patient-influx-graph-adjustments

### DIFF
--- a/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
@@ -17,7 +17,6 @@ import { getArticleParts, getLinkParts, getPagePartsQuery } from '~/queries/get-
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
-import { countTrailingNullValues, getBoundaryDateStartUnix } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
@@ -101,13 +100,6 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
       value: 'patients_influx_icu',
     },
   ];
-
-  const hospitalPatientInfluxUnderReportedRange = getBoundaryDateStartUnix(data.hospital_lcps.values, countTrailingNullValues(data.hospital_lcps.values, 'influx_covid_patients'));
-
-  const intensiveCarePatientInfluxUnderReportedRange = getBoundaryDateStartUnix(
-    data.intensive_care_lcps.values,
-    countTrailingNullValues(data.intensive_care_lcps.values, 'influx_covid_patients')
-  );
 
   const hospitalLastValue = getLastFilledValue(data.hospital_lcps);
   const icuLastValue = getLastFilledValue(data.intensive_care_lcps);
@@ -316,15 +308,6 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                   },
                 ]}
                 dataOptions={{
-                  timespanAnnotations: [
-                    {
-                      start: hospitalPatientInfluxUnderReportedRange,
-                      end: Infinity,
-                      label: textNl.hospitals.chart_patient_influx.legend_inaccurate_label,
-                      shortLabel: commonTexts.common.incomplete,
-                      cutValuesForMetricProperties: ['influx_covid_patients_moving_average'],
-                    },
-                  ],
                   timelineEvents: getTimelineEvents(content.elements.timeSeries, 'hospital_lcps'),
                 }}
               />
@@ -366,15 +349,6 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                   },
                 ]}
                 dataOptions={{
-                  timespanAnnotations: [
-                    {
-                      start: intensiveCarePatientInfluxUnderReportedRange,
-                      end: Infinity,
-                      label: textNl.icu.chart_patient_influx.legend_inaccurate_label,
-                      shortLabel: commonTexts.common.incomplete,
-                      cutValuesForMetricProperties: ['influx_covid_patients_moving_average'],
-                    },
-                  ],
                   timelineEvents: getTimelineEvents(content.elements.timeSeries, 'intensive_care_lcps'),
                 }}
               />

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,3 @@
 timestamp,action,key,document_id,move_to
+2023-02-08T09:35:46.400Z,delete,pages.hospitals_and_care_page.nl.icu.chart_patient_influx.legend_inaccurate_label,PKXdxxxKAnTg0F1ZCyB3ox,__
+2023-02-08T09:39:16.063Z,delete,pages.hospitals_and_care_page.nl.hospitals.chart_patient_influx.legend_inaccurate_label,PKXdxxxKAnTg0F1ZCyB3Vz,__


### PR DESCRIPTION
## Summary

* adjusted 'View on the hospitals' page's influx graphs (covering hospitals and ICUs) to remove the inaccurate data indicators from the graph and its legend;
* further clean-up;
* removed Sanity keys;

### Screenshots
Screenshots only cover the 'hospitals' graph of the 'Hospital admissions over time' (or patient influx) graphs. The ICU graph is also covered by the changes in this pull request.

#### Before
![COR-1411_before](https://user-images.githubusercontent.com/107395524/217494717-d2a2be69-aede-4496-8099-bed9facaa8fc.png)

#### After
![COR-1411_after](https://user-images.githubusercontent.com/107395524/217494730-ac066a0e-c1bf-46a8-88d0-6cf6b16cbbae.png)