### PR TITLE
Feature/COR-1392-text-gm-positive-tests-is-in-bold-should-be-normal-text

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -1,36 +1,34 @@
 import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
-import { useState } from 'react';
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
+import { useState } from 'react';
 import { Box } from '~/components/base';
-import { Text } from '~/components/typography';
-import {
-  ChartTile,
-  DynamicChoropleth,
-  TwoKpiSection,
-  ChoroplethTile,
-  TimeSeriesChart,
-  TileList,
-  InView,
-  CollapsibleContent,
-  KpiTile,
-  KpiValue,
-  Markdown,
-  PageInformationBlock,
-} from '~/components';
+import { ChartTile } from '~/components/chart-tile';
+import { DynamicChoropleth } from '~/components/choropleth';
+import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
-import { Layout, GmLayout } from '~/domain/layout';
+import { CollapsibleContent } from '~/components/collapsible/collapsible-content';
+import { InView } from '~/components/in-view';
+import { KpiTile } from '~/components/kpi-tile';
+import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
+import { PageInformationBlock } from '~/components/page-information-block';
+import { TileList } from '~/components/tile-list';
+import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
+import { TwoKpiSection } from '~/components/two-kpi-section';
+import { Text } from '~/components/typography';
+import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
 import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectGmData, getLokalizeTexts } from '~/static-props/get-data';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
-import { replaceComponentsInText, replaceVariablesInText, getVrForMunicipalityCode, useReverseRouter } from '~/utils';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getVrForMunicipalityCode, replaceComponentsInText, replaceVariablesInText, useReverseRouter } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
 export { getStaticPaths } from '~/static-paths/gm';
 

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -220,13 +220,13 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 <>
                   <Markdown content={textGm.map_toelichting} />
                   <Markdown
