### PR TITLE
task: Remove add new document button in navbar

### DIFF
--- a/packages/cms/src/studio/document-options/document-options.ts
+++ b/packages/cms/src/studio/document-options/document-options.ts
@@ -4,8 +4,15 @@ import { PublishOrAcceptAction } from './custom-actions/publish-or-accept';
 
 // Removes lokalize from the global "create new" interface at the top left of the navigation bar.
 export const newDocumentOptions = (prev: TemplateResponse[], { creationContext }: { creationContext: NewDocumentCreationContext }) => {
-  if (creationContext.type === 'global' || creationContext.type === 'structure') {
+  if (creationContext.type === 'structure') {
     return prev.filter((templateItem) => templateItem.templateId !== 'lokalizeText');
+  }
+  if (creationContext.type === 'global') {
+    // Removes the button visually from the header
+
+    window.document.querySelector('style')?.append('[data-ui="Navbar"] button[aria-label^="Create new document"] {display: none}');
+    // Removes the functionality from the button in the header
+    return [];
   }
 
   return prev;


### PR DESCRIPTION
## Summary

* 
* This is already deployed to Sanity Studio.
* Sanity gives you no control over this part of the navbar.
* The only way to remove this icon and functionality is 'really' dirty, by injecting some CSS and returning an empty array.
* 

## Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-09-14 at 10 21 15](https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/b518bbcb-a3de-4dc7-a330-e8731fd277a0)

</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

<img width="625" alt="Screenshot 2023-09-14 at 10 20 27" src="https://github.com/minvws/nl-covid19-data-dashboard/assets/93984341/66f7db44-7d5d-445d-a5f6-0e24c6d7d028">

</details>