### PR TITLE
Feature/cor 1815 aantal deelnemers infectieradar

### DIFF
--- a/packages/app/schema/nl/__difference.json
+++ b/packages/app/schema/nl/__difference.json
@@ -26,6 +26,9 @@
     },
     "vulnerable_hospital_admissions": {
       "$ref": "#/definitions/diff_integer"
+    },
+    "self_test_overall": {
+      "$ref": "#/definitions/diff_decimal"
     }
   },
   "required": [
@@ -34,7 +37,8 @@
     "infectious_people__estimate",
     "intensive_care_nice__admissions_on_date_of_reporting_moving_average",
     "intensive_care_lcps__beds_occupied_covid",
-    "sewer__average"
+    "sewer__average",
+    "self_test_overall"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/packages/app/schema/nl/self_test_overall.json
+++ b/packages/app/schema/nl/self_test_overall.json
@@ -3,11 +3,14 @@
     "value": {
       "title": "nl_self_test_overall_value",
       "type": "object",
-      "required": ["infected_percentage", "date_start_unix", "date_end_unix", "date_of_insertion_unix"],
+      "required": ["infected_percentage", "n_participants_total_unfiltered", "date_start_unix", "date_end_unix", "date_of_insertion_unix"],
       "additionalProperties": false,
       "properties": {
         "infected_percentage": {
           "type": ["number", "null"]
+        },
+        "n_participants_total_unfiltered": {
+          "type": ["number"]
         },
         "date_start_unix": {
           "type": "integer"

--- a/packages/app/src/pages/landelijk/infectieradar.tsx
+++ b/packages/app/src/pages/landelijk/infectieradar.tsx
@@ -22,6 +22,7 @@ import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { KpiTile, KpiValue, TwoKpiSection } from '~/components';
 
 const pageMetrics = ['self_test_overall', 'infection_radar_symptoms_per_age_group'];
 
@@ -35,7 +36,7 @@ type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData('self_test_overall', 'infectionradar_symptoms_trend_per_age_group_weekly'),
+  selectNlData('difference.self_test_overall', 'self_test_overall', 'infectionradar_symptoms_trend_per_age_group_weekly'),
   async (context: GetStaticPropsContext) => {
     const { content } = await createGetContent<{
       parts: PagePartQueryResult<ArticleParts>;
@@ -101,6 +102,29 @@ const InfectionRadar = (props: StaticProps<typeof getStaticProps>) => {
               faq: content.faqs,
             })}
           />
+
+          <TwoKpiSection>
+            <KpiTile
+              title="Hello kpi tile 1"
+              metadata={{
+                date: { start: data.self_test_overall.last_value.date_start_unix, end: data.self_test_overall.last_value.date_end_unix },
+                source: textNl.sources.self_test,
+              }}
+              description="Description KPI tile 1"
+            >
+              <KpiValue percentage={data.self_test_overall.last_value.infected_percentage} differenceFractionDigits={1} difference={data.difference.self_test_overall} isAmount />
+            </KpiTile>
+            <KpiTile
+              title="Hello KPI tile 2"
+              metadata={{
+                date: { start: data.self_test_overall.last_value.date_start_unix, end: data.self_test_overall.last_value.date_end_unix },
+                source: textNl.sources.self_test,
+              }}
+              description="Description kpi tile 2"
+            >
+              <KpiValue absolute={data.self_test_overall.last_value.n_participants_total_unfiltered} isAmount />
+            </KpiTile>
+          </TwoKpiSection>
 
           <ChartTile
             title={textNl.chart_self_tests.title}

--- a/packages/app/src/pages/landelijk/infectieradar.tsx
+++ b/packages/app/src/pages/landelijk/infectieradar.tsx
@@ -23,6 +23,7 @@ import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts'
 import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-page';
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { KpiTile, KpiValue, TwoKpiSection } from '~/components';
+import { replaceVariablesInText } from '~/utils';
 
 const pageMetrics = ['self_test_overall', 'infection_radar_symptoms_per_age_group'];
 
@@ -70,6 +71,8 @@ const InfectionRadar = (props: StaticProps<typeof getStaticProps>) => {
 
   const { metadataTexts, textNl } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
+  const totalInfectedPercentage = data.self_test_overall.last_value.infected_percentage ? data.self_test_overall.last_value.infected_percentage : 0;
+
   const metadata = {
     ...metadataTexts,
     title: textNl.metadata.title,
@@ -105,24 +108,26 @@ const InfectionRadar = (props: StaticProps<typeof getStaticProps>) => {
 
           <TwoKpiSection>
             <KpiTile
-              title="Hello kpi tile 1"
+              title={textNl.kpi_tile.infected_participants_percentage.title}
               metadata={{
                 date: { start: data.self_test_overall.last_value.date_start_unix, end: data.self_test_overall.last_value.date_end_unix },
                 source: textNl.sources.self_test,
               }}
-              description="Description KPI tile 1"
+              description={replaceVariablesInText(textNl.kpi_tile.infected_participants_percentage.description, {
+                infectedPercentage: totalInfectedPercentage,
+              })}
             >
               <KpiValue percentage={data.self_test_overall.last_value.infected_percentage} differenceFractionDigits={1} difference={data.difference.self_test_overall} isAmount />
             </KpiTile>
             <KpiTile
-              title="Hello KPI tile 2"
+              title={textNl.kpi_tile.total_participants.title}
               metadata={{
                 date: { start: data.self_test_overall.last_value.date_start_unix, end: data.self_test_overall.last_value.date_end_unix },
                 source: textNl.sources.self_test,
               }}
-              description="Description kpi tile 2"
+              description={textNl.kpi_tile.total_participants.description}
             >
-              <KpiValue absolute={data.self_test_overall.last_value.n_participants_total_unfiltered} isAmount />
+              <KpiValue absolute={data.self_test_overall.last_value.n_participants_total_unfiltered} numFractionDigits={0} isAmount />
             </KpiTile>
           </TwoKpiSection>
 

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -21,3 +21,7 @@ timestamp,action,key,document_id,move_to
 2023-10-24T11:27:38.726Z,delete,common.test_key:,itix6KXAqiuTrWiucCRIit,__
 2023-10-24T11:27:38.727Z,delete,__root.test_123,0hrRKce5hYl5O3WpoZ6oAl,__
 2023-10-24T11:27:38.727Z,delete,__root.test_key_345,0hrRKce5hYl5O3WpoZ6nXX,__
+2023-10-27T14:07:39.563Z,add,pages.infectie_radar_page.nl.kpi_tile.infected_participants_percentage.title,5if6OpiB3iy3C5t2bwoaWw,__
+2023-10-27T14:07:40.526Z,add,pages.infectie_radar_page.nl.kpi_tile.infected_participants_percentage.description,pCa5dcpJ9eiic3eFSI81Ea,__
+2023-10-27T14:07:41.538Z,add,pages.infectie_radar_page.nl.kpi_tile.total_participants.title,XnRo9vzZlQx15CHPE0aA2y,__
+2023-10-27T14:07:42.530Z,add,pages.infectie_radar_page.nl.kpi_tile.total_participants.description,5if6OpiB3iy3C5t2bwoaba,__

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -1065,6 +1065,7 @@ export interface NlDifference {
   sewer__average: DifferenceInteger;
   reproduction__index_average?: DifferenceDecimal;
   vulnerable_hospital_admissions?: DifferenceInteger;
+  self_test_overall: DifferenceDecimal;
 }
 export interface DifferenceInteger {
   old_value: number;
@@ -1252,6 +1253,7 @@ export interface NlSelfTestOverall {
 }
 export interface NlSelfTestOverallValue {
   infected_percentage: number | null;
+  n_participants_total_unfiltered: number;
   date_start_unix: number;
   date_end_unix: number;
   date_of_insertion_unix: number;


### PR DESCRIPTION
## Summary
 
* Added TwoKpiSection to infectieradar page
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/553b4e2f-1b48-4bdf-ab07-b6354fc38bce)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/47199dc6-55c9-44f4-8db6-66f264d07d48)

</details>