### PR TITLE
feat(COR-1896): Remove campaign banner and sanity keys from vaccine page

### DIFF
--- a/packages/app/src/pages/landelijk/de-coronaprik.tsx
+++ b/packages/app/src/pages/landelijk/de-coronaprik.tsx
@@ -15,7 +15,6 @@ import { WarningTile } from '~/components/warning-tile';
 import { Layout, NlLayout } from '~/domain/layout';
 import {
   Autumn2022ShotCoveragePerAgeGroup,
-  CampaignBanner,
   VaccinationsKpiHeader,
   VaccinationsOverTimeTile,
   VaccinationsShotKpiSection,
@@ -224,12 +223,6 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               date: { start: currentData.vaccine_administered_last_timeframe.date_start_unix, end: currentData.vaccine_administered_last_timeframe.date_end_unix },
               obtainedAt: currentData.vaccine_administered_last_timeframe.date_of_insertion_unix,
             }}
-          />
-
-          <CampaignBanner
-            title={textNl.vaccine_campaigns.autumn_2023.campaign_banner.title}
-            description={textNl.vaccine_campaigns.autumn_2023.campaign_banner.description}
-            altText={textNl.vaccine_campaigns.autumn_2023.campaign_banner.alt}
           />
 
           <PrimarySeriesKpiHeader

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -1,1 +1,4 @@
 timestamp,action,key,document_id,move_to
+2023-12-19T13:35:17.504Z,delete,pages.vaccinations_page.nl.vaccine_campaigns.autumn_2023.campaign_banner.alt,fQMSbwQpEgDbjt4uWKBe2g,__
+2023-12-19T13:35:17.505Z,delete,pages.vaccinations_page.nl.vaccine_campaigns.autumn_2023.campaign_banner.description,nX27LJrkVpILF9ToyJf7OI,__
+2023-12-19T13:35:17.505Z,delete,pages.vaccinations_page.nl.vaccine_campaigns.autumn_2023.campaign_banner.title,fQMSbwQpEgDbjt4uWGfKig,__


### PR DESCRIPTION
## Summary
 
* Removed vaccine campaign banner
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/6f733271-0a23-4be9-9fa7-2b1b63033307)


</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/ab25b427-c6a8-4c70-8510-6c13ebafbc77)


</details>