### PR TITLE
feature/COR-1611_Aligned_width_of_kpi_descriptions

### DIFF
--- a/packages/app/src/components/kpi/bordered-kpi-section.tsx
+++ b/packages/app/src/components/kpi/bordered-kpi-section.tsx
@@ -5,7 +5,6 @@ import { mediaQueries, space } from '~/style/theme';
 import { KpiTile } from '../kpi-tile';
 import { Metadata, MetadataProps } from '../metadata';
 import { TwoKpiSection } from '../two-kpi-section';
-import { Text } from '../typography';
 import { KpiContent } from './components/kpi-content';
 import { BorderedKpiSectionProps } from './types';
 
@@ -17,7 +16,7 @@ export const BorderedKpiSection = ({ title, description, source, dateOrRange, ti
 
   return (
     <KpiTile title={title} hasNoPaddingBottom>
-      <Text>{description}</Text>
+      <Box maxWidth="maxWidthText">{description}</Box>
       <TwoKpiSection spacing={5}>
         <KpiContentContainer>
           {tilesData.map((tile, index) => (


### PR DESCRIPTION
## Done
Fixed aligning width of kpi's descriptions.

### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-09-19 at 17 03 06](https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/d7343006-e16c-4f9e-adc6-53102558f027)


</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Screenshot 2023-09-19 at 17 02 54](https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/d5db87d9-6d33-44dd-bec2-04608d133d9c)


</details>

