### PR TITLE
Task/cor 1063 sewer choropleth enhancements

### DIFF
--- a/packages/app/src/components/chart-time-controls.tsx
+++ b/packages/app/src/components/chart-time-controls.tsx
@@ -1,8 +1,5 @@
 import { useMemo } from 'react';
-import {
-  TimeframeOption,
-  TimeframeOptionsList,
-} from '@corona-dashboard/common';
+import { TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { Box } from '~/components/base';
 import { Text } from '~/components/typography';
 import { RichContentSelect } from '~/components/rich-content-select';
@@ -15,11 +12,7 @@ interface ChartTimeControlsProps {
 }
 
 export function ChartTimeControls(props: ChartTimeControlsProps) {
-  const {
-    onChange,
-    timeframe,
-    timeframeOptions = TimeframeOptionsList,
-  } = props;
+  const { onChange, timeframe, timeframeOptions = TimeframeOptionsList } = props;
   const { commonTexts } = useIntl();
 
   const selectOptions = useMemo(

--- a/packages/app/src/components/rich-content-select/rich-content-select.tsx
+++ b/packages/app/src/components/rich-content-select/rich-content-select.tsx
@@ -28,7 +28,7 @@ type RichContentSelectProps<T extends string> = {
  * Implementation adapted from:
  * https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html
  */
-export function RichContentSelect<T extends string>(props: RichContentSelectProps<T>) {
+export const RichContentSelect = <T extends string>(props: RichContentSelectProps<T>) => {
   const { label, options, onChange, initialValue, visuallyHiddenLabel, useContentForSelectedOption: richContentForSelectedValue } = props;
 
   const { labelId, selectedOption, getComboboxProps, getListBoxProps, getListBoxOptionsProps } = useRichContentSelect(options, onChange, initialValue);
@@ -78,7 +78,7 @@ export function RichContentSelect<T extends string>(props: RichContentSelectProp
         <ListBox {...getListBoxProps()}>
           {options &&
             options.map((option, index) => (
-              <ListBoxOption key={option.value || index} {...getListBoxOptionsProps(index)}>
+              <ListBoxOption key={option.value} {...getListBoxOptionsProps(index)}>
                 <VisuallyHidden>
                   {
                     <InlineText>
@@ -95,4 +95,4 @@ export function RichContentSelect<T extends string>(props: RichContentSelectProp
       </SelectBoxRoot>
     </Box>
   );
-}
+};

--- a/packages/app/src/components/rich-content-select/rich-content-select.tsx
+++ b/packages/app/src/components/rich-content-select/rich-content-select.tsx
@@ -78,7 +78,7 @@ export function RichContentSelect<T extends string>(props: RichContentSelectProp
         <ListBox {...getListBoxProps()}>
           {options &&
             options.map((option, index) => (
-              <ListBoxOption key={option.value} {...getListBoxOptionsProps(index)}>
+              <ListBoxOption key={option.value || index} {...getListBoxOptionsProps(index)}>
                 <VisuallyHidden>
                   {
                     <InlineText>

--- a/packages/app/src/components/rich-content-select/types.ts
+++ b/packages/app/src/components/rich-content-select/types.ts
@@ -1,5 +1,5 @@
 export type Option<T extends string> = {
-  value: T;
+  value: T | undefined;
   content?: React.ReactNode;
   label: string;
 };

--- a/packages/app/src/components/rich-content-select/types.ts
+++ b/packages/app/src/components/rich-content-select/types.ts
@@ -1,5 +1,5 @@
 export type Option<T extends string> = {
-  value: T | undefined;
+  value: T;
   content?: React.ReactNode;
   label: string;
 };

--- a/packages/app/src/domain/sewer/sewer-chart/logic.ts
+++ b/packages/app/src/domain/sewer/sewer-chart/logic.ts
@@ -21,7 +21,7 @@ export type MergedSewerType = ReturnType<typeof mergeData>[number];
  * with different formats. In order to display them in the chart together we
  * need to convert them to format with the same type of timestamps.
  */
-export function mergeData(dataAverages: VrSewer | GmSewer | NlSewer, dataPerInstallation: SewerPerInstallationData, selectedInstallation: string) {
+export const mergeData = (dataAverages: VrSewer | GmSewer | NlSewer, dataPerInstallation: SewerPerInstallationData, selectedInstallation: string) => {
   const valuesForInstallation = dataPerInstallation.values.find((x) => x.rwzi_awzi_name === selectedInstallation)?.values;
 
   assert(valuesForInstallation, `[${mergeData.name}] Failed to find data for rwzi_awzi_name ${selectedInstallation}`);
@@ -73,7 +73,7 @@ export function mergeData(dataAverages: VrSewer | GmSewer | NlSewer, dataPerInst
       ...obj,
     }))
     .sort((a, b) => a.date_unix - b.date_unix);
-}
+};
 
 /**
  * Using the original data as input instead of the specific scatter plot

--- a/packages/app/src/domain/sewer/sewer-chart/logic.ts
+++ b/packages/app/src/domain/sewer/sewer-chart/logic.ts
@@ -5,7 +5,6 @@
  */
 
 import { assert, GmSewer, NlSewer, SewerPerInstallationData, VrSewer } from '@corona-dashboard/common';
-import { set } from 'lodash';
 import { useMemo, useState } from 'react';
 
 type MergedValue = {
@@ -28,11 +27,13 @@ export function mergeData(dataAverages: VrSewer | GmSewer | NlSewer, dataPerInst
   assert(valuesForInstallation, `[${mergeData.name}] Failed to find data for rwzi_awzi_name ${selectedInstallation}`);
 
   const mergedValuesByTimestamp = valuesForInstallation.reduce<MergedValuesByTimestamp>(
-    (acc, v) =>
-      set(acc, v.date_unix, {
-        selected_installation_rna_normalized: v.rna_normalized,
+    (acc, installation) => ({
+      ...acc,
+      [installation.date_unix]: {
+        selected_installation_rna_normalized: installation.rna_normalized,
         average: null,
-      }),
+      },
+    }),
     {}
   );
 

--- a/packages/app/src/domain/sewer/sewer-chart/logic.ts
+++ b/packages/app/src/domain/sewer/sewer-chart/logic.ts
@@ -80,12 +80,12 @@ export const mergeData = (dataAverages: VrSewer | GmSewer | NlSewer, dataPerInst
  * processed format. This is used the by the new sewer water chart based on
  * TimeSeriesChart
  */
-export function useSewerStationSelectPropsSimplified(data: SewerPerInstallationData, deselectLabel: string) {
+export const useSewerStationSelectPropsSimplified = (data: SewerPerInstallationData, deselectLabel: string) => {
   const [value, setValue] = useState<string>();
   const options = useMemo(
     () => [
-      { label: deselectLabel, value: undefined },
-      ...data.values.map((x) => ({ label: x.rwzi_awzi_name, value: x.rwzi_awzi_name })).sort((a, b) => a.label.localeCompare(b.label)),
+      { label: deselectLabel, value: 'average' },
+      ...data.values.map((selectValue) => ({ label: selectValue.rwzi_awzi_name, value: selectValue.rwzi_awzi_name })).sort((a, b) => a.label.localeCompare(b.label)),
     ],
     [data.values, deselectLabel]
   );
@@ -97,4 +97,4 @@ export function useSewerStationSelectPropsSimplified(data: SewerPerInstallationD
   };
 
   return props;
-}
+};

--- a/packages/app/src/domain/sewer/sewer-chart/logic.ts
+++ b/packages/app/src/domain/sewer/sewer-chart/logic.ts
@@ -80,15 +80,18 @@ export const mergeData = (dataAverages: VrSewer | GmSewer | NlSewer, dataPerInst
  * processed format. This is used the by the new sewer water chart based on
  * TimeSeriesChart
  */
+
 export const useSewerStationSelectPropsSimplified = (data: SewerPerInstallationData, deselectLabel: string) => {
   const [value, setValue] = useState<string>();
-  const options = useMemo(
-    () => [
-      { label: deselectLabel, value: 'average' },
-      ...data.values.map((selectValue) => ({ label: selectValue.rwzi_awzi_name, value: selectValue.rwzi_awzi_name })).sort((a, b) => a.label.localeCompare(b.label)),
-    ],
-    [data.values, deselectLabel]
-  );
+  const options = useMemo(() => {
+    const optionsSorted = data.values
+      .map((selectValue) => ({ label: selectValue.rwzi_awzi_name, value: selectValue.rwzi_awzi_name }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    if (deselectLabel !== '') {
+      optionsSorted.unshift({ label: deselectLabel, value: 'average' });
+    }
+    return optionsSorted;
+  }, [data.values, deselectLabel]);
 
   const props = {
     options,

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -155,7 +155,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
           </Box>
         )}
         {dataPerInstallation && (
-          <Box flexBasis={{ sm: '100%', lg: '50%', xl: '25%' }} minWidth="207px">
+          <Box>
             <strong>{text.rwziSelectDropdown.dropdown_label_rwzi}</strong>
             <RichContentSelect
               label={text.selectPlaceholder}

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -97,12 +97,10 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
 
   const scopedWarning = useScopedWarning(vrNameOrGmName || '', warning || '');
 
-  const [timeframe, setTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
+  const [timeframe, setTimeframe] = useState(TimeframeOption.ALL);
 
   useEffect(() => {
-    if (setSewerTimeframe) {
-      setSewerTimeframe(timeframe);
-    }
+    setSewerTimeframe(timeframe);
   }, [timeframe, setSewerTimeframe]);
 
   const dataOptions =

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { isPresent } from 'ts-is-present';
 import { Warning } from '@corona-dashboard/icons';
-import { Box, Spacer } from '~/components/base';
+import { Box } from '~/components/base';
 import { Text } from '~/components/typography';
 import { ChartTile } from '~/components/chart-tile';
 import { RichContentSelect } from '~/components/rich-content-select';
@@ -144,8 +144,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
       }}
       description={text.description}
     >
-      <Spacer marginBottom={space[4]} />
-      <SelectBoxes display="flex" justifyContent="flex-start" marginBottom={space[5]}>
+      <SelectBoxes display="flex" justifyContent="flex-start" marginBottom={space[3]}>
         {TimeframeOptionsList && (
           <Box>
             <strong>{text.rwziSelectDropdown?.dropdown_label_timeselection}</strong>

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -146,7 +146,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
       }}
       description={text.description}
     >
-      <Spacer marginBottom={space[5]} />
+      <Spacer marginBottom={space[4]} />
       <SelectBoxes display="flex" justifyContent="flex-start" marginBottom={space[5]}>
         {TimeframeOptionsList && (
           <Box>

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -43,7 +43,7 @@ interface SewerChartProps {
     averagesLegendLabel: string;
     averagesTooltipLabel: string;
     valueAnnotation: string;
-    rwziSelectDropdown: {
+    rwziSelectDropdown?: {
       dropdown_label_rwzi: string;
       dropdown_label_timeselection: string;
       select_none_label: string;
@@ -79,7 +79,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
           },
         ],
       } as SewerPerInstallationData),
-    text.rwziSelectDropdown.select_none_label
+    text.rwziSelectDropdown?.select_none_label || ''
   );
 
   const router = useRouter();
@@ -150,13 +150,13 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
       <SelectBoxes display="flex" justifyContent="flex-start" marginBottom={space[5]}>
         {TimeframeOptionsList && (
           <Box>
-            <strong>{text.rwziSelectDropdown.dropdown_label_timeselection}</strong>
+            <strong>{text.rwziSelectDropdown?.dropdown_label_timeselection}</strong>
             <ChartTimeControls timeframeOptions={TimeframeOptionsList} timeframe={timeframe} onChange={setTimeframe} />
           </Box>
         )}
         {dataPerInstallation && (
           <Box>
-            <strong>{text.rwziSelectDropdown.dropdown_label_rwzi}</strong>
+            <strong>{text.rwziSelectDropdown?.dropdown_label_rwzi}</strong>
             <RichContentSelect
               label={text.selectPlaceholder}
               visuallyHiddenLabel
@@ -177,7 +177,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
          * If there is installation data, and an installation was selected we need to
          * convert the data to combine the two.
          */
-        dataPerInstallation && selectedInstallation ? (
+        dataPerInstallation && selectedInstallation && selectedInstallation !== 'average' ? (
           <TimeSeriesChart
             accessibility={accessibility}
             values={mergeData(dataAverages, dataPerInstallation, selectedInstallation)}

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -224,17 +224,19 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
 };
 
 const SelectBoxes = styled(Box)`
-  gap: ${space[5]};
+  column-gap: ${space[5]};
+  row-gap: ${space[4]};
+  flex-wrap: wrap;
 
-  div {
+  > div {
     min-width: 207px;
-    flex-basis: 25%;
-  }
+    flex: 1 0;
 
-  @media ${mediaQueries.lg} {
-    flex-basis: 50%;
-  }
-  @media ${mediaQueries.sm} {
-    flex-basis: 100%;
+    @media ${mediaQueries.lg} {
+      flex: 0 33%;
+    }
+    @media ${mediaQueries.xl} {
+      flex: 0 25%;
+    }
   }
 `;

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -9,7 +9,6 @@ import { ChartTile } from '~/components/chart-tile';
 import { RichContentSelect } from '~/components/rich-content-select';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
-import { LocationTooltip } from './components/location-tooltip';
 import { WarningTile } from '~/components/warning-tile';
 import { mergeData, useSewerStationSelectPropsSimplified } from './logic';
 import { useIntl } from '~/intl';
@@ -72,7 +71,8 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
             rwzi_awzi_name: '__no_installations',
           },
         ],
-      } as SewerPerInstallationData)
+      } as SewerPerInstallationData),
+    'Deselecteren'
   );
 
   const router = useRouter();
@@ -164,8 +164,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
                 type: 'line',
                 metricProperty: 'selected_installation_rna_normalized',
                 label: selectedInstallation,
-                color: 'black',
-                style: 'dashed',
+                color: colors.orange1,
               },
               {
                 type: 'line',
@@ -173,18 +172,10 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
                 label: text.averagesLegendLabel,
                 shortLabel: text.averagesTooltipLabel,
                 color: colors.scale.blue[3],
-                nonInteractive: true,
               },
             ]}
-            formatTooltip={(data) => {
-              /**
-               * Silently fail when unable to find line configuration in location tooltip
-               */
-              if (data.config.find((x) => x.type === 'line')) {
-                return <LocationTooltip data={data} />;
-              }
-            }}
             dataOptions={dataOptions}
+            forceLegend
           />
         ) : (
           <TimeSeriesChart

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -174,6 +174,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               averagesLegendLabel: commonTexts.common.charts.averages_legend_label,
               averagesTooltipLabel: commonTexts.common.charts.weekly_averages_label,
               valueAnnotation: commonTexts.waarde_annotaties.riool_normalized,
+              rwziSelectDropdown: textGm.linechart_select,
             }}
             vrNameOrGmName={municipalityName}
             incompleteDatesAndTexts={textShared.zeewolde_incomplete_manualy_override}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -52,3 +52,5 @@ timestamp,action,key,document_id,move_to
 2023-03-13T09:41:46.521Z,add,pages.sewer_page.gm.linechart_select.select_none_label,SIWTfLRtzTv41yDNBWqalW,__
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.dropdown_label,XwwkMu8B8bd2jFtuxdHHPe,__
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.select_none_label,SIWTfLRtzTv41yDNBWGVLm,__
+2023-03-13T17:06:59.479Z,add,common.accessibility.charts.hospital_admissions_region_choropleth.description,YzrXb3vQYHnZxtu61Xgzap,__
+2023-03-13T17:06:59.480Z,delete,accessibility.charts.hospital_admissions_region_choropleth.description,G1DXw0RdifOml06twMjbPq,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -45,3 +45,10 @@ timestamp,action,key,document_id,move_to
 2023-03-08T14:22:45.816Z,delete,positief_geteste_personen.tooltip_labels.infected_per_100k,drafts.jF33EuwumlGuwav2FD3ZbQ,__
 2023-03-08T14:22:45.819Z,delete,regionaal_index.belangrijk_bericht,drafts.jF33EuwumlGuwav2FD3g7g,__
 2023-03-08T14:22:45.821Z,delete,veiligheidsregio_index.selecteer_toelichting,drafts.jF33EuwumlGuwav2FD3nGW,__
+2023-03-13T07:42:37.721Z,add,pages.sewer_page.gm.linechart_select_rwzi.dropdown_label,XwwkMu8B8bd2jFtuxdHHPe,__
+2023-03-13T07:42:38.743Z,add,pages.sewer_page.gm.linechart_select_rwzi.select_none_label,SIWTfLRtzTv41yDNBWGVLm,__
+2023-03-13T09:41:44.493Z,add,pages.sewer_page.gm.linechart_select.dropdown_label_rwzi,z1B5btfwJAFXTOIW9q7H8r,__
+2023-03-13T09:41:45.618Z,add,pages.sewer_page.gm.linechart_select.dropdown_label_timeselection,z1B5btfwJAFXTOIW9q7HwP,__
+2023-03-13T09:41:46.521Z,add,pages.sewer_page.gm.linechart_select.select_none_label,SIWTfLRtzTv41yDNBWqalW,__
+2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.dropdown_label,XwwkMu8B8bd2jFtuxdHHPe,__
+2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.select_none_label,SIWTfLRtzTv41yDNBWGVLm,__


### PR DESCRIPTION
## Summary

Adjusting the GM choropleth for Sewer per RWZI
Added a deselect option in the RWZI dropdown to unselect the active RWZI
And added the weekly average to the tooltip.

## Screenshots:
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="1029" alt="Screenshot 2023-03-13 at 11 11 02" src="https://user-images.githubusercontent.com/93984341/224671888-f2fdf8be-ffaf-49d2-a068-e8810802b6f2.png">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="968" alt="Screenshot 2023-03-13 at 11 25 54" src="https://user-images.githubusercontent.com/93984341/224675318-feded3b4-f1b5-4c57-8111-427fa6b609b5.png">

<img width="977" alt="Screenshot 2023-03-13 at 11 26 01" src="https://user-images.githubusercontent.com/93984341/224675323-4b04f981-329d-4f04-9041-28786414e41c.png">

</details>

## Mobile Screenshots:
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="369" alt="Screenshot 2023-03-13 at 11 12 50" src="https://user-images.githubusercontent.com/93984341/224674975-d891d413-52a3-4be6-81e2-e19332e80589.png">

<img width="374" alt="Screenshot 2023-03-13 at 11 13 00" src="https://user-images.githubusercontent.com/93984341/224675051-119c5fa2-aed8-4705-84cc-9b2ef4e7a044.png">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="456" alt="Screenshot 2023-03-13 at 11 24 14" src="https://user-images.githubusercontent.com/93984341/224675128-02432df2-4e30-47ea-8741-3a0d0a7a2a4a.png">

<img width="392" alt="Screenshot 2023-03-13 at 11 24 38" src="https://user-images.githubusercontent.com/93984341/224675139-526bc9d6-ad30-47ef-85ac-ce85aeb143f8.png">

<img width="915" alt="Screenshot 2023-03-13 at 11 24 21" src="https://user-images.githubusercontent.com/93984341/224675135-15f2cefb-3942-47bc-b4fd-c73012d667ca.png">

<img width="914" alt="Screenshot 2023-03-13 at 11 24 30" src="https://user-images.githubusercontent.com/93984341/224675137-627f2c54-b4df-418c-b04b-437591841ea7.png">

</details>