### PR TITLE
COR-1063 fix: removing collapsible

### DIFF
--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -48,6 +48,7 @@ interface SewerChartProps {
       dropdown_label_timeselection: string;
       select_none_label: string;
     };
+    rwziLabel?: string;
   };
   vrNameOrGmName?: string;
   incompleteDatesAndTexts?: {
@@ -183,7 +184,7 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
               {
                 type: 'line',
                 metricProperty: 'selected_installation_rna_normalized',
-                label: selectedInstallation,
+                label: text.rwziLabel ? `${text.rwziLabel} ${selectedInstallation}` : selectedInstallation,
                 color: colors.orange1,
               },
               {

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -2,7 +2,6 @@ import { NlSewer } from '@corona-dashboard/common';
 import { Experimenteel, Rioolvirus } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import { CollapsibleContent } from '~/components/collapsible';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { Markdown } from '~/components/markdown';
@@ -132,15 +131,6 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               </Text>
 
               <Markdown content={textGm.extra_uitleg} />
-
-              <CollapsibleContent label={commonTexts.gemeente_index.population_count_explanation_title}>
-                <Text>
-                  {replaceComponentsInText(textGm.population_count_explanation, {
-                    municipalityName: <strong>{municipalityName}</strong>,
-                    value: <strong>{formatNumber(sewerAverages.last_value.average)}</strong>,
-                  })}
-                </Text>
-              </CollapsibleContent>
             </KpiTile>
 
             <KpiTile

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -165,6 +165,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               averagesTooltipLabel: commonTexts.common.charts.weekly_averages_label,
               valueAnnotation: commonTexts.waarde_annotaties.riool_normalized,
               rwziSelectDropdown: textGm.linechart_select,
+              rwziLabel: textShared.RWZI_label,
             }}
             vrNameOrGmName={municipalityName}
             incompleteDatesAndTexts={textShared.zeewolde_incomplete_manualy_override}

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -53,4 +53,5 @@ timestamp,action,key,document_id,move_to
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.dropdown_label,XwwkMu8B8bd2jFtuxdHHPe,__
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.select_none_label,SIWTfLRtzTv41yDNBWGVLm,__
 2023-03-13T17:06:59.479Z,add,common.accessibility.charts.hospital_admissions_region_choropleth.description,YzrXb3vQYHnZxtu61Xgzap,__
-2023-03-13T17:06:59.480Z,delete,accessibility.charts.hospital_admissions_region_choropleth.description,G1DXw0RdifOml06twMjbPq,__2023-03-15T10:04:19.777Z,add,pages.sewer_page.shared.RWZI_label,3cSKlMyB5WS7AkuCg9V2sP,__
+2023-03-13T17:06:59.480Z,delete,accessibility.charts.hospital_admissions_region_choropleth.description,G1DXw0RdifOml06twMjbPq,__
+2023-03-15T10:04:19.777Z,add,pages.sewer_page.shared.RWZI_label,3cSKlMyB5WS7AkuCg9V2sP,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -53,4 +53,4 @@ timestamp,action,key,document_id,move_to
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.dropdown_label,XwwkMu8B8bd2jFtuxdHHPe,__
 2023-03-13T09:41:46.521Z,delete,pages.sewer_page.gm.linechart_select_rwzi.select_none_label,SIWTfLRtzTv41yDNBWGVLm,__
 2023-03-13T17:06:59.479Z,add,common.accessibility.charts.hospital_admissions_region_choropleth.description,YzrXb3vQYHnZxtu61Xgzap,__
-2023-03-13T17:06:59.480Z,delete,accessibility.charts.hospital_admissions_region_choropleth.description,G1DXw0RdifOml06twMjbPq,__
+2023-03-13T17:06:59.480Z,delete,accessibility.charts.hospital_admissions_region_choropleth.description,G1DXw0RdifOml06twMjbPq,__2023-03-15T10:04:19.777Z,add,pages.sewer_page.shared.RWZI_label,3cSKlMyB5WS7AkuCg9V2sP,__


### PR DESCRIPTION
## Summary

Removal of the collapsible on the sewer page.
Keys were not removed as those are still active on the positive tested page.

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-03-15 at 10 49 39](https://user-images.githubusercontent.com/93984341/225272369-9cfcdcc3-bd7b-489a-8770-adfaf77c8042.png)

![Screenshot 2023-03-15 at 10 49 44](https://user-images.githubusercontent.com/93984341/225272375-d12acc6a-9448-4752-947f-27c4a60e76f7.png)


![Screenshot 2023-03-15 at 11 05 12](https://user-images.githubusercontent.com/93984341/225276389-222e9865-6e96-4d03-bc64-0db5f1694f2a.png)


</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Screenshot 2023-03-15 at 10 49 33](https://user-images.githubusercontent.com/93984341/225272422-0fce97b0-27f9-480b-9d05-e6f5a2540680.png)

![Screenshot 2023-03-15 at 11 04 52](https://user-images.githubusercontent.com/93984341/225276419-4e3364b0-83c7-4d84-9afc-629dd1265711.png)

![Screenshot 2023-03-15 at 11 04 59](https://user-images.githubusercontent.com/93984341/225276421-6f6de3e6-fded-4f63-94f8-c41bf92eef4b.png)


</details>