### PR TITLE
bugfix: fixed minor alignment issue on national Variants page;

### DIFF
--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -141,15 +141,15 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               }}
             />
           )}
+
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+
+          {content.articles && content.articles.articles?.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
-
-        {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
-
-        {content.articles && content.articles.articles?.length > 0 && (
-          <InView rootMargin="400px">
-            <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
-          </InView>
-        )}
       </NlLayout>
     </Layout>
   );


### PR DESCRIPTION
## Summary

Fixing minor alignment issues on the National Variants page. Screenshots are added below, showing a before and after view.

### Before
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/11645255/cf0b2a39-c85b-4042-a753-5f99dbfa2830)

### After
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/11645255/6f9224db-9315-4732-b8ac-21b510eae090)

## Motivation

N/A

## Detailed design

N/A

## Drawbacks

N/A

## Alternatives

N/A

## Unresolved questions

N/A

### Governance

- [x] Documentation is added
- [x] Test cases are added or updated
- [x] I've read the contributing document https://github.com/minvws/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/minvws/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License
      https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/LICENSE.txt
      and the contributor license agreement https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/CLA.md
