### PR TITLE
feature/COR-1478-non-clickable-choropleth

### DIFF
--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -26,7 +26,6 @@ import { createGetStaticProps, StaticProps } from '~/static-props/create-get-sta
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
-import { useReverseRouter } from '~/utils/use-reverse-router';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
@@ -82,8 +81,6 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
 
   const { commonTexts, formatNumber } = useIntl();
   const { metadataTexts, textShared, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
-
-  const reverseRouter = useReverseRouter();
 
   const metadata = {
     ...metadataTexts,
@@ -210,9 +207,7 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
                   positive_tested_daily_per_100k: formatNumber,
                 },
               }}
-              dataOptions={{
-                getLink: reverseRouter.vr.thuiswonendeOuderen,
-              }}
+              dataOptions={{}}
             />
           </ChoroplethTile>
           <Divider />


### PR DESCRIPTION
## Summary

* removed `getLink` prop from dynamic choropleth;
* removed any other associated dependencies;

### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="400" alt="image" src="https://user-images.githubusercontent.com/107395524/229151479-bdbfac46-c373-4045-b52b-809173e89a36.png">
</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="400" alt="image" src="https://user-images.githubusercontent.com/107395524/229151593-f2b942ee-7ebd-41f6-9297-408e1395c022.png">
</details>
