### PR TITLE
task/COR-1461-remove-redirects-for-measurement-pages

### DIFF
--- a/packages/app/src/next-config/redirects/redirects.js
+++ b/packages/app/src/next-config/redirects/redirects.js
@@ -117,27 +117,6 @@ async function redirects() {
       destination: '/artikelen',
       permanent: true,
     },
-    // Redirects for removal of recommanded advices page - COR-1431
-    {
-      source: '/veiligheidsregio/:code/maatregelen',
-      destination: '/',
-      permanent: true,
-    },
-    {
-      source: '/landelijk/maatregelen',
-      destination: '/',
-      permanent: true,
-    },
-    {
-      source: '/veiligheidsregio/:code/geldende-adviezen',
-      destination: '/',
-      permanent: true,
-    },
-    {
-      source: '/landelijk/geldende-adviezen',
-      destination: '/',
-      permanent: true,
-    },
   ];
 }
 


### PR DESCRIPTION
## Summary

Removed the redirects for the (removed) measurements pages

## Screen recording
#### After
<details>
<summary>Toggle after screen recording</summary>

https://user-images.githubusercontent.com/93984341/223980363-8f1e1fd9-1e12-498c-8172-9607d8e5c59d.mov




</details>