### PR TITLE
FIX: Sanity Variable Pipeline Error

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -126,7 +126,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               <Text>
                 {replaceComponentsInText(commonTexts.gemeente_index.population_count, {
                   municipalityName: municipalityName,
-                  populationCountConnectedToRwzis: <strong>{formatNumber(populationCountConnectedToRwzis)}</strong>,
+                  populationCount: <strong>{formatNumber(populationCountConnectedToRwzis)}</strong>,
                 })}
               </Text>
 


### PR DESCRIPTION
## Summary

* 
* The build would fail because of a difference in the sanity key and the replacing variable reference
* They are now aligned and the build will run properly
* 

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

Failing build:
<img width="1128" alt="Screenshot 2023-06-24 at 10 43 48" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/2bb3ffba-7b02-4d60-8af7-83cab21be990">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

Succesful build:
<img width="1096" alt="Screenshot 2023-06-24 at 11 17 28" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/4f8ae156-2667-4d9a-91c0-e35eeb5bc581">

</details>