### PR TITLE
Feature/COR-1341-disable-7-day-timeframe

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -123,11 +123,9 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
     [options]
   );
 
-  const timeframeOptions = TimeframeOptionsList.filter((timeframeOption) => timeframeOption !== TimeframeOption.ONE_WEEK);
-
   return (
     <ChartTile
-      timeframeOptions={timeframeOptions}
+      timeframeOptions={TimeframeOptionsList}
       title={text.title}
       metadata={{
         source: text.source,

--- a/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
+++ b/packages/app/src/domain/tested/g-number-bar-chart-tile.tsx
@@ -1,9 +1,4 @@
-import {
-  colors,
-  NlGNumber,
-  TimeframeOption,
-  VrGNumber,
-} from '@corona-dashboard/common';
+import { colors, NlGNumber, TimeframeOption, TimeframeOptionsList, VrGNumber } from '@corona-dashboard/common';
 import { useState } from 'react';
 import { ChartTile } from '~/components/chart-tile';
 import { TimeSeriesChart } from '~/components/time-series-chart';
@@ -17,20 +12,14 @@ interface GNumberBarChartTileProps {
   timeframeInitialValue?: TimeframeOption;
 }
 
-export function GNumberBarChartTile({
-  data: __data,
-  timeframeInitialValue = TimeframeOption.ALL,
-}: GNumberBarChartTileProps) {
-  const [gnumberTimeframe, setGnumberTimeframe] = useState<TimeframeOption>(
-    TimeframeOption.ALL
-  );
+export function GNumberBarChartTile({ data: __data, timeframeInitialValue = TimeframeOption.ALL }: GNumberBarChartTileProps) {
+  const [gnumberTimeframe, setGnumberTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { formatPercentage, commonTexts } = useIntl();
 
   const text = commonTexts.g_number.bar_chart;
 
-  const firstOfSeptember2020Unix =
-    new Date('1 September 2020').valueOf() / 1000;
+  const firstOfSeptember2020Unix = new Date('1 September 2020').valueOf() / 1000;
   const values = __data.values.filter((value) => {
     return value.date_unix >= firstOfSeptember2020Unix;
   });
@@ -42,14 +31,7 @@ export function GNumberBarChartTile({
       title={text.title}
       description={text.description}
       timeframeInitialValue={timeframeInitialValue}
-      timeframeOptions={[
-        TimeframeOption.ALL,
-        TimeframeOption.ONE_WEEK,
-        TimeframeOption.THIRTY_DAYS,
-        TimeframeOption.THREE_MONTHS,
-        TimeframeOption.SIX_MONTHS,
-        TimeframeOption.LAST_YEAR,
-      ]}
+      timeframeOptions={TimeframeOptionsList}
       metadata={{
         date: last_value.date_of_insertion_unix,
         source: text.bronnen,
@@ -89,12 +71,8 @@ export function GNumberBarChartTile({
         ]}
         formatTooltip={(data) => (
           <TooltipSeriesListContainer {...data}>
-            <BoldText>
-              {`${formatPercentage(Math.abs(data.value.g_number))}% `}
-            </BoldText>
-            {data.value.g_number > 0
-              ? text.positive_descriptor
-              : text.negative_descriptor}
+            <BoldText>{`${formatPercentage(Math.abs(data.value.g_number))}% `}</BoldText>
+            {data.value.g_number > 0 ? text.positive_descriptor : text.negative_descriptor}
           </TooltipSeriesListContainer>
         )}
       />

--- a/packages/common/src/utils/timeframe/index.ts
+++ b/packages/common/src/utils/timeframe/index.ts
@@ -1,11 +1,4 @@
-import {
-  DateSpanValue,
-  DateValue,
-  isDateSeries,
-  isDateSpanSeries,
-  startOfDayInSeconds,
-  TimestampedValue,
-} from '../../data-sorting';
+import { DateSpanValue, DateValue, isDateSeries, isDateSpanSeries, startOfDayInSeconds, TimestampedValue } from '../../data-sorting';
 import { DAY_IN_SECONDS } from '../../time';
 
 export enum TimeframeOption {
@@ -18,14 +11,7 @@ export enum TimeframeOption {
   ALL = 'all',
 }
 
-export const TimeframeOptionsList = [
-  TimeframeOption.ALL,
-  TimeframeOption.ONE_WEEK,
-  TimeframeOption.THIRTY_DAYS,
-  TimeframeOption.THREE_MONTHS,
-  TimeframeOption.SIX_MONTHS,
-  TimeframeOption.LAST_YEAR,
-];
+export const TimeframeOptionsList = [TimeframeOption.ALL, TimeframeOption.THIRTY_DAYS, TimeframeOption.THREE_MONTHS, TimeframeOption.SIX_MONTHS, TimeframeOption.LAST_YEAR];
 
 export function getDaysForTimeframe(timeframe: TimeframeOption): number {
   switch (timeframe) {
@@ -53,10 +39,7 @@ export function getDaysForTimeframe(timeframe: TimeframeOption): number {
 
 const oneDayInMilliseconds = DAY_IN_SECONDS * 1000;
 
-export const getMinimumUnixForTimeframe = (
-  timeframe: TimeframeOption,
-  endDate: Date
-): number => {
+export const getMinimumUnixForTimeframe = (timeframe: TimeframeOption, endDate: Date): number => {
   if (timeframe === TimeframeOption.ALL) {
     return 0;
   }
@@ -74,12 +57,7 @@ type CompareCallbackFunction<T> = (value: T) => number;
  * @param endDate
  * @param compareCallback
  */
-export const getFilteredValues = <T>(
-  values: T[],
-  timeframe: TimeframeOption,
-  endDate: Date,
-  compareCallback: CompareCallbackFunction<T>
-): T[] => {
+export const getFilteredValues = <T>(values: T[], timeframe: TimeframeOption, endDate: Date, compareCallback: CompareCallbackFunction<T>): T[] => {
   const minimumUnix = getMinimumUnixForTimeframe(timeframe, endDate);
   return values.filter((value: T): boolean => {
     return compareCallback(value) >= minimumUnix;
@@ -93,11 +71,7 @@ export const getFilteredValues = <T>(
  * in as-is from the data, and we detect what type of timestamp we should filter
  * on.
  */
-export function getValuesInTimeframe<T extends TimestampedValue>(
-  values: T[],
-  timeframe: TimeframeOption,
-  endDate: Date
-): T[] {
+export function getValuesInTimeframe<T extends TimestampedValue>(values: T[], timeframe: TimeframeOption, endDate: Date): T[] {
   const start = getTimeframeBoundaryUnix(timeframe, endDate);
   const end = Math.ceil(endDate.getTime() / 1000);
 
@@ -118,10 +92,7 @@ export function getValuesInTimeframe<T extends TimestampedValue>(
   throw new Error(`Incompatible timestamps are used in value ${values[0]}`);
 }
 
-function getTimeframeBoundaryUnix(
-  timeframe: TimeframeOption,
-  endDate: Date
-): number {
+function getTimeframeBoundaryUnix(timeframe: TimeframeOption, endDate: Date): number {
   if (timeframe === TimeframeOption.ALL) {
     return 0;
   }


### PR DESCRIPTION
## Summary

* removed TimeframeOption 7 days from TimeframeOptionList
* refactored sewer chart
* refactored archived graph

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="1399" alt="before_timeselection_graph" src="https://user-images.githubusercontent.com/93994194/217517295-2548e558-6f23-4113-9e2b-69a38e27675c.png">
<img width="1409" alt="before_archived_graph" src="https://user-images.githubusercontent.com/93994194/217517305-2840737a-969a-44db-92e8-ac11c35360ec.png">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="1417" alt="after_timeselection_graph" src="https://user-images.githubusercontent.com/93994194/217517343-969c5854-48e7-4d68-8866-50cbfa7e2698.png">
<img width="1395" alt="after_sewer_chart" src="https://user-images.githubusercontent.com/93994194/217517353-9e58dc3d-5306-4aab-ae4d-8cc9bcfb5178.png">
<img width="1393" alt="after_archived_graph" src="https://user-images.githubusercontent.com/93994194/217517365-133e4424-f238-478d-b3a9-54204868be77.png">

</details>