### PR TITLE
Release/2.77.0

### DIFF
--- a/packages/app/schema/archived_gm/__index.json
+++ b/packages/app/schema/archived_gm/__index.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "archived_gm",
+  "additionalProperties": false,
+  "required": [
+    "last_generated",
+    "proto_name",
+    "name",
+    "code",
+    "sewer_archived_20230623"
+  ],
+  "properties": {
+    "last_generated": {
+      "type": "string"
+    },
+    "proto_name": {
+      "$ref": "#/$defs/archived_gm_code"
+    },
+    "name": {
+      "$ref": "#/$defs/archived_gm_code"
+    },
+    "code": {
+      "$ref": "#/$defs/archived_gm_code"
+    },
+    "sewer_archived_20230623": {
+      "$ref": "sewer.json"
+    }
+  },
+  "$defs": {
+    "archived_gm_code": {
+      "type": "string",
+      "pattern": "^GM[0-9]+$"
+    }
+  }
+}

--- a/packages/app/schema/archived_gm/sewer.json
+++ b/packages/app/schema/archived_gm/sewer.json
@@ -8,6 +8,9 @@
         "date_start_unix",
         "date_end_unix",
         "average",
+        "total_number_of_samples",
+        "sampled_installation_count",
+        "total_installation_count",
         "date_of_insertion_unix",
         "data_is_outdated"
       ],
@@ -19,6 +22,15 @@
           "type": "integer"
         },
         "average": {
+          "type": "integer"
+        },
+        "total_number_of_samples": {
+          "type": "integer"
+        },
+        "sampled_installation_count": {
+          "type": "integer"
+        },
+        "total_installation_count": {
           "type": "integer"
         },
         "date_of_insertion_unix": {

--- a/packages/app/schema/archived_gm_collection/__index.json
+++ b/packages/app/schema/archived_gm_collection/__index.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "archived_gm_collection",
+  "additionalProperties": false,
+  "required": [
+    "last_generated",
+    "proto_name",
+    "name",
+    "code",
+    "sewer_archived_20230623"
+  ],
+  "properties": {
+    "last_generated": {
+      "type": "string"
+    },
+    "proto_name": {
+      "$ref": "#/$defs/archived_gm_collection_id"
+    },
+    "name": {
+      "$ref": "#/$defs/archived_gm_collection_id"
+    },
+    "code": {
+      "$ref": "#/$defs/archived_gm_collection_id"
+    },
+    "sewer_archived_20230623": {
+      "type": "array",
+      "minItems": 342,
+      "maxItems": 342,
+      "items": {
+        "$ref": "sewer.json"
+      }
+    }
+  },
+  "$defs": {
+    "archived_gm_collection_id": {
+      "type": "string",
+      "enum": ["GM_COLLECTION"]
+    }
+  }
+}

--- a/packages/app/schema/archived_gm_collection/sewer.json
+++ b/packages/app/schema/archived_gm_collection/sewer.json
@@ -8,6 +8,7 @@
     "date_end_unix",
     "gmcode",
     "average",
+    "total_installation_count",
     "date_of_insertion_unix",
     "data_is_outdated"
   ],
