### PR TITLE
bugfix/COR-1249-image-article-fix

### DIFF
--- a/packages/app/src/components/article-teaser.tsx
+++ b/packages/app/src/components/article-teaser.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import css from '@styled-system/css';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
@@ -9,6 +10,7 @@ import { Link } from '~/utils/link';
 import { BackgroundImage } from './background-image';
 import { Box } from './base';
 import { Anchor, Heading, Text, BoldText } from './typography';
+import { getImageProps } from '~/lib/sanity';
 
 export type ArticleSummary = Pick<Article, 'title' | 'slug' | 'summary' | 'cover' | 'category' | 'categories'>;
 
@@ -24,12 +26,15 @@ export function ArticleTeaser(props: ArticleTeaserProps) {
   const { title, slug, summary, cover, coverSizes } = props;
   const { commonTexts } = useIntl();
 
+  const { src } = getImageProps(cover, {});
+
   return (
     <Link passHref href={`/artikelen/${slug}`}>
       <StyledArticleTeaser>
         {cover.asset && (
           <ZoomContainer height="200px">
-            <BackgroundImage image={cover} height="200px" sizes={coverSizes} />
+            {/* <BackgroundImage image={cover} height="200px" sizes={coverSizes} /> */}
+            <img src={src} />
           </ZoomContainer>
         )}
 


### PR DESCRIPTION
## Summary

* temporary revert to basic img element to see if that fixes anything;

## Motivation

To be honest, @VWSCoronaDashboard21 and I are a bit lost on how to further approach the bug mentioned in COR-1249. Aside from the findings documented in the ticket, we have also Dockerized a production build which does not result in the same behaviour as on any of the hosted environments such as development, staging and production. This pull request is a means to see if a standard good old HTML `img` element without any `sizes` or `srcset` attributes resolves anything on the hosted environments. For obvious reasons, this solution should be considered as a temporary fix and is to be reverted when an outcome is clear.
