### PR TITLE
feature/COR-1598-general-page-redesigns

### DIFF
--- a/packages/app/src/components/chart-tile.tsx
+++ b/packages/app/src/components/chart-tile.tsx
@@ -16,6 +16,7 @@ interface ChartTileProps {
   title: string;
   description?: string;
   disableFullscreen?: boolean;
+  id?: string;
   metadata?: MetadataProps;
   timeframeInitialValue?: TimeframeOption;
   timeframeOptions?: TimeframeOption[];
@@ -23,7 +24,18 @@ interface ChartTileProps {
   onSelectTimeframe?: (timeframe: TimeframeOption) => void;
 }
 
-export const ChartTile = ({ children, title, description, disableFullscreen, metadata, timeframeInitialValue, toggle, timeframeOptions, onSelectTimeframe }: ChartTileProps) => {
+export const ChartTile = ({
+  children,
+  title,
+  description,
+  disableFullscreen,
+  id,
+  metadata,
+  timeframeInitialValue,
+  toggle,
+  timeframeOptions,
+  onSelectTimeframe,
+}: ChartTileProps) => {
   const [timeframe, setTimeframe] = useState<TimeframeOption>(timeframeInitialValue || TimeframeOption.ALL);
 
   useEffect(() => {
@@ -33,7 +45,7 @@ export const ChartTile = ({ children, title, description, disableFullscreen, met
   }, [timeframe, onSelectTimeframe]);
 
   return (
-    <FullscreenChartTile metadata={metadata} disabled={disableFullscreen}>
+    <FullscreenChartTile metadata={metadata} disabled={disableFullscreen} id={id}>
       <ChartTileHeader title={title} description={description} toggle={toggle}>
         {timeframeOptions && timeframe && (
           <Box width={{ sm: '100%', lg: '50%', xl: '25%' }}>

--- a/packages/app/src/components/cms/rich-content.tsx
+++ b/packages/app/src/components/cms/rich-content.tsx
@@ -18,6 +18,7 @@ import { ChevronRight, Download, External as ExternalLinkIcon } from '@corona-da
 import { space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils';
 import React from 'react';
+import { InlineText } from '../typography';
 
 type ElementAlignment = 'start' | 'center' | 'end' | 'stretch';
 
@@ -34,22 +35,14 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
   const serializers = {
     types: {
       inlineBlock: (props: unknown) => {
-        assert(
-          PortableText.defaultSerializers.types?.inlineBlock,
-          `[${RichContent.name}] PortableText needs to provide a serializer for inlineBlock content`
-        );
+        assert(PortableText.defaultSerializers.types?.inlineBlock, `[${RichContent.name}] PortableText needs to provide a serializer for inlineBlock content`);
         return <ContentWrapper>{PortableText.defaultSerializers.types.inlineBlock(props)}</ContentWrapper>;
       },
       block: (props: unknown) => {
-        assert(
-          PortableText.defaultSerializers.types?.block,
-          `[${RichContent.name}] PortableText needs to provide a serializer for block content`
-        );
+        assert(PortableText.defaultSerializers.types?.block, `[${RichContent.name}] PortableText needs to provide a serializer for block content`);
         return <ContentWrapper>{PortableText.defaultSerializers.types.block(props)}</ContentWrapper>;
       },
-      image: (props: { node: ImageBlock | RichContentImageBlock }) => (
-        <ContentImage contentWrapper={contentWrapper} sizes={imageSizes} {...props} />
-      ),
+      image: (props: { node: ImageBlock | RichContentImageBlock }) => <ContentImage contentWrapper={contentWrapper} sizes={imageSizes} {...props} />,
       inlineCollapsible: (props: { node: InlineCollapsibleList }) => {
         if (!props.node.content.inlineBlockContent) return null;
 
@@ -86,12 +79,14 @@ export function RichContent({ contentWrapper, blocks, imageSizes, elementAlignme
         return (
           <>
             {children.map((child, index) => (
-              <React.Fragment key={index}>
-                {child.includes('{{kpiValue}}') && variableValue ? replaceVariablesInText(child, { kpiValue: variableValue }) : child}
-              </React.Fragment>
+              <React.Fragment key={index}>{child.includes('{{kpiValue}}') && variableValue ? replaceVariablesInText(child, { kpiValue: variableValue }) : child}</React.Fragment>
             ))}
           </>
         );
+      },
+      u: (props: { children: string[] }) => {
+        const { children } = props;
+        return <InlineText className="underline">{children}</InlineText>;
       },
     },
   };

--- a/packages/app/src/components/collapsible/collapsible-section.tsx
+++ b/packages/app/src/components/collapsible/collapsible-section.tsx
@@ -14,11 +14,21 @@ interface CollapsibleSectionProps extends BoxProps {
   className?: string;
   id?: string;
   hideBorder?: boolean;
+  fontSize?: string;
   textColor?: string;
   borderColor?: string;
 }
 
-export const CollapsibleSection = ({ summary, children, id, hideBorder, textColor = colors.blue8, borderColor = colors.gray2, className }: CollapsibleSectionProps) => {
+export const CollapsibleSection = ({
+  summary,
+  children,
+  id,
+  hideBorder,
+  textColor = colors.blue8,
+  fontSize = fontSizes[5],
+  borderColor = colors.gray2,
+  className,
+}: CollapsibleSectionProps) => {
   const section = useRef<HTMLElement>(null);
 
   const collapsible = useCollapsible();
@@ -53,7 +63,7 @@ export const CollapsibleSection = ({ summary, children, id, hideBorder, textColo
 
   return (
     <Box as="section" borderTop={hideBorder ? undefined : `1px solid ${borderColor}`} id={id} ref={section} className={`${className} ${collapsible.isOpen ? 'open' : ''}`}>
-      <StyledSummary textColor={textColor} onClick={() => collapsible.toggle()}>
+      <Summary color={textColor} onClick={() => collapsible.toggle()} fontSize={fontSize}>
         <Box width="100%" position="relative">
           {summary}
           {id && (
@@ -63,7 +73,7 @@ export const CollapsibleSection = ({ summary, children, id, hideBorder, textColo
           )}
         </Box>
         {collapsible.button()}
-      </StyledSummary>
+      </Summary>
       {collapsible.content(<Box paddingX={space[3]}>{children}</Box>)}
     </Box>
   );
@@ -85,16 +95,10 @@ const StyledAnchor = styled(Anchor)`
   }
 `;
 
-interface SummaryProps {
-  textColor: string;
-}
-
-const StyledSummary = styled(Box)<SummaryProps>`
+const Summary = styled(Box)`
   align-items: center;
-  color: ${({ textColor }) => textColor};
   cursor: pointer;
   display: flex;
-  font-size: ${fontSizes[5]};
   font-weight: ${fontWeights.bold};
   justify-content: space-between;
   padding: ${space[3]};

--- a/packages/app/src/components/fullscreen-chart-tile.tsx
+++ b/packages/app/src/components/fullscreen-chart-tile.tsx
@@ -16,11 +16,12 @@ import { Modal } from './modal';
 
 interface FullscreenChartTileProps {
   children: React.ReactNode;
-  metadata?: MetadataProps;
   disabled?: boolean;
+  id?: string;
+  metadata?: MetadataProps;
 }
 
-export function FullscreenChartTile({ children, metadata, disabled }: FullscreenChartTileProps) {
+export const FullscreenChartTile = ({ children, disabled, id, metadata }: FullscreenChartTileProps) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const wasFullscreen = usePrevious(isFullscreen);
   const breakpoints = useBreakpoints();
@@ -36,7 +37,7 @@ export function FullscreenChartTile({ children, metadata, disabled }: Fullscreen
   const label = replaceVariablesInText(isFullscreen ? commonTexts.common.modal_close : commonTexts.common.modal_open, { subject: commonTexts.common.grafiek_singular });
 
   const tile = (
-    <Tile hasNoBorder={isFullscreen} height="100%">
+    <Tile hasNoBorder={isFullscreen} height="100%" id={id}>
       <Box
         paddingX={isFullscreen ? { _: space[3], sm: space[4] } : undefined}
         paddingY={isFullscreen ? { _: space[2], sm: space[3] } : undefined}
@@ -73,7 +74,7 @@ export function FullscreenChartTile({ children, metadata, disabled }: Fullscreen
   }
 
   return <div>{tile}</div>;
-}
+};
 
 interface StyledModalCloseButtonWrapperProps {
   isFullscreen: boolean;

--- a/packages/app/src/components/page-articles-tile.tsx
+++ b/packages/app/src/components/page-articles-tile.tsx
@@ -1,13 +1,13 @@
 import { colors } from '@corona-dashboard/common';
 import { getImageProps } from '~/lib/sanity';
 import { fontWeights, mediaQueries, radii, space } from '~/style/theme';
-import { Box } from '../base';
-import { ChartTile } from '../chart-tile';
-import { SanityImage } from '../cms/sanity-image';
-import { Anchor, BoldText } from '../typography';
+import { Box } from './base';
+import { ChartTile } from './chart-tile';
+import { SanityImage } from './cms/sanity-image';
+import { Anchor, BoldText } from './typography';
 import { Link } from '~/utils/link';
 import styled, { css } from 'styled-components';
-import { PublicationDate } from '../publication-date';
+import { PublicationDate } from './publication-date';
 import { ChevronRight } from '@corona-dashboard/icons';
 import { Article } from '~/types/cms';
 import { useIntl } from '~/intl';
@@ -21,12 +21,12 @@ export const PageArticlesTile = ({ articles, title }: PageArticlesTileProps) => 
   const { commonTexts } = useIntl();
 
   return (
-    <ChartTile title={title} disableFullscreen>
+    <ChartTile title={title ?? commonTexts.article_list.title} disableFullscreen>
       <Grid>
         {articles.map((article, index) => (
           <Link passHref href={`/artikelen/${article.slug.current}`} key={index}>
             <ArticleCard>
-              <Box display="grid" gridTemplateColumns="1fr 4fr" style={{ gap: space[2] }} alignItems="center">
+              <ArticleCardHeader>
                 <ArticleImage {...getImageProps(article.cover, {})} />
 
                 <Box display="grid" color={colors.gray5}>
@@ -41,7 +41,7 @@ export const PageArticlesTile = ({ articles, title }: PageArticlesTileProps) => 
                     )}
                   </Box>
                 </Box>
-              </Box>
+              </ArticleCardHeader>
 
               <Box color={colors.black}>{article.summary}</Box>
 
@@ -83,13 +83,19 @@ const ArticleCard = styled(Anchor)`
   padding: ${space[3]};
 `;
 
+const ArticleCardHeader = styled(Box)`
+  align-items: center;
+  display: flex;
+  gap: ${space[3]};
+`;
+
 const ArticleImage = styled(SanityImage)`
   object-fit: cover;
 
   img {
     border-radius: ${radii[2]}px;
-    height: ${space[5]};
-    width: 100%;
+    height: 48px;
+    width: 48px;
   }
 `;
 

--- a/packages/app/src/components/page-articles-tile.tsx
+++ b/packages/app/src/components/page-articles-tile.tsx
@@ -4,7 +4,7 @@ import { fontWeights, mediaQueries, radii, space } from '~/style/theme';
 import { Box } from './base';
 import { ChartTile } from './chart-tile';
 import { SanityImage } from './cms/sanity-image';
-import { Anchor, BoldText } from './typography';
+import { Anchor, BoldText, Text } from './typography';
 import { Link } from '~/utils/link';
 import styled, { css } from 'styled-components';
 import { PublicationDate } from './publication-date';
@@ -17,6 +17,7 @@ interface PageArticlesTileProps {
   title: string;
 }
 
+// TODO: this should be moved to the /articles/ directory, as picked up in COR-1601
 export const PageArticlesTile = ({ articles, title }: PageArticlesTileProps) => {
   const { commonTexts } = useIntl();
 
@@ -29,17 +30,13 @@ export const PageArticlesTile = ({ articles, title }: PageArticlesTileProps) => 
               <ArticleCardHeader>
                 <ArticleImage {...getImageProps(article.cover, {})} />
 
-                <Box display="grid" color={colors.gray5}>
+                <Box display="grid">
                   <BoldText color={colors.black}>{article.title}</BoldText>
-                  <Box>
-                    {article.mainCategory === 'knowledge' ? (
-                      commonTexts.article_teaser.categories.knowledge
-                    ) : (
-                      <>
-                        {commonTexts.article_teaser.categories.news} · <PublicationDate date={article.publicationDate} />
-                      </>
-                    )}
-                  </Box>
+                  <Text color={colors.gray8}>
+                    {/* TODO: this should be updated after COR-1601 implements publicationDate vs updateDate logic */}
+                    {article.mainCategory && `${commonTexts.article_teaser.categories[article.mainCategory]} · `}
+                    <PublicationDate date={article.publicationDate} />
+                  </Text>
                 </Box>
               </ArticleCardHeader>
 
@@ -91,6 +88,7 @@ const ArticleCardHeader = styled(Box)`
 
 const ArticleImage = styled(SanityImage)`
   object-fit: cover;
+  flex-shrink: 0;
 
   img {
     border-radius: ${radii[2]}px;

--- a/packages/app/src/components/page-articles-tile/page-articles-tile.tsx
+++ b/packages/app/src/components/page-articles-tile/page-articles-tile.tsx
@@ -14,14 +14,14 @@ import { useIntl } from '~/intl';
 
 interface PageArticlesTileProps {
   articles: Article[];
+  title: string;
 }
 
-export const PageArticlesTile = ({ articles }: PageArticlesTileProps) => {
+export const PageArticlesTile = ({ articles, title }: PageArticlesTileProps) => {
   const { commonTexts } = useIntl();
 
   return (
-    // TODO: add these things as Lokalize keys
-    <ChartTile title="Artikelen over dit onderwerp" disableFullscreen id="artikelen">
+    <ChartTile title={title} disableFullscreen>
       <Grid>
         {articles.map((article, index) => (
           <Link passHref href={`/artikelen/${article.slug.current}`} key={index}>
@@ -67,18 +67,19 @@ export const PageArticlesTile = ({ articles }: PageArticlesTileProps) => {
 const Grid = styled(Box)`
   display: grid;
   gap: ${space[4]};
+  margin-bottom: ${space[3]};
+
   @media ${mediaQueries.sm} {
     grid-template-columns: repeat(2, 1fr);
   }
-  margin-bottom: ${space[3]};
 `;
 
 const ArticleCard = styled(Anchor)`
+  border-radius: ${radii[2]}px;
+  border: 1px solid ${colors.gray3};
   display: grid;
   gap: ${space[2]};
   height: 100%;
-  border: 1px solid ${colors.gray3};
-  border-radius: ${radii[2]}px;
   padding: ${space[3]};
 `;
 
@@ -87,8 +88,8 @@ const ArticleImage = styled(SanityImage)`
 
   img {
     border-radius: ${radii[2]}px;
-    width: 100%;
     height: ${space[5]};
+    width: 100%;
   }
 `;
 
@@ -97,9 +98,9 @@ const linkStyles = css`
   cursor: pointer;
 
   svg {
+    height: 10px;
     margin-left: ${space[1]};
     width: 10px;
-    height: 10px;
   }
 `;
 

--- a/packages/app/src/components/page-articles-tile/page-articles-tile.tsx
+++ b/packages/app/src/components/page-articles-tile/page-articles-tile.tsx
@@ -1,0 +1,114 @@
+import { colors } from '@corona-dashboard/common';
+import { getImageProps } from '~/lib/sanity';
+import { fontWeights, mediaQueries, radii, space } from '~/style/theme';
+import { Box } from '../base';
+import { ChartTile } from '../chart-tile';
+import { SanityImage } from '../cms/sanity-image';
+import { Anchor, BoldText } from '../typography';
+import { Link } from '~/utils/link';
+import styled, { css } from 'styled-components';
+import { PublicationDate } from '../publication-date';
+import { ChevronRight } from '@corona-dashboard/icons';
+import { Article } from '~/types/cms';
+import { useIntl } from '~/intl';
+
+interface PageArticlesTileProps {
+  articles: Article[];
+}
+
+export const PageArticlesTile = ({ articles }: PageArticlesTileProps) => {
+  const { commonTexts } = useIntl();
+
+  return (
+    // TODO: add these things as Lokalize keys
+    <ChartTile title="Artikelen over dit onderwerp" disableFullscreen id="artikelen">
+      <Grid>
+        {articles.map((article, index) => (
+          <Link passHref href={`/artikelen/${article.slug.current}`} key={index}>
+            <ArticleCard>
+              <Box display="grid" gridTemplateColumns="1fr 4fr" style={{ gap: space[2] }} alignItems="center">
+                <ArticleImage {...getImageProps(article.cover, {})} />
+
+                <Box display="grid" color={colors.gray5}>
+                  <BoldText color={colors.black}>{article.title}</BoldText>
+                  <Box>
+                    {article.mainCategory === 'knowledge' ? (
+                      commonTexts.article_teaser.categories.knowledge
+                    ) : (
+                      <>
+                        {commonTexts.article_teaser.categories.news} · <PublicationDate date={article.publicationDate} />
+                      </>
+                    )}
+                  </Box>
+                </Box>
+              </Box>
+
+              <Box color={colors.black}>{article.summary}</Box>
+
+              <ArticleLink>
+                {commonTexts.article_teaser.read_more}
+                <ChevronRight />
+              </ArticleLink>
+            </ArticleCard>
+          </Link>
+        ))}
+      </Grid>
+
+      <Link passHref href="/artikelen/">
+        <ArticlesLink>
+          {commonTexts.article_list.articles_page_link}
+          <ChevronRight />
+        </ArticlesLink>
+      </Link>
+    </ChartTile>
+  );
+};
+
+const Grid = styled(Box)`
+  display: grid;
+  gap: ${space[4]};
+  @media ${mediaQueries.sm} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  margin-bottom: ${space[3]};
+`;
+
+const ArticleCard = styled(Anchor)`
+  display: grid;
+  gap: ${space[2]};
+  height: 100%;
+  border: 1px solid ${colors.gray3};
+  border-radius: ${radii[2]}px;
+  padding: ${space[3]};
+`;
+
+const ArticleImage = styled(SanityImage)`
+  object-fit: cover;
+
+  img {
+    border-radius: ${radii[2]}px;
+    width: 100%;
+    height: ${space[5]};
+  }
+`;
+
+const linkStyles = css`
+  color: ${colors.blue8};
+  cursor: pointer;
+
+  svg {
+    margin-left: ${space[1]};
+    width: 10px;
+    height: 10px;
+  }
+`;
+
+const ArticleLink = styled(BoldText)`
+  ${linkStyles}
+`;
+
+const ArticlesLink = styled(Anchor)`
+  ${linkStyles}
+
+  font-weight: ${fontWeights.bold};
+`;

--- a/packages/app/src/components/page-faq-tile.tsx
+++ b/packages/app/src/components/page-faq-tile.tsx
@@ -8,12 +8,12 @@ import { CollapsibleSection } from './collapsible';
 
 interface PageFaqTileProps {
   questions: FAQuestionAndAnswer[];
+  title: string;
 }
 
-export const PageFaqTile = ({ questions }: PageFaqTileProps) => {
+export const PageFaqTile = ({ questions, title }: PageFaqTileProps) => {
   return (
-    // TODO: create a common Lokalize key for the below text
-    <ChartTile title="Veelgestelde vragen" id="veelgestelde-vragen" disableFullscreen>
+    <ChartTile title={title} id="veelgestelde-vragen" disableFullscreen>
       {questions.map((question, index) => (
         <CollapsibleSection key={index} summary={question.title} textColor={colors.black} fontSize={fontSizes[3]}>
           {question.content && (

--- a/packages/app/src/components/page-faq-tile.tsx
+++ b/packages/app/src/components/page-faq-tile.tsx
@@ -1,4 +1,5 @@
 import { colors } from '@corona-dashboard/common';
+import { useIntl } from '~/intl';
 import { fontSizes, space } from '~/style/theme';
 import { FAQuestionAndAnswer } from '~/types/cms';
 import { Box } from './base/box';
@@ -12,8 +13,10 @@ interface PageFaqTileProps {
 }
 
 export const PageFaqTile = ({ questions, title }: PageFaqTileProps) => {
+  const { commonTexts } = useIntl();
+
   return (
-    <ChartTile title={title} id="veelgestelde-vragen" disableFullscreen>
+    <ChartTile title={title ?? commonTexts.faq.title} id="veelgestelde-vragen" disableFullscreen>
       {questions.map((question, index) => (
         <CollapsibleSection key={index} summary={question.title} textColor={colors.black} fontSize={fontSizes[3]}>
           {question.content && (

--- a/packages/app/src/components/page-faq-tile.tsx
+++ b/packages/app/src/components/page-faq-tile.tsx
@@ -1,0 +1,28 @@
+import { colors } from '@corona-dashboard/common';
+import { fontSizes, space } from '~/style/theme';
+import { FAQuestionAndAnswer } from '~/types/cms';
+import { Box } from './base/box';
+import { ChartTile } from './chart-tile';
+import { RichContent } from './cms/rich-content';
+import { CollapsibleSection } from './collapsible';
+
+interface PageFaqTileProps {
+  questions: FAQuestionAndAnswer[];
+}
+
+export const PageFaqTile = ({ questions }: PageFaqTileProps) => {
+  return (
+    // TODO: create a common Lokalize key for the below text
+    <ChartTile title="Veelgestelde vragen" id="veelgestelde-vragen" disableFullscreen>
+      {questions.map((question, index) => (
+        <CollapsibleSection key={index} summary={question.title} textColor={colors.black} fontSize={fontSizes[3]}>
+          {question.content && (
+            <Box paddingBottom={space[3]}>
+              <RichContent blocks={question.content} />
+            </Box>
+          )}
+        </CollapsibleSection>
+      ))}
+    </ChartTile>
+  );
+};

--- a/packages/app/src/components/page-faq-tile.tsx
+++ b/packages/app/src/components/page-faq-tile.tsx
@@ -6,6 +6,7 @@ import { Box } from './base/box';
 import { ChartTile } from './chart-tile';
 import { RichContent } from './cms/rich-content';
 import { CollapsibleSection } from './collapsible';
+import styled from 'styled-components';
 
 interface PageFaqTileProps {
   questions: FAQuestionAndAnswer[];
@@ -18,14 +19,18 @@ export const PageFaqTile = ({ questions, title }: PageFaqTileProps) => {
   return (
     <ChartTile title={title ?? commonTexts.faq.title} id="veelgestelde-vragen" disableFullscreen>
       {questions.map((question, index) => (
-        <CollapsibleSection key={index} summary={question.title} textColor={colors.black} fontSize={fontSizes[3]}>
+        <StyledCollapsibleSection key={index} summary={question.title} textColor={colors.black} fontSize={fontSizes[3]} isLast={index + 1 === questions.length}>
           {question.content && (
             <Box paddingBottom={space[3]}>
               <RichContent blocks={question.content} />
             </Box>
           )}
-        </CollapsibleSection>
+        </StyledCollapsibleSection>
       ))}
     </ChartTile>
   );
 };
+
+const StyledCollapsibleSection = styled(CollapsibleSection)<{ isLast: boolean }>`
+  border-bottom: ${({ isLast }) => (isLast ? `1px solid ${colors.gray2}` : undefined)};
+`;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -2,7 +2,6 @@ import { colors } from '@corona-dashboard/common';
 import { ChevronDown, ChevronRight, Warning } from '@corona-dashboard/icons';
 import { ReactNode, isValidElement } from 'react';
 import styled from 'styled-components';
-import { ArticleSummary } from '~/components/article-teaser';
 import { Box } from '~/components/base';
 import { RichContent } from '~/components/cms/rich-content';
 import { Markdown } from '~/components/markdown';
@@ -20,7 +19,6 @@ interface InformationBlockProps {
   title?: string;
   icon?: JSX.Element;
   description?: string | RichContentBlock[] | ReactNode;
-  articles?: ArticleSummary[] | null;
   pageLinks?:
     | {
         title: string;
@@ -37,8 +35,20 @@ interface InformationBlockProps {
   warning?: string;
   isArchivedHidden?: boolean;
   pageInformationHeader?: {
-    dataExplainedLink?: string;
-    faqLink?: string;
+    dataExplained?: {
+      button: {
+        header: string;
+        text: RichContentBlock[];
+      };
+      link: string;
+    };
+    faq?: {
+      button: {
+        header: string;
+        text: RichContentBlock[];
+      };
+      link: string;
+    };
   };
   onToggleArchived?: () => void;
 }
@@ -90,7 +100,7 @@ export function PageInformationBlock({
 
       {description && (
         <Tile hasTitle={!!title}>
-          <Box spacing={3} display="grid" gridTemplateColumns={{ md: 'repeat(2, 1fr)' }} style={{ gap: space[4] }}>
+          <Grid>
             <Box spacing={3}>
               {DescriptionBlock}
               {MetaDataBlock}
@@ -98,26 +108,26 @@ export function PageInformationBlock({
 
             {isPageInformationHeader && (
               <Box flex="1" display="flex" flexDirection="column" spacing={3}>
-                {pageInformationHeader.dataExplainedLink && (
-                  <PageInformationButton href={pageInformationHeader.dataExplainedLink}>
-                    {/* TODO: add Lokalize keys for this */}
-                    <BoldText>Meer informatie en databestanden</BoldText>
-                    <p>Cijferverantwoording</p>
+                {pageInformationHeader.dataExplained && (
+                  <PageInformationButton href={pageInformationHeader.dataExplained.link}>
+                    <BoldText>{pageInformationHeader.dataExplained.button.header}</BoldText>
+                    <RichContent blocks={pageInformationHeader.dataExplained.button.text} />
+
                     <ChevronRight />
                   </PageInformationButton>
                 )}
 
-                {pageInformationHeader.faqLink && (
-                  <PageInformationButton href={`#${pageInformationHeader.faqLink}`}>
-                    {/* TODO: add Lokalize keys for this */}
-                    <BoldText>Vragen over dit onderwerp?</BoldText>
-                    <p>FAQ</p>
+                {pageInformationHeader.faq && (
+                  <PageInformationButton href={`#${pageInformationHeader.faq.link}`}>
+                    <BoldText>{pageInformationHeader.faq.button.header}</BoldText>
+                    <RichContent blocks={pageInformationHeader.faq.button.text} />
+
                     <ChevronDown />
                   </PageInformationButton>
                 )}
               </Box>
             )}
-          </Box>
+          </Grid>
 
           {pageLinks && pageLinks.length && <PageLinks links={pageLinks} />}
 
@@ -162,23 +172,36 @@ const MetadataBox = styled.div`
   }
 `;
 
+const Grid = styled(Box)`
+  display: grid;
+
+  @media ${mediaQueries.md} {
+    gap: ${space[4]};
+    grid-template-columns: repeat(2, 1fr);
+  }
+`;
+
 const PageInformationButton = styled(Anchor)`
-  padding: ${space[3]} ${space[4]};
-  border: 1px solid ${colors.gray3};
   background-color: ${colors.white};
   border-radius: ${radii[2]}px;
-  text-align: left;
-  cursor: pointer;
-  position: relative;
+  border: 1px solid ${colors.gray3};
   color: ${colors.black};
+  cursor: pointer;
+  padding: ${space[3]} ${space[4]};
+  position: relative;
+  text-align: left;
 
   svg {
     color: ${colors.primary};
-    width: 24px;
     position: absolute;
     right: ${space[2]};
     top: 50%;
     transform: translate(-50%, -50%);
+    width: 24px;
+  }
+
+  .underline {
+    text-decoration: underline;
   }
 `;
 
@@ -188,8 +211,8 @@ interface ArchiveButtonProps {
 
 const ArchiveButton = styled.button<ArchiveButtonProps>`
   background: ${({ isActive }) => (isActive ? colors.blue1 : colors.white)};
-  border: 1px solid ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   border-radius: 5px;
+  border: 1px solid ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   color: ${({ isActive }) => (isActive ? colors.blue8 : colors.blue8)};
   cursor: pointer;
   min-height: 36px;
@@ -197,8 +220,8 @@ const ArchiveButton = styled.button<ArchiveButtonProps>`
 
   &:hover {
     background: ${colors.blue8};
-    color: ${colors.white};
     border-color: ${colors.transparent};
+    color: ${colors.white};
   }
 
   &:hover:focus-visible {

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -73,7 +73,7 @@ export function PageInformationBlock({
   const showArchivedToggleButton = typeof isArchivedHidden !== 'undefined' && typeof onToggleArchived !== 'undefined';
   const { commonTexts } = useIntl();
 
-  const isPageInformationHeader = !!pageInformationHeader;
+  const hasPageInformationHeader = !!pageInformationHeader;
 
   const MetaDataBlock = metadata ? (
     <MetadataBox>
@@ -106,7 +106,7 @@ export function PageInformationBlock({
               {MetaDataBlock}
             </Box>
 
-            {isPageInformationHeader && (
+            {hasPageInformationHeader && (
               <Box flex="1" display="flex" flexDirection="column" spacing={3}>
                 {pageInformationHeader.dataExplained && (
                   <PageInformationButton href={pageInformationHeader.dataExplained.link}>

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -1,23 +1,20 @@
-import css from '@styled-system/css';
-import { Warning } from '@corona-dashboard/icons';
-import { isValidElement, ReactNode } from 'react';
+import { colors } from '@corona-dashboard/common';
+import { ChevronDown, ChevronRight, Warning } from '@corona-dashboard/icons';
+import { ReactNode, isValidElement } from 'react';
 import styled from 'styled-components';
 import { ArticleSummary } from '~/components/article-teaser';
 import { Box } from '~/components/base';
 import { RichContent } from '~/components/cms/rich-content';
 import { Markdown } from '~/components/markdown';
-import { HeadingLevel } from '~/components/typography';
-import { asResponsiveArray } from '~/style/utils';
+import { Anchor, BoldText, HeadingLevel } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
+import { useIntl } from '~/intl';
+import { mediaQueries, radii, space } from '~/style/theme';
 import { RichContentBlock } from '~/types/cms';
-import { Articles } from './components/articles';
+import { useScopedWarning } from '~/utils/use-scoped-warning';
 import { Header } from './components/header';
 import { Metadata, MetadataProps } from './components/metadata';
 import { PageLinks } from './components/page-links';
-import { WarningTile } from '~/components/warning-tile';
-import { useScopedWarning } from '~/utils/use-scoped-warning';
-import { useIntl } from '~/intl';
-import { colors } from '@corona-dashboard/common';
-import { space } from '~/style/theme';
 
 interface InformationBlockProps {
   title?: string;
@@ -39,6 +36,10 @@ interface InformationBlockProps {
   vrNameOrGmName?: string;
   warning?: string;
   isArchivedHidden?: boolean;
+  pageInformationHeader?: {
+    dataExplainedLink?: string;
+    faqLink?: string;
+  };
   onToggleArchived?: () => void;
 }
 
@@ -46,7 +47,6 @@ export function PageInformationBlock({
   title,
   icon,
   description,
-  articles,
   pageLinks,
   metadata,
   referenceLink,
@@ -56,11 +56,14 @@ export function PageInformationBlock({
   vrNameOrGmName,
   warning,
   isArchivedHidden,
+  pageInformationHeader,
   onToggleArchived,
 }: InformationBlockProps) {
   const scopedWarning = useScopedWarning(vrNameOrGmName || '', warning || '');
   const showArchivedToggleButton = typeof isArchivedHidden !== 'undefined' && typeof onToggleArchived !== 'undefined';
   const { commonTexts } = useIntl();
+
+  const isPageInformationHeader = !!pageInformationHeader;
 
   const MetaDataBlock = metadata ? (
     <MetadataBox>
@@ -87,77 +90,106 @@ export function PageInformationBlock({
 
       {description && (
         <Tile hasTitle={!!title}>
-          <Box spacing={3} width="100%">
-            <Box
-              display={{ md: 'grid' }}
-              gridTemplateColumns="repeat(2, 1fr)"
-              width="100%"
-              spacing={{
-                _: pageLinks && pageLinks.length ? 0 : 3,
-                md: 0,
-              }}
-              css={css({
-                columnGap: space[5],
-              })}
-            >
-              {articles && articles.length ? (
-                <>
-                  <Box spacing={3}>
-                    {DescriptionBlock}
-                    {MetaDataBlock}
-                  </Box>
-
-                  <Articles articles={articles} />
-                </>
-              ) : (
-                <>
-                  {DescriptionBlock}
-                  {MetaDataBlock}
-                </>
-              )}
+          <Box spacing={3} display="grid" gridTemplateColumns={{ md: 'repeat(2, 1fr)' }} style={{ gap: space[4] }}>
+            <Box spacing={3}>
+              {DescriptionBlock}
+              {MetaDataBlock}
             </Box>
 
-            {pageLinks && pageLinks.length && <PageLinks links={pageLinks} />}
-          </Box>
-          <Box marginY={space[3]}>
-            {showArchivedToggleButton && (
-              <StyledArchiveButton type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
-                {!isArchivedHidden ? commonTexts.common.show_archived : commonTexts.common.hide_archived}
-              </StyledArchiveButton>
+            {isPageInformationHeader && (
+              <Box flex="1" display="flex" flexDirection="column" spacing={3}>
+                {pageInformationHeader.dataExplainedLink && (
+                  <PageInformationButton href={pageInformationHeader.dataExplainedLink}>
+                    {/* TODO: add Lokalize keys for this */}
+                    <BoldText>Meer informatie en databestanden</BoldText>
+                    <p>Cijferverantwoording</p>
+                    <ChevronRight />
+                  </PageInformationButton>
+                )}
+
+                {pageInformationHeader.faqLink && (
+                  <PageInformationButton href={`#${pageInformationHeader.faqLink}`}>
+                    {/* TODO: add Lokalize keys for this */}
+                    <BoldText>Vragen over dit onderwerp?</BoldText>
+                    <p>FAQ</p>
+                    <ChevronDown />
+                  </PageInformationButton>
+                )}
+              </Box>
             )}
           </Box>
+
+          {pageLinks && pageLinks.length && <PageLinks links={pageLinks} />}
+
+          {showArchivedToggleButton && (
+            <Box marginY={space[3]}>
+              <ArchiveButton type="button" onClick={onToggleArchived} isActive={isArchivedHidden}>
+                {!isArchivedHidden ? commonTexts.common.show_archived : commonTexts.common.hide_archived}
+              </ArchiveButton>
+            </Box>
+          )}
         </Tile>
       )}
     </Box>
   );
 }
 
-const Tile = styled.div<{ hasTitle?: boolean }>((x) =>
-  css({
-    paddingTop: x.hasTitle ? undefined : asResponsiveArray({ _: space[2], sm: space[3] }),
-    display: 'flex',
-    flexWrap: 'wrap',
-    borderTop: x.hasTitle ? undefined : 'solid 2px gray2',
-  })
-);
+interface TileProps {
+  hasTitle?: boolean;
+}
 
-const MetadataBox = styled.div(
-  css({
-    flex: asResponsiveArray({ md: '1 1 auto', lg: '1 1 40%' }),
-    marginBottom: asResponsiveArray({ _: space[3], md: '0' }),
-  })
-);
+const Tile = styled.div<TileProps>`
+  border-top: ${({ hasTitle }) => (!hasTitle ? `2px solid ${colors.gray2}` : undefined)};
+  display: flex;
+  flex-wrap: wrap;
+  padding-top: ${({ hasTitle }) => (!hasTitle ? space[2] : undefined)};
 
-interface StyledArchiveButtonProps {
+  @media ${mediaQueries.sm} {
+    padding-top: ${({ hasTitle }) => (!hasTitle ? space[3] : undefined)};
+  }
+`;
+
+const MetadataBox = styled.div`
+  flex: 1 1 auto;
+  margin-bottom: ${space[3]};
+
+  @media ${mediaQueries.md} {
+    margin-bottom: 0;
+  }
+
+  @media ${mediaQueries.lg} {
+    flex: 1 1 40%;
+  }
+`;
+
+const PageInformationButton = styled(Anchor)`
+  padding: ${space[3]} ${space[4]};
+  border: 1px solid ${colors.gray3};
+  background-color: ${colors.white};
+  border-radius: ${radii[2]}px;
+  text-align: left;
+  cursor: pointer;
+  position: relative;
+  color: ${colors.black};
+
+  svg {
+    color: ${colors.primary};
+    width: 24px;
+    position: absolute;
+    right: ${space[2]};
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+`;
+
+interface ArchiveButtonProps {
   isActive?: boolean;
 }
 
-const StyledArchiveButton = styled.button<StyledArchiveButtonProps>`
+const ArchiveButton = styled.button<ArchiveButtonProps>`
   background: ${({ isActive }) => (isActive ? colors.blue1 : colors.white)};
-  border: ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
+  border: 1px solid ${({ isActive }) => (isActive ? colors.transparent : colors.gray3)};
   border-radius: 5px;
-  border-style: solid;
-  border-width: 1px;
   color: ${({ isActive }) => (isActive ? colors.blue8 : colors.blue8)};
   cursor: pointer;
   min-height: 36px;

--- a/packages/app/src/components/tile.tsx
+++ b/packages/app/src/components/tile.tsx
@@ -7,17 +7,18 @@ import { asResponsiveArray } from '~/style/utils';
 interface TileProps {
   children: React.ReactNode;
   height?: number | string;
+  id?: string;
   hasNoBorder?: boolean;
   hasNoPaddingBottom?: boolean;
 }
 
-export function Tile({ children, height, hasNoBorder = false, hasNoPaddingBottom = false }: TileProps) {
+export const Tile = ({ children, height, id, hasNoBorder = false, hasNoPaddingBottom = false }: TileProps) => {
   return (
-    <StyledTile height={height} hasNoBorder={hasNoBorder} hasNoPaddingBottom={hasNoPaddingBottom}>
+    <StyledTile height={height} hasNoBorder={hasNoBorder} hasNoPaddingBottom={hasNoPaddingBottom} id={id}>
       {children}
     </StyledTile>
   );
-}
+};
 
 const StyledTile = styled.article<{
   height?: number | string;

--- a/packages/app/src/domain/topical/common/categories.ts
+++ b/packages/app/src/domain/topical/common/categories.ts
@@ -1,5 +1,7 @@
 export const articleCategory = [
   '__alles',
+  'knowledge',
+  'news',
   'vaccinaties',
   'besmettingen',
   'sterfte',

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -2,7 +2,6 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { WarningTile } from '~/components';
 import { Box } from '~/components/base';
 import { ChartTile } from '~/components/chart-tile';
 import { DynamicChoropleth } from '~/components/choropleth';
@@ -20,6 +19,7 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Text } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
 import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -32,6 +32,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { replaceComponentsInText, replaceVariablesInText, useReverseRouter } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 export { getStaticPaths } from '~/static-paths/gm';
 
@@ -121,27 +122,10 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             }}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {!!textShared.warning && <WarningTile isFullWidth message={textShared.warning} variant="informational" />}
@@ -280,9 +264,9 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             </ChoroplethTile>
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -13,6 +13,8 @@ import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { Markdown } from '~/components/markdown';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
@@ -22,7 +24,7 @@ import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
@@ -71,6 +73,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'positiveTestsPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'positiveTestsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'positiveTestsPageDataExplained'),
         elements: content.elements,
       },
     } as const;
@@ -115,10 +119,29 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
             }}
-            referenceLink={textGm.reference.href}
-            articles={content.articles}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {!!textShared.warning && <WarningTile isFullWidth message={textShared.warning} variant="informational" />}
@@ -256,6 +279,18 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               />
             </ChoroplethTile>
           </InView>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </GmLayout>
     </Layout>

--- a/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positief-geteste-mensen.tsx
@@ -280,11 +280,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             </ChoroplethTile>
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -24,6 +24,7 @@ import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData 
 import { PagePart, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 
@@ -108,27 +109,10 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             }}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {!isEmpty(textGm.warning_method) && <WarningTile message={textGm.warning_method} icon={Experimenteel} />}
@@ -196,9 +180,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             warning={textGm.warning_chart}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -2,9 +2,12 @@ import { NlSewer } from '@corona-dashboard/common';
 import { Experimenteel, Rioolvirus } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
+import { InView } from '~/components';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { Markdown } from '~/components/markdown';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TwoKpiSection } from '~/components/two-kpi-section';
@@ -15,14 +18,14 @@ import { Layout } from '~/domain/layout/layout';
 import { SewerChart } from '~/domain/sewer/sewer-chart';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetContent, getLastGeneratedDate, selectGmData, getLokalizeTexts } from '~/static-props/get-data';
-import { ArticleParts, PagePartQueryResult } from '~/types/cms';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
+import { PagePart, PagePartQueryResult } from '~/types/cms';
+import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
-import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
 const pageMetrics = ['sewer_per_installation', 'sewer'];
 
@@ -40,11 +43,13 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   selectGmData('difference.sewer__average', 'sewer_per_installation', 'sewer_installation_measurement', 'static_values.population_count_connected_to_rwzis', 'sewer', 'code'),
   async (context: GetStaticPropsContext) => {
-    const { content } = await createGetContent<PagePartQueryResult<ArticleParts>>(() => getPagePartsQuery('sewer_page'))(context);
+    const { content } = await createGetContent<PagePartQueryResult<PagePart>>(() => getPagePartsQuery('sewer_page'))(context);
 
     return {
       content: {
         articles: getArticleParts(content.pageParts, 'sewerPageArticles'),
+        faqs: getFaqParts(content.pageParts, 'sewerPageFAQs'),
+        dataExplained: getDataExplainedParts(content.pageParts, 'sewerPageDataExplained'),
       },
     };
   }
@@ -101,10 +106,29 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
             }}
-            referenceLink={textGm.reference.href}
-            articles={content.articles}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {!isEmpty(textGm.warning_method) && <WarningTile message={textGm.warning_method} icon={Experimenteel} />}
@@ -171,6 +195,18 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             incompleteDatesAndTexts={textGm.zeewolde_incomplete_manualy_override}
             warning={textGm.warning_chart}
           />
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </GmLayout>
     </Layout>

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -196,11 +196,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             warning={textGm.warning_chart}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -2,7 +2,7 @@ import { NlSewer } from '@corona-dashboard/common';
 import { Experimenteel, Rioolvirus } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import { InView } from '~/components';
+import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { Markdown } from '~/components/markdown';

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -2,13 +2,15 @@ import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard
 import { Coronavirus } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
+import { ChartTile, InView, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { Text } from '~/components/typography';
 import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
@@ -46,6 +48,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'deceasedPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'deceasedPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'deceasedPageDataExplained'),
         elements: content.elements,
       },
     };
@@ -92,9 +96,29 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.section_deceased_rivm.bronnen.rivm],
             }}
-            articles={content.articles}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textGm.notification.message} variant="informational" />}
@@ -157,6 +181,18 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
               }}
             />
           </ChartTile>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </GmLayout>
     </Layout>

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -2,13 +2,16 @@ import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard
 import { Coronavirus } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, InView, Markdown, TimeSeriesChart } from '~/components';
+import { ChartTile } from '~/components/chart-tile';
+import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
+import { Markdown } from '~/components/markdown';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
 import { TileList } from '~/components/tile-list';
+import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Text } from '~/components/typography';
 import { WarningTile } from '~/components/warning-tile';

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -2,10 +2,16 @@ import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard
 import { Coronavirus } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, InView, KpiTile, KpiValue, Markdown, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection, WarningTile } from '~/components';
+import { ChartTile, InView, Markdown, TimeSeriesChart } from '~/components';
+import { KpiTile } from '~/components/kpi-tile';
+import { KpiValue } from '~/components/kpi-value';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
+import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
+import { TileList } from '~/components/tile-list';
+import { TwoKpiSection } from '~/components/two-kpi-section';
 import { Text } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
 import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
@@ -17,6 +23,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { replaceVariablesInText } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['deceased_rivm_archived_20221231'];
 
@@ -98,27 +105,10 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
             }}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textGm.notification.message} variant="informational" />}
@@ -182,9 +172,9 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -182,11 +182,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -230,11 +230,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             }}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -3,10 +3,13 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { isDefined, isPresent } from 'ts-is-present';
-import { Divider, InView, PageInformationBlock, TileList } from '~/components';
+import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
+import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
+import { TileList } from '~/components/tile-list';
 import { gmCodesByVrCode, vrCodeByGmCode } from '~/data';
 import { emptyCoverageData } from '~/data/gm/vaccinations/empty-coverage-data';
 import { GmLayout, Layout } from '~/domain/layout';
@@ -21,6 +24,7 @@ import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { assert, replaceVariablesInText, useFormatLokalizePercentage, useReverseRouter } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage_archived_20220904'];
 
@@ -135,27 +139,10 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             pageLinks={content.links}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
           {filteredVaccination.autumn2022.birthyear_range_60_plus && (
             <BorderedKpiSection
@@ -230,9 +217,9 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             }}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -3,8 +3,10 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { isDefined, isPresent } from 'ts-is-present';
-import { Divider, PageInformationBlock, TileList } from '~/components';
+import { Divider, InView, PageInformationBlock, TileList } from '~/components';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { gmCodesByVrCode, vrCodeByGmCode } from '~/data';
 import { emptyCoverageData } from '~/data/gm/vaccinations/empty-coverage-data';
 import { GmLayout, Layout } from '~/domain/layout';
@@ -12,7 +14,7 @@ import { VaccineCoveragePerAgeGroup, VaccineCoverageToggleTile } from '~/domain/
 import { VaccineCoverageChoropleth } from '~/domain/vaccine/vaccine-coverage-choropleth';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
@@ -64,6 +66,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.pageParts, 'vaccinationsPageArticles'),
+        faqs: getFaqParts(content.pageParts, 'vaccinationsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.pageParts, 'vaccinationsPageDataExplained'),
         links: getLinkParts(content.pageParts, 'vaccinationsPageLinks'),
       },
     };
@@ -129,10 +133,29 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
               dataSources: [textShared.bronnen.rivm],
             }}
             pageLinks={content.links}
-            referenceLink={textGm.vaccination_coverage.top_level_information_block.reference.href}
-            articles={content.articles}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
           {filteredVaccination.autumn2022.birthyear_range_60_plus && (
             <BorderedKpiSection
@@ -206,6 +229,19 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
               ageGroupLabel: commonTexts.choropleth.vaccination_coverage.shared.dropdown_label_age_group_select,
             }}
           />
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
+
           <Divider />
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -230,11 +230,7 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
             />
           </ChoroplethTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -2,21 +2,23 @@ import { colors, DAY_IN_SECONDS, TimeframeOption, TimeframeOptionsList, WEEK_IN_
 import { Ziekenhuis } from '@corona-dashboard/icons';
 import { last } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import { ChartTile, DynamicChoropleth, TwoKpiSection, ChoroplethTile, KpiTile, KpiValue, PageInformationBlock, TileList, TimeSeriesChart } from '~/components';
+import { useState } from 'react';
+import { ChartTile, ChoroplethTile, DynamicChoropleth, InView, KpiTile, KpiValue, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection } from '~/components';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
-import { Layout, GmLayout } from '~/domain/layout';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
+import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData } from '~/static-props/get-data';
 import { filterByRegionMunicipalities } from '~/static-props/utils/filter-by-region-municipalities';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { countTrailingNullValues, getBoundaryDateStartUnix, replaceVariablesInText, useReverseRouter } from '~/utils';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
-import { useState } from 'react';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
 const pageMetrics = ['hospital_nice'];
 
@@ -51,6 +53,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'hospitalPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'hospitalPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'hospitalPageDataExplained'),
         links: getLinkParts(content.parts.pageParts, 'hospitalPageLinks'),
         elements: content.elements,
       },
@@ -107,11 +111,30 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
             }}
-            referenceLink={textGm.reference.href}
             pageLinks={content.links}
-            articles={content.articles}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           <TwoKpiSection>
@@ -206,6 +229,18 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
               }}
             />
           </ChoroplethTile>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </GmLayout>
     </Layout>

--- a/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
+++ b/packages/app/src/pages/gemeente/[code]/ziekenhuis-opnames.tsx
@@ -3,10 +3,19 @@ import { Ziekenhuis } from '@corona-dashboard/icons';
 import { last } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, ChoroplethTile, DynamicChoropleth, InView, KpiTile, KpiValue, PageInformationBlock, TileList, TimeSeriesChart, TwoKpiSection } from '~/components';
+import { ChartTile } from '~/components/chart-tile';
+import { DynamicChoropleth } from '~/components/choropleth';
+import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
+import { InView } from '~/components/in-view';
+import { KpiTile } from '~/components/kpi-tile';
+import { KpiValue } from '~/components/kpi-value';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
+import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
+import { TileList } from '~/components/tile-list';
+import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
+import { TwoKpiSection } from '~/components/two-kpi-section';
 import { GmLayout, Layout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
@@ -19,6 +28,7 @@ import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { countTrailingNullValues, getBoundaryDateStartUnix, replaceVariablesInText, useReverseRouter } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['hospital_nice'];
 
@@ -114,27 +124,10 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
             pageLinks={content.links}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <TwoKpiSection>
@@ -230,9 +223,9 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
             />
           </ChoroplethTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -59,7 +59,7 @@ export const getStaticProps = createGetStaticProps(
     })(context);
     return {
       content: {
-        articles: getArticleParts(content.parts.pageParts, 'topicalPageArticles'),
+        articles: getArticleParts(content.parts.pageParts, 'topicalPageArticles')?.articles,
         topicalStructure: content.topicalStructure,
       },
     };
@@ -237,7 +237,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
               text={textShared}
             />
 
-            {isPresent(content.articles) && isPresent(content.articles.articles) && <TopicalArticlesList articles={content.articles.articles} text={textShared} />}
+            {isPresent(content.articles) && <TopicalArticlesList articles={content.articles} text={textShared} />}
           </MaxWidth>
         </Box>
       </Box>

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -237,7 +237,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
               text={textShared}
             />
 
-            {isPresent(content.articles) && <TopicalArticlesList articles={content.articles} text={textShared} />}
+            {isPresent(content.articles) && isPresent(content.articles.articles) && <TopicalArticlesList articles={content.articles.articles} text={textShared} />}
           </MaxWidth>
         </Box>
       </Box>

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,7 +1,10 @@
 import { colors, getLastFilledValue } from '@corona-dashboard/common';
 import { Ziektegolf } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
+import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
@@ -10,7 +13,7 @@ import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
@@ -33,6 +36,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.pageParts, 'infectiousPeoplePageArticles'),
+        faqs: getFaqParts(content.pageParts, 'infectiousPeoplePageFAQs'),
+        dataExplained: getDataExplainedParts(content.pageParts, 'infectiousPeoplePageDataExplained'),
       },
     };
   }
@@ -69,8 +74,27 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastFullValue.date_of_insertion_unix,
               dataSources: [textNl.bronnen.rivm],
             }}
-            referenceLink={textNl.reference.href}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -101,6 +125,18 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
               ]}
             />
           </ChartTile>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,8 +1,8 @@
 import { colors, getLastFilledValue } from '@corona-dashboard/common';
 import { Ziektegolf } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
-import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
+import { InView } from '~/components/in-view';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -18,6 +18,7 @@ import { createGetStaticProps, StaticProps } from '~/static-props/create-get-sta
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -74,27 +75,10 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastFullValue.date_of_insertion_unix,
               dataSources: [textNl.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -126,9 +110,9 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -126,11 +126,7 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/coronamelder.tsx
+++ b/packages/app/src/pages/landelijk/coronamelder.tsx
@@ -62,7 +62,6 @@ const CoronamelderPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: warningLastValue.date_of_insertion_unix,
               dataSources: [corona_melder_app.header.bronnen.rivm],
             }}
-            referenceLink={corona_melder_app.header.reference.href}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={corona_melder_app.belangrijk_bericht} variant="informational" />}

--- a/packages/app/src/pages/landelijk/coronamelder.tsx
+++ b/packages/app/src/pages/landelijk/coronamelder.tsx
@@ -5,7 +5,6 @@ import { ChartTile } from '~/components/chart-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { WarningTile } from '~/components';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
@@ -14,6 +13,7 @@ import { createGetStaticProps, StaticProps } from '~/static-props/create-get-sta
 import { getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { createDateFromUnixTimestamp } from '~/utils/create-date-from-unix-timestamp';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { WarningTile } from '~/components/warning-tile';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -229,11 +229,7 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
             }}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -2,8 +2,6 @@ import { Bevolking } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { middleOfDayInSeconds } from '@corona-dashboard/common';
 import { useMemo, useRef, useState } from 'react';
-import { InView, WarningTile } from '~/components';
-import { Box } from '~/components/base';
 import { Heading } from '~/components/typography';
 import { Markdown } from '~/components/markdown';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -28,6 +26,10 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { WarningTile } from '~/components/warning-tile';
+import { Box } from '~/components/base/box';
+import { InView } from '~/components/in-view';
 
 const pageMetrics = ['behavior_archived_20230411', 'behavior_annotations_archived_20230412', 'behavior_per_age_group_archived_20230411'];
 
@@ -130,27 +132,10 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -229,9 +214,9 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
             }}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -306,11 +306,7 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -2,12 +2,12 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { Coronavirus, Gehandicaptenzorg, Location } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
 import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -26,6 +26,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['disability_care'];
 
@@ -108,27 +109,10 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.positief_geteste_personen.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -306,9 +290,9 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -2,12 +2,13 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { Coronavirus, VulnerableGroups as VulnerableGroupsIcon } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { DynamicChoropleth, InView } from '~/components/';
-import { Box } from '~/components/base';
+import { Box } from '~/components/base/box';
 import { ChartTile } from '~/components/chart-tile';
+import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
@@ -31,6 +32,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = [
   'difference.nursing_home__deceased_daily_archived_20230126',
@@ -137,27 +139,10 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [positiveTestedPeopleText.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={hasActiveWarningTile} variant="informational" />}
@@ -248,9 +233,9 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -248,11 +248,7 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -346,11 +346,7 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
             )}
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -26,6 +26,7 @@ import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { countTrailingNullValues, getBoundaryDateStartUnix, useReverseRouter } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['hospital_nice_per_age_group', 'intensive_care_nice_per_age_group', 'hospital_nice', 'intensive_care_nice'];
 
@@ -136,27 +137,10 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [textNl.sources.nice],
             }}
             pageLinks={content.links}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <ChoroplethTile
@@ -346,9 +330,9 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
             )}
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -8,6 +8,8 @@ import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { InView } from '~/components/in-view';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { SEOHead } from '~/components/seo-head';
 import { TileList } from '~/components/tile-list';
@@ -17,7 +19,7 @@ import { Layout, NlLayout } from '~/domain/layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
@@ -55,6 +57,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'patientsPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'patientsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'patientsPageDataExplained'),
         links: getLinkParts(content.parts.pageParts, 'patientsPageLinks'),
         elements: content.elements,
       },
@@ -131,9 +135,28 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.nice],
             }}
-            referenceLink={textNl.reference.href}
             pageLinks={content.links}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           <ChoroplethTile
@@ -322,6 +345,18 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
               </ChartTile>
             )}
           </InView>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -367,11 +367,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             <GNumberBarChartTile data={data.g_number} />
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -11,6 +11,8 @@ import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { InView } from '~/components/in-view';
 import { Markdown } from '~/components/markdown';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
@@ -22,7 +24,7 @@ import { InfectedPerAgeGroup } from '~/domain/tested/infected-per-age-group/infe
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { space } from '~/style/theme';
@@ -73,7 +75,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'positiveTestsPageArticles'),
-        ggdArticles: getArticleParts(content.parts.pageParts, 'positiveTestsGGDArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'positiveTestsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'positiveTestsPageDataExplained'),
         elements: content.elements,
       },
     };
@@ -136,8 +139,27 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            referenceLink={textNl.reference.href}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {!!textShared.warning && <WarningTile isFullWidth message={textShared.warning} variant="informational" />}
@@ -344,6 +366,18 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
           <InView rootMargin="400px">
             <GNumberBarChartTile data={data.g_number} />
           </InView>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
+++ b/packages/app/src/pages/landelijk/positief-geteste-mensen.tsx
@@ -2,8 +2,7 @@ import { colors, NlTestedOverallValue, TimeframeOption, TimeframeOptionsList } f
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { WarningTile } from '~/components';
-import { Box } from '~/components/base';
+import { Box } from '~/components/base/box';
 import { ChartTile } from '~/components/chart-tile';
 import { ChartTileToggleItem } from '~/components/chart-tile-toggle';
 import { DynamicChoropleth } from '~/components/choropleth';
@@ -17,6 +16,7 @@ import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { BoldText } from '~/components/typography';
+import { WarningTile } from '~/components/warning-tile';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
 import { GNumberBarChartTile } from '~/domain/tested/g-number-bar-chart-tile';
@@ -31,6 +31,7 @@ import { space } from '~/style/theme';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { replaceComponentsInText } from '~/utils/replace-components-in-text';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { useReverseRouter } from '~/utils/use-reverse-router';
@@ -139,27 +140,10 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {!!textShared.warning && <WarningTile isFullWidth message={textShared.warning} variant="informational" />}
@@ -367,9 +351,9 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
             <GNumberBarChartTile data={data.g_number} />
           </InView>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -143,11 +143,7 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
 
           <ReproductionChartTile data={data.reproduction} timelineEvents={getTimelineEvents(content.elements.timeSeries, 'reproduction')} text={textNl} />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -1,7 +1,7 @@
 import { getLastFilledValue } from '@corona-dashboard/common';
 import { Reproductiegetal } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
-import { InView } from '~/components';
+import { InView } from '~/components/in-view';
 import { KpiWithIllustrationTile } from '~/components/kpi-with-illustration-tile';
 import { Markdown } from '~/components/markdown';
 import { PageArticlesTile } from '~/components/page-articles-tile';
@@ -22,6 +22,7 @@ import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData 
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['reproduction'];
 
@@ -91,27 +92,10 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <TwoKpiSection>
@@ -143,9 +127,9 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
 
           <ReproductionChartTile data={data.reproduction} timelineEvents={getTimelineEvents(content.elements.timeSeries, 'reproduction')} text={textNl} />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -197,11 +197,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChoroplethTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -1,10 +1,10 @@
 import { Experimenteel, Rioolvirus } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
-import { InView } from '~/components';
 import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
+import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { PageArticlesTile } from '~/components/page-articles-tile';
@@ -25,6 +25,7 @@ import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLok
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
 const pageMetrics = ['sewer'];
@@ -102,27 +103,10 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {!isEmpty(textNl.warning_method) && <WarningTile message={textNl.warning_method} icon={Experimenteel} />}
@@ -197,9 +181,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChoroplethTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -139,11 +139,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
 
           <DeceasedMonitorSection data={dataCbs} text={textNl.section_sterftemonitor} showCauseMessage />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -2,11 +2,11 @@ import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard
 import { Coronavirus } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { InView } from '~/components';
 import { AgeDemographic } from '~/components/age-demographic';
-import { Box } from '~/components/base';
+import { Box } from '~/components/base/box';
 import { ChartTile } from '~/components/chart-tile';
 import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
 import { Markdown } from '~/components/markdown';
@@ -30,6 +30,7 @@ import { space } from '~/style/theme';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['deceased_cbs', 'deceased_rivm_per_age_group_archived_20221231', 'deceased_rivm_archived_20221231'];
 
@@ -112,36 +113,19 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
               dataSources: [textNl.section_sterftemonitor.bronnen.cbs],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textShared.notification.message} variant="informational" />}
 
           <DeceasedMonitorSection data={dataCbs} text={textNl.section_sterftemonitor} showCauseMessage />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/testen.tsx
+++ b/packages/app/src/pages/landelijk/testen.tsx
@@ -147,11 +147,7 @@ const Tests = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/testen.tsx
+++ b/packages/app/src/pages/landelijk/testen.tsx
@@ -2,7 +2,10 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
+import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
@@ -11,7 +14,7 @@ import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
@@ -45,6 +48,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'testsPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'testsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'testsPageDataExplained'),
         elements: content.elements,
       },
     };
@@ -87,8 +92,27 @@ const Tests = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.rivm],
             }}
-            referenceLink={textNl.reference.href}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           <ChartTile
@@ -122,6 +146,18 @@ const Tests = (props: StaticProps<typeof getStaticProps>) => {
               forceLegend
             />
           </ChartTile>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/testen.tsx
+++ b/packages/app/src/pages/landelijk/testen.tsx
@@ -2,8 +2,8 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { GgdTesten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
+import { InView } from '~/components/in-view';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -20,6 +20,7 @@ import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData 
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['self_test_overall'];
 
@@ -92,27 +93,10 @@ const Tests = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <ChartTile
@@ -147,9 +131,9 @@ const Tests = (props: StaticProps<typeof getStaticProps>) => {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -2,12 +2,12 @@ import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard
 import { Elderly } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
 import { DynamicChoropleth } from '~/components/choropleth';
 import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
 import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -26,6 +26,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['elderly_at_home'];
 
@@ -107,27 +108,10 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.section_positive_tested.bronnen.rivm],
             }}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -257,9 +241,9 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -1,13 +1,16 @@
 import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
-import { useState } from 'react';
 import { Elderly } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
+import { useState } from 'react';
+import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
-import { ChoroplethTile } from '~/components/choropleth-tile';
-import { Divider } from '~/components/divider';
 import { DynamicChoropleth } from '~/components/choropleth';
-import { PageInformationBlock } from '~/components/page-information-block';
+import { ChoroplethTile } from '~/components/choropleth-tile';
 import { thresholds } from '~/components/choropleth/logic/thresholds';
+import { Divider } from '~/components/divider';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
+import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { WarningTile } from '~/components/warning-tile';
@@ -16,13 +19,13 @@ import { NlLayout } from '~/domain/layout/nl-layout';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetChoroplethData, createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
+import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, PagePartQueryResult } from '~/types/cms';
+import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
-import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 
 const pageMetrics = ['elderly_at_home'];
 
@@ -55,6 +58,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'elderlyAtHomePageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'elderlyAtHomePageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'elderlyAtHomePageDataExplained'),
         elements: content.elements,
       },
     };
