### PR TITLE
Feature/cor 1336 add kpi value as variable to description

### DIFF
--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -95,7 +95,6 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
         return <ContentWrapper>{PortableText.defaultSerializers.types.block(props)}</ContentWrapper>;
       },
       image: (props: { node: ImageBlock | RichContentImageBlock }) => <ContentImage contentWrapper={contentWrapper} sizes={imageSizes} {...props} />,
-
       inlineCollapsible: (props: { node: InlineCollapsibleList }) => {
         if (!props.node.content.inlineBlockContent) return null;
 
@@ -227,18 +226,25 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
     marks: {
       inlineAttachment: InlineAttachmentMark,
       link: InlineLinkMark,
-      richContentVariable: (props: { children: [] }) => {
+      richContentVariable: (props: { children: string[] }) => {
         const { children } = props;
         if (!children) {
           return <>{children}</>;
         }
-        return children.map((child: string, index: number) => {
-          if (child === '' || !variableValue) {
-            return <>{child}</>;
-          }
-          const replacedText = replaceVariablesInText(child as string, { kpiValue: variableValue as string });
-          return <InlineText key={index}>{replacedText}</InlineText>;
-        });
+        if (children[0] === '' || !variableValue) {
+          return <>{children[0]}</>;
+        }
+        return (
+          <InlineText>
+            {children.map((child: string) => {
+              if (child === '' || !variableValue) {
+                return <>{child}</>;
+              }
+              const replacedText = replaceVariablesInText(child as string, { kpiValue: variableValue as string });
+              return replacedText;
+            })}
+          </InlineText>
+        );
       },
     },
   };

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -228,20 +228,16 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
       link: InlineLinkMark,
       richContentVariable: (props: { children: string[] }) => {
         const { children } = props;
-        if (!children) {
+        if (!children || !variableValue) {
           return <>{children}</>;
-        }
-        if (children[0] === '' || !variableValue) {
-          return <>{children[0]}</>;
         }
         return (
           <InlineText>
             {children.map((child: string) => {
-              if (child === '' || !variableValue) {
+              if (child === '') {
                 return <>{child}</>;
               }
-              const replacedText = replaceVariablesInText(child as string, { kpiValue: variableValue as string });
-              return replacedText;
+              return replaceVariablesInText(child as string, { kpiValue: variableValue as string });
             })}
           </InlineText>
         );

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -25,7 +25,7 @@ import { assert } from '~/utils/assert';
 import { isInternalUrl } from '~/utils/is-internal-url';
 import { Link } from '~/utils/link';
 import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
-import { Heading, InlineText } from '../typography';
+import { Heading } from '../typography';
 import { ContentImage } from './content-image';
 import { InlineAgeDemographic } from './inline-age-demographic';
 import { InlineChoropleth } from './inline-choropleth';
@@ -35,6 +35,7 @@ import { InlineTimeSeriesCharts } from './inline-time-series-charts';
 import { ChevronRight, Download, External as ExternalLinkIcon } from '@corona-dashboard/icons';
 import { space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils';
+import React from 'react';
 
 type ElementAlignment = 'start' | 'center' | 'end' | 'stretch';
 
@@ -228,18 +229,12 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
       link: InlineLinkMark,
       richContentVariable: (props: { children: string[] }) => {
         const { children } = props;
-        if (!children || !variableValue) {
-          return <>{children}</>;
-        }
         return (
-          <InlineText>
-            {children.map((child: string) => {
-              if (child === '') {
-                return <>{child}</>;
-              }
-              return replaceVariablesInText(child as string, { kpiValue: variableValue as string });
-            })}
-          </InlineText>
+          <>
+            {children.map((child, index) => (
+              <React.Fragment key={index}>{child.includes('{{kpiValue}}') && variableValue ? replaceVariablesInText(child, { kpiValue: variableValue }) : child}</React.Fragment>
+            ))}
+          </>
         );
       },
     },

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -25,7 +25,7 @@ import { assert } from '~/utils/assert';
 import { isInternalUrl } from '~/utils/is-internal-url';
 import { Link } from '~/utils/link';
 import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
-import { Heading } from '../typography';
+import { Heading, InlineText } from '../typography';
 import { ContentImage } from './content-image';
 import { InlineAgeDemographic } from './inline-age-demographic';
 import { InlineChoropleth } from './inline-choropleth';
@@ -34,6 +34,7 @@ import { InlineKpi } from './inline-kpi';
 import { InlineTimeSeriesCharts } from './inline-time-series-charts';
 import { ChevronRight, Download, External as ExternalLinkIcon } from '@corona-dashboard/icons';
 import { space } from '~/style/theme';
+import { replaceVariablesInText } from '~/utils';
 
 type ElementAlignment = 'start' | 'center' | 'end' | 'stretch';
 
@@ -42,6 +43,7 @@ interface RichContentProps {
   contentWrapper?: FunctionComponent;
   imageSizes?: string[][];
   elementAlignment?: ElementAlignment;
+  variableValue?: string | false;
 }
 
 interface ChartConfigNode {
@@ -80,7 +82,7 @@ interface KpisConfigNode {
   kpis: KpiConfigNode[];
 }
 
-export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignment }: RichContentProps) {
+export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignment, variableValue }: RichContentProps) {
   const ContentWrapper = contentWrapper ?? Fragment;
   const serializers = {
     types: {
@@ -225,6 +227,19 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
     marks: {
       inlineAttachment: InlineAttachmentMark,
       link: InlineLinkMark,
+      richContentVariable: (props: { children: [] }) => {
+        const { children } = props;
+        if (!children) {
+          return <>{children}</>;
+        }
+        return children.map((child: string, index: number) => {
+          if (child === '' || !variableValue) {
+            return <>{child}</>;
+          }
+          const replacedText = replaceVariablesInText(child as string, { kpiValue: variableValue as string });
+          return <InlineText key={index}>{replacedText}</InlineText>;
+        });
+      },
     },
   };
 

--- a/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
@@ -76,7 +76,7 @@ export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue,
           padding={{ _: space[3], xs: space[4] }}
           paddingTop={formattedKpiValue ? { _: space[2] } : undefined}
         >
-          <RichContent blocks={description} elementAlignment="start" />
+          <RichContent blocks={description} elementAlignment="start" variableValue={formattedKpiValue} />
         </Box>
       </Box>
 

--- a/packages/cms/src/schemas/objects/block-fields.ts
+++ b/packages/cms/src/schemas/objects/block-fields.ts
@@ -22,19 +22,6 @@ export const blockFields = [
         { title: 'Strong', value: 'strong' },
         { title: 'Emphasis', value: 'em' },
         { title: 'Underline', value: 'u' },
-        {
-          title: 'Sup',
-          value: 'sup',
-          blockEditor: {
-            icon: () => {
-              return 'Variable';
-            },
-            render: (val: any) => {
-              console.log(val.children.props.text.text);
-              return val.children.props.text.text;
-            },
-          },
-        },
       ],
       annotations: [
         {
@@ -70,6 +57,7 @@ export const blockFields = [
               name: 'Variable naam',
               type: 'string',
               title: 'variableName',
+              hidden: true,
             },
           ],
         },

--- a/packages/cms/src/schemas/objects/block-fields.ts
+++ b/packages/cms/src/schemas/objects/block-fields.ts
@@ -22,6 +22,19 @@ export const blockFields = [
         { title: 'Strong', value: 'strong' },
         { title: 'Emphasis', value: 'em' },
         { title: 'Underline', value: 'u' },
+        {
+          title: 'Sup',
+          value: 'sup',
+          blockEditor: {
+            icon: () => {
+              return 'Variable';
+            },
+            render: (val: any) => {
+              console.log(val.children.props.text.text);
+              return val.children.props.text.text;
+            },
+          },
+        },
       ],
       annotations: [
         {
@@ -47,6 +60,18 @@ export const blockFields = [
           type: 'file',
           title: 'Bestand uploaden',
           icon: MdAttachFile,
+        },
+        {
+          name: 'richContentVariable',
+          type: 'object',
+          title: 'Rich content variable',
+          fields: [
+            {
+              name: 'Variable naam',
+              type: 'string',
+              title: 'variableName',
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Added the possibility to add variables to the rich content block.
This is made possible by adding a new type of annotation. When the annotation is applied to the selected text that part of the text is used as the variable name.


**_Before_**
<details>
  <summary>Toggle before screenshot</summary> 
<img width="627" alt="Screenshot 2023-02-21 at 15 19 47" src="https://user-images.githubusercontent.com/111750729/220370547-e7aed1ac-64c1-4646-8dc8-e39bdb5d680d.png">
</details>


**_After_**
<details>
  <summary>Toggle after screenshot</summary> 
<img width="626" alt="Screenshot 2023-02-21 at 17 12 42" src="https://user-images.githubusercontent.com/111750729/220399601-6bc496ca-5390-4db9-b632-f1feb0184fcb.png">
<img width="619" alt="Screenshot 2023-02-21 at 17 16 59" src="https://user-images.githubusercontent.com/111750729/220400302-005aadbb-0173-477a-803d-2da5c841fc51.png">
</details>