### PR TITLE
feat(vaccination page): fix white space

### DIFF
--- a/packages/app/src/domain/vaccine/vaccine-coverage-choropleth.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-choropleth.tsx
@@ -64,7 +64,7 @@ export const VaccineCoverageChoropleth = ({ data, dataOptions, text }: VaccineCo
               {commonTexts.choropleth.vaccination_coverage.shared.dropdowns_title}
             </BoldText>
 
-            <Box display="grid" gridTemplateColumns={{ _: '1 fr', lg: 'repeat(2, 1fr)' }} gridGap={{ _: '24px', lg: space[2] }} margin="24px 0" minWidth="100%">
+            <Box display="grid" gridTemplateColumns={{ _: '1 fr', lg: 'repeat(2, 1fr)' }} gridGap={{ _: '24px', lg: space[2] }} margin={`${space[2]} 0`} minWidth="100%">
               <Box>
                 {text.vaccinationKindLabel && <BoldText>{text.vaccinationKindLabel}</BoldText>}
                 <VaccinationCoverageKindSelect marginTop={space[2]} onChange={setSelectedCoverageKindAndAge} initialValue={selectedCoverageKind} />


### PR DESCRIPTION
## Summary

* Fixed white space

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="937" alt="Scherm­afbeelding 2023-04-18 om 10 24 36" src="https://user-images.githubusercontent.com/93994194/232718561-8daa1081-8c2e-4af5-96f2-13569ea2c37b.png">
<img width="360" alt="Scherm­afbeelding 2023-04-18 om 10 24 55" src="https://user-images.githubusercontent.com/93994194/232718583-9a89f6f6-3783-4a17-9c1e-e345f297467a.png">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>
<img width="931" alt="Scherm­afbeelding 2023-04-18 om 10 25 23" src="https://user-images.githubusercontent.com/93994194/232718624-33726a18-61c5-4a32-b586-288d59b9e288.png">
<img width="360" alt="Scherm­afbeelding 2023-04-18 om 10 25 37" src="https://user-images.githubusercontent.com/93994194/232718645-e052e0f3-7cd4-4b19-9e00-25b2446f966c.png">


</details>