### PR TITLE
Release/2.71.1

### DIFF
--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -32,7 +32,7 @@ import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
-const pageMetrics = ['g_number', 'tested_ggd', 'tested_overall', 'tested_per_age_group'];
+const pageMetrics = ['g_number', 'self_test_overall', 'tested_ggd', 'tested_overall', 'tested_per_age_group'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,


### PR DESCRIPTION
## What's Changed
* bugfix/COR-1566-positive-tests-page-last-insertion-date by @VWSCoronaDashboard26 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4730


**Full Changelog**: https://github.com/minvws/nl-covid19-data-dashboard/compare/2.71.0...2.71.1