### PR TITLE
Feature/cor 1713 spacing and sizing archived title

### DIFF
--- a/packages/app/src/components/divider.tsx
+++ b/packages/app/src/components/divider.tsx
@@ -11,14 +11,11 @@ import { space } from '~/style/theme';
  * top margin and bottom padding to add the correct spacing.
  */
 
-export const Divider = styled.div<{
-  hasPageInfoBlock?: boolean;
-}>(({ hasPageInfoBlock }) =>
+export const Divider = styled.div(
   css({
     width: '100%',
     borderTop: `solid 2px ${colors.gray2}`,
     marginTop: space[2],
-    marginBottom: hasPageInfoBlock ? space[8] : space[3],
     paddingY: space[2],
   })
 );

--- a/packages/app/src/components/divider.tsx
+++ b/packages/app/src/components/divider.tsx
@@ -13,13 +13,12 @@ import { space } from '~/style/theme';
 
 export const Divider = styled.div<{
   marginBottom?: any;
-  marginTop?: any;
-}>(({ marginBottom, marginTop }) =>
+}>(({ marginBottom }) =>
   css({
     width: '100%',
-    borderTop: `solid 2px ${colors.green3}`,
-    marginTop: marginTop,
-    marginBottom: marginBottom,
+    borderTop: `solid 2px ${colors.gray2}`,
+    marginTop: space[2],
+    marginBottom: `${marginBottom} !important`,
     paddingY: space[2],
   })
 );

--- a/packages/app/src/components/divider.tsx
+++ b/packages/app/src/components/divider.tsx
@@ -11,11 +11,15 @@ import { space } from '~/style/theme';
  * top margin and bottom padding to add the correct spacing.
  */
 
-export const Divider = styled.div(
+export const Divider = styled.div<{
+  marginBottom?: any;
+  marginTop?: any;
+}>(({ marginBottom, marginTop }) =>
   css({
     width: '100%',
-    borderTop: `solid 2px ${colors.gray2}`,
-    marginTop: space[2],
+    borderTop: `solid 2px ${colors.green3}`,
+    marginTop: marginTop,
+    marginBottom: marginBottom,
     paddingY: space[2],
   })
 );

--- a/packages/app/src/components/divider.tsx
+++ b/packages/app/src/components/divider.tsx
@@ -12,13 +12,13 @@ import { space } from '~/style/theme';
  */
 
 export const Divider = styled.div<{
-  marginBottom?: any;
-}>(({ marginBottom }) =>
+  hasPageInfoBlock: boolean;
+}>(({ hasPageInfoBlock }) =>
   css({
     width: '100%',
     borderTop: `solid 2px ${colors.gray2}`,
     marginTop: space[2],
-    marginBottom: `${marginBottom} !important`,
+    marginBottom: hasPageInfoBlock ? space[8] : space[3],
     paddingY: space[2],
   })
 );

--- a/packages/app/src/components/divider.tsx
+++ b/packages/app/src/components/divider.tsx
@@ -12,7 +12,7 @@ import { space } from '~/style/theme';
  */
 
 export const Divider = styled.div<{
-  hasPageInfoBlock: boolean;
+  hasPageInfoBlock?: boolean;
 }>(({ hasPageInfoBlock }) =>
   css({
     width: '100%',

--- a/packages/app/src/components/page-information-block/components/header.tsx
+++ b/packages/app/src/components/page-information-block/components/header.tsx
@@ -2,7 +2,7 @@ import css from '@styled-system/css';
 import React from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
-import { Heading } from '~/components/typography';
+import { Heading, HeadingLevel } from '~/components/typography';
 import { VisuallyHidden } from '~/components/visually-hidden';
 import { space } from '~/style/theme';
 import { useBreakpoints } from '~/utils/use-breakpoints';
@@ -17,9 +17,10 @@ type HeaderProps = {
   icon?: JSX.Element;
   category?: string;
   screenReaderCategory?: string;
+  level?: HeadingLevel;
 };
 
-export function Header({ icon, title, category, screenReaderCategory }: HeaderProps) {
+export function Header({ icon, title, category, screenReaderCategory, level }: HeaderProps) {
   const breakpoints = useBreakpoints();
   const isMediumScreen = breakpoints.md;
 
@@ -35,7 +36,7 @@ export function Header({ icon, title, category, screenReaderCategory }: HeaderPr
         </Box>
       )}
       {icon && isMediumScreen && <Icon gridArea="sideIcon">{icon}</Icon>}
-      <Heading level={1} hyphens="auto" css={css({ gridArea: 'title' })}>
+      <Heading level={level ? level : 1} hyphens="auto" css={css({ gridArea: 'title' })}>
         {title}
       </Heading>
     </GridLayout>

--- a/packages/app/src/components/page-information-block/components/header.tsx
+++ b/packages/app/src/components/page-information-block/components/header.tsx
@@ -20,7 +20,7 @@ type HeaderProps = {
   level?: HeadingLevel;
 };
 
-export function Header({ icon, title, category, screenReaderCategory, level }: HeaderProps) {
+export function Header({ icon, title, category, screenReaderCategory, level = 1 }: HeaderProps) {
   const breakpoints = useBreakpoints();
   const isMediumScreen = breakpoints.md;
 
@@ -36,7 +36,7 @@ export function Header({ icon, title, category, screenReaderCategory, level }: H
         </Box>
       )}
       {icon && isMediumScreen && <Icon gridArea="sideIcon">{icon}</Icon>}
-      <Heading level={level ? level : 1} hyphens="auto" css={css({ gridArea: 'title' })}>
+      <Heading level={level} hyphens="auto" css={css({ gridArea: 'title' })}>
         {title}
       </Heading>
     </GridLayout>

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Box } from '~/components/base';
 import { RichContent } from '~/components/cms/rich-content';
 import { Markdown } from '~/components/markdown';
-import { Anchor, BoldText, HeadingLevel } from '~/components/typography';
+import { Anchor, BoldText } from '~/components/typography';
 import { WarningTile } from '~/components/warning-tile';
 import { useIntl } from '~/intl';
 import { mediaQueries, radii, space } from '~/style/theme';
@@ -25,7 +25,6 @@ interface InformationBlockProps {
         href: string;
       }[]
     | null;
-  headingLevel?: HeadingLevel;
   metadata?: MetadataProps;
   referenceLink?: string;
   id?: string;

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -67,7 +67,6 @@ export function PageInformationBlock({
   warning,
   isArchivedHidden,
   pageInformationHeader,
-  headingLevel,
   onToggleArchived,
 }: InformationBlockProps) {
   const scopedWarning = useScopedWarning(vrNameOrGmName || '', warning || '');
@@ -95,8 +94,14 @@ export function PageInformationBlock({
   ) : null;
 
   return (
-    <Box as="header" id={id} spacing={{ _: 3, md: 4 }}>
-      {title && <Header level={headingLevel} icon={icon} title={title} category={category} screenReaderCategory={screenReaderCategory} />}
+    <Box
+      as="header"
+      id={id}
+      spacing={{ _: 3, md: 4 }}
+      borderTop={showArchivedToggleButton ? `solid 2px ${colors.gray2}` : undefined}
+      paddingTop={showArchivedToggleButton ? space[4] : undefined}
+    >
+      {title && <Header level={showArchivedToggleButton ? 3 : undefined} icon={icon} title={title} category={category} screenReaderCategory={screenReaderCategory} />}
       {scopedWarning && <WarningTile variant="emphasis" message={scopedWarning} icon={Warning} isFullWidth />}
 
       {description && (

--- a/packages/app/src/components/page-information-block/page-information-block.tsx
+++ b/packages/app/src/components/page-information-block/page-information-block.tsx
@@ -67,6 +67,7 @@ export function PageInformationBlock({
   warning,
   isArchivedHidden,
   pageInformationHeader,
+  headingLevel,
   onToggleArchived,
 }: InformationBlockProps) {
   const scopedWarning = useScopedWarning(vrNameOrGmName || '', warning || '');
@@ -95,7 +96,7 @@ export function PageInformationBlock({
 
   return (
     <Box as="header" id={id} spacing={{ _: 3, md: 4 }}>
-      {title && <Header icon={icon} title={title} category={category} screenReaderCategory={screenReaderCategory} />}
+      {title && <Header level={headingLevel} icon={icon} title={title} category={category} screenReaderCategory={screenReaderCategory} />}
       {scopedWarning && <WarningTile variant="emphasis" message={scopedWarning} icon={Warning} isFullWidth />}
 
       {description && (

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -221,7 +221,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             </InView>
           )}
 
-          <Divider marginTop={space[3]} marginBottom={space[8]} style={{ marginBottom: `0px` }} />
+          <Divider marginBottom={space[4]} />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -25,7 +25,6 @@ import { assert, replaceVariablesInText, useFormatLokalizePercentage, useReverse
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
-import { space } from '~/style/theme';
 
 const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage_archived_20220904'];
 
@@ -221,7 +220,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             </InView>
           )}
 
-          <Divider marginBottom={space[4]} />
+          <Divider />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -25,6 +25,7 @@ import { assert, replaceVariablesInText, useFormatLokalizePercentage, useReverse
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { space } from '~/style/theme';
 
 const pageMetrics = ['vaccine_coverage_per_age_group', 'vaccine_coverage_per_age_group_archived', 'booster_coverage_archived_20220904'];
 
@@ -220,7 +221,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             </InView>
           )}
 
-          <Divider />
+          <Divider style={{ marginBottom: space[3] }} />
           <PageInformationBlock
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -221,7 +221,8 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             </InView>
           )}
 
-          <Divider style={{ marginBottom: space[3] }} />
+          <Divider marginTop={space[3]} marginBottom={space[8]} style={{ marginBottom: `0px` }} />
+
           <PageInformationBlock
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}
@@ -229,6 +230,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
             headingLevel={3}
           />
+
           {hasHideArchivedCharts && (
             <>
               <VaccineCoverageToggleTile

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -226,6 +226,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             description={textNl.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
+            headingLevel={3}
           />
           {hasHideArchivedCharts && (
             <>

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -3,7 +3,6 @@ import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { isDefined, isPresent } from 'ts-is-present';
-import { Divider } from '~/components/divider';
 import { InView } from '~/components/in-view';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { PageArticlesTile } from '~/components/articles/page-articles-tile';
@@ -220,14 +219,11 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
             </InView>
           )}
 
-          <Divider />
-
           <PageInformationBlock
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
-            headingLevel={3}
           />
 
           {hasHideArchivedCharts && (

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -231,14 +231,6 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
             />
           </ChartTile>
 
-          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
-
-          {content.articles && content.articles.articles?.length > 0 && (
-            <InView rootMargin="400px">
-              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
-            </InView>
-          )}
-
           <Box spacing={5}>
             <TwoKpiSection>
               <KpiTile
@@ -370,6 +362,14 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               />
             </ChartTile>
           </Box>
+
+          {content.faqs && content.faqs.questions?.length > 0 && <PageFaqTile questions={content.faqs.questions} title={content.faqs.sectionTitle} />}
+
+          {content.articles && content.articles.articles?.length > 0 && (
+            <InView rootMargin="400px">
+              <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
+            </InView>
+          )}
         </TileList>
       </NlLayout>
     </Layout>

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -132,7 +132,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
             </InView>
           )}
 
-          <Divider />
+          <Divider style={{ marginBottom: space[3] }} />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -132,7 +132,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
             </InView>
           )}
 
-          <Divider style={{ marginBottom: space[3] }} />
+          <Divider marginBottom={space[4]} />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -136,7 +136,6 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
             description={textNl.section_archived.description}
             isArchivedHidden={isArchivedContentShown}
             onToggleArchived={() => setIsArchivedContentShown(!isArchivedContentShown)}
-            headingLevel={3}
           />
 
           {isArchivedContentShown && (

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -139,6 +139,7 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
             description={textNl.section_archived.description}
             isArchivedHidden={isArchivedContentShown}
             onToggleArchived={() => setIsArchivedContentShown(!isArchivedContentShown)}
+            headingLevel={3}
           />
 
           {isArchivedContentShown && (

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { AgeDemographic } from '~/components/age-demographic';
 import { Box } from '~/components/base/box';
 import { ChartTile } from '~/components/chart-tile';
-import { Divider } from '~/components/divider';
 import { InView } from '~/components/in-view';
 import { KpiTile } from '~/components/kpi-tile';
 import { KpiValue } from '~/components/kpi-value';
@@ -131,8 +130,6 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
               <PageArticlesTile articles={content.articles.articles} title={content.articles.sectionTitle} />
             </InView>
           )}
-
-          <Divider marginBottom={space[4]} />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -42,6 +42,7 @@ import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts'
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { useReverseRouter } from '~/utils/use-reverse-router';
+import { space } from '~/style/theme';
 
 const pageMetrics = [
   'vaccine_administered_doctors',
@@ -310,7 +311,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             </InView>
           )}
 
-          <Divider />
+          <Divider style={{ marginBottom: space[3] }} />
 
           <PageInformationBlock
             title={textNl.section_archived.title}

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -311,11 +311,13 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
           )}
 
           <Divider />
+
           <PageInformationBlock
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
+            headingLevel={3}
           />
           {hasHideArchivedCharts && (
             <>

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -4,7 +4,6 @@ import { isEmpty } from 'lodash';
 import { GetStaticPropsContext } from 'next';
 import { useState } from 'react';
 import { ChartTile } from '~/components/chart-tile';
-import { Divider } from '~/components/divider';
 import { InView } from '~/components/in-view';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { PageArticlesTile } from '~/components/articles/page-articles-tile';
@@ -310,14 +309,11 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             </InView>
           )}
 
-          <Divider hasPageInfoBlock />
-
           <PageInformationBlock
             title={textNl.section_archived.title}
             description={textNl.section_archived.description}
             isArchivedHidden={hasHideArchivedCharts}
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
-            headingLevel={3}
           />
 
           {hasHideArchivedCharts && (

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -319,6 +319,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             onToggleArchived={() => setHideArchivedCharts(!hasHideArchivedCharts)}
             headingLevel={3}
           />
+
           {hasHideArchivedCharts && (
             <>
               <BoosterShotCoveragePerAgeGroup

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -42,7 +42,6 @@ import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts'
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { useReverseRouter } from '~/utils/use-reverse-router';
-import { space } from '~/style/theme';
 
 const pageMetrics = [
   'vaccine_administered_doctors',
@@ -311,7 +310,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             </InView>
           )}
 
-          <Divider style={{ marginBottom: space[3] }} />
+          <Divider hasPageInfoBlock />
 
           <PageInformationBlock
             title={textNl.section_archived.title}


### PR DESCRIPTION
## Summary

Chaining the sizing of the title and moving one article section to the bottom

## Motivation

To maintain a clear hierarchy structure of the section on the pages

## Changes

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/141616488/d5d697da-f3cc-44c0-b55e-be4ddd4ce3c7)


