### PR TITLE
fix: update wrong casing for variable name

### DIFF
--- a/packages/cms/src/schemas/topical/theme-tile.ts
+++ b/packages/cms/src/schemas/topical/theme-tile.ts
@@ -58,7 +58,7 @@ export const themeTile = {
     },
     {
       title: 'Metadata label',
-      description: 'Bij {{DATE}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
+      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
       name: 'sourceLabel',
       type: 'localeString',
     },


### PR DESCRIPTION
Fixing a wrong description in a sanity data field.

This change is already deployed to the Sanity studio.