### PR TITLE
feature/COR-1811 adjust variant page

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -139,7 +139,7 @@
     "bootstrap": "exit 0",
     "export": "next export",
     "dev": "yarn workspace @corona-dashboard/icons build && yarn workspace @corona-dashboard/common build && run-p dev:common dev:next dev:lokalize",
-    "dev:next": "node next-server.js",
+    "dev:next": "cross-env NODE_OPTIONS='--inspect' node next-server.js",
     "dev:lokalize": "chokidar \"./src/locale/nl_export.json\" -c \"yarn workspace @corona-dashboard/cms lokalize:generate-types\"",
     "dev:common": "yarn workspace @corona-dashboard/common build:watch",
     "build": "cross-env NEXT_TELEMETRY_DISABLED=1 && next build",

--- a/packages/app/schema/archived_nl/__index.json
+++ b/packages/app/schema/archived_nl/__index.json
@@ -42,6 +42,7 @@
     "vaccine_vaccinated_or_support_archived_20230411",
     "vaccine_delivery_per_supplier_archived_20211101",
     "vaccine_stock_archived_20211024",
+    "variants_archived_20231101",
     "tested_ggd_archived_20230321",
     "tested_overall_archived_20230331",
     "tested_per_age_group_archived_20230331",
@@ -185,6 +186,9 @@
     },
     "vaccine_stock_archived_20211024": {
       "$ref": "vaccine_stock.json"
+    },
+    "variants_archived_20231101": {
+      "$ref": "variants.json"
     },
     "repeating_shot_administered_20220713": {
       "$ref": "repeating_shot_administered.json"

--- a/packages/app/schema/archived_nl/variants.json
+++ b/packages/app/schema/archived_nl/variants.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "archived_nl_variants",
+  "required": ["values"],
+  "additionalProperties": false,
+  "properties": {
+    "values": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/variant"
+      }
+    }
+  },
+  "definitions": {
+    "variant": {
+      "type": "object",
+      "title": "archived_nl_variants_variant",
+      "additionalProperties": false,
+      "required": ["variant_code", "values", "last_value"],
+      "properties": {
+        "variant_code": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/value"
+          }
+        },
+        "last_value": {
+          "$ref": "#/definitions/value"
+        }
+      }
+    },
+    "value": {
+      "type": "object",
+      "title": "archived_nl_variants_variant_value",
+      "additionalProperties": false,
+      "required": [
+        "order",
+        "occurrence",
+        "percentage",
+        "sample_size",
+        "date_start_unix",
+        "date_end_unix",
+        "date_of_report_unix",
+        "date_of_insertion_unix",
+        "label_nl",
+        "label_en"
+      ],
+      "properties": {
+        "order": {
+          "type": "integer"
+        },
+        "occurrence": {
+          "type": "integer"
+        },
+        "percentage": {
+          "type": "number"
+        },
+        "sample_size": {
+          "type": "integer"
+        },
+        "date_start_unix": {
+          "type": "integer"
+        },
+        "date_end_unix": {
+          "type": "integer"
+        },
+        "date_of_insertion_unix": {
+          "type": "integer"
+        },
+        "date_of_report_unix": {
+          "type": "integer"
+        },
+        "label_nl": {
+          "type": "string"
+        },
+        "label_en": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -20,7 +20,8 @@
     "infectionradar_symptoms_trend_per_age_group_weekly",
     "sewer",
     "vaccine_campaigns",
-    "vaccine_administered_last_timeframe"
+    "vaccine_administered_last_timeframe",
+    "variants"
   ],
   "additionalProperties": false,
   "properties": {

--- a/packages/app/src/components/kpi/bordered-kpi-section.tsx
+++ b/packages/app/src/components/kpi/bordered-kpi-section.tsx
@@ -9,10 +9,11 @@ import { KpiContent } from './components/kpi-content';
 import { BorderedKpiSectionProps } from './types';
 import { Markdown } from '../markdown';
 
-export const BorderedKpiSection = ({ title, description, source, dateOrRange, tilesData }: BorderedKpiSectionProps) => {
+export const BorderedKpiSection = ({ title, description, source, dateOrRange, tilesData, disclaimer }: BorderedKpiSectionProps) => {
   const metadata: MetadataProps = {
     date: dateOrRange,
     source: source,
+    disclaimer: disclaimer,
   };
 
   return (

--- a/packages/app/src/components/kpi/types.ts
+++ b/packages/app/src/components/kpi/types.ts
@@ -29,6 +29,7 @@ export interface BorderedKpiSectionProps {
   };
   tilesData: [TileData, TileData];
   title: string;
+  disclaimer?: string;
 }
 
 type BarType = {

--- a/packages/app/src/components/metadata.tsx
+++ b/packages/app/src/components/metadata.tsx
@@ -5,6 +5,7 @@ import { space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { Box } from './base';
 import { InlineText, Text } from './typography';
+import { Markdown } from '~/components/markdown';
 
 type source = {
   text: string;
@@ -25,9 +26,10 @@ export interface MetadataProps extends MarginBottomProps {
   isTileFooter?: boolean;
   datumsText?: string;
   intervalCount?: string;
+  disclaimer?: string;
 }
 
-export function Metadata({ date, source, obtainedAt, isTileFooter, datumsText, marginBottom, dataSources, intervalCount }: MetadataProps) {
+export function Metadata({ date, source, obtainedAt, isTileFooter, datumsText, marginBottom, dataSources, intervalCount, disclaimer }: MetadataProps) {
   const { commonTexts, formatDateFromSeconds } = useIntl();
 
   const dateString =
@@ -77,6 +79,11 @@ export function Metadata({ date, source, obtainedAt, isTileFooter, datumsText, m
               })
             ) : (
               <>
+                {disclaimer && (
+                  <Box paddingBottom={space[3]}>
+                    <Markdown content={disclaimer}></Markdown>
+                  </Box>
+                )}
                 {dateString}
                 {obtainedAt &&
                   ` ${replaceVariablesInText(commonTexts.common.metadata.obtained, {

--- a/packages/app/src/components/stacked-chart/stacked-chart.tsx
+++ b/packages/app/src/components/stacked-chart/stacked-chart.tsx
@@ -65,6 +65,7 @@ type StackedChartProps<T extends TimestampedValue> = {
   config: Config<T>[];
   valueAnnotation?: string;
   initialWidth?: number;
+  disableLegend?: boolean;
   expectedLabel?: string;
   formatTooltip?: TooltipFormatter<T & StackedBarTooltipData>;
   isPercentage?: boolean;
@@ -105,6 +106,7 @@ export function StackedChart<T extends TimestampedValue>(props: StackedChartProp
     config,
     initialWidth = 840,
     isPercentage,
+    disableLegend,
     expectedLabel,
     formatTickValue: formatYTickValue,
     formatTooltip,
@@ -461,9 +463,11 @@ export function StackedChart<T extends TimestampedValue>(props: StackedChartProp
           )}
         </ResponsiveContainer>
       </Box>
-      <Box paddingLeft={`${padding.left}px`}>
-        <Legend items={legendItems} />
-      </Box>
+      {!disableLegend && legendItems && (
+        <Box paddingLeft={`${padding.left}px`}>
+          <Legend items={legendItems} />
+        </Box>
+      )}
     </>
   );
 }

--- a/packages/app/src/domain/vaccine/vaccine-campaigns-tile/vaccine-campaigns-tile.tsx
+++ b/packages/app/src/domain/vaccine/vaccine-campaigns-tile/vaccine-campaigns-tile.tsx
@@ -1,16 +1,11 @@
 import { useBreakpoints } from '~/utils/use-breakpoints';
-import { ChartTile, Markdown, MetadataProps } from '~/components';
-import { Text } from '~/components/typography';
+import { ChartTile, MetadataProps } from '~/components';
 import { NarrowVaccineCampaignTable } from './components/narrow-vaccine-campaign-table';
 import { WideVaccineCampaignTable } from './components/wide-vaccine-campaign-table';
 import { VaccineCampaign, VaccineCampaignDescriptions, VaccineCampaignHeaders, VaccineCampaignOptions } from './types';
-import { Box } from '~/components/base';
-import { space } from '~/style/theme';
-
 interface VaccineCampaignsTileProps {
   title: string;
   description: string;
-  descriptionFooter: string;
   metadata: MetadataProps;
   headers: VaccineCampaignHeaders;
   campaigns: VaccineCampaign[];
@@ -18,7 +13,7 @@ interface VaccineCampaignsTileProps {
   campaignOptions?: VaccineCampaignOptions;
 }
 
-export const VaccineCampaignsTile = ({ title, headers, campaigns, campaignDescriptions, description, descriptionFooter, metadata, campaignOptions }: VaccineCampaignsTileProps) => {
+export const VaccineCampaignsTile = ({ title, headers, campaigns, campaignDescriptions, description, metadata, campaignOptions }: VaccineCampaignsTileProps) => {
   const breakpoints = useBreakpoints();
 
   // Display only the campaigns that are not hidden in the campaignOptions prop
@@ -36,11 +31,6 @@ export const VaccineCampaignsTile = ({ title, headers, campaigns, campaignDescri
         ) : (
           <NarrowVaccineCampaignTable campaigns={sortedAndFilteredCampaigns} campaignDescriptions={campaignDescriptions} headers={headers} showTotals={totalsAvailable} />
         )}
-        <Box marginTop={space[3]}>
-          <Text variant="label1" color="gray7">
-            <Markdown content={descriptionFooter} />
-          </Text>
-        </Box>
       </ChartTile>
     </>
   );

--- a/packages/app/src/domain/variants/data-selection/get-archived-variant-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-archived-variant-chart-data.ts
@@ -1,13 +1,6 @@
 import { ArchivedNlVariants } from '@corona-dashboard/common';
 import { isDefined } from 'ts-is-present';
-
-export type VariantCode = string;
-
-export type VariantChartValue = {
-  date_start_unix: number;
-  date_end_unix: number;
-  is_reliable: boolean;
-} & Record<string, number>;
+import { VariantChartValue } from '~/domain/variants/data-selection/types';
 
 const EMPTY_VALUES = {
   archivedVariantChart: null,

--- a/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
@@ -15,7 +15,7 @@ const EMPTY_VALUES = {
  * Returns values for variant timeseries chart
  * @param variants
  */
-export function getVariantBarChartData(variants: NlVariants | undefined) {
+export function getVariantBarChartData(variants: NlVariants) {
   if (!isDefined(variants) || !isDefined(variants.values)) {
     return EMPTY_VALUES;
   }
@@ -33,11 +33,11 @@ export function getVariantBarChartData(variants: NlVariants | undefined) {
       is_reliable: true,
       date_start_unix: value.date_start_unix,
       date_end_unix: value.date_end_unix,
-      [`${firstVariantInList.variant_code}_percentage`]: value.percentage,
+      [`${firstVariantInList.variant_code}_occurrence`]: value.occurrence,
     } as VariantChartValue;
 
     sortedVariants.forEach((variant) => {
-      (item as unknown as Record<string, number>)[`${variant.variant_code}_percentage`] = variant.values[index].percentage;
+      (item as unknown as Record<string, number>)[`${variant.variant_code}_occurrence`] = variant.values[index].occurrence;
     });
 
     return item;

--- a/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
@@ -1,3 +1,54 @@
-export function getVariantBarChartData() {
-  return null;
+import { NlVariants } from '@corona-dashboard/common';
+import { isDefined } from 'ts-is-present';
+import { VariantChartValue } from '~/domain/variants/data-selection/types';
+
+const EMPTY_VALUES = {
+  variantChart: null,
+  dates: {
+    date_of_report_unix: 0,
+    date_start_unix: 0,
+    date_end_unix: 0,
+  },
+} as const;
+
+/**
+ * Returns values for variant timeseries chart
+ * @param variants
+ */
+export function getVariantBarChartData(variants: NlVariants | undefined) {
+  if (!isDefined(variants) || !isDefined(variants.values)) {
+    return EMPTY_VALUES;
+  }
+
+  const sortedVariants = variants.values.sort((a, b) => b.last_value.order - a.last_value.order);
+
+  const firstVariantInList = sortedVariants.shift();
+
+  if (!isDefined(firstVariantInList)) {
+    return EMPTY_VALUES;
+  }
+
+  const values = firstVariantInList.values.map<VariantChartValue>((value, index) => {
+    const item = {
+      is_reliable: true,
+      date_start_unix: value.date_start_unix,
+      date_end_unix: value.date_end_unix,
+      [`${firstVariantInList.variant_code}_percentage`]: value.percentage,
+    } as VariantChartValue;
+
+    sortedVariants.forEach((variant) => {
+      (item as unknown as Record<string, number>)[`${variant.variant_code}_percentage`] = variant.values[index].percentage;
+    });
+
+    return item;
+  });
+
+  return {
+    variantChart: values,
+    dates: {
+      date_of_report_unix: firstVariantInList.last_value.date_of_report_unix,
+      date_start_unix: firstVariantInList.last_value.date_start_unix,
+      date_end_unix: firstVariantInList.last_value.date_end_unix,
+    },
+  } as const;
 }

--- a/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
@@ -1,0 +1,3 @@
+export function getVariantBarChartData() {
+  return null;
+}

--- a/packages/app/src/domain/variants/data-selection/get-variant-order-colors.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-order-colors.ts
@@ -1,11 +1,6 @@
 import { NlVariants, colors } from '@corona-dashboard/common';
 import { isDefined } from 'ts-is-present';
-import { VariantCode } from './';
-
-export type ColorMatch = {
-  variant: VariantCode;
-  color: string;
-};
+import { ColorMatch, VariantCode } from '~/domain/variants/data-selection/types';
 
 const getColorForVariant = (variantCode: VariantCode, index: number): string => {
   if (variantCode === 'other_variants') return colors.gray5;

--- a/packages/app/src/domain/variants/data-selection/get-variant-table-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-table-data.ts
@@ -1,18 +1,7 @@
-import { colors, NlNamedDifference, NlVariants, NlVariantsVariant, NamedDifferenceDecimal } from '@corona-dashboard/common';
+import { colors, NlNamedDifference, NlVariants, NlVariantsVariant } from '@corona-dashboard/common';
 import { first } from 'lodash';
 import { isDefined } from 'ts-is-present';
-import { ColorMatch } from './get-variant-order-colors';
-import { VariantCode } from '../static-props';
-
-export type VariantRow = {
-  variantCode: VariantCode;
-  order: number;
-  percentage: number | null;
-  difference?: NamedDifferenceDecimal | null;
-  color: string;
-};
-
-export type VariantTableData = ReturnType<typeof getVariantTableData>;
+import { ColorMatch, VariantRow } from '~/domain/variants/data-selection/types';
 
 /**
  * Return values to populate the variants table

--- a/packages/app/src/domain/variants/data-selection/index.ts
+++ b/packages/app/src/domain/variants/data-selection/index.ts
@@ -1,3 +1,4 @@
+export * from './get-variant-bar-chart-data';
 export * from './get-archived-variant-chart-data';
 export * from './get-variant-order-colors';
 export * from './get-variant-table-data';

--- a/packages/app/src/domain/variants/data-selection/types.ts
+++ b/packages/app/src/domain/variants/data-selection/types.ts
@@ -1,0 +1,31 @@
+import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
+import { SiteText } from '~/locale';
+import { NamedDifferenceDecimal } from '@corona-dashboard/common';
+import { getVariantTableData } from '~/domain/variants/data-selection/get-variant-table-data';
+
+export type VariantCode = string;
+
+export type ColorMatch = {
+  variant: VariantCode;
+  color: string;
+};
+
+export type VariantTableData = ReturnType<typeof getVariantTableData>;
+
+export type VariantChartValue = {
+  date_start_unix: number;
+  date_end_unix: number;
+  is_reliable: boolean;
+} & Record<string, number>;
+
+export type VariantRow = {
+  variantCode: VariantCode;
+  order: number;
+  percentage: number | null;
+  difference?: NamedDifferenceDecimal | null;
+  color: string;
+};
+
+export type VariantsStackedAreaTileText = {
+  variantCodes: VariantDynamicLabels;
+} & SiteText['pages']['variants_page']['nl']['varianten_over_tijd_grafiek'];

--- a/packages/app/src/domain/variants/data-selection/types.ts
+++ b/packages/app/src/domain/variants/data-selection/types.ts
@@ -1,5 +1,5 @@
 import { SiteText } from '~/locale';
-import { NamedDifferenceDecimal } from '@corona-dashboard/common';
+import { NamedDifferenceDecimal, TimestampedValue } from '@corona-dashboard/common';
 import { getVariantTableData } from '~/domain/variants/data-selection/get-variant-table-data';
 
 export type VariantCode = string;
@@ -30,3 +30,9 @@ export type VariantDynamicLabels = Record<string, string>;
 export type VariantsStackedAreaTileText = {
   variantCodes: VariantDynamicLabels;
 } & SiteText['pages']['variants_page']['nl']['varianten_over_tijd_grafiek'];
+
+export type StackedBarConfig<T extends TimestampedValue> = {
+  metricProperty: keyof T;
+  label: string;
+  color: string;
+};

--- a/packages/app/src/domain/variants/data-selection/types.ts
+++ b/packages/app/src/domain/variants/data-selection/types.ts
@@ -1,4 +1,3 @@
-import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
 import { SiteText } from '~/locale';
 import { NamedDifferenceDecimal } from '@corona-dashboard/common';
 import { getVariantTableData } from '~/domain/variants/data-selection/get-variant-table-data';
@@ -25,6 +24,8 @@ export type VariantRow = {
   difference?: NamedDifferenceDecimal | null;
   color: string;
 };
+
+export type VariantDynamicLabels = Record<string, string>;
 
 export type VariantsStackedAreaTileText = {
   variantCodes: VariantDynamicLabels;

--- a/packages/app/src/domain/variants/index.ts
+++ b/packages/app/src/domain/variants/index.ts
@@ -1,0 +1,4 @@
+export * from './variants-stacked-bar-chart-tile';
+export * from './variants-stacked-area-tile';
+export * from './variants-table-tile';
+export * from './data-selection';

--- a/packages/app/src/domain/variants/logic/use-bar-config.ts
+++ b/packages/app/src/domain/variants/logic/use-bar-config.ts
@@ -1,0 +1,44 @@
+import { ColorMatch, VariantChartValue, VariantsStackedAreaTileText, StackedBarConfig } from '~/domain/variants/data-selection/types';
+import { useMemo } from 'react';
+
+export const useBarConfig = (values: VariantChartValue[], selectedOptions: (keyof VariantChartValue)[], text: VariantsStackedAreaTileText, colors: ColorMatch[]) => {
+  return useMemo(() => {
+    const listOfVariantCodes = values
+      .flatMap((variantChartValue) => Object.keys(variantChartValue))
+      .filter((keyName, index, array) => array.indexOf(keyName) === index)
+      .filter((keyName) => keyName.endsWith('_occurrence'))
+      .reverse();
+
+    const barChartConfig: StackedBarConfig<VariantChartValue>[] = [];
+
+    listOfVariantCodes.forEach((variantKey) => {
+      const variantCodeName = variantKey.split('_').slice(0, -1).join('_');
+
+      const variantMetricPropertyName = variantCodeName.concat('_occurrence');
+
+      const variantDynamicLabel = text.variantCodes[variantCodeName];
+
+      const color = colors.find((variantColors) => variantColors.variant === variantCodeName)?.color;
+
+      if (variantDynamicLabel) {
+        const barChartConfigEntry = {
+          metricProperty: variantMetricPropertyName,
+          color: color,
+          label: variantDynamicLabel,
+          shape: 'gapped-area',
+        };
+
+        barChartConfig.push(barChartConfigEntry as StackedBarConfig<VariantChartValue>);
+      }
+    });
+
+    const selectOptions: StackedBarConfig<VariantChartValue>[] = [...barChartConfig];
+
+    if (selectedOptions.length > 0) {
+      const selection = barChartConfig.filter((selectedConfig) => selectedOptions.includes(selectedConfig.metricProperty));
+      return [selection, selectOptions];
+    } else {
+      return [barChartConfig, selectOptions];
+    }
+  }, [values, text.tooltip_labels.other_percentage, text.variantCodes, colors, selectedOptions]);
+};

--- a/packages/app/src/domain/variants/logic/use-bar-config.ts
+++ b/packages/app/src/domain/variants/logic/use-bar-config.ts
@@ -9,7 +9,6 @@ const extractVariantNamesFromValues = (values: VariantChartValue[]) => {
     .filter((keyName, index, array) => array.indexOf(keyName) === index)
     .filter((keyName) => keyName.endsWith('_occurrence'));
 };
-
 export const useBarConfig = (
   values: VariantChartValue[],
   selectedOptions: (keyof VariantChartValue)[],

--- a/packages/app/src/domain/variants/logic/use-series-config.ts
+++ b/packages/app/src/domain/variants/logic/use-series-config.ts
@@ -1,0 +1,60 @@
+import { ColorMatch, VariantChartValue, VariantsStackedAreaTileText } from '~/domain/variants/data-selection/types';
+import { useMemo } from 'react';
+import { GappedAreaSeriesDefinition } from '~/components/time-series-chart/logic';
+
+/**
+ * Create a configuration with appropriate mnemonic label (e.g. "Alpha", "Delta", "Omikron", etc.) and colour for all variants
+ * present in data.
+ * @param text
+ * @param values
+ * @param colors
+ */
+export const useSeriesConfig = (
+  text: VariantsStackedAreaTileText,
+  values: VariantChartValue[],
+  colors: ColorMatch[]
+): readonly [GappedAreaSeriesDefinition<VariantChartValue>[], GappedAreaSeriesDefinition<VariantChartValue>[]] => {
+  return useMemo(() => {
+    const baseVariantsFiltered = values
+      .flatMap((x) => Object.keys(x)) // Get all key names
+      .filter((x, index, array) => array.indexOf(x) === index) // De-dupe keys
+      .filter((x) => x.endsWith('_percentage')) // Filter out any keys that don't end in '_percentage'
+      .reverse(); // Reverse to be in alphabetical order
+
+    /* Enrich config with dynamic data / locale */
+    const seriesConfig: GappedAreaSeriesDefinition<VariantChartValue>[] = [];
+
+    baseVariantsFiltered.forEach((variantKey) => {
+      // Remove _percentage from variant key name
+      const variantCodeFragments = variantKey.split('_');
+      variantCodeFragments.pop();
+      const variantCode = variantCodeFragments.join('_');
+
+      // Match mnenonic variant name in lokalize to code-based variant name
+      const variantDynamicLabel = text.variantCodes[variantCode];
+
+      // Match appropriate variant color
+      const color = colors.find((variantColors) => variantColors.variant === variantCode)?.color;
+
+      // Create a variant label configuration and push into array
+      if (variantDynamicLabel) {
+        const variantConfig = {
+          type: 'gapped-area',
+          metricProperty: variantKey as keyof VariantChartValue,
+          color,
+          label: variantDynamicLabel,
+          strokeWidth: 2,
+          fillOpacity: 0.2,
+          shape: 'gapped-area',
+          mixBlendMode: 'multiply',
+        };
+
+        seriesConfig.push(variantConfig as GappedAreaSeriesDefinition<VariantChartValue>);
+      }
+    });
+
+    const selectOptions: GappedAreaSeriesDefinition<VariantChartValue>[] = [...seriesConfig];
+
+    return [seriesConfig, selectOptions] as const;
+  }, [values, text.tooltip_labels.other_percentage, text.variantCodes, colors]);
+};

--- a/packages/app/src/domain/variants/logic/use-series-config.ts
+++ b/packages/app/src/domain/variants/logic/use-series-config.ts
@@ -31,7 +31,7 @@ export const useSeriesConfig = (
       const variantCode = variantCodeFragments.join('_');
 
       // Match mnenonic variant name in lokalize to code-based variant name
-      const variantDynamicLabel = text.variantCodes[variantCode];
+      const variantDynamicLabel = text.variantCodes[variantCode] + ' '; // THIS IS NECESSARY TO DIFFERENTIATE STATE BETWEEN THE TWO INTERACTIVE LEGENDS ON THE PAGE;
 
       // Match appropriate variant color
       const color = colors.find((variantColors) => variantColors.variant === variantCode)?.color;

--- a/packages/app/src/domain/variants/logic/use-unreliable-data-annotations.ts
+++ b/packages/app/src/domain/variants/logic/use-unreliable-data-annotations.ts
@@ -4,19 +4,14 @@ import { useMemo } from 'react';
 import { isDefined } from 'ts-is-present';
 import { TimespanAnnotationConfig } from '~/components/time-series-chart/logic';
 
-export function useUnreliableDataAnnotations(
-  values: (DateSpanValue & { is_reliable: boolean })[],
-  label: string
-) {
+export function useUnreliableDataAnnotations(values: (DateSpanValue & { is_reliable: boolean })[], label: string) {
   return useMemo(
     () =>
       values
         .reduce<TimespanAnnotationConfig[]>(
           (acc, x) => {
             if (!x.is_reliable) {
-              const annotation =
-                last(acc) ??
-                ({ label, fill: 'dotted' } as TimespanAnnotationConfig);
+              const annotation = last(acc) ?? ({ label, fill: 'dotted' } as TimespanAnnotationConfig);
               if (!isDefined(annotation.start)) {
                 annotation.start = x.date_start_unix;
                 annotation.end = x.date_end_unix;

--- a/packages/app/src/domain/variants/static-props/get-archived-variant-chart-data.ts
+++ b/packages/app/src/domain/variants/static-props/get-archived-variant-chart-data.ts
@@ -1,4 +1,4 @@
-import { NlVariants } from '@corona-dashboard/common';
+import { ArchivedNlVariants } from '@corona-dashboard/common';
 import { isDefined } from 'ts-is-present';
 
 export type VariantCode = string;
@@ -10,7 +10,7 @@ export type VariantChartValue = {
 } & Record<string, number>;
 
 const EMPTY_VALUES = {
-  variantChart: null,
+  archivedVariantChart: null,
   dates: {
     date_of_report_unix: 0,
     date_start_unix: 0,
@@ -22,7 +22,7 @@ const EMPTY_VALUES = {
  * Returns values for variant timeseries chart
  * @param variants
  */
-export function getVariantChartData(variants: NlVariants | undefined) {
+export function getArchivedVariantChartData(variants: ArchivedNlVariants | undefined) {
   if (!isDefined(variants) || !isDefined(variants.values)) {
     return EMPTY_VALUES;
   }
@@ -51,7 +51,7 @@ export function getVariantChartData(variants: NlVariants | undefined) {
   });
 
   return {
-    variantChart: values,
+    archivedVariantChart: values,
     dates: {
       date_of_report_unix: firstVariantInList.last_value.date_of_report_unix,
       date_start_unix: firstVariantInList.last_value.date_start_unix,

--- a/packages/app/src/domain/variants/static-props/index.ts
+++ b/packages/app/src/domain/variants/static-props/index.ts
@@ -1,3 +1,3 @@
-export * from './get-variant-chart-data';
+export * from './get-archived-variant-chart-data';
 export * from './get-variant-order-colors';
 export * from './get-variant-table-data';

--- a/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
@@ -13,6 +13,7 @@ import { useList } from '~/utils/use-list';
 import { space } from '~/style/theme';
 import { useUnreliableDataAnnotations } from './logic/use-unreliable-data-annotations';
 import { ColorMatch, VariantChartValue, VariantsStackedAreaTileText } from '~/domain/variants/data-selection/types';
+import { useSeriesConfig } from '~/domain/variants/logic/use-series-config';
 
 const alwaysEnabled: (keyof VariantChartValue)[] = [];
 
@@ -114,45 +115,4 @@ const useFilteredSeriesConfig = (seriesConfig: GappedAreaSeriesDefinition<Varian
   return useMemo(() => {
     return seriesConfig.filter((item) => compareList.includes(item.metricProperty) || compareList.length === alwaysEnabled.length);
   }, [seriesConfig, compareList]);
-};
-
-const useSeriesConfig = (text: VariantsStackedAreaTileText, values: VariantChartValue[], variantColors: ColorMatch[]) => {
-  return useMemo(() => {
-    const baseVariantsFiltered = values
-      .flatMap((x) => Object.keys(x))
-      .filter((x, index, array) => array.indexOf(x) === index) // de-dupe
-      .filter((x) => x.endsWith('_percentage'))
-      .reverse(); // Reverse to be in an alphabetical order
-
-    /* Enrich config with dynamic data / locale */
-    const seriesConfig: GappedAreaSeriesDefinition<VariantChartValue>[] = [];
-    baseVariantsFiltered.forEach((variantKey) => {
-      const variantCodeFragments = variantKey.split('_');
-      variantCodeFragments.pop();
-      const variantCode = variantCodeFragments.join('_');
-
-      const variantDynamicLabel = text.variantCodes[variantCode];
-
-      const color = variantColors.find((variantColors) => variantColors.variant === variantCode)?.color;
-
-      if (variantDynamicLabel) {
-        const newConfig = {
-          type: 'gapped-area',
-          metricProperty: variantKey as keyof VariantChartValue,
-          color,
-          label: variantDynamicLabel,
-          strokeWidth: 2,
-          fillOpacity: 0.2,
-          shape: 'gapped-area',
-          mixBlendMode: 'multiply',
-        };
-
-        seriesConfig.push(newConfig as GappedAreaSeriesDefinition<VariantChartValue>);
-      }
-    });
-
-    const selectOptions = [...seriesConfig];
-
-    return [seriesConfig, selectOptions] as const;
-  }, [values, text.tooltip_labels.other_percentage, text.variantCodes, variantColors]);
 };

--- a/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
@@ -9,17 +9,10 @@ import { MetadataProps } from '~/components/metadata';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
 import { GappedAreaSeriesDefinition } from '~/components/time-series-chart/logic';
-import { VariantChartValue } from '~/domain/variants/static-props';
-import { SiteText } from '~/locale';
 import { useList } from '~/utils/use-list';
-import { ColorMatch } from '~/domain/variants/static-props';
-import { useUnreliableDataAnnotations } from './logic/use-unreliable-data-annotations';
 import { space } from '~/style/theme';
-import { VariantDynamicLabels } from '../variants-table-tile/types';
-
-type VariantsStackedAreaTileText = {
-  variantCodes: VariantDynamicLabels;
-} & SiteText['pages']['variants_page']['nl']['varianten_over_tijd_grafiek'];
+import { useUnreliableDataAnnotations } from './logic/use-unreliable-data-annotations';
+import { ColorMatch, VariantChartValue, VariantsStackedAreaTileText } from '~/domain/variants/data-selection/types';
 
 const alwaysEnabled: (keyof VariantChartValue)[] = [];
 

--- a/packages/app/src/domain/variants/variants-stacked-area-tile/index.ts
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile/index.ts
@@ -1,1 +1,0 @@
-export { VariantsStackedAreaTile } from './variants-stacked-area-tile';

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -73,13 +73,11 @@ export const VariantsStackedBarChartTile = ({ title, description, helpText, valu
 
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
 
-  const selectedOptions = list;
-
   const [variantTimeFrame, setVariantTimeFrame] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
 
-  const [barChartConfig, selectionOptions] = useBarConfig(values, selectedOptions, variantLabels, variantColors, variantTimeFrame, today);
+  const [barChartConfig, selectionOptions] = useBarConfig(values, list, variantLabels, variantColors, variantTimeFrame, today);
 
-  const hasTwoColumns = selectedOptions.length === 0 || selectedOptions.length > 4;
+  const hasTwoColumns = list.length === 0 || list.length > 4;
 
   return (
     <ChartTile
@@ -90,7 +88,7 @@ export const VariantsStackedBarChartTile = ({ title, description, helpText, valu
       timeframeInitialValue={TimeframeOption.THREE_MONTHS}
       onSelectTimeframe={setVariantTimeFrame}
     >
-      <InteractiveLegend helpText={helpText} selectOptions={selectionOptions} selection={selectedOptions} onToggleItem={toggle} onReset={clear} />
+      <InteractiveLegend helpText={helpText} selectOptions={selectionOptions} selection={list} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
       <StackedChart
         accessibility={{

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -35,8 +35,8 @@ const hasMetricProperty = (config: any): config is { metricProperty: string } =>
 /**
  * Only variants that have a greater occurrence than 0 must be shown in the tooltip, except when the user narrows down
  * the total amount of visible variants by selecting one or more from the legend
- * @param context
- * @param selectionOptions
+ * @param context - Tooltip data context
+ * @param selectionOptions - Currently selected variants
  */
 const reorderAndFilter = (context: TooltipData<VariantChartValue & StackedBarTooltipData>, selectionOptions: StackedBarConfig<VariantChartValue>[]) => {
   const metricAmount = context.config.length;

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -1,0 +1,11 @@
+import { MetadataProps } from '~/components';
+
+interface VariantsStackedBarChartTileProps {
+  title: string;
+  description: string;
+  metadata: MetadataProps;
+}
+
+export const VariantsStackedBarChartTile = (_props: VariantsStackedBarChartTileProps) => {
+  return <></>;
+};

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -1,23 +1,63 @@
 import { ChartTile, Markdown, MetadataProps } from '~/components';
 import { Box } from '~/components/base';
+import { colors, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
+import { useState } from 'react';
+import { ColorMatch, VariantChartValue, VariantsStackedAreaTileText } from '~/domain/variants/data-selection/types';
+import { StackedChart } from '~/components/stacked-chart';
+
+//const alwaysEnabled: (keyof VariantChartValue)[] = [];
 
 interface VariantsStackedBarChartTileProps {
   title: string;
   description: string;
   _helpText: string;
+  values: VariantChartValue[];
+  _variantLabels: VariantsStackedAreaTileText;
+  _variantColors: ColorMatch[];
   metadata: MetadataProps;
 }
 
-export const VariantsStackedBarChartTile = ({ title, description, _helpText, metadata }: VariantsStackedBarChartTileProps) => {
+export const VariantsStackedBarChartTile = ({ title, description, _helpText, values, _variantLabels, _variantColors, metadata }: VariantsStackedBarChartTileProps) => {
+  //const {list, toggle, clear} = useList<keyof VariantChartValue>(alwaysEnabled);
+
+  const [variantTimeFrame, setVariantTimeFrame] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
+
+  //const [seriesConfig, selectionOptions] = useSeriesConfig(variantLabels, values, variantColors);
+
   return (
-    <ChartTile title={title} description={description} metadata={metadata}>
+    <ChartTile
+      title={title}
+      description={description}
+      metadata={metadata}
+      timeframeOptions={TimeframeOptionsList}
+      timeframeInitialValue={TimeframeOption.THREE_MONTHS}
+      onSelectTimeframe={setVariantTimeFrame}
+    >
       <Box>
         <Box>
           <Markdown content="placeholder"></Markdown>
         </Box>
       </Box>
-      {/*<InteractiveLegend helpText={helpText} selectOptions={} selection={} onToggleItem={} />*/}
-      {/*<StackedChart accessibility={{key: 'variants_stacked_area_over_time_chart'}} values={} config={} />*/}
+      {/*<InteractiveLegend helpText={helpText} selectOptions={selectionOptions} selection={list} onToggleItem={toggle} onReset={clear} />*/}
+      <StackedChart
+        accessibility={{
+          key: 'variants_stacked_area_over_time_chart',
+        }}
+        values={values}
+        config={[
+          {
+            metricProperty: 'other_variants_percentage' as const,
+            color: colors.blue2,
+            label: 'hello',
+          },
+          {
+            metricProperty: 'eg5_percentage' as const,
+            color: colors.green1,
+            label: 'hi',
+          },
+        ]}
+        timeframe={variantTimeFrame}
+      />
     </ChartTile>
   );
 };

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -1,11 +1,23 @@
-import { MetadataProps } from '~/components';
+import { ChartTile, Markdown, MetadataProps } from '~/components';
+import { Box } from '~/components/base';
 
 interface VariantsStackedBarChartTileProps {
   title: string;
   description: string;
+  _helpText: string;
   metadata: MetadataProps;
 }
 
-export const VariantsStackedBarChartTile = (_props: VariantsStackedBarChartTileProps) => {
-  return <></>;
+export const VariantsStackedBarChartTile = ({ title, description, _helpText, metadata }: VariantsStackedBarChartTileProps) => {
+  return (
+    <ChartTile title={title} description={description} metadata={metadata}>
+      <Box>
+        <Box>
+          <Markdown content="placeholder"></Markdown>
+        </Box>
+      </Box>
+      {/*<InteractiveLegend helpText={helpText} selectOptions={} selection={} onToggleItem={} />*/}
+      {/*<StackedChart accessibility={{key: 'variants_stacked_area_over_time_chart'}} values={} config={} />*/}
+    </ChartTile>
+  );
 };

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -11,6 +11,7 @@ import { TooltipData } from '~/components/time-series-chart/components';
 import { isDefined, isPresent } from 'ts-is-present';
 import { TooltipSeriesList } from '~/components/time-series-chart/components/tooltip/tooltip-series-list';
 import { space } from '~/style/theme';
+import { useCurrentDate } from '~/utils/current-date-context';
 
 interface VariantsStackedBarChartTileProps {
   title: string;
@@ -68,13 +69,17 @@ const reorderAndFilter = (context: TooltipData<VariantChartValue & StackedBarToo
  * @constructor
  */
 export const VariantsStackedBarChartTile = ({ title, description, helpText, values, variantLabels, variantColors, metadata }: VariantsStackedBarChartTileProps) => {
+  const today = useCurrentDate();
+
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
+
+  const selectedOptions = list;
 
   const [variantTimeFrame, setVariantTimeFrame] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
 
-  const [barChartConfig, selectionOptions] = useBarConfig(values, list, variantLabels, variantColors);
+  const [barChartConfig, selectionOptions] = useBarConfig(values, selectedOptions, variantLabels, variantColors, variantTimeFrame, today);
 
-  const hasTwoColumns = list.length === 0 || list.length > 4;
+  const hasTwoColumns = selectedOptions.length === 0 || selectedOptions.length > 4;
 
   return (
     <ChartTile
@@ -85,7 +90,7 @@ export const VariantsStackedBarChartTile = ({ title, description, helpText, valu
       timeframeInitialValue={TimeframeOption.THREE_MONTHS}
       onSelectTimeframe={setVariantTimeFrame}
     >
-      <InteractiveLegend helpText={helpText} selectOptions={selectionOptions} selection={list} onToggleItem={toggle} onReset={clear} />
+      <InteractiveLegend helpText={helpText} selectOptions={selectionOptions} selection={selectedOptions} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
       <StackedChart
         accessibility={{

--- a/packages/app/src/domain/variants/variants-table-tile.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile.tsx
@@ -8,13 +8,13 @@ import { FullscreenChartTile } from '~/components/fullscreen-chart-tile';
 import { Markdown } from '~/components/markdown';
 import { MetadataProps } from '~/components/metadata';
 import { Heading } from '~/components/typography';
-import { VariantRow } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
 import { fontSizes, space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
-import { VariantsTable } from './components/variants-table';
-import { TableText } from './types';
+import { VariantsTable } from './variants-table-tile/components/variants-table';
+import { TableText } from './variants-table-tile/types';
 import { Tile } from '~/components';
+import { VariantRow } from '~/domain/variants/data-selection/types';
 
 interface VariantsTableTileProps {
   text: TableText;

--- a/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/narrow-variants-table.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { isPresent } from 'ts-is-present';
 import { Box } from '~/components/base';
 import { InlineText } from '~/components/typography';
-import { VariantRow } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
 import { space } from '~/style/theme';
 import { getMaximumNumberOfDecimals } from '~/utils/get-maximum-number-of-decimals';
@@ -12,6 +11,7 @@ import { useCollapsible } from '~/utils/use-collapsible';
 import { Cell, HeaderCell, PercentageBarWithNumber, StyledTable, VariantDifference, VariantNameCell } from '.';
 import { TableText } from '../types';
 import { NoPercentageData } from './no-percentage-data';
+import { VariantRow } from '~/domain/variants/data-selection/types';
 
 interface NarrowVariantsTableProps {
   rows: VariantRow[];

--- a/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variant-difference.tsx
@@ -33,7 +33,7 @@ export const VariantDifference = ({ value, text, isWideTable }: VariantDifferenc
     {
       condition: value?.difference > 0,
       renderingValue: (
-        <Difference color={colors.black}>
+        <Difference color={colors.red2}>
           <TrendIcon trendDirection={TrendDirection.UP} />
           {formatPercentage(value.difference, options)} {text.verschil.meer}
         </Difference>
@@ -42,7 +42,7 @@ export const VariantDifference = ({ value, text, isWideTable }: VariantDifferenc
     {
       condition: value?.difference < 0,
       renderingValue: (
-        <Difference color={colors.black}>
+        <Difference color={colors.green1}>
           <TrendIcon trendDirection={TrendDirection.DOWN} />
           {formatPercentage(-value.difference, options)} {text.verschil.minder}
         </Difference>

--- a/packages/app/src/domain/variants/variants-table-tile/components/variant-name-cell.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variant-name-cell.tsx
@@ -1,7 +1,7 @@
 import { BoldText } from '~/components/typography';
 import { Cell } from '.';
 import { TableText } from '../types';
-import { VariantCode } from '../../static-props';
+import { VariantCode } from '~/domain/variants/data-selection/types';
 
 type VariantNameCellProps = {
   variantCode: VariantCode;

--- a/packages/app/src/domain/variants/variants-table-tile/components/variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/variants-table.tsx
@@ -1,8 +1,8 @@
-import { VariantRow } from '~/domain/variants/static-props';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { TableText } from '../types';
 import { NarrowVariantsTable } from './narrow-variants-table';
 import { WideVariantsTable } from './wide-variants-table';
+import { VariantRow } from '~/domain/variants/data-selection/types';
 
 type VariantsTableProps = {
   rows: VariantRow[];
@@ -12,13 +12,5 @@ type VariantsTableProps = {
 export function VariantsTable({ rows, text }: VariantsTableProps) {
   const breakpoints = useBreakpoints();
 
-  return (
-    <>
-      {breakpoints.sm ? (
-        <WideVariantsTable rows={rows} text={text} />
-      ) : (
-        <NarrowVariantsTable rows={rows} text={text} />
-      )}
-    </>
-  );
+  return <>{breakpoints.sm ? <WideVariantsTable rows={rows} text={text} /> : <NarrowVariantsTable rows={rows} text={text} />}</>;
 }

--- a/packages/app/src/domain/variants/variants-table-tile/components/wide-variants-table.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/components/wide-variants-table.tsx
@@ -2,12 +2,12 @@ import { DifferenceDecimal } from '@corona-dashboard/common';
 import { useMemo } from 'react';
 import { isPresent } from 'ts-is-present';
 import { Box } from '~/components/base';
-import { VariantRow } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
 import { getMaximumNumberOfDecimals } from '~/utils/get-maximum-number-of-decimals';
 import { Cell, HeaderCell, PercentageBarWithNumber, StyledTable, VariantDifference, VariantNameCell } from '.';
 import { TableText } from '../types';
 import { NoPercentageData } from './no-percentage-data';
+import { VariantRow } from '~/domain/variants/data-selection/types';
 
 const columnKeys = ['variant_titel', 'percentage', 'vorige_meting'] as const;
 

--- a/packages/app/src/domain/variants/variants-table-tile/index.ts
+++ b/packages/app/src/domain/variants/variants-table-tile/index.ts
@@ -1,1 +1,0 @@
-export * from './variants-table-tile';

--- a/packages/app/src/domain/variants/variants-table-tile/types.ts
+++ b/packages/app/src/domain/variants/variants-table-tile/types.ts
@@ -1,4 +1,4 @@
-export type VariantDynamicLabels = Record<string, string>;
+import { VariantDynamicLabels } from '~/domain/variants/data-selection/types';
 
 export type TableText = {
   anderen_tooltip: string;

--- a/packages/app/src/domain/variants/variants-table-tile/variants-table-tile.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/variants-table-tile.tsx
@@ -15,14 +15,7 @@ import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { VariantsTable } from './components/variants-table';
 import { TableText } from './types';
 
-export function VariantsTableTile({
-  text,
-  noDataMessage = '',
-  source,
-  data,
-  dates,
-  children = null,
-}: {
+interface VariantsTableTileProps {
   text: TableText;
   noDataMessage?: ReactNode;
   data?: VariantRow[] | null;
@@ -37,7 +30,9 @@ export function VariantsTableTile({
     date_of_report_unix: number;
   };
   children?: ReactNode;
-}) {
+}
+
+export function VariantsTableTile({ text, noDataMessage = '', source, data, dates, children = null }: VariantsTableTileProps) {
   if (!isPresent(data) || !isPresent(dates)) {
     return (
       <FullscreenChartTile>
@@ -62,13 +57,7 @@ export function VariantsTableTile({
   );
 }
 
-function VariantsTableTileWithData({
-  text,
-  source,
-  data,
-  dates,
-  children = null,
-}: {
+interface VariantsTableTileWithDataProps {
   text: TableText;
   data: VariantRow[];
   source: {
@@ -82,7 +71,9 @@ function VariantsTableTileWithData({
     date_of_report_unix: number;
   };
   children?: ReactNode;
-}) {
+}
+
+function VariantsTableTileWithData({ text, source, data, dates, children = null }: VariantsTableTileWithDataProps) {
   const { formatDateSpan } = useIntl();
 
   const metadata: MetadataProps = {

--- a/packages/app/src/domain/variants/variants-table-tile/variants-table-tile.tsx
+++ b/packages/app/src/domain/variants/variants-table-tile/variants-table-tile.tsx
@@ -10,15 +10,17 @@ import { MetadataProps } from '~/components/metadata';
 import { Heading } from '~/components/typography';
 import { VariantRow } from '~/domain/variants/static-props';
 import { useIntl } from '~/intl';
-import { space } from '~/style/theme';
+import { fontSizes, space } from '~/style/theme';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { VariantsTable } from './components/variants-table';
 import { TableText } from './types';
+import { Tile } from '~/components';
 
 interface VariantsTableTileProps {
   text: TableText;
   noDataMessage?: ReactNode;
   data?: VariantRow[] | null;
+  sampleThresholdPassed: boolean;
   source: {
     download: string;
     href: string;
@@ -32,7 +34,7 @@ interface VariantsTableTileProps {
   children?: ReactNode;
 }
 
-export function VariantsTableTile({ text, noDataMessage = '', source, data, dates, children = null }: VariantsTableTileProps) {
+export function VariantsTableTile({ text, noDataMessage = '', sampleThresholdPassed, source, data, dates, children = null }: VariantsTableTileProps) {
   if (!isPresent(data) || !isPresent(dates)) {
     return (
       <FullscreenChartTile>
@@ -51,7 +53,7 @@ export function VariantsTableTile({ text, noDataMessage = '', source, data, date
   }
 
   return (
-    <VariantsTableTileWithData text={text} source={source} data={data} dates={dates}>
+    <VariantsTableTileWithData text={text} sampleThresholdPassed={sampleThresholdPassed} source={source} data={data} dates={dates}>
       {children}
     </VariantsTableTileWithData>
   );
@@ -60,6 +62,7 @@ export function VariantsTableTile({ text, noDataMessage = '', source, data, date
 interface VariantsTableTileWithDataProps {
   text: TableText;
   data: VariantRow[];
+  sampleThresholdPassed: boolean;
   source: {
     download: string;
     href: string;
@@ -73,7 +76,7 @@ interface VariantsTableTileWithDataProps {
   children?: ReactNode;
 }
 
-function VariantsTableTileWithData({ text, source, data, dates, children = null }: VariantsTableTileWithDataProps) {
+function VariantsTableTileWithData({ text, sampleThresholdPassed, source, data, dates, children = null }: VariantsTableTileWithDataProps) {
   const { formatDateSpan } = useIntl();
 
   const metadata: MetadataProps = {
@@ -90,12 +93,25 @@ function VariantsTableTileWithData({ text, source, data, dates, children = null 
   });
 
   return (
-    <ChartTile metadata={metadata} title={text.titel} description={descriptionText}>
-      {children}
-      <Box overflow="auto" marginBottom={space[3]} marginTop={space[4]}>
-        <VariantsTable rows={data} text={text} />
-      </Box>
-    </ChartTile>
+    <>
+      {sampleThresholdPassed ? (
+        <ChartTile metadata={metadata} title={text.titel} description={descriptionText}>
+          {children}
+          <Box overflow="auto" marginBottom={space[3]} marginTop={space[4]}>
+            <VariantsTable rows={data} text={text} />
+          </Box>
+        </ChartTile>
+      ) : (
+        <Tile>
+          <Box spacing={3}>
+            <Heading level={3}>{text.titel}</Heading>
+            <Box maxWidth="400px" fontSize={fontSizes[2]} lineHeight={2}>
+              <Markdown content={text.description} />
+            </Box>
+          </Box>
+        </Tile>
+      )}
+    </>
   );
 }
 

--- a/packages/app/src/pages/landelijk/vaccinaties.tsx
+++ b/packages/app/src/pages/landelijk/vaccinaties.tsx
@@ -352,7 +352,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               <VaccineCampaignsTile
                 title={textNl.vaccine_campaigns.autumn_2022.title}
                 description={textNl.vaccine_campaigns.autumn_2022.description}
-                descriptionFooter={textNl.vaccine_campaigns.description_footer}
                 headers={textNl.vaccine_campaigns.headers}
                 campaigns={archivedData.vaccine_campaigns_archived_20231004.vaccine_campaigns}
                 campaignDescriptions={textNl.vaccine_campaigns.campaigns}
@@ -360,6 +359,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
                   datumsText: textNl.dates,
                   date: archivedData.vaccine_campaigns_archived_20231004.date_unix,
                   source: textNl.vaccine_campaigns.bronnen.rivm,
+                  disclaimer: textNl.vaccine_campaigns.description_footer,
                 }}
               />
 
@@ -427,7 +427,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               <VaccineCampaignsTile
                 title={textNl.vaccine_campaigns.title}
                 description={textNl.vaccine_campaigns.description_archived}
-                descriptionFooter={textNl.vaccine_campaigns.description_footer}
                 headers={textNl.vaccine_campaigns.headers}
                 campaigns={archivedData.vaccine_campaigns_archived_20220908.vaccine_campaigns}
                 campaignDescriptions={textNl.vaccine_campaigns.campaigns}
@@ -435,6 +434,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
                   datumsText: textNl.dates,
                   date: archivedData.vaccine_campaigns_archived_20220908.date_unix,
                   source: textNl.vaccine_campaigns.bronnen.rivm,
+                  disclaimer: textNl.vaccine_campaigns.description_footer,
                 }}
               />
 

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -7,9 +7,6 @@ import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
-import { getArchivedVariantChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/static-props';
-import { VariantsStackedAreaTile } from '~/domain/variants/variants-stacked-area-tile';
-import { VariantsTableTile } from '~/domain/variants/variants-table-tile';
 import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
@@ -22,6 +19,8 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { useState } from 'react';
+import { getArchivedVariantChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/data-selection';
+import { VariantsStackedAreaTile, VariantsTableTile } from '~/domain/variants';
 
 const pageMetrics = ['variants', 'named_difference'];
 

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -20,6 +20,7 @@ import { ArticleParts, LinkParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 
 const pageMetrics = ['variants', 'named_difference'];
 
@@ -77,6 +78,8 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
+  const totalVariants = data.named_difference.variants__percentage.filter((namedDifferenceEntry) => namedDifferenceEntry.variant_code !== 'other_variants').length;
+
   const variantLabels: VariantDynamicLabels = {};
 
   data.variants?.values.forEach((variant) => {
@@ -107,6 +110,29 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               dataExplained: content.dataExplained,
               faq: content.faqs,
             })}
+          />
+
+          <BorderedKpiSection
+            title={textNl.kpi_amount_of_samples.kpi_tile_title}
+            description={textNl.kpi_amount_of_samples.kpi_tile_description}
+            source={textNl.bronnen.rivm}
+            disclaimer={textNl.kpi_amount_of_samples.disclaimer}
+            dateOrRange={{
+              start: dates.date_start_unix,
+              end: dates.date_end_unix,
+            }}
+            tilesData={[
+              {
+                value: data.variants ? data.variants!.values[0].last_value.sample_size : null,
+                title: textNl.kpi_amount_of_samples.tile_total_samples.title,
+                description: textNl.kpi_amount_of_samples.tile_total_samples.description,
+              },
+              {
+                value: totalVariants,
+                title: textNl.kpi_amount_of_samples.tile_total_variants.title,
+                description: textNl.kpi_amount_of_samples.tile_total_samples.description,
+              },
+            ]}
           />
 
           {variantChart && variantLabels && (

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -147,24 +147,6 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
             ]}
           />
 
-          {variantLabels && (
-            <VariantsTableTile
-              data={variantTable}
-              text={{
-                ...textNl.varianten_tabel,
-                variantCodes: variantLabels,
-                description: variantenTableDescription,
-              }}
-              sampleThresholdPassed={sampleThresholdPassed}
-              source={textNl.bronnen.rivm}
-              dates={{
-                date_end_unix: dates.date_end_unix,
-                date_of_report_unix: getLastInsertionDateOfPage(data, ['variants']),
-                date_start_unix: dates.date_start_unix,
-              }}
-            />
-          )}
-
           {variantChart && variantLabels && (
             <VariantsStackedBarChartTile
               title={textNl.varianten_barchart.titel}
@@ -180,6 +162,24 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
                 datumsText: textNl.datums,
                 date: getLastInsertionDateOfPage(data, ['variants']),
                 source: textNl.bronnen.rivm,
+              }}
+            />
+          )}
+
+          {variantLabels && (
+            <VariantsTableTile
+              data={variantTable}
+              text={{
+                ...textNl.varianten_tabel,
+                variantCodes: variantLabels,
+                description: variantenTableDescription,
+              }}
+              sampleThresholdPassed={sampleThresholdPassed}
+              source={textNl.bronnen.rivm}
+              dates={{
+                date_end_unix: dates.date_end_unix,
+                date_of_report_unix: getLastInsertionDateOfPage(data, ['variants']),
+                date_start_unix: dates.date_start_unix,
               }}
             />
           )}

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -80,7 +80,11 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
 
   const totalVariants = data.named_difference.variants__percentage.filter((namedDifferenceEntry) => namedDifferenceEntry.variant_code !== 'other_variants').length;
 
+  const sampleThresholdPassed = data.variants ? data.variants!.values[0].last_value.sample_size > 100 : false;
+
   const variantLabels: VariantDynamicLabels = {};
+
+  const variantenTableDescription = sampleThresholdPassed ? textNl.varianten_omschrijving : textNl.varianten_tabel.omschrijving_te_weinig_samples;
 
   data.variants?.values.forEach((variant) => {
     variantLabels[`${variant.variant_code}`] = locale === 'nl' ? variant.values[0].label_nl : variant.values[0].label_en;
@@ -157,8 +161,9 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               text={{
                 ...textNl.varianten_tabel,
                 variantCodes: variantLabels,
-                description: textNl.varianten_omschrijving,
+                description: variantenTableDescription,
               }}
+              sampleThresholdPassed={sampleThresholdPassed}
               source={textNl.bronnen.rivm}
               dates={{
                 date_end_unix: dates.date_end_unix,

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -7,7 +7,6 @@ import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { Layout } from '~/domain/layout/layout';
 import { NlLayout } from '~/domain/layout/nl-layout';
-import { VariantDynamicLabels } from '~/domain/variants/variants-table-tile/types';
 import { useIntl } from '~/intl';
 import { Languages, SiteText } from '~/locale';
 import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
@@ -19,8 +18,9 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { useState } from 'react';
-import { getArchivedVariantChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/data-selection';
-import { VariantsStackedAreaTile, VariantsTableTile } from '~/domain/variants';
+import { getArchivedVariantChartData, getVariantBarChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/data-selection';
+import { VariantsStackedAreaTile, VariantsStackedBarChartTile, VariantsTableTile } from '~/domain/variants';
+import { VariantDynamicLabels } from '~/domain/variants/data-selection/types';
 
 const pageMetrics = ['variants', 'named_difference'];
 
@@ -51,6 +51,7 @@ export const getStaticProps = createGetStaticProps(
 
     return {
       ...getVariantTableData(variants, data.selectedNlData.named_difference, variantColors),
+      ...getVariantBarChartData(variants),
       ...getArchivedVariantChartData(variants_archived_20231101),
       variantColors,
     };
@@ -70,7 +71,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 export default function CovidVariantenPage(props: StaticProps<typeof getStaticProps>) {
-  const { pageText, selectedNlData: data, lastGenerated, content, variantTable, archivedVariantChart, variantColors, dates } = props;
+  const { pageText, selectedNlData: data, lastGenerated, content, variantTable, variantChart, archivedVariantChart, variantColors, dates } = props;
 
   const { commonTexts, locale } = useIntl();
   const { metadataTexts, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
@@ -160,6 +161,25 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
                 date_end_unix: dates.date_end_unix,
                 date_of_report_unix: getLastInsertionDateOfPage(data, ['variants']),
                 date_start_unix: dates.date_start_unix,
+              }}
+            />
+          )}
+
+          {variantLabels && (
+            <VariantsStackedBarChartTile
+              title={textNl.varianten_barchart.titel}
+              description={textNl.varianten_barchart.description}
+              helpText={textNl.varianten_over_tijd_grafiek.legend_help_tekst}
+              values={variantChart}
+              variantLabels={{
+                ...textNl.varianten_over_tijd_grafiek,
+                variantCodes: variantLabels,
+              }}
+              variantColors={variantColors}
+              metadata={{
+                datumsText: textNl.datums,
+                date: getLastInsertionDateOfPage(data, ['variants']),
+                source: textNl.bronnen.rivm,
               }}
             />
           )}

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -165,7 +165,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
             />
           )}
 
-          {variantLabels && (
+          {variantChart && variantLabels && (
             <VariantsStackedBarChartTile
               title={textNl.varianten_barchart.titel}
               description={textNl.varianten_barchart.description}

--- a/packages/cms/src/studio/data/data-structure.ts
+++ b/packages/cms/src/studio/data/data-structure.ts
@@ -261,6 +261,7 @@ export const dataStructure = {
       'janssen_not_available',
       'janssen_total',
     ],
+    variants_archived_20231101: ['variant_code', 'values', 'last_value'],
     repeating_shot_administered_20220713: ['ggd_administered_total'],
     corona_melder_app_warning_archived_20220421: ['count'],
     corona_melder_app_download_archived_20220421: ['count'],

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -231,6 +231,7 @@ export interface ArchivedNl {
   vaccine_coverage_per_age_group_estimated_fully_vaccinated_archived_20231004: NlVaccineCoveragePerAgeGroupEstimatedFullyVaccinatedValue;
   vaccine_delivery_per_supplier_archived_20211101: ArchivedNlVaccineDeliveryPerSupplier;
   vaccine_stock_archived_20211024: ArchivedNlVaccineStock;
+  variants_archived_20231101: ArchivedNlVariants;
   repeating_shot_administered_20220713: ArchivedNlRepeatingShotAdministered;
   corona_melder_app_warning_archived_20220421: ArchivedNlCoronaMelderAppWarning;
   corona_melder_app_download_archived_20220421: ArchivedNlCoronaMelderAppDownload;
@@ -833,6 +834,26 @@ export interface ArchivedNlVaccineStockValue {
   date_of_insertion_unix: number;
   date_unix: number;
 }
+export interface ArchivedNlVariants {
+  values: ArchivedNlVariantsVariant[];
+}
+export interface ArchivedNlVariantsVariant {
+  variant_code: string;
+  values: ArchivedNlVariantsVariantValue[];
+  last_value: ArchivedNlVariantsVariantValue;
+}
+export interface ArchivedNlVariantsVariantValue {
+  order: number;
+  occurrence: number;
+  percentage: number;
+  sample_size: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  date_of_insertion_unix: number;
+  date_of_report_unix: number;
+  label_nl: string;
+  label_en: string;
+}
 export interface ArchivedNlRepeatingShotAdministered {
   values: ArchivedNlRepeatingShotAdministeredValue[];
   last_value: ArchivedNlRepeatingShotAdministeredValue;
@@ -1031,7 +1052,7 @@ export interface Nl {
   deceased_cbs: NlDeceasedCbs;
   vaccine_administered_last_timeframe: NlVaccineAdministeredLastTimeframe;
   vaccine_campaigns: NlVaccineCampaign;
-  variants?: NlVariants;
+  variants: NlVariants;
   self_test_overall: NlSelfTestOverall;
   infectionradar_symptoms_trend_per_age_group_weekly: NlInfectionradarSymptomsTrendPerAgeGroupWeekly;
 }


### PR DESCRIPTION
## Summary
 
* Refactored existing code for variants page
* Added KPI section
* Added variants bar graph
* Archived variants timeseries chart
* Added mechanism to hide table when lower than 100 samples
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/0c8102de-e48d-4581-8fec-6012aa07f48f)
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/7b2494a3-2044-4e3e-9a66-e4da010d0131)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/40103ee9-7419-4576-a8dd-561ad25fae46)
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/1ce2b2d8-9aff-4f1d-8673-ae8eb2cbb218)
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/3bd9d22c-dd7a-4b2d-95f2-88febfdd56c0)

</details>