### PR TITLE
bugfix(COR-1801): Removed the duplicated metadata and fixed date

### DIFF
--- a/packages/app/src/domain/vaccine/vaccine-coverage-toggle-tile.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-coverage-toggle-tile.tsx
@@ -71,7 +71,7 @@ export function VaccineCoverageToggleTile({
   };
 
   return (
-    <KpiTile title={title} metadata={metadata}>
+    <KpiTile title={title}>
       <Box css={css({ '& div': { justifyContent: 'flex-start' } })} marginBottom={space[3]}>
         <RadioGroup
           value={selectedTab}

--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -116,7 +116,7 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
     archivedData.vaccine_coverage_per_age_group_archived_20220908.values.find((x) => x.age_group_range === '12+') ||
     emptyCoverageData.vaccine_coverage_per_age_group_archived_20220908.values[1];
 
-  const lastInsertionDateOfPage = getLastInsertionDateOfPage(currentData, pageMetrics);
+  const lastInsertionDateOfPage = getLastInsertionDateOfPage(archivedData, pageMetrics);
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>


### PR DESCRIPTION
 - Fixed PageInformationBlock on municipality page rendering 1 January 1970.
 - Fixed the duplicated metadata from the Vaccine coverage KPI tile.