### PR TITLE
fix(COR-1690): fix incorrect date being shown at ggd-test graph

### DIFF
--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -196,7 +196,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                   infected_total: formatNumber(archivedDataGgdLastValue.infected),
                 })}
                 metadata={{
-                  date: getLastInsertionDateOfPage(data, ['tested_ggd']),
+                  date: getLastInsertionDateOfPage(data, ['tested_ggd_archived_20230321']),
                   source: textNl.ggd.bronnen.rivm,
                 }}
                 onSelectTimeframe={setConfirmedCasesInfectedPercentageTimeframe}


### PR DESCRIPTION
Fix graph positive ggd tests showing date of 1970