### PR TITLE
bugfix/COR-1232-redirect-3-articles-to-all-articles-page

### DIFF
--- a/packages/app/src/next-config/redirects/redirects.js
+++ b/packages/app/src/next-config/redirects/redirects.js
@@ -111,6 +111,22 @@ async function redirects() {
       destination: `/landelijk/ziekenhuizen-en-zorg`,
       permanent: true,
     },
+    // Redirects for unpublished articles - COR-1232
+    {
+      source: '/artikelen/wat-betekent-de-britse-variant-voor-nederland',
+      destination: '/artikelen',
+      permanent: true,
+    },
+    {
+      source: '/artikelen/hoe-weten-we-hoeveel-besmettelijke-mensen-er-zijn',
+      destination: '/artikelen',
+      permanent: true,
+    },
+    {
+      source: '/artikelen/waarom-mogelijke-situaties-van-besmetting-niet-altijd-te-zien-zijn-op-het-dashboard',
+      destination: '/artikelen',
+      permanent: true,
+    },
   ];
 }
 


### PR DESCRIPTION
## Summary

Based on the discussion in the pre-release call yesterday, this solution aims to redirect the 3 articles mentioned in COR-1232. The initial idea was to create a more dynamic solution which would redirect any unpublished articles to the all articles page. The ticket for that is COR-1379. However, as that is still in progress, for the sake of the release, I have hardcoded redirects for the three articles in question in COR-1232. I have also moved COR-1232 back from DONE to REVIEW.

There are no screenshots to show for this change.