### PR TITLE
feature/COR-1837-update-archived-timeframes

### DIFF
--- a/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
@@ -25,7 +25,7 @@ interface VariantsStackedAreaTileProps {
 }
 
 export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata }: VariantsStackedAreaTileProps) => {
-  const [variantTimeframe, setVariantTimeframe] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
+  const [variantStackedAreaTimeframe, setVariantStackedAreaTimeframe] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
 
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
 
@@ -55,7 +55,7 @@ export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata 
       metadata={metadata}
       timeframeOptions={TimeframeOptionsList}
       timeframeInitialValue={TimeframeOption.THREE_MONTHS}
-      onSelectTimeframe={setVariantTimeframe}
+      onSelectTimeframe={setVariantStackedAreaTimeframe}
     >
       <InteractiveLegend helpText={text.legend_help_tekst} selectOptions={selectOptions} selection={list} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
@@ -64,7 +64,7 @@ export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata 
           key: 'variants_stacked_area_over_time_chart',
         }}
         values={values}
-        timeframe={variantTimeframe}
+        timeframe={variantStackedAreaTimeframe}
         seriesConfig={filteredConfig}
         disableLegend
         dataOptions={{

--- a/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
@@ -25,7 +25,7 @@ interface VariantsStackedAreaTileProps {
 }
 
 export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata }: VariantsStackedAreaTileProps) => {
-  const [variantStackedAreaTimeframe, setVariantStackedAreaTimeframe] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
+  const [variantStackedAreaTimeframe, setVariantStackedAreaTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
 
@@ -54,7 +54,7 @@ export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata 
       description={text.toelichting}
       metadata={metadata}
       timeframeOptions={TimeframeOptionsList}
-      timeframeInitialValue={TimeframeOption.THREE_MONTHS}
+      timeframeInitialValue={variantStackedAreaTimeframe}
       onSelectTimeframe={setVariantStackedAreaTimeframe}
     >
       <InteractiveLegend helpText={text.legend_help_tekst} selectOptions={selectOptions} selection={list} onToggleItem={toggle} onReset={clear} />

--- a/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
@@ -79,7 +79,7 @@ export const getStaticProps = createGetStaticProps(
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedGmData: data, selectedArchivedGmData: archivedData, archivedChoropleth, municipalityName, content, lastGenerated } = props;
-  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
+  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
   const reverseRouter = useReverseRouter();
   const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);

--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -78,7 +78,7 @@ export const getStaticProps = createGetStaticProps(
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedArchivedNlData: data, archivedChoropleth, content, lastGenerated } = props;
 
-  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
+  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const [confirmedCasesInfectedPercentageTimeframe, setConfirmedCasesInfectedPercentageTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 


### PR DESCRIPTION
## Summary
 
* Set timeframe to always be 'ALL TIME' on archived graphs
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/f81e77ad-65b1-475e-a5cc-c9d52ff70741)


</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/6ddd21e7-897c-43ac-aaf9-1f2e47e0b263)


</details>