### PR TITLE
feat(COR-1811): Different way of using interactive legend

### DIFF
--- a/packages/app/src/components/interactive-legend.tsx
+++ b/packages/app/src/components/interactive-legend.tsx
@@ -37,7 +37,7 @@ export function InteractiveLegend<T = string>({ helpText, selectOptions, selecti
             const isSelected = selection.includes(item.metricProperty);
             return (
               <Item key={item.label}>
-                <StyledLabel htmlFor={`checkboxgroup-${item.label}`} isActive={hasSelection && isSelected} borderColor={item.color} data-text={item.label}>
+                <StyledLabel htmlFor={`checkboxgroup-${item.metricProperty}`} isActive={hasSelection && isSelected} borderColor={item.color} data-text={item.label}>
                   {item.label}
                   {item.shape === 'line' && <Line color={item.color} />}
                   {item.shape === 'dashed' && (
@@ -51,7 +51,7 @@ export function InteractiveLegend<T = string>({ helpText, selectOptions, selecti
                 </StyledLabel>
                 <StyledInput
                   type="checkbox"
-                  id={`checkboxgroup-${item.label}`}
+                  id={`checkboxgroup-${item.metricProperty}`}
                   value={item.label}
                   onClick={() => onToggleItem(item.metricProperty)}
                   aria-label={item.legendAriaLabel}

--- a/packages/app/src/domain/variants/logic/use-bar-config.ts
+++ b/packages/app/src/domain/variants/logic/use-bar-config.ts
@@ -10,6 +10,16 @@ const extractVariantNamesFromValues = (values: VariantChartValue[]) => {
     .filter((keyName) => keyName.endsWith('_occurrence'));
 };
 
+/**
+ * Create configuration labels for interactive legend
+ * @param values
+ * @param selectedOptions
+ * @param variantLabels
+ * @param tooltipLabels
+ * @param colors
+ * @param timeframe
+ * @param today
+ */
 export const useBarConfig = (
   values: VariantChartValue[],
   selectedOptions: (keyof VariantChartValue)[],

--- a/packages/app/src/domain/variants/logic/use-series-config.ts
+++ b/packages/app/src/domain/variants/logic/use-series-config.ts
@@ -31,7 +31,7 @@ export const useSeriesConfig = (
       const variantCode = variantCodeFragments.join('_');
 
       // Match mnenonic variant name in lokalize to code-based variant name
-      const variantDynamicLabel = text.variantCodes[variantCode] + ' '; // THIS IS NECESSARY TO DIFFERENTIATE STATE BETWEEN THE TWO INTERACTIVE LEGENDS ON THE PAGE;
+      const variantDynamicLabel = text.variantCodes[variantCode];
 
       // Match appropriate variant color
       const color = colors.find((variantColors) => variantColors.variant === variantCode)?.color;


### PR DESCRIPTION
## Summary
 
* use metricProperty instead of label in interactive legend form I
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/0a0de8da-417b-41e5-a4f8-7dbd27f67011)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/f2f63bd8-f3ed-4d2c-8c2c-678263a8a26a)

</details>