### PR TITLE
task: Update sample threshold to 0

### DIFF
--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -106,7 +106,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
       )
     : NaN;
 
-  const sampleThresholdPassed = data.variants ? data.variants!.values[0].last_value.sample_size > 100 : false;
+  const sampleThresholdPassed = data.variants ? data.variants!.values[0].last_value.sample_size > 0 : false; // Hack to set to 0 because we aim to match the variants page on RIVM.nl
 
   const variantLabels: VariantDynamicLabels = {};
 

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -1064,13 +1064,13 @@ export interface NlDifference {
   vulnerable_hospital_admissions?: DifferenceInteger;
   self_test_overall: DifferenceDecimal;
 }
-export interface DifferenceInteger {
+export interface DifferenceDecimal {
   old_value: number;
   difference: number;
   old_date_unix: number;
   new_date_unix: number;
 }
-export interface DifferenceDecimal {
+export interface DifferenceInteger {
   old_value: number;
   difference: number;
   old_date_unix: number;


### PR DESCRIPTION
Set sample threshold to 0 in variants page in order to always display the breakdown table