### PR TITLE
release/2.85.0

### DIFF
--- a/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-area-tile.tsx
@@ -25,7 +25,7 @@ interface VariantsStackedAreaTileProps {
 }
 
 export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata }: VariantsStackedAreaTileProps) => {
-  const [variantTimeframe, setVariantTimeframe] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
+  const [variantStackedAreaTimeframe, setVariantStackedAreaTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
 
@@ -54,8 +54,8 @@ export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata 
       description={text.toelichting}
       metadata={metadata}
       timeframeOptions={TimeframeOptionsList}
-      timeframeInitialValue={TimeframeOption.THREE_MONTHS}
-      onSelectTimeframe={setVariantTimeframe}
+      timeframeInitialValue={variantStackedAreaTimeframe}
+      onSelectTimeframe={setVariantStackedAreaTimeframe}
     >
       <InteractiveLegend helpText={text.legend_help_tekst} selectOptions={selectOptions} selection={list} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
@@ -64,7 +64,7 @@ export const VariantsStackedAreaTile = ({ text, values, variantColors, metadata 
           key: 'variants_stacked_area_over_time_chart',
         }}
         values={values}
-        timeframe={variantTimeframe}
+        timeframe={variantStackedAreaTimeframe}
         seriesConfig={filteredConfig}
         disableLegend
         dataOptions={{

--- a/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
@@ -79,7 +79,7 @@ export const getStaticProps = createGetStaticProps(
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedGmData: data, selectedArchivedGmData: archivedData, archivedChoropleth, municipalityName, content, lastGenerated } = props;
-  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
+  const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
   const reverseRouter = useReverseRouter();
   const { textGm, textShared } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);

--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -78,7 +78,7 @@ export const getStaticProps = createGetStaticProps(
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedArchivedNlData: data, archivedChoropleth, content, lastGenerated } = props;
 
-  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
+  const [confirmedCasesInfectedTimeframe, setConfirmedCasesInfectedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const [confirmedCasesInfectedPercentageTimeframe, setConfirmedCasesInfectedPercentageTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 

--- a/packages/app/src/utils/__tests__/get-last-insertion-date-of-page.spec.ts
+++ b/packages/app/src/utils/__tests__/get-last-insertion-date-of-page.spec.ts
@@ -4,17 +4,15 @@ import { getLastInsertionDateOfPage } from '../get-last-insertion-date-of-page';
 
 const GetLastDateOfInsertion = suite('getLastInsertionDateOfPage');
 
-GetLastDateOfInsertion('returns zero when data is empty', () => {
-  const result = getLastInsertionDateOfPage({}, ['key1']);
-  assert.is(result, 0);
+GetLastDateOfInsertion('returns error when data is empty', () => {
+  assert.throws(() => getLastInsertionDateOfPage({}, ['key1']), /Pagemetrics not found in data/)
 });
 
-GetLastDateOfInsertion('returns zero when metrics are empty', () => {
-  const result = getLastInsertionDateOfPage(
-    { key1: { last_value: { date_of_insertion_unix: 123 } } },
-    []
-  );
-  assert.is(result, 0);
+GetLastDateOfInsertion('returns error when metrics are empty', () => {
+    assert.throws(() => getLastInsertionDateOfPage(
+        { key1: { last_value: { date_of_insertion_unix: 123 } } },
+        []
+      ), /Pagemetrics not found in data/);
 });
 
 GetLastDateOfInsertion('returns the max date_of_insertion_unix', () => {

--- a/packages/app/src/utils/get-last-insertion-date-of-page.ts
+++ b/packages/app/src/utils/get-last-insertion-date-of-page.ts
@@ -59,10 +59,18 @@ export function getLastInsertionDateOfPage(
   data: unknown,
   pageMetrics: string[]
 ) {
-  return pageMetrics.reduce((lastDate, metricProperty) => {
+  const metricsAvailableInData: string[] = pageMetrics.filter((metricProperty) => {
+    return typeof get(data, metricProperty) !== 'undefined';
+  });
+
+  if (metricsAvailableInData.length === 0) {
+    throw new Error(`Pagemetrics not found in data`);
+  }
+
+  return metricsAvailableInData.reduce((lastDate, metricProperty) => {
     const metric: any = get(data, metricProperty);
     const metricDate = getMetricDate(metric);
-    
     return Math.max(metricDate, lastDate);
   }, 0);
 };
+


### PR DESCRIPTION
## What's Changed
* task(sync-after-release): Executed the script by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4949
* feature/fix ts node esm+upgrade sharp by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4952
* feature/COR-1837-update-archived-timeframes by @VWSCoronaDashboard29 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4954
* feat(COR-1896): Remove campaign banner and sanity keys from vaccine page by @VWSCoronaDashboard29 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4956
* bugfix/COR-1865-no-auto-resolve-1970 by @VWSCoronaDashboard29 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4955


**Full Changelog**: https://github.com/minvws/nl-covid19-data-dashboard/compare/2.84.1...2.85.0