@@ -102,8 +107,27 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.section_positive_tested.bronnen.rivm],
             }}
-            referenceLink={textNl.section_positive_tested.reference.href}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={textNl.belangrijk_bericht} variant="informational" />}
@@ -232,6 +256,18 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
               }}
             />
           </ChartTile>
+
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
+
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-ouderen.tsx
@@ -257,11 +257,7 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -178,17 +178,28 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             }}
             pageLinks={content.links}
             referenceLink={textNl.information_block.reference.href}
-            articles={content.articles}
             pageInformationHeader={{
-              dataExplainedLink: content.dataExplained ? `/verantwoording/${content.dataExplained.slug.current}` : undefined,
-              faqLink: content.faqs?.length ? 'veelgestelde-vragen' : undefined,
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: `veelgestelde-vragen`,
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
             }}
           />
-
-          {/* TODO: always place these above archived section */}
-          {content.faqs?.length && content.faqs?.length > 0 && <PageFaqTile questions={content.faqs} />}
-
-          {content.articles?.length && content.articles?.length > 0 && <PageArticlesTile articles={content.articles} />}
 
           <BorderedKpiSection
             title={textShared.vaccination_grade_tile.autumn_labels.title}
@@ -298,6 +309,13 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             }}
             values={data.vaccine_coverage_per_age_group.values}
           />