-                    content={replaceVariablesInText(textGm.map_last_value_text__renamed, {
+                    content={replaceVariablesInText(textGm.map_last_value_text, {
                       infected_per_100k: formatNumber(lastValue.infected_per_100k),
                       municipality: municipalityName,
                     })}
                   />
                   <Markdown
-                    content={replaceVariablesInText(textGm.map_safety_region_last_value_text__renamed, {
+                    content={replaceVariablesInText(textGm.map_safety_region_last_value_text, {
                       infected_per_100k: formatNumber(vrData?.infected_per_100k),
                       safetyRegion: vrForMunicipality?.name,
                     })}

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -66,8 +66,8 @@ export const getStaticProps = createGetStaticProps(
     }>((context) => {
       const { locale } = context;
       return `{
-       "parts": ${getPagePartsQuery('positive_tests_page')},
-       "elements": ${getElementsQuery('gm', ['tested_overall'], locale)}
+        "parts": ${getPagePartsQuery('positive_tests_page')},
+        "elements": ${getElementsQuery('gm', ['tested_overall'], locale)}
       }`;
     })(context);
     return {
@@ -219,18 +219,18 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               description={
                 <>
                   <Markdown content={textGm.map_toelichting} />
-                  <BoldText variant="body2">
-                    {replaceComponentsInText(textGm.map_last_value_text, {
-                      infected_per_100k: <InlineText color="data.primary">{`${formatNumber(lastValue.infected_per_100k)}`}</InlineText>,
+                  <Markdown
+                    content={replaceVariablesInText(textGm.map_last_value_text__renamed, {
+                      infected_per_100k: formatNumber(lastValue.infected_per_100k),
                       municipality: municipalityName,
                     })}
-                  </BoldText>
-                  <BoldText variant="body2">
-                    {replaceComponentsInText(textGm.map_safety_region_last_value_text, {
-                      infected_per_100k: <InlineText color="data.primary">{`${formatNumber(vrData?.infected_per_100k)}`}</InlineText>,
+                  />
+                  <Markdown
+                    content={replaceVariablesInText(textGm.map_safety_region_last_value_text__renamed, {
+                      infected_per_100k: formatNumber(vrData?.infected_per_100k),
                       safetyRegion: vrForMunicipality?.name,
                     })}
-                  </BoldText>
+                  />
                 </>
               }
               legend={{

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { Box } from '~/components/base';
-import { Text, InlineText, BoldText } from '~/components/typography';
+import { Text } from '~/components/typography';
 import {
   ChartTile,
   DynamicChoropleth,
@@ -143,12 +143,12 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               <Markdown content={textGm.infected_kpi.description} />
 
               <Box spacing={3}>
-                <BoldText variant="body2">
-                  {replaceComponentsInText(textGm.infected_kpi.last_value_text, {
-                    infected: <InlineText color="data.primary">{`${formatNumber(lastValue.infected)}`}</InlineText>,
+                <Markdown
+                  content={replaceVariablesInText(textGm.infected_kpi.last_value_text, {
+                    infected: formatNumber(lastValue.infected),
                     dateTo: formatDateFromSeconds(lastValue.date_unix, 'weekday-long'),
                   })}
-                </BoldText>
+                />
                 {textGm.infected_kpi.link_cta && <Markdown content={textGm.infected_kpi.link_cta} />}
               </Box>
             </KpiTile>

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,7 +9,5 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.288Z,add,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average__renamed,xjLKnlFrh2WM7l3TeFR9rD,__
 2023-02-10T14:27:20.295Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_infected_percentage,jF33EuwumlGuwav2FD3Zd6,__
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
-2023-02-15T15:31:58.572Z,add,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
-2023-02-15T15:31:59.442Z,add,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__
-2023-02-15T15:47:31.649Z,delete,pages.positive_tests_page.gm.map_last_value_text,Hpcrbv9k01wdsU0EheZaiI,__
-2023-02-15T15:47:31.651Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text,0ztyMU2xVVOl2tFNiaUuSE,__
+2023-02-16T10:12:52.969Z,delete,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
+2023-02-16T10:12:52.970Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,3 +9,5 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.288Z,add,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average__renamed,xjLKnlFrh2WM7l3TeFR9rD,__
 2023-02-10T14:27:20.295Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_infected_percentage,jF33EuwumlGuwav2FD3Zd6,__
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
+2023-02-17T09:24:14.946Z,delete,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
+2023-02-17T09:24:14.948Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -11,3 +11,5 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
 2023-02-15T15:31:58.572Z,add,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
 2023-02-15T15:31:59.442Z,add,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__
+2023-02-15T15:47:31.649Z,delete,pages.positive_tests_page.gm.map_last_value_text,Hpcrbv9k01wdsU0EheZaiI,__
+2023-02-15T15:47:31.651Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text,0ztyMU2xVVOl2tFNiaUuSE,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,5 +9,3 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.288Z,add,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average__renamed,xjLKnlFrh2WM7l3TeFR9rD,__
 2023-02-10T14:27:20.295Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_infected_percentage,jF33EuwumlGuwav2FD3Zd6,__
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
-2023-02-17T09:24:14.946Z,delete,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
-2023-02-17T09:24:14.948Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,5 +9,3 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.288Z,add,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average__renamed,xjLKnlFrh2WM7l3TeFR9rD,__
 2023-02-10T14:27:20.295Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_infected_percentage,jF33EuwumlGuwav2FD3Zd6,__
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
-2023-02-16T10:12:52.969Z,delete,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
-2023-02-16T10:12:52.970Z,delete,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -9,3 +9,5 @@ timestamp,action,key,document_id,move_to
 2023-02-10T14:27:20.288Z,add,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average__renamed,xjLKnlFrh2WM7l3TeFR9rD,__
 2023-02-10T14:27:20.295Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_infected_percentage,jF33EuwumlGuwav2FD3Zd6,__
 2023-02-10T14:27:20.301Z,delete,pages.positive_tests_page.shared.tooltip_labels.ggd_tested_total_moving_average,6s2ymgdY1hbg7zMfb8Z5wD,__
+2023-02-15T15:31:58.572Z,add,pages.positive_tests_page.gm.map_last_value_text__renamed,cQD0A3OGksV3pY6pYGz5LJ,__
+2023-02-15T15:31:59.442Z,add,pages.positive_tests_page.gm.map_safety_region_last_value_text__renamed,xjLKnlFrh2WM7l3TehfRNX,__


### PR DESCRIPTION
## Summary

Converted two `BoldText` components to `Markdown`. Specified that only the `infected_per_100k` variable should be bold - achieved by adding markdown to the lokalize key's value.

The ticket was not too clear for me, so if someone has a better understanding, could you please check this out and make sure its working as expected?

I ran into the issue with the lokalize keys where it would not let me update the existing value. So I had to create two new ones with `__renamed` in the name of the key.

Before:
![image](https://user-images.githubusercontent.com/116002914/219076768-46ae1149-99ec-4023-87e4-dc8801fe5e9d.png)

After:
![image](https://user-images.githubusercontent.com/116002914/219076911-935b3a20-f35f-4986-b785-b4dec36b00f4.png)