@@ -24,6 +25,9 @@
     },
     "average": {
       "type": "integer"
+    },
+    "total_installation_count": {
+      "type": "number"
     },
     "date_of_insertion_unix": {
       "type": "integer"

--- a/packages/app/schema/archived_nl/__index.json
+++ b/packages/app/schema/archived_nl/__index.json
@@ -3,14 +3,15 @@
   "type": "object",
   "title": "archived_nl",
   "required": [
+    "last_generated",
+    "proto_name",
+    "name",
+    "code",
     "behavior_archived_20230411",
     "behavior_annotations_archived_20230412",
     "behavior_per_age_group_archived_20230411",
-    "code",
     "doctor_archived_20210903",
-    "last_generated",
-    "name",
-    "proto_name"
+    "sewer_archived_20230623"
   ],
   "additionalProperties": false,
   "properties": {
@@ -37,6 +38,9 @@
     },
     "doctor_archived_20210903": {
       "$ref": "doctor.json"
+    },
+    "sewer_archived_20230623": {
+      "$ref": "sewer.json"
     }
   },
   "$defs": {

--- a/packages/app/schema/archived_nl/sewer.json
+++ b/packages/app/schema/archived_nl/sewer.json
@@ -1,37 +1,25 @@
 {
   "definitions": {
     "value": {
-      "title": "gm_sewer_value",
+      "title": "nl_sewer_value",
       "type": "object",
+      "required": ["average", "date_of_insertion_unix", "date_unix"],
       "additionalProperties": false,
-      "required": [
-        "date_start_unix",
-        "date_end_unix",
-        "average",
-        "date_of_insertion_unix",
-        "data_is_outdated"
-      ],
       "properties": {
-        "date_start_unix": {
-          "type": "integer"
-        },
-        "date_end_unix": {
-          "type": "integer"
-        },
         "average": {
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "date_of_insertion_unix": {
           "type": "integer"
         },
-        "data_is_outdated": {
-          "type": "boolean"
+        "date_unix": {
+          "type": "integer"
         }
       }
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "gm_sewer",
+  "title": "nl_sewer",
   "type": "object",
   "required": ["values", "last_value"],
   "additionalProperties": false,

--- a/packages/app/schema/gm/__index.json
+++ b/packages/app/schema/gm/__index.json
@@ -4,20 +4,22 @@
   "title": "gm",
   "additionalProperties": false,
   "required": [
-    "last_generated",
-    "proto_name",
     "name",
+    "proto_name",
     "code",
-    "tested_overall",
-    "hospital_nice",
-    "deceased_rivm_archived_20221231",
     "difference",
     "static_values",
+    "booster_coverage_archived_20220904",
+    "deceased_rivm_archived_20221231",
+    "hospital_nice",
+    "sewer_installation_measurement",
+    "sewer_per_installation",
     "sewer",
+    "tested_overall",
     "vaccine_coverage_per_age_group",
     "vaccine_coverage_per_age_group_archived",
     "vaccine_coverage_per_age_group_archived_20220908",
-    "booster_coverage_archived_20220904"
+    "last_generated"
   ],
   "properties": {
     "last_generated": {
@@ -52,6 +54,9 @@
     },
     "sewer_per_installation": {
       "$ref": "sewer_per_installation.json"
+    },
+    "sewer_installation_measurement": {
+      "$ref": "sewer_installation_measurement.json"
     },
     "vaccine_coverage_per_age_group": {
       "$ref": "vaccine_coverage_per_age_group.json"

--- a/packages/app/schema/gm/__static_values.json
+++ b/packages/app/schema/gm/__static_values.json
@@ -5,8 +5,11 @@
   "properties": {
     "population_count": {
       "type": "integer"
+    },
+    "population_count_connected_to_rwzis": {
+      "type": "integer"
     }
   },
-  "required": ["population_count"],
+  "required": ["population_count", "population_count_connected_to_rwzis"],
   "additionalProperties": false
 }

--- a/packages/app/schema/gm/sewer_installation_measurement.json
+++ b/packages/app/schema/gm/sewer_installation_measurement.json
@@ -1,16 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "gm_collection_sewer",
+  "title": "gm_sewer_installation_measurement",
   "type": "object",
-  "additionalProperties": false,
   "required": [
     "date_start_unix",
     "date_end_unix",
-    "gmcode",
-    "average",
-    "date_of_insertion_unix",
-    "data_is_outdated"
-  ],
+    "total_number_of_samples",
+    "sampled_installation_count",
+    "total_installation_count",
+    "date_of_insertion_unix"],
+  "additionalProperties": false,
   "properties": {
     "date_start_unix": {
       "type": "integer"
@@ -18,18 +17,17 @@
     "date_end_unix": {
       "type": "integer"
     },
-    "gmcode": {
-      "type": "string",
-      "pattern": "^GM[0-9]+$"
+    "total_number_of_samples": {
+      "type": "integer"
     },
-    "average": {
+    "sampled_installation_count": {
+      "type": "integer"
+    },
+    "total_installation_count": {
       "type": "integer"
     },
     "date_of_insertion_unix": {
       "type": "integer"
-    },
-    "data_is_outdated": {
-      "type": "boolean"
     }
   }
 }

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -38,7 +38,7 @@ export { getStaticPaths } from '~/static-paths/gm';
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectGmData('difference.sewer__average', 'sewer_per_installation', 'static_values.population_count', 'sewer', 'code'),
+  selectGmData('difference.sewer__average', 'sewer_per_installation', 'sewer_installation_measurement', 'static_values.population_count_connected_to_rwzis', 'sewer', 'code'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<PagePartQueryResult<ArticleParts>>(() => getPagePartsQuery('sewer_page'))(context);
 
@@ -57,7 +57,8 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
   const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
   const sewerAverages = data.sewer;
-  const populationCount = data.static_values.population_count;
+  const sewerInstallationMeasurement = data.sewer_installation_measurement;
+  const populationCountConnectedToRwzis = data.static_values.population_count_connected_to_rwzis;
 
   if (!sewerAverages) {
     /**
@@ -125,7 +126,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               <Text>
                 {replaceComponentsInText(commonTexts.gemeente_index.population_count, {
                   municipalityName: municipalityName,
-                  populationCount: <strong>{formatNumber(populationCount)}</strong>,
+                  populationCount: <strong>{formatNumber(populationCountConnectedToRwzis)}</strong>,
                 })}
               </Text>
 
@@ -136,15 +137,15 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               title={textGm.total_measurements_title}
               description={textGm.total_measurements_description}
               metadata={{
-                date: [sewerAverages.last_value.date_start_unix, sewerAverages.last_value.date_end_unix],
+                date: [sewerInstallationMeasurement.date_start_unix, sewerInstallationMeasurement.date_end_unix],
                 source: textGm.bronnen.rivm,
               }}
             >
-              <KpiValue absolute={sewerAverages.last_value.total_number_of_samples} />
+              <KpiValue absolute={sewerInstallationMeasurement.total_number_of_samples} />
               <Text>
                 {replaceComponentsInText(textGm.total_measurements_locations, {
-                  sampled_installation_count: <strong>{sewerAverages.last_value.sampled_installation_count}</strong>,
-                  total_installation_count: <strong>{sewerAverages.last_value.total_installation_count}</strong>,
+                  sampled_installation_count: <strong>{sewerInstallationMeasurement.sampled_installation_count}</strong>,
+                  total_installation_count: <strong>{sewerInstallationMeasurement.total_installation_count}</strong>,
                 })}
               </Text>
             </KpiTile>

--- a/packages/cli/src/schema/schema-info.ts
+++ b/packages/cli/src/schema/schema-info.ts
@@ -18,6 +18,7 @@ export function getSchemaInfo(jsonDirectory: string = defaultJsonDirectory): Sch
   assert(fs.existsSync(jsonDirectory), `Path ${jsonDirectory} does not exist`);
 
   const fileList = fs.readdirSync(jsonDirectory);
+  const archivedFileList = fs.readdirSync(path.join(jsonDirectory, 'archived'));
 
   return {
     nl: {
@@ -33,6 +34,18 @@ export function getSchemaInfo(jsonDirectory: string = defaultJsonDirectory): Sch
     gm_collection: { files: ['GM_COLLECTION.json'], basePath: jsonDirectory },
     archived_nl: {
       files: ['NL.json'],
+      basePath: path.join(jsonDirectory, 'archived'),
+    },
+    archived_gm: {
+      files: getFileNames(archivedFileList, /^GM[0-9]+.json$/),
+      basePath: path.join(jsonDirectory, 'archived'),
+      customValidations: [
+        createChoroplethValidation(path.join(defaultJsonDirectory, 'archived', 'GM_COLLECTION.json'), 'gmcode', ['vaccine_coverage_per_age_group']),
+        validateMovingAverages,
+      ],
+    },
+    archived_gm_collection: {
+      files: ['GM_COLLECTION.json'],
       basePath: path.join(jsonDirectory, 'archived'),
     },
   };

--- a/packages/cms/sanity.cli.ts
+++ b/packages/cms/sanity.cli.ts
@@ -6,13 +6,20 @@ export default defineCliConfig({
     projectId: '5mog5ask',
     dataset: 'development',
   },
-  vite: {
-    resolve: {
-      alias: {
-        '@corona-dashboard/common': path.resolve(__dirname, '../common/src'),
-        '@corona-dashboard/app': path.resolve(__dirname, '../app/src'),
-        '@corona-dashboard/icons': path.resolve(__dirname, '../icons/src'),
+  vite: (config) => {
+    return {
+      ...config,
+      resolve: {
+        alias: {
+          '@corona-dashboard/common': path.resolve(__dirname, '../common/src'),
+          '@corona-dashboard/app': path.resolve(__dirname, '../app/src'),
+          '@corona-dashboard/icons': path.resolve(__dirname, '../icons/src'),
+        },
       },
-    },
+      build: {
+        ...config.build,
+        target: 'esnext',
+      },
+    };
   },
 });

--- a/packages/cms/sanity.config.ts
+++ b/packages/cms/sanity.config.ts
@@ -1,7 +1,6 @@
 import { dashboardTool } from '@sanity/dashboard';
 import { languageFilter } from '@sanity/language-filter';
 import { visionTool } from '@sanity/vision';
-import { theme } from 'https://themer.sanity.build/api/hues?primary=007bc7&positive=69c253&caution=ffc000&critical=f35065';
 import { defineConfig } from 'sanity';
 import { media } from 'sanity-plugin-media';
 import { deskTool } from 'sanity/desk';
@@ -10,6 +9,7 @@ import { schemaTypes } from './src/schemas';
 import { deskStructure } from './src/studio/desk-structure/desk-structure';
 import { actions, newDocumentOptions } from './src/studio/document-options/document-options';
 import { supportedLanguages } from './src/studio/i18n';
+import { theme } from './src/studio/theme';
 import { tools } from './src/studio/tools';
 import { widgets } from './src/studio/widgets';
 

--- a/packages/cms/src/studio/data/data-structure.ts
+++ b/packages/cms/src/studio/data/data-structure.ts
@@ -3,6 +3,8 @@
  * This file is generated based on the JSON schema's by yarn generate-data-structures in the cli package.
  */
 export const dataStructure = {
+  archived_gm: { sewer_archived_20230623: ['average', 'total_number_of_samples', 'sampled_installation_count', 'total_installation_count', 'data_is_outdated'] },
+  archived_gm_collection: { sewer_archived_20230623: ['average', 'total_installation_count', 'data_is_outdated'] },
   archived_nl: {
     behavior_archived_20230411: [
       'number_of_participants',
@@ -65,6 +67,7 @@ export const dataStructure = {
     ],
     behavior_annotations_archived_20230412: ['behavior_indicator', 'message_title_nl', 'message_title_en', 'message_desc_nl', 'message_desc_en'],
     doctor_archived_20210903: ['covid_symptoms_per_100k', 'covid_symptoms'],
+    sewer_archived_20230623: ['average'],
   },
   gm: {
     deceased_rivm_archived_20221231: ['covid_daily', 'covid_daily_moving_average', 'covid_total'],
@@ -75,7 +78,7 @@ export const dataStructure = {
       'admissions_on_date_of_reporting',
     ],
     tested_overall: ['infected', 'infected_moving_average', 'infected_moving_average_rounded', 'infected_per_100k', 'infected_per_100k_moving_average'],
-    sewer: ['average', 'total_number_of_samples', 'sampled_installation_count', 'total_installation_count', 'data_is_outdated'],
+    sewer: ['average', 'data_is_outdated'],
     vaccine_coverage_per_age_group: [
       'vaccination_type',
       'birthyear_range_12_plus',
@@ -112,7 +115,7 @@ export const dataStructure = {
     hospital_nice: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     hospital_nice_choropleth: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     tested_overall: ['infected_per_100k', 'infected'],
-    sewer: ['average', 'total_installation_count', 'data_is_outdated'],
+    sewer: ['average', 'data_is_outdated'],
     vaccine_coverage_per_age_group: [
       'vaccination_type',
       'birthyear_range_12_plus',

--- a/packages/cms/src/studio/theme.ts
+++ b/packages/cms/src/studio/theme.ts
@@ -1,0 +1,3 @@
+export const { theme } = (await import('https://themer.sanity.build/api/hues?primary=007bc7&positive=69c253&caution=ffc000&critical=f35065')) as {
+  theme: import('sanity').StudioTheme;
+};

--- a/packages/common/src/types/data-utils.ts
+++ b/packages/common/src/types/data-utils.ts
@@ -1,4 +1,4 @@
-import { ArchivedNl, Gm, Nl } from '.';
+import { ArchivedGm, ArchivedNl, Gm, Nl } from '.';
 
 /**
  * All possible datascopes. Can be used to access the types of a scope based on
@@ -7,10 +7,11 @@ import { ArchivedNl, Gm, Nl } from '.';
 export type ScopedData = {
   gm: Gm;
   nl: Nl;
+  archived_gm: ArchivedGm;
   archived_nl: ArchivedNl;
 };
 
-export type ScopedRouterData = Omit<ScopedData, 'archived_nl'>;
+export type ScopedRouterData = Omit<ScopedData, 'archived_nl' | 'archived_gm'>;
 
 export type DataScopeKey = keyof ScopedData;
 export type RouterDataScopeKey = keyof ScopedRouterData;

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -4,6 +4,49 @@
  * and run 'yarn generate-data-types' to regenerate this file.
  */
 
+export type ArchivedGmCode = string;
+
+export interface ArchivedGm {
+  last_generated: string;
+  proto_name: ArchivedGmCode;
+  name: ArchivedGmCode;
+  code: ArchivedGmCode;
+  sewer_archived_20230623: GmSewer;
+}
+export interface GmSewer {
+  values: GmSewerValue[];
+  last_value: GmSewerValue;
+}
+export interface GmSewerValue {
+  date_start_unix: number;
+  date_end_unix: number;
+  average: number;
+  total_number_of_samples: number;
+  sampled_installation_count: number;
+  total_installation_count: number;
+  date_of_insertion_unix: number;
+  data_is_outdated: boolean;
+}
+
+export type ArchivedGmCollectionId = 'GM_COLLECTION';
+
+export interface ArchivedGmCollection {
+  last_generated: string;
+  proto_name: ArchivedGmCollectionId;
+  name: ArchivedGmCollectionId;
+  code: ArchivedGmCollectionId;
+  sewer_archived_20230623: GmCollectionSewer[];
+}
+export interface GmCollectionSewer {
+  date_start_unix: number;
+  date_end_unix: number;
+  gmcode: string;
+  average: number;
+  total_installation_count: number;
+  date_of_insertion_unix: number;
+  data_is_outdated: boolean;
+}
+
 export type ArchivedNlId = 'NL';
 
 export interface ArchivedNl {
@@ -15,6 +58,7 @@ export interface ArchivedNl {
   behavior_annotations_archived_20230412: NlBehaviorAnnotations;
   behavior_per_age_group_archived_20230411: NlBehaviorPerAgeGroup;
   doctor_archived_20210903: NlDoctor;
+  sewer_archived_20230623: NlSewer;
 }
 export interface NlBehavior {
   values: NlBehaviorValue[];
@@ -146,6 +190,15 @@ export interface NlDoctorValue {
   covid_symptoms: number;
   date_of_insertion_unix: number;
 }
+export interface NlSewer {
+  values: NlSewerValue[];
+  last_value: NlSewerValue;
+}
+export interface NlSewerValue {
+  average: number | null;
+  date_of_insertion_unix: number;
+  date_unix: number;
+}
 
 export type GmCode = string;
 
@@ -160,7 +213,8 @@ export interface Gm {
   hospital_nice: GmHospitalNice;
   tested_overall: GmTestedOverall;
   sewer: GmSewer;
-  sewer_per_installation?: GmSewerPerInstallation;
+  sewer_per_installation: GmSewerPerInstallation;
+  sewer_installation_measurement: GmSewerInstallationMeasurement;
   vaccine_coverage_per_age_group: GmVaccineCoveragePerAgeGroup;
   vaccine_coverage_per_age_group_archived: GmVaccineCoveragePerAgeGroupArchived;
   vaccine_coverage_per_age_group_archived_20220908: GmVaccineCoveragePerAgeGroupArchived_20220908;
@@ -168,6 +222,7 @@ export interface Gm {
 }
 export interface GmStaticValues {
   population_count: number;
+  population_count_connected_to_rwzis: number;
 }
 export interface GmDeceasedRivmArchived_20221231 {
   values: GmDeceasedRivmArchived_20221231Value[];
@@ -232,9 +287,6 @@ export interface GmSewerValue {
   date_start_unix: number;
   date_end_unix: number;
   average: number;
-  total_number_of_samples: number;
-  sampled_installation_count: number;
-  total_installation_count: number;
   date_of_insertion_unix: number;
   data_is_outdated: boolean;
 }
@@ -249,6 +301,14 @@ export interface MunicipalSewerPerInstallationInstallation {
 export interface GmSewerPerInstallationValue {
   date_unix: number;
   rna_normalized: number;
+  date_of_insertion_unix: number;
+}
+export interface GmSewerInstallationMeasurement {
+  date_start_unix: number;
+  date_end_unix: number;
+  total_number_of_samples: number;
+  sampled_installation_count: number;
+  total_installation_count: number;
   date_of_insertion_unix: number;
 }
 export interface GmVaccineCoveragePerAgeGroup {
@@ -340,7 +400,6 @@ export interface GmCollectionSewer {
   date_end_unix: number;
   gmcode: string;
   average: number;
-  total_installation_count: number;
   date_of_insertion_unix: number;
   data_is_outdated: boolean;
 }

--- a/packages/common/src/types/feature-flags.ts
+++ b/packages/common/src/types/feature-flags.ts
@@ -39,4 +39,4 @@ export type VerboseFeature = {
   metricProperties?: string[];
 } & SimpleFeature;
 
-export type JsonDataScope = DataScopeKey | 'vr_collection' | 'gm_collection';
+export type JsonDataScope = DataScopeKey | 'vr_collection' | 'gm_collection' | 'archived_gm_collection';


### PR DESCRIPTION
# Release 2.77.0

* Updated RWZI measurements by @VWSCoronaDashboard18. You can find more details [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4789).
* Added RWZI inhabitants per municipality. Thanks to @VWSCoronaDashboard21 for the contribution. Check out the details [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4787).
* Fixed Sanity Variable Pipeline Error. Thanks to @VWSCoronaDashboard18 for addressing this issue. Details can be found [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4798).
* Resolved a bug related to studio theming issues. Thanks to @VWSCoronaDashboard26 for fixing this problem. See the details [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4795).
* Added sewer data on NL, GM, and GM_collection to the archived section. This improvement was made by @VWSCoronaDashboard25. You can find the details [here](https://github.com/minvws/nl-covid19-data-dashboard/pull/4796).
* For a complete list of changes, please visit the [Full Changelog](https://github.com/minvws/nl-covid19-data-dashboard/compare/2.76.2...2.77.0).