### PR TITLE
fix(COR-1851): Fix incorrect dates being displayed on positive tests …

### DIFF
--- a/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
@@ -43,7 +43,7 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
-const pageMetrics = ['tested_overall'];
+const pageMetrics = ['tested_overall_archived_20230331'];
 
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
@@ -78,13 +78,13 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
-  const { pageText, selectedGmData: data, selectedArchivedGmData: archived_data, archivedChoropleth, municipalityName, content, lastGenerated } = props;
+  const { pageText, selectedGmData: data, selectedArchivedGmData: archivedData, archivedChoropleth, municipalityName, content, lastGenerated } = props;
   const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
   const reverseRouter = useReverseRouter();
   const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
-  const archivedLastValue = archived_data.tested_overall_archived_20230331.last_value;
+  const archivedLastValue = archivedData.tested_overall_archived_20230331.last_value;
   const populationCount = data.static_values.population_count;
   const metadata = {
     ...commonTexts.gemeente_index.metadata,
@@ -96,7 +96,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
     }),
   };
 
-  const lastInsertionDateOfPage = getLastInsertionDateOfPage(data, pageMetrics);
+  const lastInsertionDateOfPage = getLastInsertionDateOfPage(archivedData, pageMetrics);
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
@@ -188,7 +188,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               accessibility={{
                 key: 'confirmed_cases_infected_over_time_chart',
               }}
-              values={archived_data.tested_overall_archived_20230331.values}
+              values={archivedData.tested_overall_archived_20230331.values}
               timeframe={positivelyTestedPeopleTimeframe}
               seriesConfig={[
                 {

--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -236,7 +236,7 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
                 })}
                 metadata={{
                   source: textNl.ggd.bronnen.rivm,
-                  date: getLastInsertionDateOfPage(data, ['tested_ggd']),
+                  date: getLastInsertionDateOfPage(data, ['tested_ggd_archived_20230321']),
                 }}
                 onSelectTimeframe={setConfirmedCasesTestedOverTimeTimeframe}
                 toggle={{


### PR DESCRIPTION
## Summary
 
* Corrected dates on positive tests page
*
*
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/49800461-7c64-42cb-9ac4-6bc456246eb1)
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/9119b54e-a4b7-453c-a80d-77e985b62152)


</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>

 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/0b9c32cb-cb1a-4cfd-9ec2-d89fb5d7bc2c)

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/e9353d93-b12f-4193-ae3d-6a19b1d4da18)


</details>