### PR TITLE
fix: Rename schemas to avoid conflicting names and update types

### DIFF
--- a/packages/app/schema/archived_nl/vaccinaties/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/archived_nl/vaccinaties/vaccine_coverage_per_age_group.json
@@ -14,7 +14,7 @@
   },
   "definitions": {
     "value": {
-      "title": "archived_nl_vaccine_coverage_per_age_group_value",
+      "title": "archived_nl_vaccine_coverage_per_age_group_autumn_2022_value",
       "additionalProperties": false,
       "type": "object",
       "required": [

--- a/packages/app/schema/archived_nl/vaccine_coverage_per_age_group.json
+++ b/packages/app/schema/archived_nl/vaccine_coverage_per_age_group.json
@@ -14,7 +14,7 @@
   },
   "definitions": {
     "value": {
-      "title": "archived_nl_vaccine_coverage_per_age_group_value",
+      "title": "archived_nl_vaccine_coverage_per_age_group_primary_series_and_booster_value",
       "additionalProperties": false,
       "type": "object",
       "required": [

--- a/packages/app/src/domain/vaccine/autumn-2022-shot-coverage-per-age-group/autumn-2022-shot-coverage-per-age-group.tsx
+++ b/packages/app/src/domain/vaccine/autumn-2022-shot-coverage-per-age-group/autumn-2022-shot-coverage-per-age-group.tsx
@@ -1,4 +1,4 @@
-import { NlVaccineCoveragePerAgeGroupValue } from '@corona-dashboard/common';
+import { ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value } from '@corona-dashboard/common';
 import { AgeGroup } from '~/components/age-groups/age-group';
 import { ChartTile } from '~/components/chart-tile';
 import { MetadataProps } from '~/components/metadata';
@@ -16,7 +16,7 @@ interface Autumn2022ShotCoveragePerAgeGroupProps {
   description: string;
   metadata: MetadataProps;
   sortingOrder: string[];
-  values: NlVaccineCoveragePerAgeGroupValue[];
+  values: ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value[];
   text: SiteText['pages']['vaccinations_page']['nl']['vaccination_coverage'];
 }
 

--- a/packages/app/src/domain/vaccine/primary-series-coverage-per-age-group/primary-series-coverage-per-age-group.tsx
+++ b/packages/app/src/domain/vaccine/primary-series-coverage-per-age-group/primary-series-coverage-per-age-group.tsx
@@ -1,4 +1,4 @@
-import { NlVaccineCoveragePerAgeGroupValue } from '@corona-dashboard/common';
+import { ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value } from '@corona-dashboard/common';
 import { AgeGroup } from '~/components/age-groups/age-group';
 import { ChartTile } from '~/components/chart-tile';
 import { MetadataProps } from '~/components/metadata';
@@ -16,7 +16,7 @@ interface PrimarySeriesShotCoveragePerAgeGroupProps {
   description: string;
   metadata: MetadataProps;
   sortingOrder: string[];
-  values: NlVaccineCoveragePerAgeGroupValue[];
+  values: ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value[];
   text: SiteText['pages']['vaccinations_page']['nl']['vaccination_coverage'];
 }
 

--- a/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group/vaccine-coverage-per-age-group.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-per-age-group/vaccine-coverage-per-age-group.tsx
@@ -1,4 +1,4 @@
-import { ArchivedGmVaccineCoveragePerAgeGroupValue, ArchivedNlVaccineCoveragePerAgeGroupValue } from '@corona-dashboard/common';
+import { ArchivedGmVaccineCoveragePerAgeGroupValue, ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBoosterValue } from '@corona-dashboard/common';
 import { AgeGroup } from '~/components/age-groups/age-group';
 import { ChartTile } from '~/components/chart-tile';
 import { MetadataProps } from '~/components/metadata';
@@ -16,7 +16,7 @@ interface VaccineCoveragePerAgeGroupProps {
   description: string;
   metadata: MetadataProps;
   sortingOrder: string[];
-  values: ArchivedNlVaccineCoveragePerAgeGroupValue[] | ArchivedGmVaccineCoveragePerAgeGroupValue[];
+  values: ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBoosterValue[] | ArchivedGmVaccineCoveragePerAgeGroupValue[];
   text: SiteText['pages']['vaccinations_page']['nl'];
 }
 

--- a/packages/app/src/static-props/vaccinations/get-coverage-per-age-group-latest-values.ts
+++ b/packages/app/src/static-props/vaccinations/get-coverage-per-age-group-latest-values.ts
@@ -1,14 +1,10 @@
-import { NlVaccineCoveragePerAgeGroupValue } from '@corona-dashboard/common';
+import { ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value } from '@corona-dashboard/common';
 
-export function getCoveragePerAgeGroupLatestValues(
-  values: NlVaccineCoveragePerAgeGroupValue[]
-) {
+export function getCoveragePerAgeGroupLatestValues(values: ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value[]) {
   /**
    * Get all the unique age groups in the data.
    */
-  const uniqueAgeKeys = [
-    ...new Set(values.map((item) => item.age_group_range).flat()),
-  ];
+  const uniqueAgeKeys = [...new Set(values.map((item) => item.age_group_range).flat())];
 
   /**
    * Per unique age group get the latest value available.

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -211,7 +211,7 @@ export interface ArchivedNl {
   vaccine_campaigns_archived_20220908: ArchivedNlVaccineCampaigns_2022;
   vaccine_campaigns_archived_20231004: ArchivedNlVaccineCampaign_2023;
   vaccine_planned_archived_20220908: ArchivedNlVaccinePlanned;
-  vaccine_coverage_per_age_group_archived_20220622: ArchivedNlVaccineCoveragePerAgeGroup;
+  vaccine_coverage_per_age_group_archived_20220622: ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBooster;
   vaccine_coverage_per_age_group_archived_20220908: ArchivedNlVaccineCoveragePerAgeGroupWithBoosterShot;
   vaccine_coverage_per_age_group_estimated_archived_20220908: NlVaccineCoveragePerAgeGroupEstimatedArchived_20220908Value;
   vulnerable_nursing_home_archived_20230711: ArchivedNlVulnerableNursingHome;
@@ -226,7 +226,7 @@ export interface ArchivedNl {
   vaccine_administered_total_archived_20220324: NlVaccineAdministeredTotal;
   vaccine_administered_planned_archived_20220518: NlVaccineAdministeredPlanned;
   vaccine_coverage_archived_20220518: ArchivedNlVaccineCoverage;
-  vaccine_coverage_per_age_group_archived_20231004: NlVaccineCoveragePerAgeGroup;
+  vaccine_coverage_per_age_group_archived_20231004: ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022;
   vaccine_coverage_per_age_group_estimated_autumn_2022_archived_20231004: NlVaccineCoveragePerAgeGroupEstimatedAutumn_2022Value;
   vaccine_coverage_per_age_group_estimated_fully_vaccinated_archived_20231004: NlVaccineCoveragePerAgeGroupEstimatedFullyVaccinatedValue;
   vaccine_delivery_per_supplier_archived_20211101: ArchivedNlVaccineDeliveryPerSupplier;
@@ -574,10 +574,10 @@ export interface ArchivedNlVaccinePlanned {
   date_end_unix: number;
   date_of_insertion_unix: number;
 }
-export interface ArchivedNlVaccineCoveragePerAgeGroup {
-  values: ArchivedNlVaccineCoveragePerAgeGroupValue[];
+export interface ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBooster {
+  values: ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBoosterValue[];
 }
-export interface ArchivedNlVaccineCoveragePerAgeGroupValue {
+export interface ArchivedNlVaccineCoveragePerAgeGroupPrimarySeriesAndBoosterValue {
   age_group_range: '5-11' | '12-17' | '18-30' | '31-40' | '41-50' | '51-60' | '61-70' | '71-80' | '81+';
   age_group_percentage: number;
   age_group_total: number;
@@ -752,10 +752,10 @@ export interface ArchivedNlVaccineCoverageValue {
   date_unix: number;
   date_of_insertion_unix: number;
 }
-export interface NlVaccineCoveragePerAgeGroup {
-  values: NlVaccineCoveragePerAgeGroupValue[];
+export interface ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022 {
+  values: ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value[];
 }
-export interface NlVaccineCoveragePerAgeGroupValue {
+export interface ArchivedNlVaccineCoveragePerAgeGroupAutumn_2022Value {
   age_group_range: '5-11' | '12-17' | '18-29' | '30-39' | '40-49' | '50-59' | '60-69' | '70-79' | '80+';
   age_group_percentage: number;
   age_group_total: number;


### PR DESCRIPTION
- Update titles in vaccine_coverage_per_age_group.json
- Update types