### PR TITLE
fix(COR-1666) wrong metric date

### DIFF
--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -28,7 +28,7 @@ import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
-const pageMetrics = ['disability_care'];
+const pageMetrics = ['disability_care_archived_20230126'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   categoryTexts: {

--- a/packages/app/src/pages/landelijk/thuiswonende-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-70-plussers.tsx
@@ -28,7 +28,7 @@ import { getBoundaryDateStartUnix } from '~/utils/get-boundary-date-start-unix';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 
-const pageMetrics = ['elderly_at_home'];
+const pageMetrics = ['elderly_at_home_archived_20230126'];
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,


### PR DESCRIPTION
## Summary

Replaced PageMetrics key to Archived key on  `gehandicaptenzorg` and `thuiswonende-70-plussers` pages.