### PR TITLE
Feature/COR-1389-remove-more-info-section-from-behaviour-page

### DIFF
--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -14,7 +14,6 @@ import { BehaviorChoroplethsTile } from '~/domain/behavior/behavior-choropleths-
 import { BehaviorLineChartTile } from '~/domain/behavior/behavior-line-chart-tile';
 import { BehaviorPerAgeGroup } from '~/domain/behavior/behavior-per-age-group-tile';
 import { BehaviorTableTile } from '~/domain/behavior/behavior-table-tile';
-import { MoreInformation } from '~/domain/behavior/components/more-information';
 import { BehaviorIdentifier } from '~/domain/behavior/logic/behavior-types';
 import { useBehaviorLookupKeys } from '~/domain/behavior/logic/use-behavior-lookup-keys';
 import { Layout } from '~/domain/layout/layout';
@@ -228,7 +227,6 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
               text={text}
             />
           )}
-          <MoreInformation text={textShared.meer_onderzoeksresultaten} />
         </TileList>
       </NlLayout>
     </Layout>


### PR DESCRIPTION
## Summary

Removed the more info section.

Before:

![image](https://user-images.githubusercontent.com/116002914/219067530-f6f3e17b-86d8-4740-89a1-d2f5b7d1e6a4.png)

After:

![image](https://user-images.githubusercontent.com/116002914/219067621-6870a595-0e70-461a-8e4f-0ec74ce49cc9.png)
