### PR TITLE
fix: PR feedback

### DIFF
--- a/packages/app/src/components/anchor-tile.tsx
+++ b/packages/app/src/components/anchor-tile.tsx
@@ -37,9 +37,7 @@ export function AnchorTile({ title, href, label, children, external = false }: A
             </ExternalLink>
           ) : (
             <Link href={href} passHref>
-              <Anchor display="flex">
-                <span>{label}</span>
-              </Anchor>
+              <Anchor>{label}</Anchor>
             </Link>
           )}
         </LinkContainer>

--- a/packages/app/src/components/anchor-tile.tsx
+++ b/packages/app/src/components/anchor-tile.tsx
@@ -37,7 +37,7 @@ export function AnchorTile({ title, href, label, children, external = false }: A
             </ExternalLink>
           ) : (
             <Link href={href} passHref>
-              <Anchor>
+              <Anchor display="flex">
                 <span>{label}</span>
               </Anchor>
             </Link>

--- a/packages/app/src/components/anchor-tile.tsx
+++ b/packages/app/src/components/anchor-tile.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@corona-dashboard/common';
 import { External as ExternalLinkIcon } from '@corona-dashboard/icons';
 import styled from 'styled-components';
-import { AnchorProps, Heading } from '~/components/typography';
+import { Anchor, AnchorProps, Heading } from '~/components/typography';
 import { Box } from '~/components/base';
 import { Link } from '~/utils/link';
 import { ExternalLink } from './external-link';
@@ -80,7 +80,7 @@ const Content = styled.div`
   max-width: ${sizes.maxWidthText}px;
 `;
 
-const StyledAnchor = styled.a<AnchorProps>`
+const StyledAnchor = styled(Anchor)<AnchorProps>`
   display: flex;
 `;
 

--- a/packages/app/src/components/anchor-tile.tsx
+++ b/packages/app/src/components/anchor-tile.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@corona-dashboard/common';
 import { External as ExternalLinkIcon } from '@corona-dashboard/icons';
 import styled from 'styled-components';
-import { Anchor, AnchorProps, Heading } from '~/components/typography';
+import { Anchor, Heading } from '~/components/typography';
 import { Box } from '~/components/base';
 import { Link } from '~/utils/link';
 import { ExternalLink } from './external-link';
@@ -37,9 +37,9 @@ export function AnchorTile({ title, href, label, children, external = false }: A
             </ExternalLink>
           ) : (
             <Link href={href} passHref>
-              <StyledAnchor>
+              <Anchor>
                 <span>{label}</span>
-              </StyledAnchor>
+              </Anchor>
             </Link>
           )}
         </LinkContainer>
@@ -78,10 +78,6 @@ const Content = styled.div`
   flex-grow: 1;
   flex: 1 1 70%;
   max-width: ${sizes.maxWidthText}px;
-`;
-
-const StyledAnchor = styled(Anchor)<AnchorProps>`
-  display: flex;
 `;
 
 const LinkContainer = styled.div`


### PR DESCRIPTION
changed `styled.a` to `styled(Anchor)`

Because of feedback on already merged PR.