### PR TITLE
bugfix/COR-1566-positive-tests-page-last-insertion-date

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -32,7 +32,7 @@ import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
-const pageMetrics = ['g_number', 'tested_ggd', 'tested_overall', 'tested_per_age_group'];
+const pageMetrics = ['g_number', 'self_test_overall', 'tested_ggd', 'tested_overall', 'tested_per_age_group'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,


### PR DESCRIPTION
## Summary

* added self_test_overall as metric to metrics array;

### Screenshots
Screenshots somehow exclude images for articles. This is probably due to Chrome's built-in screenshot tool. Essentially, not changes visually. These screenshots are mainly meant to see the difference in dates used because of the missing metric.

#### Before
<details>
<summary>Toggle before screenshots</summary>

![COR-1566_before](https://user-images.githubusercontent.com/107395524/230391457-28f68aa7-1ace-43ae-884f-5415fa766154.png)
</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![COR-1566_after](https://user-images.githubusercontent.com/107395524/230391447-6a983b27-52a3-4db7-a4f4-1aee02119e2a.png)
</details>