### PR TITLE
feature/COR-1470_separate_source_from_value_row_on_kpi_tiles

### DIFF
--- a/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
@@ -24,12 +24,13 @@ interface TopicalTileProps {
   hideTrendIcon: boolean;
   kpiValue: string | null;
   sourceLabel: string | null;
+  dateLabel: string | null;
   tileIcon: TopicalIcon;
   title: string;
   trendIcon: TrendIconType;
 }
 
-export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue, cta, sourceLabel, hideTrendIcon }: TopicalTileProps) => {
+export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue, cta, sourceLabel, dateLabel, hideTrendIcon }: TopicalTileProps) => {
   const { formatNumber } = useIntl();
 
   const formattedKpiValue = typeof kpiValue === 'number' ? formatNumber(kpiValue) : typeof kpiValue === 'string' ? kpiValue : false;
@@ -45,7 +46,7 @@ export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue,
 
   return (
     <TopicalTileWrapper cta={cta}>
-      <Box display="flex" flexDirection="column" justifyContent="start">
+      <Box display="flex" flexDirection="column" justifyContent="start" flexGrow={1}>
         <Box display="flex" justifyContent="space-between">
           <Box fontSize={{ _: fontSizes[6], xs: fontSizes[7] }} paddingLeft={{ _: space[3], xs: space[4] }} paddingTop={{ _: space[3], xs: space[4] }}>
             <StyledHeading level={3} color={colors.blue8}>
@@ -79,6 +80,12 @@ export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue,
           <RichContent blocks={description} elementAlignment="start" variableValue={formattedKpiValue} />
         </Box>
       </Box>
+
+      {dateLabel && (
+        <Box padding={{ _: `0 ${space[3]} ${space[3]}`, xs: `0 ${space[4]} ${space[1]}` }}>
+          <InlineText color={colors.gray7}>{dateLabel}</InlineText>
+        </Box>
+      )}
 
       {sourceLabel && (
         <Box padding={{ _: `0 ${space[3]} ${space[3]}`, xs: `0 ${space[4]} ${space[4]}` }}>

--- a/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
@@ -82,7 +82,7 @@ export const TopicalTile = ({ title, tileIcon, trendIcon, description, kpiValue,
       </Box>
 
       {dateLabel && (
-        <Box padding={{ _: `0 ${space[3]} ${space[3]}`, xs: `0 ${space[4]} ${space[1]}` }}>
+        <Box padding={{ _: `0 ${space[3]} ${space[1]}`, xs: `0 ${space[4]} ${space[1]}` }}>
           <InlineText color={colors.gray7}>{dateLabel}</InlineText>
         </Box>
       )}

--- a/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
@@ -24,7 +24,7 @@ interface TopicalTileProps {
   hideTrendIcon: boolean;
   kpiValue: string | null;
   sourceLabel: string | null;
-  dateLabel: string | null;
+  dateLabel?: string | null;
   tileIcon: TopicalIcon;
   title: string;
   trendIcon: TrendIconType;

--- a/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
+++ b/packages/app/src/domain/topical/components/topical-kpi-tile/topical-tile.tsx
@@ -23,8 +23,8 @@ interface TopicalTileProps {
   description: PortableTextEntry[];
   hideTrendIcon: boolean;
   kpiValue: string | null;
-  sourceLabel: string | null;
-  dateLabel?: string | null;
+  sourceLabel?: string;
+  dateLabel?: string;
   tileIcon: TopicalIcon;
   title: string;
   trendIcon: TrendIconType;

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -114,7 +114,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                       marginBottom={{ _: space[4], sm: space[5] }}
                     >
                       {theme.tiles.map((themeTile) => {
-                        const sourceLabel = themeTile.sourceLabel ? replaceVariablesInText(themeTile.sourceLabel, { date: themeTile.tileDate }) : null;
+                        const dateLabel = themeTile.dateLabel ? replaceVariablesInText(themeTile.dateLabel, { date: themeTile.tileDate }) : null;
                         return (
                           <TopicalTile
                             hideTrendIcon={themeTile.hideTrendIcon}
@@ -125,7 +125,8 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                             cta={themeTile.cta}
                             key={themeTile.title}
                             kpiValue={themeTile.kpiValue}
-                            sourceLabel={sourceLabel}
+                            sourceLabel={themeTile.sourceLabel}
+                            dateLabel={dateLabel}
                           />
                         );
                       })}

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -114,7 +114,7 @@ const Home = (props: StaticProps<typeof getStaticProps>) => {
                       marginBottom={{ _: space[4], sm: space[5] }}
                     >
                       {theme.tiles.map((themeTile) => {
-                        const dateLabel = themeTile.dateLabel ? replaceVariablesInText(themeTile.dateLabel, { date: themeTile.tileDate }) : null;
+                        const dateLabel = themeTile.dateLabel ? replaceVariablesInText(themeTile.dateLabel, { date: themeTile.tileDate }) : undefined;
                         return (
                           <TopicalTile
                             hideTrendIcon={themeTile.hideTrendIcon}

--- a/packages/app/src/queries/get-topical-structure-query.ts
+++ b/packages/app/src/queries/get-topical-structure-query.ts
@@ -41,6 +41,7 @@ export function getTopicalStructureQuery(locale: string) {
             'description':description.${locale},
             tileIcon,
             'title':title.${locale},
+            'dateLabel':dateLabel.${locale},
             'sourceLabel':sourceLabel.${locale},
             'tileDate': tileDate.${locale},
             'kpiValue': kpiValue.${locale},

--- a/packages/app/src/queries/query-types.ts
+++ b/packages/app/src/queries/query-types.ts
@@ -83,7 +83,7 @@ export interface BaseTile {
 
 interface TopicalTile extends BaseTile {
   title: string;
-  dateLabel: string | null;
+  dateLabel?: string | null;
   sourceLabel: string | null;
   tileDate: string;
   kpiValue: string | null;

--- a/packages/app/src/queries/query-types.ts
+++ b/packages/app/src/queries/query-types.ts
@@ -83,6 +83,7 @@ export interface BaseTile {
 
 interface TopicalTile extends BaseTile {
   title: string;
+  dateLabel: string | null;
   sourceLabel: string | null;
   tileDate: string;
   kpiValue: string | null;

--- a/packages/app/src/queries/query-types.ts
+++ b/packages/app/src/queries/query-types.ts
@@ -83,8 +83,8 @@ export interface BaseTile {
 
 interface TopicalTile extends BaseTile {
   title: string;
-  dateLabel?: string | null;
-  sourceLabel: string | null;
+  dateLabel?: string;
+  sourceLabel?: string;
   tileDate: string;
   kpiValue: string | null;
   cta: Cta;

--- a/packages/cms-v2/src/schemas/topical/theme-tile.ts
+++ b/packages/cms-v2/src/schemas/topical/theme-tile.ts
@@ -59,6 +59,12 @@ export const themeTile = {
     {
       title: 'Metadata label',
       description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
+      name: 'dateLabel',
+      type: 'localeString',
+    },
+    {
+      title: 'Metadata label',
+      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
       name: 'sourceLabel',
       type: 'localeString',
     },

--- a/packages/cms-v2/src/schemas/topical/theme-tile.ts
+++ b/packages/cms-v2/src/schemas/topical/theme-tile.ts
@@ -59,12 +59,6 @@ export const themeTile = {
     {
       title: 'Metadata label',
       description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
-      name: 'dateLabel',
-      type: 'localeString',
-    },
-    {
-      title: 'Metadata label',
-      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
       name: 'sourceLabel',
       type: 'localeString',
     },

--- a/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
+++ b/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
@@ -64,6 +64,12 @@ export const themeTile = defineType({
     defineField({
       title: 'Metadata label',
       description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
+      name: 'dateLabel',
+      type: 'localeString',
+    }),
+    defineField({
+      title: 'Source label',
+      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
       name: 'sourceLabel',
       type: 'localeString',
     }),

--- a/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
+++ b/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
@@ -69,7 +69,7 @@ export const themeTile = defineType({
     }),
     defineField({
       title: 'Source label',
-      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
+      description: 'Deze velden krijgen hun input van de bron.   Deze kan handmatig overschreven worden.',
       name: 'sourceLabel',
       type: 'localeString',
     }),

--- a/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
+++ b/packages/cms/src/schemas/documents/pages/homepage/theme-tile.ts
@@ -63,13 +63,13 @@ export const themeTile = defineType({
     }),
     defineField({
       title: 'Metadata label',
-      description: 'Bij {{date}} wordt de tekst geplaatst van het tegeldatumveld. Deze kan handmatig overschreven worden.',
+      description: 'Bij {{date}} is de tekst van het tegeldatumveld optioneel',
       name: 'dateLabel',
       type: 'localeString',
     }),
     defineField({
       title: 'Source label',
-      description: 'Deze velden krijgen hun input van de bron.   Deze kan handmatig overschreven worden.',
+      description: 'Deze velden zijn optionele broninformatie.',
       name: 'sourceLabel',
       type: 'localeString',
     }),


### PR DESCRIPTION
## Summary
The date and source were splitted by creating an extra sanity field. Now they are on separate lines and alined.

### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![Screenshot 2023-09-21 at 13 39 40](https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/3413fe1a-504d-4dcf-b073-6d7d2f9a1360)


</details>

#### After
<details>
<summary>Toggle after screenshots</summary>

![Screenshot 2023-09-21 at 13 40 10](https://github.com/minvws/nl-covid19-data-dashboard/assets/111750729/366abde7-481c-4baa-b800-550724efb981)



</details>

