### PR TITLE
fix: set OS and NodeJS version to use in GitHub workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -32,6 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-22.04 ]
+        node-version: [ 18.18.2 ]
         language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
@@ -40,6 +42,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
         node-version: [ 18.18.2 ]
         language: ['javascript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]

--- a/.github/workflows/infra-acceptance.yml
+++ b/.github/workflows/infra-acceptance.yml
@@ -10,7 +10,7 @@ jobs:
   trigger-acceptance-build:
     environment: Acceptance
     name: Call Azure Pipeline
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1.2

--- a/.github/workflows/infra-acceptance.yml
+++ b/.github/workflows/infra-acceptance.yml
@@ -10,7 +10,7 @@ jobs:
   trigger-acceptance-build:
     environment: Acceptance
     name: Call Azure Pipeline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1.2

--- a/.github/workflows/infra-develop.yml
+++ b/.github/workflows/infra-develop.yml
@@ -8,7 +8,7 @@ jobs:
   trigger-develop-build:
     environment: Development
     name: Call Azure Pipeline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1

--- a/.github/workflows/infra-develop.yml
+++ b/.github/workflows/infra-develop.yml
@@ -8,7 +8,7 @@ jobs:
   trigger-develop-build:
     environment: Development
     name: Call Azure Pipeline
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Call Azure Pipeline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Call Azure Pipeline
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Azure Pipelines Action
         uses: Azure/pipelines@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,11 @@ jobs:
         run: yarn lint
 
   compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [18.18.2]
     needs: init
     steps:
       - name: Get target branch name (pull request)
@@ -48,6 +52,11 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel previous workflow
         uses: styfle/cancel-workflow-action@0.4.0
@@ -12,7 +12,7 @@ jobs:
           access_token: ${{ github.token }}
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: init
     steps:
       - name: Check out repository
@@ -38,7 +38,7 @@ jobs:
         run: yarn lint
 
   compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: init
     steps:
       - name: Get target branch name (pull request)
@@ -83,7 +83,7 @@ jobs:
         run: yarn typecheck
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: init
     steps:
       - name: Check out repository
@@ -118,7 +118,7 @@ jobs:
         run: yarn test:ci
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: init
     if: contains(github.head_ref, 'release')
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,11 @@ on: pull_request
 
 jobs:
   init:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        node-version: [18.18.2]
     steps:
       - name: Cancel previous workflow
         uses: styfle/cancel-workflow-action@0.4.0
@@ -12,7 +16,11 @@ jobs:
           access_token: ${{ github.token }}
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        node-version: [18.18.2]
     needs: init
     steps:
       - name: Check out repository
@@ -38,10 +46,10 @@ jobs:
         run: yarn lint
 
   compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         node-version: [18.18.2]
     needs: init
     steps:
@@ -92,7 +100,11 @@ jobs:
         run: yarn typecheck
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        node-version: [18.18.2]
     needs: init
     steps:
       - name: Check out repository
@@ -127,7 +139,11 @@ jobs:
         run: yarn test:ci
 
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        node-version: [18.18.2]
     needs: init
     if: contains(github.head_ref, 'release')
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         node-version: [18.18.2]
     needs: init
     steps:
@@ -50,7 +49,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         node-version: [18.18.2]
     needs: init
     steps:
@@ -104,7 +102,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         node-version: [18.18.2]
     needs: init
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -109,6 +114,11 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,6 @@ on: pull_request
 jobs:
   init:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-        node-version: [18.18.2]
     steps:
       - name: Cancel previous workflow
         uses: styfle/cancel-workflow-action@0.4.0
@@ -150,10 +146,6 @@ jobs:
 
   docker:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        os: [ubuntu-22.04]
-        node-version: [18.18.2]
     needs: init
     if: contains(github.head_ref, 'release')
     steps:

--- a/.github/workflows/sync-sanity-lokalize.yml
+++ b/.github/workflows/sync-sanity-lokalize.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-22.04]
         node-version: [18.18.2]
     steps:
       - name: Check out repository

--- a/.github/workflows/sync-sanity-lokalize.yml
+++ b/.github/workflows/sync-sanity-lokalize.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync-after-feature:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/sync-sanity-lokalize.yml
+++ b/.github/workflows/sync-sanity-lokalize.yml
@@ -7,10 +7,19 @@ on:
 
 jobs:
   sync-after-feature:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        node-version: [18.18.2]
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
- Set specific version number for NodeJS version used in GH workflow to 18.18.4
- Set specific OS version for Ubuntu in GH workflow to 22.04
