### PR TITLE
Sanity-updates-for-COR-1618-1620-1622-1624

### DIFF
--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -5,3 +5,10 @@ timestamp,action,key,document_id,move_to
 2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.normalized_kpi_titel,jF33EuwumlGuwav2FD3X8m,__
 2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.normalized_kpi_toelichting,jF33EuwumlGuwav2FD3XAS,__
 2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.titel_kpi,jF33EuwumlGuwav2FD3XC8,__
+2023-05-30T05:55:00.820Z,delete,common.corona_melder_app.rapport.description,jF33EuwumlGuwav2FD4Hq0,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.rapport.link.href,jF33EuwumlGuwav2FD4HtM,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.rapport.link.text,jF33EuwumlGuwav2FD4Hrg,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.rapport.title,jF33EuwumlGuwav2FD4HoK,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.waarschuwingen.description,jF33EuwumlGuwav2FD4Hky,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.waarschuwingen.title,jF33EuwumlGuwav2FD4HjI,__
+2023-05-30T05:55:00.821Z,delete,common.corona_melder_app.waarschuwingen.total,jF33EuwumlGuwav2FD4Hme,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,7 @@
 timestamp,action,key,document_id,move_to
+2023-05-26T09:50:37.406Z,delete,common.verdenkingen_huisartsen.barscale_screenreader_text,jF33EuwumlGuwav2FD3X24,__
+2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.barscale_toelichting,jF33EuwumlGuwav2FD3WvM,__
+2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.kpi_titel,jF33EuwumlGuwav2FD3Wx2,__
+2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.normalized_kpi_titel,jF33EuwumlGuwav2FD3X8m,__
+2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.normalized_kpi_toelichting,jF33EuwumlGuwav2FD3XAS,__
+2023-05-26T09:50:37.407Z,delete,common.verdenkingen_huisartsen.titel_kpi,jF33EuwumlGuwav2FD3XC8,__


### PR DESCRIPTION
## Summary

* 
* The removal of the keys for branches: 
* 
* task/COR-1618-remove-KPI-from-Disability-care-homes
* task/COR-1920-remove-KPI-from-People-over-70-living-at-home
* task/COR-1622-remove-KPI-from-Coronamelder
* task/COR-1624-remove-KPI-from-GPs
* 
* This is done to prevent merge conflicts. So new approvals will not be necessary after one of them is merged
* 
