### PR TITLE
Bugfix/cor 1784 corrections releaseday

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
+++ b/packages/app/src/pages/gemeente/[code]/vaccinaties.tsx
@@ -16,7 +16,7 @@ import { VaccineCoveragePerAgeGroup, VaccineCoverageToggleTile } from '~/domain/
 import { VaccineCoverageChoropleth } from '~/domain/vaccine/vaccine-coverage-choropleth';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
 import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectGmData, selectArchivedGmData, createGetArchivedChoroplethData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
@@ -77,7 +77,6 @@ export const getStaticProps = createGetStaticProps(
         articles: getArticleParts(content.pageParts, 'vaccinationsPageArticles'),
         faqs: getFaqParts(content.pageParts, 'vaccinationsPageFAQs'),
         dataExplained: getDataExplainedParts(content.pageParts, 'vaccinationsPageDataExplained'),
-        links: getLinkParts(content.pageParts, 'vaccinationsPageLinks'),
       },
     };
   }
@@ -140,7 +139,6 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textShared.bronnen.rivm],
             }}
-            pageLinks={content.links}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}
             pageInformationHeader={getPageInformationHeaderContent({

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -290,8 +290,8 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
           <PrimarySeriesShotCoveragePerAgeGroup
             text={textNl.vaccination_coverage}
-            title={textNl.vaccination_coverage.title}
-            description={textNl.vaccination_coverage.description_autumn_2022_shot}
+            title={textNl.vaccination_coverage.title_primary_series}
+            description={textNl.vaccination_coverage.description_primary_shot}
             sortingOrder={['80+', '70-79', '60-69', '50-59', '40-49', '30-39', '18-29', '12-17', '5-11']}
             metadata={{
               datumsText: textNl.dates,
@@ -376,7 +376,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
               <Autumn2022ShotCoveragePerAgeGroup
                 text={textNl.vaccination_coverage}
-                title={textNl.vaccination_coverage.title}
+                title={textNl.vaccination_coverage.title_autumn_2022_shot}
                 description={textNl.vaccination_coverage.description_autumn_2022_shot}
                 sortingOrder={['80+', '70-79', '60-69', '50-59', '40-49', '30-39', '18-29', '12-17', '5-11']}
                 metadata={{
@@ -389,8 +389,8 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
               <BoosterShotCoveragePerAgeGroup
                 text={textNl}
-                title={textNl.vaccination_coverage.title}
-                description={textNl.archived.vaccination_coverage.top_level_description_booster_shot}
+                title={textNl.vaccination_coverage.title_archived}
+                description={textNl.vaccination_coverage.description_archived}
                 sortingOrder={['80+', '70-79', '60-69', '50-59', '40-49', '30-39', '18-29', '12-17', '5-11']}
                 metadata={{
                   datumsText: textNl.datums,

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -116,7 +116,6 @@ export const getStaticProps = createGetStaticProps(
         articles: getArticleParts(content.parts.pageParts, 'vaccinationsPageArticles'),
         faqs: getFaqParts(content.parts.pageParts, 'vaccinationsPageFAQs'),
         dataExplained: getDataExplainedParts(content.parts.pageParts, 'vaccinationsPageDataExplained'),
-        links: getLinkParts(content.parts.pageParts, 'vaccinationsPageLinks'),
         boosterArticles: getArticleParts(content.parts.pageParts, 'vaccineBoosterArticles'),
         thirdShotArticles: getArticleParts(content.parts.pageParts, 'vaccineThirdShotArticles'),
         boosterLinks: getLinkParts(content.parts.pageParts, 'vaccinationsBoosterPageLinks'),
@@ -189,7 +188,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textShared.bronnen.rivm],
             }}
-            pageLinks={content.links}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,
               faq: content.faqs,

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -45,3 +45,9 @@ timestamp,action,key,document_id,move_to
 2023-10-04T06:46:58.690Z,add,pages.vaccinations_page.nl.vaccine_campaigns.autumn_2022.title,22Xg3hRGtxwin2PlGEkt4Q,__
 2023-10-04T06:46:58.690Z,delete,pages.vaccinations_page.nl.vaccine_campaigns.atuumn_2022.description,fQMSbwQpEgDbjt4uWKxuMY,__
 2023-10-04T06:46:58.691Z,delete,pages.vaccinations_page.nl.vaccine_campaigns.atuumn_2022.title,uM9i5K7TlE0aLwmg4eRLuC,__
+2023-10-10T12:55:03.940Z,add,pages.vaccinations_page.nl.vaccination_coverage.description_primary_shot,rohM7ceZTOpkR9JaOOFLxH,__
+2023-10-10T12:55:04.767Z,add,pages.vaccinations_page.nl.vaccination_coverage.description_archived,kfsdp23RRJLNMtloMWl01t,__
+2023-10-10T12:55:05.790Z,add,pages.vaccinations_page.nl.vaccination_coverage.title_primary_series,ISH0YLnLyUv5o4crieNScU,__
+2023-10-10T12:55:06.790Z,add,pages.vaccinations_page.nl.vaccination_coverage.title_autumn_2022_shot,Lfn0X6iH0v4r6Hw7fQhx7Z,__
+2023-10-10T12:55:07.777Z,add,pages.vaccinations_page.nl.vaccination_coverage.title_archived,rohM7ceZTOpkR9JaOOFM43,__
+2023-10-10T12:55:07.777Z,delete,pages.vaccinations_page.nl.vaccination_coverage.title,jF33EuwumlGuwav2FD464K,__


### PR DESCRIPTION
## Summary
 
* Remove 'usefull links' from vaccine page on national and municpal level
* Create seperate sanity keys for different vaccine coverage tables
  * Title
  * Descriptions