### PR TITLE
COR-1618-remove-KPI-from-Disability-care-homes

### DIFF
--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -54,12 +54,6 @@
     "corona_melder_app_warning__count": {
       "$ref": "#/definitions/diff_integer"
     },
-    "disability_care__newly_infected_people_archived_20230126": {
-      "$ref": "#/definitions/diff_integer"
-    },
-    "disability_care__infected_locations_total_archived_20230126": {
-      "$ref": "#/definitions/diff_integer"
-    },
     "elderly_at_home__positive_tested_daily_archived_20230126": {
       "$ref": "#/definitions/diff_integer"
     },
@@ -85,8 +79,6 @@
     "vulnerable_tested_per_age_group",
     "vulnerable_hospital_admissions",
     "corona_melder_app_warning__count",
-    "disability_care__newly_infected_people_archived_20230126",
-    "disability_care__infected_locations_total_archived_20230126",
     "elderly_at_home__positive_tested_daily_archived_20230126",
     "deceased_rivm__covid_daily_archived_20221231"
   ],

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -7,14 +7,10 @@ import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Divider } from '~/components/divider';
-import { KpiTile } from '~/components/kpi-tile';
-import { KpiValue } from '~/components/kpi-value';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { TwoKpiSection } from '~/components/two-kpi-section';
 import { WarningTile } from '~/components/warning-tile';
-import { Text } from '~/components/typography';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
@@ -44,11 +40,7 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData(
-    'difference.disability_care__newly_infected_people_archived_20230126',
-    'difference.disability_care__infected_locations_total_archived_20230126',
-    'disability_care_archived_20230126'
-  ),
+  selectNlData('disability_care_archived_20230126'),
   createGetChoroplethData({
     vr: ({ disability_care_archived_20230126 }) => ({ disability_care_archived_20230126 }),
   }),
@@ -117,19 +109,6 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
 
-          <TwoKpiSection>
-            <KpiTile
-              title={textNl.positief_geteste_personen.barscale_titel}
-              description={textNl.positief_geteste_personen.extra_uitleg}
-              metadata={{
-                date: lastValue.date_unix,
-                source: textNl.positief_geteste_personen.bronnen.rivm,
-              }}
-            >
-              <KpiValue absolute={lastValue.newly_infected_people} difference={data.difference.disability_care__newly_infected_people_archived_20230126} isAmount />
-            </KpiTile>
-          </TwoKpiSection>
-
           <ChartTile
             metadata={{ source: textNl.positief_geteste_personen.bronnen.rivm }}
             title={textNl.positief_geteste_personen.linechart_titel}
@@ -188,34 +167,6 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             }}
             referenceLink={textNl.besmette_locaties.reference.href}
           />
-
-          <TwoKpiSection>
-            <KpiTile
-              title={textNl.besmette_locaties.kpi_titel}
-              metadata={{
-                date: lastValue.date_unix,
-                source: textNl.besmette_locaties.bronnen.rivm,
-              }}
-            >
-              <KpiValue
-                absolute={lastValue.infected_locations_total}
-                percentage={lastValue.infected_locations_percentage}
-                difference={data.difference.disability_care__infected_locations_total_archived_20230126}
-                isAmount
-              />
-              <Text>{textNl.besmette_locaties.kpi_toelichting}</Text>
-            </KpiTile>
-            <KpiTile
-              title={textNl.besmette_locaties.barscale_titel}
-              metadata={{
-                date: lastValue.date_unix,
-                source: textNl.besmette_locaties.bronnen.rivm,
-              }}
-            >
-              <KpiValue absolute={lastValue.newly_infected_locations} />
-              <Text>{textNl.besmette_locaties.barscale_toelichting}</Text>
-            </KpiTile>
-          </TwoKpiSection>
 
           <ChoroplethTile
             title={textNl.besmette_locaties.map_titel}
@@ -288,19 +239,6 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             }}
             referenceLink={textNl.oversterfte.reference.href}
           />
-
-          <TwoKpiSection>
-            <KpiTile
-              title={textNl.oversterfte.barscale_titel}
-              description={textNl.oversterfte.extra_uitleg}
-              metadata={{
-                date: lastValue.date_unix,
-                source: textNl.oversterfte.bronnen.rivm,
-              }}
-            >
-              <KpiValue absolute={lastValue.deceased_daily} />
-            </KpiTile>
-          </TwoKpiSection>
 
           <ChartTile
             metadata={{ source: textNl.oversterfte.bronnen.rivm }}

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -339,8 +339,6 @@ export interface NlDifference {
   vulnerable_hospital_admissions: DifferenceInteger;
   reproduction__index_average: DifferenceDecimal;
   corona_melder_app_warning__count: DifferenceInteger;
-  disability_care__newly_infected_people_archived_20230126: DifferenceInteger;
-  disability_care__infected_locations_total_archived_20230126: DifferenceInteger;
   elderly_at_home__positive_tested_daily_archived_20230126: DifferenceInteger;
   deceased_rivm__covid_daily_archived_20221231: DifferenceInteger;
 }


### PR DESCRIPTION
## Summary

* 
* Remove the KPI tiles from the "Disability care homes" page
* Sanity changes are done in [this PR](https://github.com/minvws/nl-covid19-data-dashboard/pull/4775)
* 

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-05-30 at 09 04 56](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/b65a8e8f-0e74-479a-905e-2696c73d5a23)
![Screenshot 2023-05-30 at 09 05 01](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/bedbee34-e574-4591-b3f1-6f475926d60d)
![Screenshot 2023-05-30 at 09 05 05](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/4d7bb1e1-9896-4f26-9964-ceb608928048)

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Screenshot 2023-05-30 at 09 05 34](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/f5ff0eb3-c6fc-498b-8217-9c802e37d3a7)
![Screenshot 2023-05-30 at 09 05 36](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/724de857-4d22-4bed-9da1-f55cac62cb4d)
![Screenshot 2023-05-30 at 09 05 40](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/44cbe5da-8edc-4bde-98bb-c90f7d54913e)

</details>