### PR TITLE
feat(COR-1666): Added extra categories to the Sewer choropleth

### DIFF
--- a/packages/app/src/components/choropleth-legenda.tsx
+++ b/packages/app/src/components/choropleth-legenda.tsx
@@ -16,27 +16,37 @@ interface ChoroplethLegendaProps {
 }
 
 export function ChoroplethLegenda({ title, thresholds, valueAnnotation, pageType, outdatedDataLabel }: ChoroplethLegendaProps) {
-  const { commonTexts } = useIntl();
+  const { commonTexts, formatNumber } = useIntl();
+
   const breakpoints = useBreakpoints(true);
 
-  const legendItems = thresholds.map(
-    (x: ChoroplethThresholdsValue, i) =>
-      ({
-        label: thresholds[i + 1]
-          ? replaceVariablesInText(commonTexts.common.value_until_value, {
-              value_1: x.threshold,
-              value_2: thresholds[i + 1].threshold,
-            })
-          : replaceVariablesInText(commonTexts.common.value_and_higher, {
-              value: x.threshold,
-            }),
-        shape: 'square',
-        color: x.color,
-      } as LegendItem)
-  );
+  const legendItems = thresholds.map((x: ChoroplethThresholdsValue, i) => {
+    let label = thresholds[i + 1]
+      ? replaceVariablesInText(commonTexts.common.value_until_value, {
+          value_1: formatNumber(x.threshold),
+          value_2: formatNumber(thresholds[i + 1].threshold),
+        })
+      : replaceVariablesInText(commonTexts.common.value_and_higher, {
+          value: formatNumber(x.threshold),
+        });
+    if (pageType === 'sewer' && i === 0 && x.threshold === 0) {
+      label = commonTexts.common.no_virus_particles_measured;
+    }
+    if (pageType === 'sewer' && i === 1) {
+      label = replaceVariablesInText(commonTexts.common.greate_than_value, {
+        value_1: x.threshold,
+        value_2: thresholds[i + 1].threshold,
+      });
+    }
+    return {
+      label: label,
+      shape: 'square',
+      color: x.color,
+    } as LegendItem;
+  });
 
   if (pageType === 'sewer') {
-    legendItems.push({
+    legendItems.unshift({
       label: outdatedDataLabel,
       shape: 'square',
       color: colors.yellow1,
@@ -48,7 +58,6 @@ export function ChoroplethLegenda({ title, thresholds, valueAnnotation, pageType
       {title && <Text variant="subtitle1">{title}</Text>}
 
       <Legend items={legendItems} columns={breakpoints.lg ? 1 : 2} />
-
       <ValueAnnotation>{valueAnnotation}</ValueAnnotation>
     </Box>
   );

--- a/packages/app/src/components/choropleth/logic/thresholds.ts
+++ b/packages/app/src/components/choropleth/logic/thresholds.ts
@@ -96,28 +96,36 @@ const sewerThresholds: ChoroplethThresholdsValue[] = [
     threshold: 0,
   },
   {
-    color: colors.scale.blue[0],
-    threshold: 0.01,
+    color: colors.scale.blueDetailed[0],
+    threshold: 0,
   },
   {
-    color: colors.scale.blue[1],
+    color: colors.scale.blueDetailed[1],
     threshold: 50,
   },
   {
-    color: colors.scale.blue[2],
+    color: colors.scale.blueDetailed[2],
     threshold: 250,
   },
   {
-    color: colors.scale.blue[3],
+    color: colors.scale.blueDetailed[3],
     threshold: 500,
   },
   {
-    color: colors.scale.blue[4],
+    color: colors.scale.blueDetailed[4],
     threshold: 750,
   },
   {
-    color: colors.scale.blue[5],
+    color: colors.scale.blueDetailed[5],
     threshold: 1000,
+  },
+  {
+    color: colors.scale.blueDetailed[6],
+    threshold: 1500,
+  },
+  {
+    color: colors.scale.blueDetailed[8],
+    threshold: 2000,
   },
 ];
 

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,3 @@
 timestamp,action,key,document_id,move_to
+2023-08-21T14:27:33.421Z,add,common.common.no_virus_particles_measured,J4TD0W3ViFgya1T3ReztMI,__
+2023-08-21T14:27:34.547Z,add,common.common.greate_than_value,hLG40qywMr1wCqg8ytKijJ,__


### PR DESCRIPTION
## Summary

- Moved the 'No recent measurements' block to the top of the legend
- Changed text from **0 tot 0.01** to **Geen virusdeeltjes gemeten**
- Changed **0.01** to **Groter dan 0 tot 50** and **Greater than 0 - up to 50**
- Changed **to** to **up to** for English locales (for all items)
- Change text format **1000** to **1.000** for the NL locale and **1,000** for the EN locale 
- Changed categories/thresholds **1000 en hoger** to **1.000 tot 1.500** (and equivalent for EN locale)
- Add threshold **1.500 tot 2.000** (and equivalent for EN locale)
- Add threshold **2.000 en hoger** (and equivalent for EN locale)

**_Before_**
<details>
  <summary>Toggle before screenshot</summary> 

<img width="987" alt="Screenshot 2023-08-22 at 09 45 38" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/17ad768f-690d-4212-ba2d-ad1cd356fd35">

</details>

**_After_**
<details>
  <summary>Toggle after screenshot</summary> 

<img width="910" alt="Screenshot 2023-08-22 at 09 46 13" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/5a330f72-d254-4a2a-bd60-5e99d48f968f">

</details>
