### PR TITLE
feat(kwetsbare-groepen-70-plussers): removed getLink and reverse rout…

### DIFF
--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -27,7 +27,6 @@ import { createGetStaticProps, StaticProps } from '~/static-props/create-get-sta
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
-import { useReverseRouter } from '~/utils/use-reverse-router';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
@@ -104,7 +103,6 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
   const nusingHomeArchivedUnderReportedDateStart = getBoundaryDateStartUnix(data.nursing_home_archived_20230126.values, 7);
 
   const { commonTexts, formatNumber } = useIntl();
-  const reverseRouter = useReverseRouter();
   const { metadataTexts, textNl, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
   const infectedLocationsText = textShared.verpleeghuis_besmette_locaties;
   const positiveTestedPeopleText = textNl.verpleeghuis_positief_geteste_personen;
@@ -259,7 +257,6 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               }}
               dataOptions={{
                 isPercentage: true,
-                getLink: reverseRouter.vr.kwetsbareGroepen,
               }}
             />
           </ChoroplethTile>

--- a/packages/common/src/data/reverse-router.ts
+++ b/packages/common/src/data/reverse-router.ts
@@ -42,7 +42,6 @@ export function getReverseRouter(isMobile: boolean) {
       positiefGetesteMensen: (code: string) => `/veiligheidsregio/${code}/positief-geteste-mensen`,
       sterfte: (code: string) => `/veiligheidsregio/${code}/sterfte`,
       ziekenhuisopnames: (code: string) => `/veiligheidsregio/${code}/ziekenhuis-opnames`,
-      kwetsbareGroepen: (code: string) => `/veiligheidsregio/${code}/kwetsbare-groepen-70-plussers`,
       gehandicaptenzorg: (code: string) => `/veiligheidsregio/${code}/gehandicaptenzorg`,
       thuiswonendeOuderen: (code: string) => `/veiligheidsregio/${code}/thuiswonende-ouderen`,
       rioolwater: (code: string) => `/veiligheidsregio/${code}/rioolwater`,


### PR DESCRIPTION
## Summary

* Choropleth on 'Kwetsbare-groepen-70-plussers' page is no longer clickable.

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Scherm­afbeelding 2023-03-27 om 17 25 16](https://user-images.githubusercontent.com/93994194/227987421-9910c7ed-fb94-4806-af58-089e425743a8.png)

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Scherm­afbeelding 2023-03-27 om 16 47 01](https://user-images.githubusercontent.com/93994194/227987259-5198eb2e-c062-4d0b-ac67-fab104315564.png)

![Scherm­afbeelding 2023-03-27 om 17 28 15](https://user-images.githubusercontent.com/93994194/227988184-e39d6318-7f3c-45e2-8658-e15f395476e5.png)



</details>