### PR TITLE
fix(zks-graphs): Fixed range dates to date

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -66,7 +66,7 @@ By making a commit to develop first, you prevent getting merge conflicts in
 later releases and the flow of the commit history is one-directional and
 easy to follow.
 
-1. Create a topic branch based on `develop`.
+1. Create a hotfix branch based on `develop`.
 2. Commit changes and create a PR on `develop` just like a normal feature
    branch.
 3. Merged the branch to `develop` using **squash and merge**.

--- a/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
@@ -106,6 +106,8 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
   const hospitalLastValue = getLastFilledValue(data.hospital_lcps);
   const icuLastValue = getLastFilledValue(data.intensive_care_lcps);
 
+  const valuesWithoutDateRange = data.hospital_lcps.values.map((value) => ({ ...value, date_end_unix: undefined, date_start_unix: undefined }));
+
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
   return (
@@ -171,7 +173,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'hospital_beds_occupied_over_time_chart',
                 }}
-                values={data.hospital_lcps.values}
+                values={valuesWithoutDateRange}
                 timeframe={hospitalBedsOccupiedOverTimeTimeframe}
                 forceLegend
                 seriesConfig={[
@@ -294,7 +296,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'hospital_patient_influx_over_time_chart',
                 }}
-                values={trimLeadingNullValues(data.hospital_lcps.values, 'influx_covid_patients')}
+                values={trimLeadingNullValues(valuesWithoutDateRange, 'influx_covid_patients')}
                 timeframe={hospitalPatientInfluxOverTimeTimeframe}
                 seriesConfig={[
                   {


### PR DESCRIPTION
- Graphs in ziekenhuizen-in-beeld were showing date-ranges on hover because of the KPI receiving date_unix, date_start_unix and date_end_unix. Now it displays a date on hover.