### PR TITLE
bugfix/COR-1644-vulnerable-groups-metric-references

### DIFF
--- a/packages/app/schema/vr_collection/__index.json
+++ b/packages/app/schema/vr_collection/__index.json
@@ -3,7 +3,7 @@
   "type": "object",
   "title": "vr_collection",
   "additionalProperties": false,
-  "required": ["last_generated", "proto_name", "name", "code", "disability_care_archived_20230126", "elderly_at_home_archived_20230126", "nursing_home_archived_20230126"],
+  "required": ["last_generated", "proto_name", "name", "code", "disability_care_archived_20230126", "elderly_at_home_archived_20230126", "vulnerable_nursing_home"],
   "properties": {
     "last_generated": {
       "type": "string"
@@ -33,12 +33,12 @@
         "$ref": "elderly_at_home_archived_20230126.json"
       }
     },
-    "nursing_home_archived_20230126": {
+    "vulnerable_nursing_home": {
       "type": "array",
       "minItems": 25,
       "maxItems": 25,
       "items": {
-        "$ref": "nursing_home_archived_20230126.json"
+        "$ref": "vulnerable_nursing_home.json"
       }
     }
   },

--- a/packages/app/schema/vr_collection/vulnerable_nursing_home.json
+++ b/packages/app/schema/vr_collection/vulnerable_nursing_home.json
@@ -1,12 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
 
-  "title": "vr_collection_nursing_home_archived_20230126",
+  "title": "vr_collection_vulnerable_nursing_home",
   "type": "object",
   "properties": {
-    "newly_infected_people": {
-      "type": "integer"
-    },
     "newly_infected_locations": {
       "type": "integer"
     },
@@ -16,29 +13,24 @@
     "infected_locations_percentage": {
       "type": "number"
     },
-    "deceased_daily": {
+    "date_of_insertion_unix": {
       "type": "integer"
     },
     "date_unix": {
       "type": "integer"
     },
-    "date_of_insertion_unix": {
-      "type": "integer"
-    },
     "vrcode": {
       "type": "string",
-      "pattern": "^VR[0-9]+$"
+      "equalsRootProperty": "code"
     }
   },
   "required": [
-    "newly_infected_people",
     "newly_infected_locations",
     "infected_locations_total",
     "infected_locations_percentage",
-    "deceased_daily",
     "date_unix",
-    "date_of_insertion_unix",
-    "vrcode"
+    "vrcode",
+    "date_of_insertion_unix"
   ],
   "additionalProperties": false
 }

