### PR TITLE
fix: refactored choropleth map dataOptions to be optional

### DIFF
--- a/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/canvas-choropleth-map.tsx
@@ -21,7 +21,7 @@ export interface CanvasChoroplethMapProps {
   annotations: AccessibilityAnnotations;
   choroplethFeatures: ChoroplethFeatures;
   containerRef: MutableRefObject<HTMLDivElement | null>;
-  dataOptions: DataOptions;
+  dataOptions?: DataOptions;
   featureOutHandler: ChoroplethTooltipHandlers[1];
   featureOverHandler: ChoroplethTooltipHandlers[0];
   featureProps: FeatureProps;
@@ -69,7 +69,7 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
 
   const [outlineGeoInfo] = useProjectedCoordinates(choroplethFeatures.outline, mapProjection, fitExtent);
 
-  const highlightedFeature = useHighlightedFeature(geoInfo, dataOptions);
+  const highlightedFeature = useHighlightedFeature(geoInfo, dataOptions ?? {});
 
   const selectFeature = useCallback(
     (code: CodeProp | undefined, isKeyboardAction = false) => {
@@ -124,7 +124,7 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
     }
   }, [hoverCode, hoveredRef, tooltipTrigger, isKeyboardActive]);
 
-  const { getLink } = dataOptions;
+  const getLink = dataOptions?.getLink;
 
   const mapId = useUniqueId();
 
@@ -169,7 +169,7 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
         >
           <Outlines geoInfo={outlineGeoInfo} featureProps={featureProps} />
           <Features geoInfo={geoInfo} featureProps={featureProps}>
-            <HighlightedFeature feature={highlightedFeature} featureProps={featureProps} code={dataOptions.selectedCode} hoverCode={hoverCode} />
+            <HighlightedFeature feature={highlightedFeature} featureProps={featureProps} code={dataOptions?.selectedCode} hoverCode={hoverCode} />
           </Features>
           <HoveredFeature hoveredRef={hoveredRef} hover={hover} hoverCode={hoverCode} featureProps={featureProps} isKeyboardActive={isKeyboardActive} />
         </Stage>
