### PR TITLE
fix(COR-1809): Remove unused variable replacement

### DIFF
--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -164,10 +164,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(currentData, pageMetrics);
 
-  const variables = {
-    regio: commonTexts.choropleth.choropleth_vaccination_coverage.nl,
-  };
-
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
       <NlLayout>
@@ -281,8 +277,8 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
             data={choropleth.gm}
             dataOptions={{ getLink: (gmcode) => reverseRouter.gm.vaccinaties(gmcode), isPercentage: true }}
             text={{
-              title: replaceVariablesInText(commonTexts.choropleth.choropleth_vaccination_coverage.nl.title, variables),
-              description: replaceVariablesInText(commonTexts.choropleth.choropleth_vaccination_coverage.nl.description, variables),
+              title: commonTexts.choropleth.choropleth_vaccination_coverage.nl.title,
+              description: commonTexts.choropleth.choropleth_vaccination_coverage.nl.description,
               vaccinationKindLabel: commonTexts.choropleth.vaccination_coverage.shared.dropdown_label_vaccination_coverage_kind_select,
               ageGroupLabel: commonTexts.choropleth.vaccination_coverage.shared.dropdown_label_age_group_select,
             }}


### PR DESCRIPTION
## Summary
- Wrongly used and unneccesary replaceVariablesInText call in vaccinations page is currently breaking the use of the sanity development dataset across all branches. This branch removes the call in order to fix the development pipeline.