+
+          {content.faqs?.questions.length && content.faqs?.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+
+          {content.articles?.articles.length && content.articles?.articles.length > 0 && (
+            <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+          )}
+
           <Divider />
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -3,9 +3,9 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, Divider, PageInformationBlock, TileList, TimeSeriesChart, WarningTile } from '~/components';
+import { ChartTile, Divider, InView, PageInformationBlock, TileList, TimeSeriesChart, WarningTile } from '~/components';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
-import { PageArticlesTile } from '~/components/page-articles-tile/page-articles-tile';
+import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { Layout, NlLayout } from '~/domain/layout';
 import {
@@ -177,7 +177,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               dataSources: [textShared.bronnen.rivm],
             }}
             pageLinks={content.links}
-            referenceLink={textNl.information_block.reference.href}
             pageInformationHeader={{
               dataExplained: content.dataExplained
                 ? {
@@ -191,7 +190,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               faq:
                 content.faqs && content.faqs.questions.length > 0
                   ? {
-                      link: `veelgestelde-vragen`,
+                      link: 'veelgestelde-vragen',
                       button: {
                         header: content.faqs.buttonTitle,
                         text: content.faqs.buttonText,
@@ -310,10 +309,16 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             values={data.vaccine_coverage_per_age_group.values}
           />
 
-          {content.faqs?.questions.length && content.faqs?.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions.length > 0 && (
+            <InView rootMargin="400px">
+              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+            </InView>
+          )}
 
-          {content.articles?.articles.length && content.articles?.articles.length > 0 && (
-            <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+          {content.articles && content.articles.articles.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
           )}
 
           <Divider />

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -309,11 +309,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             values={data.vaccine_coverage_per_age_group.values}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -3,10 +3,16 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, Divider, InView, PageInformationBlock, TileList, TimeSeriesChart, WarningTile } from '~/components';
+import { ChartTile } from '~/components/chart-tile';
+import { Divider } from '~/components/divider';
+import { InView } from '~/components/in-view';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
+import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
+import { TileList } from '~/components/tile-list';
+import { TimeSeriesChart } from '~/components/time-series-chart/time-series-chart';
+import { WarningTile } from '~/components/warning-tile';
 import { Layout, NlLayout } from '~/domain/layout';
 import {
   Autumn2022ShotCoveragePerAgeGroup,
@@ -34,6 +40,7 @@ import { ArticleParts, LinkParts, PagePartQueryResult, RichTextParts } from '~/t
 import { replaceVariablesInText, useFormatLokalizePercentage } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { useReverseRouter } from '~/utils/use-reverse-router';
 
 const pageMetrics = [
@@ -177,27 +184,10 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               dataSources: [textShared.bronnen.rivm],
             }}
             pageLinks={content.links}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <BorderedKpiSection
@@ -309,9 +299,9 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             values={data.vaccine_coverage_per_age_group.values}
           />
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -3,36 +3,38 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { ChartTile, PageInformationBlock, TileList, TimeSeriesChart, WarningTile, Divider } from '~/components';
+import { ChartTile, Divider, PageInformationBlock, TileList, TimeSeriesChart, WarningTile } from '~/components';
+import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
+import { PageArticlesTile } from '~/components/page-articles-tile/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { Layout, NlLayout } from '~/domain/layout';
-import { useReverseRouter } from '~/utils/use-reverse-router';
 import {
-  selectAdministrationData,
-  VaccinationsOverTimeTile,
-  VaccineBoosterAdministrationsKpiSection,
-  VaccinationsShotKpiSection,
+  Autumn2022ShotCoveragePerAgeGroup,
+  BoosterShotCoveragePerAgeGroup,
   VaccinationsKpiHeader,
+  VaccinationsOverTimeTile,
+  VaccinationsShotKpiSection,
+  VaccineBoosterAdministrationsKpiSection,
   VaccineCoverageChoropleth,
   VaccineCoveragePerAgeGroup,
   VaccineCoverageToggleTile,
   VaccineDeliveryBarChart,
   VaccineStockPerSupplierChart,
-  BoosterShotCoveragePerAgeGroup,
-  Autumn2022ShotCoveragePerAgeGroup,
+  selectAdministrationData,
 } from '~/domain/vaccine';
 import { VaccinationsPerSupplierOverLastTimeframeTile } from '~/domain/vaccine/vaccinations-per-supplier-over-last-timeframe-tile';
 import { VaccineCampaignsTile } from '~/domain/vaccine/vaccine-campaigns-tile/vaccine-campaigns-tile';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
-import { getArticleParts, getLinkParts, getPagePartsQuery, getRichTextParts } from '~/queries/get-page-parts-query';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery, getRichTextParts } from '~/queries/get-page-parts-query';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
 import { createGetChoroplethData, createGetContent, getLastGeneratedDate, getLokalizeTexts, getNlData, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult, RichTextParts } from '~/types/cms';
 import { replaceVariablesInText, useFormatLokalizePercentage } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
-import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
+import { useReverseRouter } from '~/utils/use-reverse-router';
 
 const pageMetrics = [
   'vaccine_administered_doctors',
@@ -103,6 +105,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.parts.pageParts, 'vaccinationsPageArticles'),
+        faqs: getFaqParts(content.parts.pageParts, 'vaccinationsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.parts.pageParts, 'vaccinationsPageDataExplained'),
         links: getLinkParts(content.parts.pageParts, 'vaccinationsPageLinks'),
         boosterArticles: getArticleParts(content.parts.pageParts, 'vaccineBoosterArticles'),
         thirdShotArticles: getArticleParts(content.parts.pageParts, 'vaccineThirdShotArticles'),
@@ -175,7 +179,17 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             pageLinks={content.links}
             referenceLink={textNl.information_block.reference.href}
             articles={content.articles}
+            pageInformationHeader={{
+              dataExplainedLink: content.dataExplained ? `/verantwoording/${content.dataExplained.slug.current}` : undefined,
+              faqLink: content.faqs?.length ? 'veelgestelde-vragen' : undefined,
+            }}
           />
+
+          {/* TODO: always place these above archived section */}
+          {content.faqs?.length && content.faqs?.length > 0 && <PageFaqTile questions={content.faqs} />}
+
+          {content.articles?.length && content.articles?.length > 0 && <PageArticlesTile articles={content.articles} />}
+
           <BorderedKpiSection
             title={textShared.vaccination_grade_tile.autumn_labels.title}
             description={textShared.vaccination_grade_tile.autumn_labels.description}

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -1,6 +1,6 @@
 import { Varianten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
-import { InView } from '~/components';
+import { InView } from '~/components/in-view';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
@@ -19,6 +19,7 @@ import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData 
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
 const pageMetrics = ['variants', 'named_difference'];
 
@@ -102,27 +103,10 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               dataSources: [textNl.bronnen.rivm],
             }}
             pageLinks={content.links}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           {variantChart && variantLabels && (
@@ -159,9 +143,9 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
           )}
         </TileList>
 
-        {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+        {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-        {content.articles && content.articles.articles.length > 0 && (
+        {content.articles && content.articles.articles?.length > 0 && (
           <InView rootMargin="400px">
             <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
           </InView>

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -159,11 +159,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
           )}
         </TileList>
 
-        {content.faqs && content.faqs.questions.length > 0 && (
-          <InView rootMargin="400px">
-            <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-          </InView>
-        )}
+        {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
         {content.articles && content.articles.articles.length > 0 && (
           <InView rootMargin="400px">

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -1,5 +1,8 @@
 import { Varianten } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
+import { InView } from '~/components';
+import { PageArticlesTile } from '~/components/page-articles-tile';
+import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { Layout } from '~/domain/layout/layout';
@@ -7,15 +10,15 @@ import { NlLayout } from '~/domain/layout/nl-layout';
 import { getVariantChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/static-props';
 import { VariantsStackedAreaTile } from '~/domain/variants/variants-stacked-area-tile';
 import { VariantsTableTile } from '~/domain/variants/variants-table-tile';
+import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetContent, getLastGeneratedDate, selectNlData, getLokalizeTexts } from '~/static-props/get-data';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
-import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
-import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
+import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 
 const pageMetrics = ['variants', 'named_difference'];
 
@@ -51,6 +54,8 @@ export const getStaticProps = createGetStaticProps(
     return {
       content: {
         articles: getArticleParts(content.pageParts, 'variantsPageArticles'),
+        faqs: getFaqParts(content.pageParts, 'variantsPageFAQs'),
+        dataExplained: getDataExplainedParts(content.pageParts, 'variantsPageDataExplained'),
         links: getLinkParts(content.pageParts, 'variantsPageLinks'),
       },
     };
@@ -96,9 +101,28 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
             }}
-            referenceLink={textNl.reference.href}
             pageLinks={content.links}
-            articles={content.articles}
+            pageInformationHeader={{
+              dataExplained: content.dataExplained
+                ? {
+                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
+                    button: {
+                      header: content.dataExplained.buttonTitle,
+                      text: content.dataExplained.buttonText,
+                    },
+                  }
+                : undefined,
+              faq:
+                content.faqs && content.faqs.questions.length > 0
+                  ? {
+                      link: 'veelgestelde-vragen',
+                      button: {
+                        header: content.faqs.buttonTitle,
+                        text: content.faqs.buttonText,
+                      },
+                    }
+                  : undefined,
+            }}
           />
 
           {variantChart && variantLabels && (
@@ -134,6 +158,18 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
             />
           )}
         </TileList>
+
+        {content.faqs && content.faqs.questions.length > 0 && (
+          <InView rootMargin="400px">
+            <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
+          </InView>
+        )}
+
+        {content.articles && content.articles.articles.length > 0 && (
+          <InView rootMargin="400px">
+            <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+          </InView>
+        )}
       </NlLayout>
     </Layout>
   );

--- a/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/verdenkingen-huisartsen.tsx
@@ -56,7 +56,6 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
               dateOfInsertionUnix: lastValue.date_of_insertion_unix,
               dataSources: [text.bronnen.nivel],
             }}
-            referenceLink={text.reference.href}
           />
 
           {hasActiveWarningTile && <WarningTile isFullWidth message={text.belangrijk_bericht} variant="informational" />}

--- a/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
@@ -2,9 +2,9 @@ import { colors, getLastFilledValue, TimeframeOption, TimeframeOptionsList } fro
 import { IntensiveCareOpnames } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
-import { InView } from '~/components';
 import { ChartTile } from '~/components/chart-tile';
 import { ChartTileToggleItem } from '~/components/chart-tile-toggle';
+import { InView } from '~/components/in-view';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { PageArticlesTile } from '~/components/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
@@ -22,6 +22,7 @@ import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectNlData 
 import { PagePart, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { trimLeadingNullValues } from '~/utils/trim-leading-null-values';
 
 const pageMetrics = [
@@ -126,27 +127,10 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
               dataSources: [textNl.sources.lnaz],
             }}
             pageLinks={content.links}
-            pageInformationHeader={{
-              dataExplained: content.dataExplained
-                ? {
-                    link: `/verantwoording/${content.dataExplained.item.slug.current}`,
-                    button: {
-                      header: content.dataExplained.buttonTitle,
-                      text: content.dataExplained.buttonText,
-                    },
-                  }
-                : undefined,
-              faq:
-                content.faqs && content.faqs.questions.length > 0
-                  ? {
-                      link: 'veelgestelde-vragen',
-                      button: {
-                        header: content.faqs.buttonTitle,
-                        text: content.faqs.buttonText,
-                      },
-                    }
-                  : undefined,
-            }}
+            pageInformationHeader={getPageInformationHeaderContent({
+              dataExplained: content.dataExplained,
+              faq: content.faqs,
+            })}
           />
 
           <BorderedKpiSection
@@ -375,9 +359,9 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
             </ChartTile>
           )}
 
-          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
-          {content.articles && content.articles.articles.length > 0 && (
+          {content.articles && content.articles.articles?.length > 0 && (
             <InView rootMargin="400px">
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>

--- a/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-en-zorg.tsx
@@ -375,11 +375,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
             </ChartTile>
           )}
 
-          {content.faqs && content.faqs.questions.length > 0 && (
-            <InView rootMargin="400px">
-              <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />
-            </InView>
-          )}
+          {content.faqs && content.faqs.questions.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
 
           {content.articles && content.articles.articles.length > 0 && (
             <InView rootMargin="400px">

--- a/packages/app/src/queries/get-page-parts-query.ts
+++ b/packages/app/src/queries/get-page-parts-query.ts
@@ -10,17 +10,18 @@ export const getPagePartsQuery = (pageIdentifier: PageIdentifier) => {
         _type,
         pageDataKind,
         (_type == 'pageArticles') => {
+          // TODO: add updateDate field as introduced by COR-1601
           articles[]->{_id, title, slug, summary, intro, "cover": {"asset": cover.asset->}, mainCategory[0], publicationDate},
           sectionTitle
         },
         (_type == 'pageFAQs') => {
-          faqQuestions[]->{_id, title, content},
+          questions[]->{_id, title, content},
           buttonTitle,
           buttonText,
           sectionTitle
         },
         (_type == 'pageDataExplained') => {
-          dataExplainedItem->{slug},
+          item->{slug},
           buttonTitle,
           buttonText
         },
@@ -58,7 +59,7 @@ export const getDataExplainedParts = (pageParts: PagePart[], pageDataKind: strin
   const parts = filterByType<DataExplainedParts>(pageParts, 'pageDataExplained').find((pagePart) => pagePart.pageDataKind === pageDataKind);
   return isDefined(parts)
     ? {
-        item: parts.dataExplainedItem,
+        item: parts.item,
         buttonTitle: parts.buttonTitle,
         buttonText: parts.buttonText,
       }
@@ -69,7 +70,7 @@ export const getFaqParts = (pageParts: PagePart[], pageDataKind: string) => {
   const parts = filterByType<FaqParts>(pageParts, 'pageFAQs').find((pagePart) => pagePart.pageDataKind === pageDataKind);
   return isDefined(parts)
     ? {
-        questions: parts.faqQuestions,
+        questions: parts.questions,
         buttonTitle: parts.buttonTitle,
         buttonText: parts.buttonText,
         sectionTitle: parts.sectionTitle,

--- a/packages/app/src/queries/get-page-parts-query.ts
+++ b/packages/app/src/queries/get-page-parts-query.ts
@@ -1,33 +1,32 @@
 import { isDefined } from 'ts-is-present';
-import {
-  ArticleParts,
-  HighlightedItemParts,
-  LinkParts,
-  PageIdentifier,
-  PagePart,
-  RichTextParts,
-} from '~/types/cms';
+import { ArticleParts, DataExplainedParts, FaqParts, HighlightedItemParts, LinkParts, PageIdentifier, PagePart, RichTextParts } from '~/types/cms';
 
-export function isArticleParts(value: PagePart): value is ArticleParts {
+export const isArticleParts = (value: PagePart): value is ArticleParts => {
   return value._type === 'pageArticles';
-}
+};
 
-export function isLinkParts(value: PagePart): value is LinkParts {
-  return value._type === 'pageLinks';
-}
+export const isDataExplainedParts = (value: PagePart): value is DataExplainedParts => {
+  return value._type === 'pageDataExplained';
+};
 
-export function isHighlightedItemParts(
-  value: PagePart
-): value is HighlightedItemParts {
+export const isFaqParts = (value: PagePart): value is FaqParts => {
+  return value._type === 'pageFAQs';
+};
+
+export const isHighlightedItemParts = (value: PagePart): value is HighlightedItemParts => {
   return value._type === 'pageHighlightedItems';
-}
+};
 
-export function isRichTextParts(value: PagePart): value is RichTextParts {
+export const isLinkParts = (value: PagePart): value is LinkParts => {
+  return value._type === 'pageLinks';
+};
+
+export const isRichTextParts = (value: PagePart): value is RichTextParts => {
   return value._type === 'pageRichText';
-}
+};
 
-export function getPagePartsQuery(pageIdentifier: PageIdentifier) {
-  const query = `
+export const getPagePartsQuery = (pageIdentifier: PageIdentifier) => {
+  const query = `//groq
     *[_type == 'pageIdentifier' && identifier == '${pageIdentifier}']
     {
       identifier,
@@ -35,14 +34,20 @@ export function getPagePartsQuery(pageIdentifier: PageIdentifier) {
         _type,
         pageDataKind,
         (_type == 'pageArticles') => {
-          articles[]->{_id, title, slug, intro, "cover": {"asset": cover.asset->}}
+          articles[]->{_id, title, slug, summary, intro, "cover": {"asset": cover.asset->}, mainCategory[0], publicationDate}
         },
-        (_type == 'pageLinks') => {
-          links[]{href, title}
+        (_type == 'pageFAQs') => {
+          faqQuestions[]->{_id, title, content}
+        },
+        (_type == 'pageDataExplained') => {
+          dataExplainedItem->{slug}
         },
         (_type == 'pageHighlightedItems') => {
           showWeeklyHighlight,
           highlights[]{title, category, "slug": {"current": href}, "cover": {"asset": cover.asset->}}
+        },
+        (_type == 'pageLinks') => {
+          links[]{href, title}
         },
         (_type == 'pageRichText') => {
           text
@@ -51,40 +56,39 @@ export function getPagePartsQuery(pageIdentifier: PageIdentifier) {
     }[0]`;
 
   return query;
-}
+};
 
-export function getArticleParts(pageParts: PagePart[], pageDataKind: string) {
-  const parts = pageParts
-    .filter(isArticleParts)
-    .find((x) => x.pageDataKind === pageDataKind)?.articles;
+export const getArticleParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isArticleParts).find((pagePart) => pagePart.pageDataKind === pageDataKind)?.articles;
   return isDefined(parts) ? parts : null;
-}
+};
 
-export function getLinkParts(pageParts: PagePart[], pageDataKind: string) {
-  const parts = pageParts
-    .filter(isLinkParts)
-    .find((x) => x.pageDataKind === pageDataKind)?.links;
+export const getDataExplainedParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isDataExplainedParts).find((pagePart) => pagePart.pageDataKind === pageDataKind)?.dataExplainedItem;
   return isDefined(parts) ? parts : null;
-}
+};
 
-export function getHighlightedItemParts(
-  pageParts: PagePart[],
-  pageDataKind: string
-) {
-  const parts = pageParts
-    .filter(isHighlightedItemParts)
-    .find((x) => x.pageDataKind === pageDataKind);
+export const getFaqParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isFaqParts).find((pagePart) => pagePart.pageDataKind === pageDataKind)?.faqQuestions;
+  return isDefined(parts) ? parts : null;
+};
+
+export const getHighlightedItemParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isHighlightedItemParts).find((pagePart) => pagePart.pageDataKind === pageDataKind);
   return isDefined(parts)
     ? {
         highlights: parts.highlights,
         showWeeklyHighlight: parts.showWeeklyHighlight,
       }
     : null;
-}
+};
 
-export function getRichTextParts(pageParts: PagePart[], pageDataKind: string) {
-  const parts = pageParts
-    .filter(isRichTextParts)
-    .find((x) => x.pageDataKind === pageDataKind)?.text;
+export const getLinkParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isLinkParts).find((pagePart) => pagePart.pageDataKind === pageDataKind)?.links;
   return isDefined(parts) ? parts : null;
-}
+};
+
+export const getRichTextParts = (pageParts: PagePart[], pageDataKind: string) => {
+  const parts = pageParts.filter(isRichTextParts).find((pagePart) => pagePart.pageDataKind === pageDataKind)?.text;
+  return isDefined(parts) ? parts : null;
+};

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -35,7 +35,7 @@ export type ArticleParts = {
 
 export type DataExplainedParts = {
   _type: 'pageDataExplained';
-  dataExplainedItem: {
+  item: {
     slug: { current: string };
   };
   buttonTitle: string;
@@ -44,7 +44,7 @@ export type DataExplainedParts = {
 
 export type FaqParts = {
   _type: 'pageFAQs';
-  faqQuestions: FAQuestionAndAnswer[];
+  questions: FAQuestionAndAnswer[];
   sectionTitle: string;
   buttonTitle: string;
   buttonText: RichContentBlock[];

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -21,6 +21,8 @@ export type PageIdentifier =
   | 'vaccinations_page'
   | 'variants_page';
 
+export type PartTypes = 'pageArticles' | 'pageDataExplained' | 'pageFAQs' | 'pageHighlightedItems' | 'pageLinks' | 'pageRichText';
+
 export type PageBasePart = {
   pageDataKind: string;
 };
@@ -28,6 +30,7 @@ export type PageBasePart = {
 export type ArticleParts = {
   _type: 'pageArticles';
   articles: Article[];
+  sectionTitle: string;
 } & PageBasePart;
 
 export type DataExplainedParts = {
@@ -35,12 +38,16 @@ export type DataExplainedParts = {
   dataExplainedItem: {
     slug: { current: string };
   };
+  buttonTitle: string;
+  buttonText: RichContentBlock[];
 } & PageBasePart;
 
 export type FaqParts = {
   _type: 'pageFAQs';
   faqQuestions: FAQuestionAndAnswer[];
-  title: string;
+  sectionTitle: string;
+  buttonTitle: string;
+  buttonText: RichContentBlock[];
 } & PageBasePart;
 
 export type HighlightedItemParts = {

--- a/packages/app/src/types/cms.d.ts
+++ b/packages/app/src/types/cms.d.ts
@@ -27,7 +27,26 @@ export type PageBasePart = {
 
 export type ArticleParts = {
   _type: 'pageArticles';
-  articles: ArticleSummary[];
+  articles: Article[];
+} & PageBasePart;
+
+export type DataExplainedParts = {
+  _type: 'pageDataExplained';
+  dataExplainedItem: {
+    slug: { current: string };
+  };
+} & PageBasePart;
+
+export type FaqParts = {
+  _type: 'pageFAQs';
+  faqQuestions: FAQuestionAndAnswer[];
+  title: string;
+} & PageBasePart;
+
+export type HighlightedItemParts = {
+  _type: 'pageHighlightedItems';
+  highlights: ArticleSummary[];
+  showWeeklyHighlight: boolean;
 } & PageBasePart;
 
 export type LinkParts = {
@@ -38,18 +57,12 @@ export type LinkParts = {
   }[];
 } & PageBasePart;
 
-export type HighlightedItemParts = {
-  _type: 'pageHighlightedItems';
-  highlights: ArticleSummary[];
-  showWeeklyHighlight: boolean;
-} & PageBasePart;
-
 export type RichTextParts = {
   _type: 'pageRichText';
   text: RichContentBlock[];
 } & PageBasePart;
 
-export type PagePart = ArticleParts | LinkParts | HighlightedItemParts | RichTextParts;
+export type PagePart = ArticleParts | DataExplainedParts | FaqParts | HighlightedItemParts | LinkParts | RichTextParts;
 
 export type PagePartQueryResult<T extends PagePart = PagePart> = {
   pageParts: T[];
@@ -106,6 +119,7 @@ export interface Article {
     _type: 'slug';
     current: string;
   };
+  mainCategory: 'knowledge' | 'news';
   categories?: CategoriesTypes[];
   cover: ImageBlock;
   imageMobile?: ImageBlock;

--- a/packages/app/src/utils/get-page-information-header-content.ts
+++ b/packages/app/src/utils/get-page-information-header-content.ts
@@ -1,0 +1,31 @@
+import { DataExplainedParts, FaqParts } from '~/types/cms';
+
+type KeysToOmit = '_type' | 'pageDataKind';
+
+export const getPageInformationHeaderContent = ({
+  dataExplained,
+  faq,
+}: {
+  dataExplained: Omit<DataExplainedParts, KeysToOmit> | null;
+  faq: Omit<FaqParts, KeysToOmit> | null;
+}) => ({
+  dataExplained: dataExplained
+    ? {
+        link: `/verantwoording/${dataExplained.item.slug.current}`,
+        button: {
+          header: dataExplained.buttonTitle,
+          text: dataExplained.buttonText,
+        },
+      }
+    : undefined,
+  faq:
+    faq && faq.questions?.length > 0
+      ? {
+          link: 'veelgestelde-vragen',
+          button: {
+            header: faq.buttonTitle,
+            text: faq.buttonText,
+          },
+        }
+      : undefined,
+});

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,5 @@
 timestamp,action,key,document_id,move_to
+2023-06-28T11:28:23.814Z,add,common.article_list.articles_page_link,i4tC336oRzoosjJ7ciMAty,__
+2023-06-28T11:28:25.329Z,add,common.article_teaser.categories.knowledge,1CbY4BczrwxgbzbvsJsVot,__
+2023-06-28T11:28:26.304Z,add,common.article_teaser.categories.news,i4tC336oRzoosjJ7ciMBOt,__
+2023-06-28T11:28:27.381Z,add,common.article_teaser.read_more,posbL87hXRea8MK3Cj6fYl,__

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -3,3 +3,5 @@ timestamp,action,key,document_id,move_to
 2023-06-28T11:28:25.329Z,add,common.article_teaser.categories.knowledge,1CbY4BczrwxgbzbvsJsVot,__
 2023-06-28T11:28:26.304Z,add,common.article_teaser.categories.news,i4tC336oRzoosjJ7ciMBOt,__
 2023-06-28T11:28:27.381Z,add,common.article_teaser.read_more,posbL87hXRea8MK3Cj6fYl,__
+2023-06-28T14:26:47.680Z,add,common.article_list.title,OFLiaClUFOlqnxmWMBQD0u,__
+2023-06-28T14:26:49.003Z,add,common.faq.title,OFLiaClUFOlqnxmWMBQDuu,__

--- a/packages/cms/src/schemas/documents/page-parts/articles.ts
+++ b/packages/cms/src/schemas/documents/page-parts/articles.ts
@@ -2,6 +2,7 @@ import { BsNewspaper } from 'react-icons/bs';
 import { ValidationContext, defineArrayMember, defineField, defineType } from 'sanity';
 import { isDefined } from 'ts-is-present';
 import { isAdmin } from '../../../studio/roles';
+import { localeStringValidation } from '../../../studio/validation/locale-validation';
 import { PAGE_IDENTIFIER_REFERENCE_FIELDS, PAGE_IDENTIFIER_REFERENCE_FIELDSET } from '../../fields/page-fields';
 import { isArticleValidationContextParent } from '../../utils/articles';
 
@@ -58,6 +59,12 @@ export const articles = defineType({
 
           return true;
         }),
+    }),
+    defineField({
+      title: 'Sectie titel',
+      name: 'sectionTitle',
+      type: 'localeString',
+      validation: localeStringValidation((rule) => rule.required()),
     }),
   ],
 });

--- a/packages/cms/src/schemas/documents/page-parts/data-explained.ts
+++ b/packages/cms/src/schemas/documents/page-parts/data-explained.ts
@@ -35,7 +35,7 @@ export const dataExplained = defineType({
     }),
     defineField({
       title: 'Cijferverantwoordingpagina-link',
-      name: 'dataExplainedItem',
+      name: 'item',
       type: 'reference',
       to: [{ type: 'cijferVerantwoordingItem' }],
       validation: (rule) => rule.required(),

--- a/packages/cms/src/schemas/documents/page-parts/data-explained.ts
+++ b/packages/cms/src/schemas/documents/page-parts/data-explained.ts
@@ -1,0 +1,30 @@
+import { Bs123 } from 'react-icons/bs';
+import { defineField, defineType } from 'sanity';
+import { PAGE_IDENTIFIER_REFERENCE_FIELDS, PAGE_IDENTIFIER_REFERENCE_FIELDSET } from '../../fields/page-fields';
+
+export const dataExplained = defineType({
+  title: 'Pagina cijferverantwoording',
+  name: 'pageDataExplained',
+  type: 'document',
+  icon: Bs123,
+  fieldsets: [
+    PAGE_IDENTIFIER_REFERENCE_FIELDSET,
+    {
+      title: 'FAQ Configuratie',
+      name: 'faqConfiguration',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+  ],
+  fields: [
+    ...PAGE_IDENTIFIER_REFERENCE_FIELDS,
+    defineField({
+      title: 'Cijferverantwoordingpagina-link',
+      name: 'dataExplainedItem',
+      type: 'reference',
+      to: [{ type: 'cijferVerantwoordingItem' }],
+    }),
+  ],
+});

--- a/packages/cms/src/schemas/documents/page-parts/data-explained.ts
+++ b/packages/cms/src/schemas/documents/page-parts/data-explained.ts
@@ -1,5 +1,6 @@
 import { Bs123 } from 'react-icons/bs';
 import { defineField, defineType } from 'sanity';
+import { localeStringValidation, localeValidation } from '../../../studio/validation/locale-validation';
 import { PAGE_IDENTIFIER_REFERENCE_FIELDS, PAGE_IDENTIFIER_REFERENCE_FIELDSET } from '../../fields/page-fields';
 
 export const dataExplained = defineType({
@@ -21,10 +22,23 @@ export const dataExplained = defineType({
   fields: [
     ...PAGE_IDENTIFIER_REFERENCE_FIELDS,
     defineField({
+      title: 'Button kop',
+      name: 'buttonTitle',
+      type: 'localeString',
+      validation: localeStringValidation((rule) => rule.required()),
+    }),
+    defineField({
+      title: 'Button tekst',
+      name: 'buttonText',
+      type: 'localeBlock',
+      validation: localeValidation((rule) => rule.required()),
+    }),
+    defineField({
       title: 'Cijferverantwoordingpagina-link',
       name: 'dataExplainedItem',
       type: 'reference',
       to: [{ type: 'cijferVerantwoordingItem' }],
+      validation: (rule) => rule.required(),
     }),
   ],
 });

--- a/packages/cms/src/schemas/documents/page-parts/faq.ts
+++ b/packages/cms/src/schemas/documents/page-parts/faq.ts
@@ -1,5 +1,6 @@
 import { BsQuestionCircle } from 'react-icons/bs';
 import { defineArrayMember, defineField, defineType } from 'sanity';
+import { localeStringValidation, localeValidation } from '../../../studio/validation/locale-validation';
 import { PAGE_IDENTIFIER_REFERENCE_FIELDS, PAGE_IDENTIFIER_REFERENCE_FIELDSET } from '../../fields/page-fields';
 
 export const faq = defineType({
@@ -20,6 +21,24 @@ export const faq = defineType({
   ],
   fields: [
     ...PAGE_IDENTIFIER_REFERENCE_FIELDS,
+    defineField({
+      title: 'Button titel',
+      name: 'buttonTitle',
+      type: 'localeString',
+      validation: localeStringValidation((rule) => rule.required()),
+    }),
+    defineField({
+      title: 'Button tekst',
+      name: 'buttonText',
+      type: 'localeBlock',
+      validation: localeValidation((rule) => rule.required()),
+    }),
+    defineField({
+      title: 'Sectie titel',
+      name: 'sectionTitle',
+      type: 'localeString',
+      validation: localeStringValidation((rule) => rule.required()),
+    }),
     defineField({
       title: 'Vragen',
       name: 'faqQuestions',

--- a/packages/cms/src/schemas/documents/page-parts/faq.ts
+++ b/packages/cms/src/schemas/documents/page-parts/faq.ts
@@ -41,7 +41,7 @@ export const faq = defineType({
     }),
     defineField({
       title: 'Vragen',
-      name: 'faqQuestions',
+      name: 'questions',
       type: 'array',
       of: [
         defineArrayMember({

--- a/packages/cms/src/schemas/documents/page-parts/faq.ts
+++ b/packages/cms/src/schemas/documents/page-parts/faq.ts
@@ -1,0 +1,36 @@
+import { BsQuestionCircle } from 'react-icons/bs';
+import { defineArrayMember, defineField, defineType } from 'sanity';
+import { PAGE_IDENTIFIER_REFERENCE_FIELDS, PAGE_IDENTIFIER_REFERENCE_FIELDSET } from '../../fields/page-fields';
+
+export const faq = defineType({
+  title: "Pagina FAQ's",
+  name: 'pageFAQs',
+  type: 'document',
+  icon: BsQuestionCircle,
+  fieldsets: [
+    PAGE_IDENTIFIER_REFERENCE_FIELDSET,
+    {
+      title: 'FAQ Configuratie',
+      name: 'faqConfiguration',
+      options: {
+        collapsible: true,
+        collapsed: true,
+      },
+    },
+  ],
+  fields: [
+    ...PAGE_IDENTIFIER_REFERENCE_FIELDS,
+    defineField({
+      title: 'Vragen',
+      name: 'faqQuestions',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'reference',
+          to: { type: 'faqQuestion' },
+        }),
+      ],
+      validation: (rule) => rule.unique(),
+    }),
+  ],
+});

--- a/packages/cms/src/schemas/fields/article-fields.ts
+++ b/packages/cms/src/schemas/fields/article-fields.ts
@@ -39,6 +39,20 @@ export const ARTICLE_FIELDS = [
     validation: (rule) => rule.required(),
   }),
   defineField({
+    title: 'Hoofdcategorie',
+    name: 'mainCategory',
+    type: 'array',
+    of: [defineArrayMember({ type: 'string' })],
+    options: {
+      layout: 'grid',
+      list: [
+        { title: 'Kennisartikelen', value: 'knowledge' },
+        { title: 'Nieuwsartikelen', value: 'news' },
+      ],
+    },
+    validation: (rule) => rule.required().min(1).max(1),
+  }),
+  defineField({
     title: 'Categorieën instellen',
     name: 'categories',
     type: 'array',

--- a/packages/cms/src/schemas/index.ts
+++ b/packages/cms/src/schemas/index.ts
@@ -2,6 +2,8 @@ import { article } from './documents/article';
 import { lokalizeText } from './documents/lokalize-text';
 import { pageIdentifier } from './documents/page-identifier';
 import { articles } from './documents/page-parts/articles';
+import { dataExplained as dataExplainedParts } from './documents/page-parts/data-explained';
+import { faq as faqParts } from './documents/page-parts/faq';
 import { highlights } from './documents/page-parts/highlights';
 import { links } from './documents/page-parts/links';
 import { about } from './documents/pages/about';
@@ -70,7 +72,7 @@ const documentSchemas = [
   trendIcon,
 ];
 const pageSchemas = [about, accessibility, contact, dataExplained, faq, homepage, notFound];
-const pagePartSchemas = [articles, highlights, links];
+const pagePartSchemas = [articles, dataExplainedParts, faqParts, highlights, links];
 const elementSchemas = [timelineEvent, timelineEventCollection, timeSeries];
 const objectSchemas = [link];
 

--- a/packages/cms/src/studio/desk-structure/page-parts-structure-item.ts
+++ b/packages/cms/src/studio/desk-structure/page-parts-structure-item.ts
@@ -9,6 +9,10 @@ export const pagePartsStructureItem = (S: StructureBuilder) => {
     .child(
       S.list()
         .title("Pagina's en onderdelen")
-        .items([...S.documentTypeListItems().filter((item) => ['pageIdentifier', 'pageArticles', 'pageLinks', 'pageHighlightedItems'].includes(item.getId() ?? ''))])
+        .items([
+          ...S.documentTypeListItems().filter((item) =>
+            ['pageIdentifier', 'pageArticles', 'pageDataExplained', 'pageFAQs', 'pageLinks', 'pageHighlightedItems'].includes(item.getId() ?? '')
+          ),
+        ])
     );
 };

--- a/packages/cms/src/studio/desk-structure/pages-structure-item.ts
+++ b/packages/cms/src/studio/desk-structure/pages-structure-item.ts
@@ -1,4 +1,4 @@
-import { BsBook, BsBookHalf, BsFileRichtext, BsLink, BsNewspaper, BsTranslate } from 'react-icons/bs';
+import { Bs123, BsBook, BsBookHalf, BsFileRichtext, BsLink, BsNewspaper, BsQuestionCircle, BsTranslate } from 'react-icons/bs';
 import { IconType } from 'react-icons/lib';
 import { map } from 'rxjs/operators';
 import { StructureBuilder, StructureResolverContext } from 'sanity/desk';
@@ -112,6 +112,8 @@ const pageDataListItem = (page: PagePartPage, S: StructureBuilder, context: Stru
 const pageDataItem = (pageData: PagePartChildPage, S: StructureBuilder) => {
   const iconForType: { [key: string]: IconType } = {
     pageArticles: BsNewspaper,
+    pageDataExplained: Bs123,
+    pageFAQs: BsQuestionCircle,
     pageHighlightedItems: BsNewspaper,
     pageLinks: BsLink,
     pageRichText: BsFileRichtext,


### PR DESCRIPTION
## Summary

* added FAQ and Data Explained schemas for page parts;
* added and updated components to facilitate new page parts;
* updated types;
* applied Sanity JSON edits;
* updated all applicable pages;

## Notes

I have, for the time being, only configured the 'Sterfte' and 'Vaccinaties' pages (or 'Mortality' and 'Vaccinations' respectively) inside Sanity. This is as to save time, but I think it makes sense to configure this pages at some later point. I did test the feature on all pages, and they work accordingly. Obviously, all pages will have to be configured on the production dataset of Sanity once this feature is merged and released. Pages that are covered both by NL and GM levels only have to be configured once, as they pull the same content in (as was already the case with articles, for example).

### Screenshots

After screenshots cover more components than the before screenshots, as some new components have been introduced and thus have no 'before' state.

#### Before
<details>
<summary>Toggle before screenshots</summary>

![COR-1598_header_before](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/0d1732ac-7195-40c9-96d9-2eb67cade381)
</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

**Desktop**
![COR-1598_header_after](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/983c38d9-11fc-4f90-9eb0-1116dda28871)
![COR-1598_faq_after](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/6b43c0bd-b633-49a3-a9d9-a75fe5733006)
![COR-1598_articles_after](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/a6c5688c-6dd0-42d2-9b9d-f5751126c372)

**Mobile**
![COR-1598_faq_mobile_after](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/7b047c5c-175d-4e89-918d-36ec9ae936c2)
![COR-1598_articles_mobile_after](https://github.com/minvws/nl-covid19-data-dashboard/assets/107395524/0478e7a6-85e8-4cc9-acba-81d6d1613542)
</details>

