### PR TITLE
feature/COR-1510-non-clickable-choropleth

### DIFF
--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -25,7 +25,6 @@ import { createGetStaticProps, StaticProps } from '~/static-props/create-get-sta
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
-import { useReverseRouter } from '~/utils/use-reverse-router';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
@@ -89,7 +88,6 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
   const underReportedDateStart = getBoundaryDateStartUnix(values, 7);
 
   const { commonTexts, formatNumber } = useIntl();
-  const reverseRouter = useReverseRouter();
   const { categoryTexts, metadataTexts, textShared, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const metadata = {
@@ -250,7 +248,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                 },
               }}
               dataOptions={{
-                getLink: reverseRouter.vr.gehandicaptenzorg,
+                isPercentage: true,
               }}
             />
           </ChoroplethTile>

--- a/packages/common/src/data/reverse-router.ts
+++ b/packages/common/src/data/reverse-router.ts
@@ -42,7 +42,6 @@ export function getReverseRouter(isMobile: boolean) {
       positiefGetesteMensen: (code: string) => `/veiligheidsregio/${code}/positief-geteste-mensen`,
       sterfte: (code: string) => `/veiligheidsregio/${code}/sterfte`,
       ziekenhuisopnames: (code: string) => `/veiligheidsregio/${code}/ziekenhuis-opnames`,
-      gehandicaptenzorg: (code: string) => `/veiligheidsregio/${code}/gehandicaptenzorg`,
       thuiswonendeOuderen: (code: string) => `/veiligheidsregio/${code}/thuiswonende-ouderen`,
       rioolwater: (code: string) => `/veiligheidsregio/${code}/rioolwater`,
       gedrag: (code: string) => `/veiligheidsregio/${code}/gedrag`,


### PR DESCRIPTION
## Summary

* Choropleth on 'Gehandicaptenzorg' page is no longer clickable.

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Scherm­afbeelding 2023-03-29 om 14 17 31](https://user-images.githubusercontent.com/93994194/228533519-a9ffefd1-85f9-4071-baa3-ce3e98d9369a.png)


</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Scherm­afbeelding 2023-03-29 om 14 16 57](https://user-images.githubusercontent.com/93994194/228533571-48141f50-47bf-407d-8bb6-bb3e9ca443b1.png)

![Scherm­afbeelding 2023-03-29 om 14 17 15](https://user-images.githubusercontent.com/93994194/228533574-1a1f45f0-b257-48f3-8513-517af571f117.png)

</details>