### PR TITLE
fix(COR-1819): Fix article layout safari

### DIFF
--- a/packages/app/src/components/articles/page-articles-tile.tsx
+++ b/packages/app/src/components/articles/page-articles-tile.tsx
@@ -77,7 +77,6 @@ const ArticleCard = styled(Anchor)`
   display: flex;
   flex-direction: column;
   gap: ${space[2]};
-  height: 100%;
   padding: ${space[3]};
 
   ${Text} {


### PR DESCRIPTION
## Summary
 
* Removed height: 100% in pageArticleTile component
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/1db41875-2c28-4691-8c42-de714430183d)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/10b17edd-7b72-4e99-84cd-61887c6f37f1)

</details>