### PR TITLE
fix(COR-1812): Remove date ranges from last zkh graphs

### DIFF
--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -172,11 +172,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
           {variantLabels && (
             <VariantsTableTile
               data={variantTable}
-              text={{
-                ...textNl.varianten_tabel,
-                variantCodes: variantLabels,
-                description: variantenTableDescription,
-              }}
+              text={{ ...textNl.varianten_tabel, variantCodes: variantLabels, description: variantenTableDescription }}
               sampleThresholdPassed={sampleThresholdPassed}
               source={textNl.bronnen.rivm}
               dates={{
@@ -206,10 +202,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
             <>
               {archivedVariantChart && variantLabels && (
                 <VariantsStackedAreaTile
-                  text={{
-                    ...textNl.varianten_over_tijd_grafiek,
-                    variantCodes: variantLabels as VariantDynamicLabels,
-                  }}
+                  text={{ ...textNl.varianten_over_tijd_grafiek, variantCodes: variantLabels as VariantDynamicLabels }}
                   values={archivedVariantChart}
                   variantColors={variantColors}
                   metadata={{

--- a/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
@@ -106,7 +106,8 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
   const hospitalLastValue = getLastFilledValue(data.hospital_lcps);
   const icuLastValue = getLastFilledValue(data.intensive_care_lcps);
 
-  const valuesWithoutDateRange = data.hospital_lcps.values.map((value) => ({ ...value, date_end_unix: undefined, date_start_unix: undefined }));
+  const lcpsHospitalWithoutRange = data.hospital_lcps.values.map((value) => ({ ...value, date_end_unix: undefined, date_start_unix: undefined }));
+  const lcpsICWithoutRange = data.intensive_care_lcps.values.map((value) => ({ ...value, date_end_unix: undefined, date_start_unix: undefined }));
 
   const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
 
@@ -173,7 +174,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'hospital_beds_occupied_over_time_chart',
                 }}
-                values={valuesWithoutDateRange}
+                values={lcpsHospitalWithoutRange}
                 timeframe={hospitalBedsOccupiedOverTimeTimeframe}
                 forceLegend
                 seriesConfig={[
@@ -225,7 +226,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'intensive_care_beds_occupied_over_time_chart',
                 }}
-                values={data.intensive_care_lcps.values}
+                values={lcpsICWithoutRange}
                 timeframe={intensiveCareBedsTimeframe}
                 forceLegend
                 seriesConfig={[
@@ -254,6 +255,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                     },
                   ],
                   timelineEvents: getTimelineEvents(content.elements.timeSeries, 'intensive_care_lcps', 'beds_occupied_covid'),
+                  useDatesAsRange: false,
                 }}
               />
             </ChartTile>
@@ -296,7 +298,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'hospital_patient_influx_over_time_chart',
                 }}
-                values={trimLeadingNullValues(valuesWithoutDateRange, 'influx_covid_patients')}
+                values={trimLeadingNullValues(lcpsHospitalWithoutRange, 'influx_covid_patients')}
                 timeframe={hospitalPatientInfluxOverTimeTimeframe}
                 seriesConfig={[
                   {
@@ -337,7 +339,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
                 accessibility={{
                   key: 'intensive_care_patient_influx_over_time_chart',
                 }}
-                values={trimLeadingNullValues(data.intensive_care_lcps.values, 'influx_covid_patients')}
+                values={trimLeadingNullValues(lcpsICWithoutRange, 'influx_covid_patients')}
                 timeframe={intensiveCarePatientInfluxOverTimeTimeframe}
                 seriesConfig={[
                   {


### PR DESCRIPTION
## Summary
 
* Change date range to singular date on Intensive-Care graphs at Ziekenhuizen-in-beeld page 
* Refactor variants page
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/1da3ff06-7c8f-47f5-b3c8-61e884c63efa)

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/642bb2ff-0d3a-4685-b7b9-9d929a99c429)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/79f68a68-5c13-4d6a-bec8-f20943df4b18)

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/19a55a63-809e-4d69-9d6e-95ea2d03ec0e)

</details>