### PR TITLE
ci/cd: add the epic prefix temporarily to acceptance

### DIFF
--- a/.github/workflows/infra-acceptance.yml
+++ b/.github/workflows/infra-acceptance.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'release/*'
       - 'hotfix/*'
+      - 'epic/*'
 
 jobs:
   trigger-acceptance-build:


### PR DESCRIPTION
This will also trigger a build for the acceptance environment if something is pushed to a branch with the epic prefix