--- a/packages/app/src/components/choropleth/logic/types.ts
+++ b/packages/app/src/components/choropleth/logic/types.ts
@@ -7,7 +7,7 @@ import type {
   VrCollection,
   VrCollectionDisabilityCareArchived_20230126,
   VrCollectionElderlyAtHomeArchived_20230126,
-  VrCollectionNursingHomeArchived_20230126,
+  VrCollectionVulnerableNursingHome,
 } from '@corona-dashboard/common';
 import type { ParsedFeature } from '@visx/geo/lib/projections/Projection';
 import type { Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
@@ -49,7 +49,7 @@ export type InferedMapType<T extends ChoroplethDataItem> = T extends GmDataItem 
 
 export type InferedDataCollection<T extends ChoroplethDataItem> = T extends GmDataItem ? GmCollection : T extends VrDataItem ? VrCollection : never;
 
-export type VrDataCollection = VrCollectionDisabilityCareArchived_20230126[] | VrCollectionElderlyAtHomeArchived_20230126[] | VrCollectionNursingHomeArchived_20230126[];
+export type VrDataCollection = VrCollectionDisabilityCareArchived_20230126[] | VrCollectionElderlyAtHomeArchived_20230126[] | VrCollectionVulnerableNursingHome[];
 export type VrDataItem = VrDataCollection[number];
 
 export type GmDataCollection = GmCollectionHospitalNice[] | GmCollectionTestedOverall[] | GmCollectionSewer[] | GmCollectionVaccineCoveragePerAgeGroup[];

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -60,7 +60,7 @@ export const getStaticProps = createGetStaticProps(
     'vulnerable_hospital_admissions'
   ),
   createGetChoroplethData({
-    vr: ({ nursing_home_archived_20230126 }) => ({ nursing_home_archived_20230126 }),
+    vr: ({ vulnerable_nursing_home }) => ({ vulnerable_nursing_home }),
   }),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
@@ -156,16 +156,16 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
             title={textNl.kpi_tiles.infected_locations.title}
             description={textNl.kpi_tiles.infected_locations.description}
             source={infectedLocationsText.bronnen.rivm}
-            dateUnix={nursinghomeDataLastValue.date_unix}
+            dateUnix={vulnerableNursingHomeDataLastValue.date_unix}
             tilesData={[
               {
-                value: nursinghomeDataLastValue.infected_locations_total,
+                value: vulnerableNursingHomeDataLastValue.infected_locations_total,
                 differenceValue: data.difference.vulnerable_nursing_home__infected_locations_total,
                 title: infectedLocationsText.kpi_titel,
                 description: infectedLocationsText.kpi_toelichting,
               },
               {
-                value: nursinghomeDataLastValue.newly_infected_locations,
+                value: vulnerableNursingHomeDataLastValue.newly_infected_locations,
                 title: infectedLocationsText.barscale_titel,
                 description: infectedLocationsText.barscale_toelichting,
               },
@@ -176,7 +176,7 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
             title={infectedLocationsText.map_titel}
             description={infectedLocationsText.map_toelichting}
             metadata={{
-              date: nursinghomeDataLastValue.date_unix,
+              date: vulnerableNursingHomeDataLastValue.date_unix,
               source: infectedLocationsText.bronnen.rivm,
             }}
             legend={{
@@ -189,9 +189,9 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               accessibility={{
                 key: 'nursing_home_infected_people_choropleth',
               }}
-              data={choropleth.vr.nursing_home_archived_20230126}
+              data={choropleth.vr.vulnerable_nursing_home}
               dataConfig={{
-                metricName: 'nursing_home_archived_20230126',
+                metricName: 'vulnerable_nursing_home',
                 metricProperty: 'infected_locations_percentage',
                 dataFormatters: {
                   infected_locations_percentage: formatNumber,
@@ -211,7 +211,7 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               accessibility={{
                 key: 'nursing_home_infected_locations_over_time_chart',
               }}
-              values={data.nursing_home_archived_20230126.values}
+              values={data.vulnerable_nursing_home.values}
               timeframe={nursingHomeInfectedLocationsTimeframe}
               seriesConfig={[
                 {

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -1217,7 +1217,7 @@ export interface VrCollection {
   code: VrCollectionId;
   disability_care_archived_20230126: VrCollectionDisabilityCareArchived_20230126[];
   elderly_at_home_archived_20230126: VrCollectionElderlyAtHomeArchived_20230126[];
-  nursing_home_archived_20230126: VrCollectionNursingHomeArchived_20230126[];
+  vulnerable_nursing_home: VrCollectionVulnerableNursingHome[];
 }
 export interface VrCollectionDisabilityCareArchived_20230126 {
   newly_infected_people: number;
@@ -1237,13 +1237,11 @@ export interface VrCollectionElderlyAtHomeArchived_20230126 {
   date_of_insertion_unix: number;
   vrcode: string;
 }
-export interface VrCollectionNursingHomeArchived_20230126 {
-  newly_infected_people: number;
+export interface VrCollectionVulnerableNursingHome {
   newly_infected_locations: number;
   infected_locations_total: number;
   infected_locations_percentage: number;
-  deceased_daily: number;
-  date_unix: number;
   date_of_insertion_unix: number;
+  date_unix: number;
   vrcode: string;
 }


### PR DESCRIPTION
## Summary

* re-introduced vulnerable_nursing_home metric for VR_COLLECTION schemas;
* updated types;
* updated VulnerableGroups route component to point to the correct data metrics for the two KPIs, the choropleth and a time series chart;
  * KPIs found at 'Nursing and care homes'
  * Choropleth found at 'Nursing and care homes with positive tests'
  * Time series chart found at 'Number of locations with positive tests over time'

### Screenshots

There is no big visual difference as a result of this change, or at least not a change that is easily conveyed through screenshots. Essentially, the aforementioned KPIs and charts now show up-to-date data.