@@ -182,10 +182,10 @@ export const CanvasChoroplethMap = (props: CanvasChoroplethMapProps) => {
 };
 
 interface HighlightedFeatureProps {
-  feature: [number, number][][] | undefined;
+  feature?: [number, number][][];
   featureProps: FeatureProps;
-  code: string | undefined;
-  hoverCode: string | undefined;
+  code?: string;
+  hoverCode?: string;
 }
 
 const HighlightedFeature = memo((props: HighlightedFeatureProps) => {

--- a/packages/app/src/components/choropleth/components/choropleth-map.tsx
+++ b/packages/app/src/components/choropleth/components/choropleth-map.tsx
@@ -49,24 +49,24 @@ export const ChoroplethMap: <T extends ChoroplethDataItem>(props: ChoroplethMapP
 
   const dataConfig = createDataConfig(partialDataConfig);
 
-  const mapProjection = isDefined(dataOptions.projection) ? geoConicConformal : geoMercator;
+  const mapProjection = isDefined(dataOptions?.projection) ? geoConicConformal : geoMercator;
 
   const annotations = useAccessibilityAnnotations(accessibility);
-  const data = useChoroplethData(originalData, map, dataOptions.selectedCode);
+  const data = useChoroplethData(originalData, map, dataOptions?.selectedCode);
 
   const [containerRef, { width = 0, height = minHeight }] = useResizeObserver<HTMLDivElement>();
 
   const [mapHeight, padding] = useResponsiveSize(width, height, boundingBoxPadding, responsiveSizeConfiguration);
 
-  const choroplethFeatures = useChoroplethFeatures(map, data, dataOptions.selectedCode);
+  const choroplethFeatures = useChoroplethFeatures(map, data, dataOptions?.selectedCode);
 
   const getFillColor = useFillColor(data, map, dataConfig, thresholdMap);
 
-  const featureProps = useFeatureProps(map, getFillColor, dataOptions, dataConfig);
+  const featureProps = useFeatureProps(map, getFillColor, dataOptions ?? {}, dataConfig);
 
-  const [featureOverHandler, featureOutHandler, tooltipTrigger] = useChoroplethTooltip(map, data, dataConfig, dataOptions, isTabInteractive, setTooltip, containerRef);
+  const [featureOverHandler, featureOutHandler, tooltipTrigger] = useChoroplethTooltip(map, data, dataConfig, dataOptions ?? {}, isTabInteractive, setTooltip, containerRef);
 
-  const getFeatureName = useFeatureName(map, dataOptions.getFeatureName);
+  const getFeatureName = useFeatureName(map, dataOptions?.getFeatureName);
 
   const fitExtent: FitExtent = useMemo(
     () => [

--- a/packages/app/src/components/choropleth/index.tsx
+++ b/packages/app/src/components/choropleth/index.tsx
@@ -151,7 +151,7 @@ export type ChoroplethProps<T extends ChoroplethDataItem> = {
   /**
    * Several options that indicate how the map and its different parts are shown
    */
-  dataOptions: DataOptions;
+  dataOptions?: DataOptions;
   /**
    * Indicates which map is rendered.
    */
@@ -253,7 +253,7 @@ export const DynamicChoropleth = withLoadingProps((getLoadingProps) =>
     ssr: false,
     loading: () => {
       const { map, dataConfig, minHeight = 500, dataOptions } = getLoadingProps();
-      return <img src={`/api/choropleth/${map}/${dataConfig.metricName.toString()}/${dataConfig.metricProperty.toString()}/${minHeight}/${dataOptions.selectedCode ?? ''}`} />;
+      return <img src={`/api/choropleth/${map}/${dataConfig.metricName.toString()}/${dataConfig.metricProperty.toString()}/${minHeight}/${dataOptions?.selectedCode || ''}`} />;
     },
   })
 ) as ChoroplethComponent;

--- a/packages/app/src/components/choropleth/logic/use-highlighted-feature.ts
+++ b/packages/app/src/components/choropleth/logic/use-highlighted-feature.ts
@@ -13,15 +13,10 @@ import { ProjectedGeoInfo } from './use-projected-coordinates';
  * @param dataOptions
  * @returns
  */
-export function useHighlightedFeature(
-  geoInfo: ProjectedGeoInfo[],
-  dataOptions: DataOptions
-) {
+export function useHighlightedFeature(geoInfo: ProjectedGeoInfo[], dataOptions: DataOptions) {
   return useMemo(() => {
-    if (dataOptions.highlightSelection && isDefined(dataOptions.selectedCode)) {
-      return geoInfo
-        .filter((x) => x.code === dataOptions.selectedCode)
-        .map((x) => x.coordinates);
+    if (dataOptions?.highlightSelection && isDefined(dataOptions?.selectedCode)) {
+      return geoInfo.filter((x) => x.code === dataOptions?.selectedCode).map((x) => x.coordinates);
     }
   }, [geoInfo, dataOptions]);
 }

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -242,9 +242,6 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
                   infected_locations_percentage: formatNumber,
                 },
               }}
-              dataOptions={{
-                isPercentage: true,
-              }}
             />
           </ChoroplethTile>
 

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -197,9 +197,6 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
                   infected_locations_percentage: formatNumber,
                 },
               }}
-              dataOptions={{
-                isPercentage: true,
-              }}
             />
           </ChoroplethTile>
 

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -206,7 +206,6 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
                   positive_tested_daily_per_100k: formatNumber,
                 },
               }}
-              dataOptions={{}}
             />
           </ChoroplethTile>
           <Divider />


### PR DESCRIPTION
## Summary

# Done
- Made a choropleth map dataOptions optional;
- removed redundant `dataOptions={{isPercentage: true}}` from 
[gehandicaptenzorg.tsx](https://github.com/minvws/nl-covid19-data-dashboard/compare/feature/COR-1552-choropleth-dataOptions-is-to-be-optional?expand=1#diff-5b6ae0edf7b0c2c623a12580360615217b6ea01e385a31ba29a4ec90726dd36e)
[kwetsbare-groepen-70-plussers.tsx](https://github.com/minvws/nl-covid19-data-dashboard/compare/feature/COR-1552-choropleth-dataOptions-is-to-be-optional?expand=1#diff-c5e885aa0ae1b556a9169cd32c92c96442a314d7f45a479bbe95a9925c592744) 
[thuiswonende-ouderen.tsx](https://github.com/minvws/nl-covid19-data-dashboard/compare/feature/COR-1552-choropleth-dataOptions-is-to-be-optional?expand=1#diff-836c54dc7955e415c78d10a95e0ca215b1eed8fa3768011cd47034909c311cae)

#### This PR has no visible changes, no screenshots added.


