### PR TITLE
feat(404 pages): Added one more rewrite for reserved route.

### DIFF
--- a/packages/app/src/next-config/rewrites.js
+++ b/packages/app/src/next-config/rewrites.js
@@ -43,6 +43,14 @@ async function rewrites() {
         source: '/gemeente/(g|G)(m|M)(\\d{5,})(\\/?)(\\S*):slug*',
         destination: '/gemeente/code/404',
       },
+      /**
+       * The rewrite below is a workaround. 404 seems to be a reserved route, so it does not go to the
+       * catch-all route by default. This rewrite ensures that basePath/404 will also go to the catch-all route.
+       */
+      {
+        source: '/(404):slug*',
+        destination: '/landelijk/404',
+      },
     ],
   };
 }

--- a/packages/app/src/next-config/rewrites.js
+++ b/packages/app/src/next-config/rewrites.js
@@ -49,7 +49,7 @@ async function rewrites() {
        */
       {
         source: '/(404):slug*',
-        destination: '/landelijk/404',
+        destination: '/not-found/404',
       },
     ],
   };


### PR DESCRIPTION
## Summary

* This pull request adds one more rewrite to `rewrites.js`.
* This rewrite is specifically for the route `basePath/404`. 
* I believe that `/404` like `/500` is a reserved route and therefore if you were to try to go to `basePath/404` on the development environment (before this PR is merged) it would take you to the default `_error.tsx` page. The chances that someone would find themselves at `/404` are low, but its still an edge case so its probably good to have it covered. 

### Screenshots
No new screenshots, if you'd like to see them, you can visit this [link](https://github.com/minvws/nl-covid19-data-dashboard/pull/4736).