### PR TITLE
Feature/COR-1610 about page improvements

### DIFF
--- a/packages/app/src/components/cms/content-image.tsx
+++ b/packages/app/src/components/cms/content-image.tsx
@@ -6,7 +6,7 @@ import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
 import { SanityImage } from '~/components/cms/sanity-image';
 import { getImageProps } from '~/lib/sanity';
-import { space } from '~/style/theme';
+import theme, { space } from '~/style/theme';
 import { ImageBlock, RichContentImageBlock } from '~/types/cms';
 import { Text } from '../typography';
 
@@ -14,6 +14,7 @@ interface ContentImageProps {
   node: ImageBlock | RichContentImageBlock;
   contentWrapper?: FunctionComponent;
   sizes?: string[][];
+  enableShadow?: boolean;
 }
 
 const SanityImageTile = styled(SanityImage)(
@@ -25,7 +26,7 @@ const SanityImageTile = styled(SanityImage)(
 
 const IMAGE_MAX_WIDTH = '980px';
 
-export function ContentImage({ node, contentWrapper, sizes }: ContentImageProps) {
+export function ContentImage({ node, contentWrapper, sizes, enableShadow = false }: ContentImageProps) {
   const caption = 'caption' in node && node.caption && (
     <Text as="figcaption" variant="body2" textAlign="left">
       {node.caption}
@@ -53,7 +54,13 @@ export function ContentImage({ node, contentWrapper, sizes }: ContentImageProps)
   ) : (
     <ContentWrapper>
       <Box as="figure" role="group" spacing={3} marginY={space[2]} textAlign="center">
-        <Box marginBottom={space[3]}>{node.asset && <SanityImage {...getImageProps(node, { sizes })} />}</Box>
+        <Box marginBottom={space[3]}>
+          {node.asset && (
+            <Box boxShadow={enableShadow ? theme.shadows.tile : null}>
+              <SanityImage {...getImageProps(node, { sizes })} />
+            </Box>
+          )}
+        </Box>
         {caption}
       </Box>
     </ContentWrapper>

--- a/packages/app/src/components/cms/content-image.tsx
+++ b/packages/app/src/components/cms/content-image.tsx
@@ -6,7 +6,7 @@ import { Box } from '~/components/base';
 import { ContentBlock } from '~/components/cms/content-block';
 import { SanityImage } from '~/components/cms/sanity-image';
 import { getImageProps } from '~/lib/sanity';
-import theme, { space } from '~/style/theme';
+import { space, shadows } from '~/style/theme';
 import { ImageBlock, RichContentImageBlock } from '~/types/cms';
 import { Text } from '../typography';
 
@@ -54,12 +54,8 @@ export function ContentImage({ node, contentWrapper, sizes, enableShadow = false
   ) : (
     <ContentWrapper>
       <Box as="figure" role="group" spacing={3} marginY={space[2]} textAlign="center">
-        <Box marginBottom={space[3]}>
-          {node.asset && (
-            <Box boxShadow={enableShadow ? theme.shadows.tile : null}>
-              <SanityImage {...getImageProps(node, { sizes })} />
-            </Box>
-          )}
+        <Box marginBottom={space[3]} boxShadow={enableShadow ? shadows.tile : null}>
+          {node.asset && <SanityImage {...getImageProps(node, { sizes })} />}
         </Box>
         {caption}
       </Box>

--- a/packages/app/src/components/fullscreen-chart-tile.tsx
+++ b/packages/app/src/components/fullscreen-chart-tile.tsx
@@ -18,9 +18,10 @@ interface FullscreenChartTileProps {
   children: React.ReactNode;
   metadata?: MetadataProps;
   disabled?: boolean;
+  disableBorder?: boolean;
 }
 
-export function FullscreenChartTile({ children, metadata, disabled }: FullscreenChartTileProps) {
+export function FullscreenChartTile({ children, metadata, disabled, disableBorder }: FullscreenChartTileProps) {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const wasFullscreen = usePrevious(isFullscreen);
   const breakpoints = useBreakpoints();
@@ -36,7 +37,7 @@ export function FullscreenChartTile({ children, metadata, disabled }: Fullscreen
   const label = replaceVariablesInText(isFullscreen ? commonTexts.common.modal_close : commonTexts.common.modal_open, { subject: commonTexts.common.grafiek_singular });
 
   const tile = (
-    <Tile hasNoBorder={isFullscreen} height="100%">
+    <Tile hasNoBorder={isFullscreen || disableBorder} height="100%">
       <Box
         paddingX={isFullscreen ? { _: space[3], sm: space[4] } : undefined}
         paddingY={isFullscreen ? { _: space[2], sm: space[3] } : undefined}

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -69,7 +69,9 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
         <Box textVariant="body1" bg="white">
           <Box paddingBottom={space[5]}>
             <Box marginBottom={space[4]} maxWidth={sizes.maxWidthText}>
-              <Heading level={1}>{content.title}</Heading>
+              <Heading variant="h2" level={1}>
+                {content.title}
+              </Heading>
             </Box>
             <TwoColumnLayout>
               <div>

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -4,19 +4,18 @@ import { Box } from '~/components/base';
 import { ContentImage } from '~/components/cms/content-image';
 import { RichContent } from '~/components/cms/rich-content';
 import { FullscreenChartTile } from '~/components/fullscreen-chart-tile';
-import { MaxWidth } from '~/components/max-width';
 import { Heading } from '~/components/typography';
 import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
-import { mediaQueries, space } from '~/style/theme';
+import { mediaQueries, sizes, space } from '~/style/theme';
 import { ImageBlock, RichContentBlock } from '~/types/cms';
 interface OverData {
   title: string | null;
-  intro: RichContentBlock[] | null;
-  description: RichContentBlock[] | null;
-  timelineImage: ImageBlock | null;
+  intro: RichContentBlock[];
+  description: RichContentBlock[];
+  timelineImage: ImageBlock;
 }
 
 export const getStaticProps = createGetStaticProps(
@@ -24,33 +23,31 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<OverData>((context) => {
     const { locale = 'nl' } = context;
     return `// groq
-      *[
-          _type == 'overDitDashboard' && !(_id in path('drafts.**'))
-      ][0]{...,
+      *[_type == 'overDitDashboard' && !(_id in path('drafts.**'))][0]{
+        ...,
         "description": {
           "_type": description._type,
           "${locale}": [
-            ...description.${locale}[]
-            {
+            ...description.${locale}[]{
               ...,
               "asset": asset->
-             },
+            },
           ]
         },
         "intro": {
           "_type": intro._type,
           "${locale}": [
-            ...intro.${locale}[]
-            {
+            ...intro.${locale}[]{
               ...,
               "asset": asset->
-             },
+            },
           ]
         },
         "timelineImage": {
           "_type": timelineImage._type,
-          "${locale}": {...timelineImage.${locale},
-            },
+          "${locale}": {
+            ...timelineImage.${locale},
+          },
         }
       }
     `;
@@ -63,26 +60,32 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
 
   return (
     <Layout {...commonTexts.over_metadata} lastGenerated={lastGenerated}>
-      <Head>
-        <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
-        <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
-      </Head>
+      <Box margin={`${space[5]} auto`} maxWidth={`${sizes.maxWidth}px`} padding={` 0 ${space[4]}`}>
+        <Head>
+          <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
+          <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
+        </Head>
 
-      <Box textVariant="body1" bg="white">
-        <MaxWidth paddingTop={space[6]} paddingBottom={space[5]} paddingX={space[3]}>
-          <TwoColumnLayout>
-            <Box spacing={4}>{content.title && <Heading level={1}>{content.title}</Heading>}</Box>
-          </TwoColumnLayout>
-          <TwoColumnLayout>
-            <Box>
-              {content.intro && <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />}
-              <FullscreenChartTile disableBorder>
-                <Box marginTop={space[2]}>{content.timelineImage && <ContentImage node={content.timelineImage} contentWrapper={RichContentWrapper} enableShadow />}</Box>
-              </FullscreenChartTile>
+        <Box textVariant="body1" bg="white">
+          <Box paddingBottom={space[5]}>
+            <Box marginBottom={space[4]} maxWidth={sizes.maxWidthText}>
+              <Heading level={1}>{content.title}</Heading>
             </Box>
-            <div>{content.description && <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />}</div>
-          </TwoColumnLayout>
-        </MaxWidth>
+            <TwoColumnLayout>
+              <div>
+                <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />
+                <FullscreenChartTile disableBorder>
+                  <Box marginTop={space[2]}>
+                    <ContentImage node={content.timelineImage} contentWrapper={RichContentWrapper} enableShadow />
+                  </Box>
+                </FullscreenChartTile>
+              </div>
+              <div>
+                <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />
+              </div>
+            </TwoColumnLayout>
+          </Box>
+        </Box>
       </Box>
     </Layout>
   );
@@ -97,7 +100,7 @@ const RichContentWrapper = styled('div')`
 const TwoColumnLayout = styled(Box)`
   display: grid;
   grid-template-columns: 1fr;
-  gap: ${space[4]};
+  gap: ${space[4]} ${space[5]};
   
   @media ${mediaQueries.sm} {
     grid-template-columns: 1fr 1fr;

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -65,28 +65,25 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
           <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
           <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
         </Head>
-
-        <Box textVariant="body1" bg="white">
-          <Box paddingBottom={space[5]}>
-            <Box marginBottom={space[4]} maxWidth={sizes.maxWidthText}>
-              <Heading variant="h2" level={1}>
-                {content.title}
-              </Heading>
-            </Box>
-            <TwoColumnLayout>
-              <div>
-                <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />
-                <FullscreenChartTile disableBorder>
-                  <Box marginTop={space[2]}>
-                    <ContentImage node={content.timelineImage} contentWrapper={RichContentWrapper} enableShadow />
-                  </Box>
-                </FullscreenChartTile>
-              </div>
-              <div>
-                <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />
-              </div>
-            </TwoColumnLayout>
+        <Box paddingBottom={space[5]}>
+          <Box marginBottom={space[4]} maxWidth={sizes.maxWidthText}>
+            <Heading variant="h2" level={1}>
+              {content.title}
+            </Heading>
           </Box>
+          <TwoColumnLayout>
+            <div>
+              <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />
+              <FullscreenChartTile disableBorder>
+                <Box marginTop={space[2]}>
+                  <ContentImage node={content.timelineImage} contentWrapper={RichContentWrapper} enableShadow />
+                </Box>
+              </FullscreenChartTile>
+            </div>
+            <div>
+              <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />
+            </div>
+          </TwoColumnLayout>
         </Box>
       </Box>
     </Layout>

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -3,22 +3,19 @@ import Head from 'next/head';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
 import { RichContent } from '~/components/cms/rich-content';
+import { MaxWidth } from '~/components/max-width';
 import { Heading } from '~/components/typography';
-import { Content } from '~/domain/layout/content';
 import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetContent,
-  getLastGeneratedDate,
-} from '~/static-props/get-data';
-import { RichContentBlock } from '~/types/cms';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
+import { space } from '~/style/theme';
+import { ImageBlock, RichContentBlock } from '~/types/cms';
 interface OverData {
   title: string | null;
+  intro: RichContentBlock[] | null;
   description: RichContentBlock[] | null;
+  timelineImage: ImageBlock | null;
 }
 
 export const getStaticProps = createGetStaticProps(
@@ -26,19 +23,41 @@ export const getStaticProps = createGetStaticProps(
   createGetContent<OverData>((context) => {
     const { locale = 'nl' } = context;
     return `
-    *[_type == 'overDitDashboard']{
-      ...,
-      "description": {
-        "_type": description._type,
-        "${locale}": [
-          ...description.${locale}[]
-          {
-            ...,
-            "asset": asset->
-           },
-        ]
-      }
-    }[0]
+      *[
+          _type == 'overDitDashboard' && !(_id in path('drafts.**'))
+      ][0]{...,
+        "description": {
+          "_type": description._type,
+          "${locale}": [
+            ...description.${locale}[]
+            {
+              ...,
+              "asset": asset->
+             },
+          ]
+        },
+        "intro": {
+          "_type": intro._type && !(_id in path('drafts.**')),
+          "${locale}": [
+            ...intro.${locale}[]
+            {
+              ...,
+              "asset": asset->
+             },
+          ]
+        },
+        "timelineImage": {
+          "_type": timelineImage._type && !(_id in path('drafts.**')),
+          "${locale}": [
+            ...intro.${locale}[]
+            {
+              "alt": alt,
+              "caption": caption,
+              "asset": asset->
+            },
+          ]
+        }
+      },
     `;
   })
 );
@@ -50,30 +69,19 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
   return (
     <Layout {...commonTexts.over_metadata} lastGenerated={lastGenerated}>
       <Head>
-        <link
-          key="dc-type"
-          rel="dcterms:type"
-          href="https://standaarden.overheid.nl/owms/terms/webpagina"
-        />
-        <link
-          key="dc-type-title"
-          rel="dcterms:type"
-          href="https://standaarden.overheid.nl/owms/terms/webpagina"
-          title="webpagina"
-        />
+        <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
+        <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
       </Head>
 
-      <Content>
-        <Box spacing={4}>
-          {content.title && <Heading level={1}>{content.title}</Heading>}
-          {content.description && (
-            <RichContent
-              blocks={content.description}
-              contentWrapper={RichContentWrapper}
-            />
-          )}
-        </Box>
-      </Content>
+      <Box textVariant="body1" bg="white">
+        <MaxWidth paddingTop={space[6]} paddingBottom={space[5]} paddingX={{ _: space[3], sm: '0' }}>
+          <Box spacing={4}>{content.title && <Heading level={1}>{content.title}</Heading>}</Box>
+          <Box spacing={4} display="grid" gridTemplateColumns={{ _: '1fr', xl: '1fr 1fr' }} gridGap={space[6]}>
+            <div>{content.intro && <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />}</div>
+            <div>{content.description && <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />}</div>
+          </Box>
+        </MaxWidth>
+      </Box>
     </Layout>
   );
 };

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -101,9 +101,8 @@ const TwoColumnLayout = styled(Box)`
   display: grid;
   grid-template-columns: 1fr;
   gap: ${space[4]} ${space[5]};
-  
+
   @media ${mediaQueries.sm} {
     grid-template-columns: 1fr 1fr;
   }
-}
 `;

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -1,15 +1,16 @@
-import css from '@styled-system/css';
 import Head from 'next/head';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
+import { ContentImage } from '~/components/cms/content-image';
 import { RichContent } from '~/components/cms/rich-content';
+import { FullscreenChartTile } from '~/components/fullscreen-chart-tile';
 import { MaxWidth } from '~/components/max-width';
 import { Heading } from '~/components/typography';
 import { Layout } from '~/domain/layout/layout';
 import { useIntl } from '~/intl';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
-import { space } from '~/style/theme';
+import { mediaQueries, space } from '~/style/theme';
 import { ImageBlock, RichContentBlock } from '~/types/cms';
 interface OverData {
   title: string | null;
@@ -22,7 +23,7 @@ export const getStaticProps = createGetStaticProps(
   getLastGeneratedDate,
   createGetContent<OverData>((context) => {
     const { locale = 'nl' } = context;
-    return `
+    return `// groq
       *[
           _type == 'overDitDashboard' && !(_id in path('drafts.**'))
       ][0]{...,
@@ -37,7 +38,7 @@ export const getStaticProps = createGetStaticProps(
           ]
         },
         "intro": {
-          "_type": intro._type && !(_id in path('drafts.**')),
+          "_type": intro._type,
           "${locale}": [
             ...intro.${locale}[]
             {
@@ -47,17 +48,11 @@ export const getStaticProps = createGetStaticProps(
           ]
         },
         "timelineImage": {
-          "_type": timelineImage._type && !(_id in path('drafts.**')),
-          "${locale}": [
-            ...intro.${locale}[]
-            {
-              "alt": alt,
-              "caption": caption,
-              "asset": asset->
+          "_type": timelineImage._type,
+          "${locale}": {...timelineImage.${locale},
             },
-          ]
         }
-      },
+      }
     `;
   })
 );
@@ -74,22 +69,38 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
       </Head>
 
       <Box textVariant="body1" bg="white">
-        <MaxWidth paddingTop={space[6]} paddingBottom={space[5]} paddingX={{ _: space[3], sm: '0' }}>
-          <Box spacing={4}>{content.title && <Heading level={1}>{content.title}</Heading>}</Box>
-          <Box spacing={4} display="grid" gridTemplateColumns={{ _: '1fr', xl: '1fr 1fr' }} gridGap={space[6]}>
-            <div>{content.intro && <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />}</div>
+        <MaxWidth paddingTop={space[6]} paddingBottom={space[5]} paddingX={space[3]}>
+          <TwoColumnLayout>
+            <Box spacing={4}>{content.title && <Heading level={1}>{content.title}</Heading>}</Box>
+          </TwoColumnLayout>
+          <TwoColumnLayout>
+            <Box>
+              {content.intro && <RichContent blocks={content.intro} contentWrapper={RichContentWrapper} />}
+              <FullscreenChartTile disableBorder>
+                <Box marginTop={space[2]}>{content.timelineImage && <ContentImage node={content.timelineImage} contentWrapper={RichContentWrapper} enableShadow />}</Box>
+              </FullscreenChartTile>
+            </Box>
             <div>{content.description && <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />}</div>
-          </Box>
+          </TwoColumnLayout>
         </MaxWidth>
       </Box>
     </Layout>
   );
 };
 
-const RichContentWrapper = styled.div(
-  css({
-    width: '100%',
-  })
-);
-
 export default Over;
+
+const RichContentWrapper = styled('div')`
+  width: 100%;
+`;
+
+const TwoColumnLayout = styled(Box)`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: ${space[4]};
+  
+  @media ${mediaQueries.sm} {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+`;

--- a/packages/cms/src/schemas/documents/pages/about.ts
+++ b/packages/cms/src/schemas/documents/pages/about.ts
@@ -15,7 +15,7 @@ export const about = defineType({
     defineField({
       name: 'intro',
       type: 'localeBlock',
-      title: 'introductie (linker column)',
+      title: 'Introductie (linker column)',
       validation: localeValidation((rule) => rule.required()),
     }),
     defineField({

--- a/packages/cms/src/schemas/documents/pages/about.ts
+++ b/packages/cms/src/schemas/documents/pages/about.ts
@@ -15,7 +15,7 @@ export const about = defineType({
     defineField({
       name: 'intro',
       type: 'localeBlock',
-      title: 'Introductie (linker column)',
+      title: 'Introductie (linkerkolom)',
       validation: localeValidation((rule) => rule.required()),
     }),
     defineField({
@@ -27,7 +27,7 @@ export const about = defineType({
     defineField({
       name: 'description',
       type: 'localeBlock',
-      title: 'Beschrijving (rechter column)',
+      title: 'Beschrijving (rechterkolom)',
       validation: localeValidation((rule) => rule.required()),
     }),
   ],

--- a/packages/cms/src/schemas/documents/pages/about.ts
+++ b/packages/cms/src/schemas/documents/pages/about.ts
@@ -13,9 +13,21 @@ export const about = defineType({
       validation: localeStringValidation((rule) => rule.required()),
     }),
     defineField({
+      name: 'intro',
+      type: 'localeBlock',
+      title: 'introductie (linker column)',
+      validation: localeValidation((rule) => rule.required()),
+    }),
+    defineField({
+      name: 'timelineImage',
+      type: 'localeImage',
+      title: 'Afbeelding tijdslijn',
+      validation: localeValidation((rule) => rule.required()),
+    }),
+    defineField({
       name: 'description',
       type: 'localeBlock',
-      title: 'Beschrijving',
+      title: 'Beschrijving (rechter column)',
       validation: localeValidation((rule) => rule.required()),
     }),
   ],

--- a/packages/cms/src/schemas/index.ts
+++ b/packages/cms/src/schemas/index.ts
@@ -38,11 +38,12 @@ import { block } from './locale/block';
 import { richContentBlock } from './locale/rich-content-block';
 import { string } from './locale/string';
 import { text } from './locale/text';
+import { image } from './locale/image';
 import { inlineBlock } from './objects/inline-block';
 import { inlineCollapsible } from './objects/inline-collapsible';
 import { link } from './objects/link';
 
-const localeSpecificSchemas = [block, richContentBlock, string, text];
+const localeSpecificSchemas = [block, richContentBlock, string, text, image];
 const richContentSchemas = [inlineBlock, inlineCollapsible];
 const documentSchemas = [
   advice,

--- a/packages/cms/src/schemas/locale/image.ts
+++ b/packages/cms/src/schemas/locale/image.ts
@@ -2,10 +2,6 @@ import { StringRule, defineField, defineType } from 'sanity';
 import { supportedLanguages } from '../../studio/i18n';
 import { BsCardImage } from 'react-icons/bs';
 
-export type LocaleText = {
-  [key: string]: string;
-};
-
 export const image = defineType({
   name: 'localeImage',
   type: 'object',

--- a/packages/cms/src/schemas/locale/image.ts
+++ b/packages/cms/src/schemas/locale/image.ts
@@ -1,4 +1,4 @@
-import { StringRule, defineField, defineType } from 'sanity';
+import { defineField, defineType } from 'sanity';
 import { supportedLanguages } from '../../studio/i18n';
 import { BsCardImage } from 'react-icons/bs';
 

--- a/packages/cms/src/schemas/locale/image.ts
+++ b/packages/cms/src/schemas/locale/image.ts
@@ -20,12 +20,13 @@ export const image = defineType({
           name: 'alt',
           title: 'Alternatieve tekst (toegankelijkheid)',
           type: 'string',
-          validation: (rule: StringRule) => rule.required().error('Alt text is verplicht'),
+          validation: (rule) => rule.required().error('Alt text is verplicht'),
         }),
         defineField({
           name: 'isFullWidth',
           title: 'Afbeelding breed weergeven?',
           type: 'boolean',
+          initialValue: false,
         }),
         defineField({
           name: 'caption',

--- a/packages/cms/src/schemas/locale/image.ts
+++ b/packages/cms/src/schemas/locale/image.ts
@@ -1,0 +1,42 @@
+import { StringRule, defineField, defineType } from 'sanity';
+import { supportedLanguages } from '../../studio/i18n';
+import { BsCardImage } from 'react-icons/bs';
+
+export type LocaleText = {
+  [key: string]: string;
+};
+
+export const image = defineType({
+  name: 'localeImage',
+  type: 'object',
+  title: 'Locale Image Content',
+  fields: supportedLanguages.map(({ title, id }) =>
+    defineField({
+      title,
+      name: id,
+      type: 'image',
+      icon: BsCardImage,
+      initialValue: {
+        isFullWidth: true,
+      },
+      fields: [
+        defineField({
+          name: 'alt',
+          title: 'Alternatieve tekst (toegankelijkheid)',
+          type: 'string',
+          validation: (rule: StringRule) => rule.required().error('Alt text is verplicht'),
+        }),
+        defineField({
+          name: 'isFullWidth',
+          title: 'Afbeelding breed weergeven?',
+          type: 'boolean',
+        }),
+        defineField({
+          name: 'caption',
+          title: 'Onderschrift',
+          type: 'text',
+        }),
+      ],
+    })
+  ),
+});

--- a/packages/cms/src/studio/data/data-structure.ts
+++ b/packages/cms/src/studio/data/data-structure.ts
@@ -75,7 +75,7 @@ export const dataStructure = {
       'admissions_on_date_of_reporting',
     ],
     tested_overall: ['infected', 'infected_moving_average', 'infected_moving_average_rounded', 'infected_per_100k', 'infected_per_100k_moving_average'],
-    sewer: ['average', 'total_number_of_samples', 'sampled_installation_count', 'total_installation_count', 'data_is_outdated'],
+    sewer: ['average', 'data_is_outdated'],
     vaccine_coverage_per_age_group: [
       'vaccination_type',
       'birthyear_range_12_plus',
@@ -112,7 +112,7 @@ export const dataStructure = {
     hospital_nice: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     hospital_nice_choropleth: ['admissions_on_date_of_admission', 'admissions_on_date_of_admission_per_100000', 'admissions_on_date_of_reporting'],
     tested_overall: ['infected_per_100k', 'infected'],
-    sewer: ['average', 'total_installation_count', 'data_is_outdated'],
+    sewer: ['average', 'data_is_outdated'],
     vaccine_coverage_per_age_group: [
       'vaccination_type',
       'birthyear_range_12_plus',


### PR DESCRIPTION
## Summary

features changed:
* Divided the content into two columns on the page.
* Extended the Sanity schema to accept two description fields: one for the left column and one for the right column.
* Added a new field in Sanity. where a image can be uploaded to the about page 
* Added a timeline image to the left column with interactive functionality, similar to the graphs on the dashboard. When clicked, the timeline will appear full screen, darkening the dashboard in the background.
* Added the ability to upload separate versions for both the NL and EN languages in Sanity.
* Included a caption for the figure/image, sourced from Sanity.


## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

<img width="1428" alt="Screenshot 2023-06-28 at 17 15 26" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/2ac8b8f3-8037-4e59-86a9-c1eb749dca29">
<img width="616" alt="Screenshot 2023-06-28 at 17 15 45" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/7ad4474f-0e0e-49c4-bd07-5ec292428ea9">

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="1618" alt="Screenshot 2023-06-28 at 17 13 41" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/1765e3e4-d222-4f1a-bfa4-3f484e97e848">
<img width="1722" alt="Screenshot 2023-06-28 at 17 13 49" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/479160a7-567d-4970-8faf-2c8d97709204">
<img width="761" alt="Screenshot 2023-06-28 at 17 14 51" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/a14a4d43-8eec-4110-9b31-135f943b0bdb">
<img width="619" alt="Screenshot 2023-06-28 at 17 15 39" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/6416e827-d8c0-4164-ba55-76d2deb40cb1">

</details>