### PR TITLE
fix(COR-1420): Fixed NL and GM links for the positive tests page

### DIFF
--- a/packages/app/src/components/sitemap/use-data-sitemap.ts
+++ b/packages/app/src/components/sitemap/use-data-sitemap.ts
@@ -14,7 +14,7 @@ export function useDataSitemap(base: 'nl' | 'gm', code?: string, data?: Pick<Nl,
         links: [
           {
             text: commonTexts.sidebar.metrics.positive_tests.title,
-            href: reverseRouter.gm.positiefTesten(code),
+            href: reverseRouter.gm.positieveTesten(code),
           },
           {
             text: commonTexts.sidebar.metrics.mortality.title,
@@ -58,7 +58,7 @@ export function useDataSitemap(base: 'nl' | 'gm', code?: string, data?: Pick<Nl,
       links: [
         {
           text: commonTexts.sidebar.metrics.positive_tests.title,
-          href: reverseRouter.nl.positiefTesten(),
+          href: reverseRouter.nl.positieveTesten(),
         },
         {
           text: commonTexts.sidebar.metrics.reproduction_number.title,

--- a/packages/app/src/domain/layout/logic/use-sidebar.tsx
+++ b/packages/app/src/domain/layout/logic/use-sidebar.tsx
@@ -28,7 +28,7 @@ const mapKeysToReverseRouter = {
   // Still the nursing home care name is used because of legacy naming inside of sanity's lokalize texts.
   nursing_home_care: 'kwetsbareGroepen',
   patients: 'patientenInBeeld',
-  positive_tests: 'positiefTesten',
+  positive_tests: 'positieveTesten',
   reproduction_number: 'reproductiegetal',
   sewage_measurement: 'rioolwater',
   tests: 'testen',

--- a/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
@@ -253,7 +253,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 dataOptions={{
                   selectedCode: data.code,
                   highlightSelection: true,
-                  getLink: reverseRouter.gm.positiefTesten,
+                  getLink: reverseRouter.gm.positieveTesten,
                 }}
               />
             </ChoroplethTile>

--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -332,7 +332,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                   },
                 }}
                 dataOptions={{
-                  getLink: reverseRouter.gm.positiefTesten,
+                  getLink: reverseRouter.gm.positieveTesten,
                 }}
               />
             </ChoroplethTile>

--- a/packages/common/src/data/reverse-router.ts
+++ b/packages/common/src/data/reverse-router.ts
@@ -17,7 +17,7 @@ export function getReverseRouter(isMobile: boolean) {
     nl: {
       index: () => (isMobile ? '/landelijk' : reverseRouter.nl.rioolwater()),
       vaccinaties: () => '/landelijk/vaccinaties',
-      positiefTesten: () => '/landelijk/positief-testen',
+      positieveTesten: () => '/landelijk/positieve-testen',
       testen: () => '/landelijk/testen',
       besmettelijkeMensen: () => '/landelijk/besmettelijke-mensen',
       reproductiegetal: () => '/landelijk/reproductiegetal',
@@ -39,7 +39,7 @@ export function getReverseRouter(isMobile: boolean) {
 
     gm: {
       index: (code?: string) => (code ? (isMobile ? `/gemeente/${code}` : reverseRouter.gm.rioolwater(code)) : '/gemeente'),
-      positiefTesten: (code: string) => `/gemeente/${code}/positief-testen`,
+      positieveTesten: (code: string) => `/gemeente/${code}/positieve-testen`,
       sterfte: (code: string) => `/gemeente/${code}/sterfte`,
       ziekenhuisopnames: (code: string) => `/gemeente/${code}/ziekenhuis-opnames`,
       rioolwater: (code: string) => `/gemeente/${code}/rioolwater`,


### PR DESCRIPTION
- Fixed the typo for the national and gm level link for positive tests