### PR TITLE
Feature/cor 1866 sync master to dev (#4960)

### DIFF
--- a/packages/app/next.config.js
+++ b/packages/app/next.config.js
@@ -62,7 +62,7 @@ const nextConfig = {
   productionBrowserSourceMaps: true,
 
   webpack(config) {
-    config.optimization.chunkIds = 'named';
+    config.optimization.chunkIds = 'size';
     config.module.rules.push({
       test: /\.svg$/,
       type: 'asset',

--- a/packages/app/src/components/combo-box/combo-box.tsx
+++ b/packages/app/src/components/combo-box/combo-box.tsx
@@ -21,6 +21,7 @@ type TProps<Option extends TOption> = {
   options: Option[];
   placeholder: string;
   onSelect: (option: Option) => void;
+  sorter?: (a: Option, b: Option) => number;
   selectedOption?: Option;
   shouldFocusInput?: boolean;
 };

--- a/packages/app/src/domain/layout/components/gm-combo-box.tsx
+++ b/packages/app/src/domain/layout/components/gm-combo-box.tsx
@@ -16,6 +16,7 @@ export function GmComboBox(props: GmComboBoxProps) {
   const { commonTexts } = useIntl();
   const reverseRouter = useReverseRouter();
   const router = useRouter();
+  const expStr = new RegExp(["'s-"].join(' | '), 'g');
 
   return (
     <ComboBox
@@ -24,6 +25,7 @@ export function GmComboBox(props: GmComboBoxProps) {
       onSelect={({ gemcode }) => {
         router.push(typeof getLink === 'function' ? getLink(gemcode) : reverseRouter.gm.index(gemcode));
       }}
+      sorter={(a, b) => a.name.replace(expStr, '').localeCompare(b.name.replace(expStr, ''))}
       selectedOption={gmData.find((gm) => gm.gemcode === selectedGmCode)}
       shouldFocusInput={shouldFocusInput}
     />


### PR DESCRIPTION
* Fix/vaccine coverage date (#4207)

* fix: use date_unix for vaccine coverage data

* fix: use date_unix instead of date_end_unix for vaccine coverage chart



* Fix/cor 610 incosistent dates on topical pages headers (#4213)

* create hook for getting the last date of insertion

* Added hook to vaccinaties page

* Added all NL pages

* Added all VR pages

* Added to all GM pages

* Exclude difference data

* Improving the Hook

(cherry picked from commit 76ef6543d1c1e63dd44965b5b38d1609661d2d0e)

* COR-604 - Use new hospital_nice_choropleth key for hospital choropleths (#4215)

* fix: use correct boundry when no null values are found

* feat: update schemas with hospital_nice_graph and hospital_nice_choropleth

* feat: update schemas with hospital_nice_choropleth

* fix: use correct format for vr and gm hospital_nice

* fix: use correct hospital_nice schema gm and vr

* feat: use new json key for hospital_nice choropleths

* fix: use date_unix from gm and vr collections for choropleths



* fix: add missing import for DAY_IN_SECONDS

* fix: remove failing test

* fix: revert Sanity key move (hospital_admissions_region_choropleth.description)

* fix: update generate types

* fix merge conflicts

* fix: remove hospital_nice_choropleth from vr schema

* COR-676 - Behavior keys optional in json schemas (#4241)

* fix: make selftest_visit_behavior optional in json schemas

* feat: make behavior json keys optional



* updated get last date logic

(cherry picked from commit f731f7a02064026eb4fa9352a65bbd164e80d9ca)

* Fix typescript error

* Solve PR feedback

* Squashed commit of the following:

commit 77ff7813298ad16ec14df33fe6f98b2128c50295
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Tue May 31 11:12:17 2022 +0200

    feature(CMS): slice first 3 path elements of for the title because they are redundant in the preview (#4272)

    closes: COR-543

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit f5bd004f8f688169093c7ceb9c50dbd0accac1c7
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Mon May 30 16:10:34 2022 +0200

    COR-725 unix date correction (#4255)

    * fix: use startOfDay for all graph values

    * fix: convert dates to startOfDay

    * fix: use endOfDay instead of middleOfDay for current date hook

    * fix: update tests

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 6fcf9b4e1fc6a9a9b74921de1866458fd0f4f37f
Author: J <93984341+VWSCoronaDashboard18@users.noreply.github.com>
Date:   Fri May 27 10:52:13 2022 +0200

    Feature/cor 750 add dotted time series style (#4267)

    * Added a dot line for the time series graph

    * Added laganda support and group scatter plot dots

commit 4eeff200484c1302a4c36698a5c30d3ecf01caa3
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 25 15:22:14 2022 +0200

    Removed obsolete code for international pages (#4268)

    * Removed obsolete code for international pages

    * Removed type parameter

commit 10d97063c626167c4eda20cc4bb069fef1b4ce9e
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Wed May 25 14:24:46 2022 +0200

    fix: set icon size for the top menu icons on smaller screens (#4266)

    These were forgotten with the refactor

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit 4f4abc9e9045f8a13de18678966c8e92c8072cb2
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 25 13:27:53 2022 +0200

    Implemented redesign combobox and select list (#4264)

    * Implemented redesign combobox and select list

    * Removed unused imports

    * Removed sorting by score

    * Added padding to no results message

    * Always keep the same width for search form

    * Removed unused import

    * Fixed padding search results

commit 38ec557d8dcca63bdf40a87a39a54993d76deeb8
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 24 16:29:36 2022 +0200

    COR-736 Behavior Choropleth Tooltip (#4262)

    * fix: fall back to - when no data is available for behavior choropleth tooltip

    * fix: show 0% when data is not null but 0

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit cb44e92806b5a335d887ce30bbd7f74db8c69136
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 24 14:45:50 2022 +0200

    fix: revert changes, replace with empty div and pass optional props (#4263)

commit 26a07c71e2ef4bf6e8cdc27dae0176806d9e7c38
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 24 11:34:08 2022 +0200

    COR-618 Resolve duplicate IDs (#4261)

    * fix: only render mini charts once based on screen size

    * fix: use unique ids for different chart elements and accessibility-annotations

    * fix: mock useUniqueId hook

    * fix: cleanup mock after test

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 64861ee575314aae0d8d6faf2c20dbb335974bfc
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Mon May 23 15:02:23 2022 +0200

    Archive page and add warning tile (#4260)

    * feat(situationsPage): archive page and add warning tile

    * feat: added new key for warning

commit 1ab4c1b2096bc7e3681f6edc8e37b24575e7cba3
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Mon May 23 12:05:16 2022 +0200

    Refactor/cor 73 remove fixed width and height in icons (#4256)

    * refactor: remove width and height of icons with a viewBox

    * refactor: replace width and height of icons with a viewBox

    * refactor: set size of metadata icon in metadata instead

    Use a styled span similar to the icon in the header component

    * refactor: set size of situation icon in code

    Using the extended properties of the generated React element

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit 2605658f00edd7830e4e2f15795d2c28002016a6
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Thu May 19 15:05:53 2022 +0200

    Added string year to age group (#4259)

commit f506760b93fcd698fdb312c1faa6027b31daca6b
Author: J <93984341+VWSCoronaDashboard18@users.noreply.github.com>
Date:   Thu May 19 13:58:38 2022 +0200

    Feature/cor 615 fix two kpi tiles with one column (#4257)

    * change to grid

    * Remove extra KPI tile

    * Fix margins and paddings

commit 4d02ed502742fb416644de6a176bb7315cd587c1
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Thu May 19 13:46:30 2022 +0200

    fix: fall back to - when no data is available for behavior choropleth tooltip (#4258)

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 2fd679be8c713b031b8f47e0e6acbb5898ae8e5d
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Thu May 19 08:46:13 2022 +0200

    Feature/cor 733 hospital admissions per 100000 (#4254)

    * Removed user-scalable and added maximum-scale=5

    * Changed metric key and legend on hospital admissions choropleth

commit ed58ee4d00890423f15e192a0dc72e1cd1e6c2e9
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 12:37:29 2022 +0200

    Removed user-scalable and added maximum-scale=5 (#4253)

commit eed6f66e0daf8e2c0f204a878a0e4712a27de47d
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Wed May 18 10:05:48 2022 +0200

    feat: upgrade version sanity cli (#4251)

commit 479eab055186af493ddc188d49b7864709eb77a5
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 09:51:22 2022 +0200

    Set text y axis to bold and black (#4250)

commit 20f9d6a91fa4c44fa01e931fce14dc56549f99b6
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 08:37:22 2022 +0200

    Ignore forced maximum when out of bounds value is outside time domain (#4246)

    * Ignore forced maximum when out of bounds value is outside time domain

    * Lint fixes

    * Added hasOutofBoudsValues to useMemo dependency array

    * Use Math.min instead of ternary operator

    * Type check calculatedForcedMaximumValue for seriesMax

commit f34638fb79a8a1dd821a2e93cdadb732b387925a
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 17 14:58:00 2022 +0200

    COR-676 - Behavior keys optional in json schemas (#4241)

    * fix: make selftest_visit_behavior optional in json schemas

    * feat: make behavior json keys optional

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 390905ba1284762aea9b61bb49736dc777718028
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 13:57:11 2022 +0200

    Remove booster past seven days from vaccinations page (#4249)

    * feat: updated schemas

    * feat(booster): remove last seven days from booster

commit 50fc1e85cdd22452d408899a58d63a9b6414b338
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 09:54:11 2022 +0200

    feat(measures): change h2 to h1 for page title (#4247)

commit 7d0b918b86c6b4ca389bfa88a4598e00858a4374
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 09:03:53 2022 +0200

    feat: change display names to search terms (#4245)

commit 83dff1849e50b6c60cf877863c446eaabaa9047f
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Fri May 13 11:50:42 2022 +0200

    feat: flip h1 with h2 and keep styling as it is (#4244)

* Squashed commit of the following:

commit 6b825c262c7a49d370e89382d2002cc2b6f42f9e
Author: J <93984341+VWSCoronaDashboard18@users.noreply.github.com>
Date:   Thu Jun 2 10:42:50 2022 +0200

    removed feature flag and added archived graphs to NL, VR and GM (#4274)

commit e6b8ae7728d9c7a6c245d813e777e147e4439514
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed Jun 1 09:42:11 2022 +0200

    Style changes select component (#4273)

    * Style changes select component

    * Use theme variables

commit 77ff7813298ad16ec14df33fe6f98b2128c50295
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Tue May 31 11:12:17 2022 +0200

    feature(CMS): slice first 3 path elements of for the title because they are redundant in the preview (#4272)

    closes: COR-543

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit f5bd004f8f688169093c7ceb9c50dbd0accac1c7
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Mon May 30 16:10:34 2022 +0200

    COR-725 unix date correction (#4255)

    * fix: use startOfDay for all graph values

    * fix: convert dates to startOfDay

    * fix: use endOfDay instead of middleOfDay for current date hook

    * fix: update tests

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 6fcf9b4e1fc6a9a9b74921de1866458fd0f4f37f
Author: J <93984341+VWSCoronaDashboard18@users.noreply.github.com>
Date:   Fri May 27 10:52:13 2022 +0200

    Feature/cor 750 add dotted time series style (#4267)

    * Added a dot line for the time series graph

    * Added laganda support and group scatter plot dots

commit 4eeff200484c1302a4c36698a5c30d3ecf01caa3
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 25 15:22:14 2022 +0200

    Removed obsolete code for international pages (#4268)

    * Removed obsolete code for international pages

    * Removed type parameter

commit 10d97063c626167c4eda20cc4bb069fef1b4ce9e
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Wed May 25 14:24:46 2022 +0200

    fix: set icon size for the top menu icons on smaller screens (#4266)

    These were forgotten with the refactor

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit 4f4abc9e9045f8a13de18678966c8e92c8072cb2
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 25 13:27:53 2022 +0200

    Implemented redesign combobox and select list (#4264)

    * Implemented redesign combobox and select list

    * Removed unused imports

    * Removed sorting by score

    * Added padding to no results message

    * Always keep the same width for search form

    * Removed unused import

    * Fixed padding search results

commit 38ec557d8dcca63bdf40a87a39a54993d76deeb8
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 24 16:29:36 2022 +0200

    COR-736 Behavior Choropleth Tooltip (#4262)

    * fix: fall back to - when no data is available for behavior choropleth tooltip

    * fix: show 0% when data is not null but 0

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit cb44e92806b5a335d887ce30bbd7f74db8c69136
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 24 14:45:50 2022 +0200

    fix: revert changes, replace with empty div and pass optional props (#4263)

commit 26a07c71e2ef4bf6e8cdc27dae0176806d9e7c38
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 24 11:34:08 2022 +0200

    COR-618 Resolve duplicate IDs (#4261)

    * fix: only render mini charts once based on screen size

    * fix: use unique ids for different chart elements and accessibility-annotations

    * fix: mock useUniqueId hook

    * fix: cleanup mock after test

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 64861ee575314aae0d8d6faf2c20dbb335974bfc
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Mon May 23 15:02:23 2022 +0200

    Archive page and add warning tile (#4260)

    * feat(situationsPage): archive page and add warning tile

    * feat: added new key for warning

commit 1ab4c1b2096bc7e3681f6edc8e37b24575e7cba3
Author: VWSCoronaDashboard25 <98813868+VWSCoronaDashboard25@users.noreply.github.com>
Date:   Mon May 23 12:05:16 2022 +0200

    Refactor/cor 73 remove fixed width and height in icons (#4256)

    * refactor: remove width and height of icons with a viewBox

    * refactor: replace width and height of icons with a viewBox

    * refactor: set size of metadata icon in metadata instead

    Use a styled span similar to the icon in the header component

    * refactor: set size of situation icon in code

    Using the extended properties of the generated React element

    Co-authored-by: VWSCoronaDashboard25 <VWSCoronaDashboard25@users.noreply.github.com>

commit 2605658f00edd7830e4e2f15795d2c28002016a6
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Thu May 19 15:05:53 2022 +0200

    Added string year to age group (#4259)

commit f506760b93fcd698fdb312c1faa6027b31daca6b
Author: J <93984341+VWSCoronaDashboard18@users.noreply.github.com>
Date:   Thu May 19 13:58:38 2022 +0200

    Feature/cor 615 fix two kpi tiles with one column (#4257)

    * change to grid

    * Remove extra KPI tile

    * Fix margins and paddings

commit 4d02ed502742fb416644de6a176bb7315cd587c1
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Thu May 19 13:46:30 2022 +0200

    fix: fall back to - when no data is available for behavior choropleth tooltip (#4258)

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 2fd679be8c713b031b8f47e0e6acbb5898ae8e5d
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Thu May 19 08:46:13 2022 +0200

    Feature/cor 733 hospital admissions per 100000 (#4254)

    * Removed user-scalable and added maximum-scale=5

    * Changed metric key and legend on hospital admissions choropleth

commit ed58ee4d00890423f15e192a0dc72e1cd1e6c2e9
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 12:37:29 2022 +0200

    Removed user-scalable and added maximum-scale=5 (#4253)

commit eed6f66e0daf8e2c0f204a878a0e4712a27de47d
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Wed May 18 10:05:48 2022 +0200

    feat: upgrade version sanity cli (#4251)

commit 479eab055186af493ddc188d49b7864709eb77a5
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 09:51:22 2022 +0200

    Set text y axis to bold and black (#4250)

commit 20f9d6a91fa4c44fa01e931fce14dc56549f99b6
Author: VWSCoronaDashboard22 <93981265+VWSCoronaDashboard22@users.noreply.github.com>
Date:   Wed May 18 08:37:22 2022 +0200

    Ignore forced maximum when out of bounds value is outside time domain (#4246)

    * Ignore forced maximum when out of bounds value is outside time domain

    * Lint fixes

    * Added hasOutofBoudsValues to useMemo dependency array

    * Use Math.min instead of ternary operator

    * Type check calculatedForcedMaximumValue for seriesMax

commit f34638fb79a8a1dd821a2e93cdadb732b387925a
Author: MN <97020799+VWSCoronaDashboard24@users.noreply.github.com>
Date:   Tue May 17 14:58:00 2022 +0200

    COR-676 - Behavior keys optional in json schemas (#4241)

    * fix: make selftest_visit_behavior optional in json schemas

    * feat: make behavior json keys optional

    Co-authored-by: VWSCoronaDashboard24 <VWSCoronaDashboard24@users.noreply.github.com>

commit 390905ba1284762aea9b61bb49736dc777718028
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 13:57:11 2022 +0200

    Remove booster past seven days from vaccinations page (#4249)

    * feat: updated schemas

    * feat(booster): remove last seven days from booster

commit 50fc1e85cdd22452d408899a58d63a9b6414b338
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 09:54:11 2022 +0200

    feat(measures): change h2 to h1 for page title (#4247)

commit 7d0b918b86c6b4ca389bfa88a4598e00858a4374
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Tue May 17 09:03:53 2022 +0200

    feat: change display names to search terms (#4245)

commit 83dff1849e50b6c60cf877863c446eaabaa9047f
Author: HO <93981322+VWSCoronaDashboard19@users.noreply.github.com>
Date:   Fri May 13 11:50:42 2022 +0200

    feat: flip h1 with h2 and keep styling as it is (#4244)

* force legends for LCPS graphs (#4286)

(cherry picked from commit 097197ce99e4a576cb1e31785bf8994e9e92036a)

* fix: only show topical mini charts when we know the correct breakpoints (#4289)


(cherry picked from commit 42081ff9b9f022c51d09e60d2b69bf26dccde307)

* fix: positive tests page design consistancy (#4290)

(cherry picked from commit ab50b7d5c2fcaa2a2b0771d8993accd2ce9b5892)

* COR-48 Update packages + audit fix (#4296)

* chore: update styled-components and friends

* chore: update typescript for app

* chore: update typescript for cli

* chore: update ts-node, sanity, typescript

* fix: fall back to variantName in json when not provided in sanity

* chore: audit fix

* restore data-structure



* COR-749 Fix responsive Choropleth sizing (#4293)

* fix: remove minHeight for vr and gm pages choropleth

* fix: only set minHeight when provided

* fix: remove console.log

* fix: code cleanup



* feat: align left axis label with tick value (#4297)

- Align label next to top axis-left tick value
- Align top axis left tick value with chart line
- Some code formatting

* Scroll through list of results with keyboard (#4294)

* feat: scroll through list of results with keyboard

* feat: Add guard pattern and named functions

- Change if statement and add guard
- Add extra comment for specific calculations
- Change functions to named functions

* feat: rename function according to coding standards

* fix: stop using archived data for unarchived chart (#4302)

The graph was unarchived but still pointed to the archived dataset. This commit fixes that. And properly removes it from other calculations as well.



* Release/2.51.2 (#4315)

* bugfix: expand the functionality of getLastInsertionDateOfPage so it covers all scenario's (removes occasional January 1st 1970 from the pages) (#4314)

Also removed some entries as 'pageMetrics' that are backend data, but no page metrics, e.g. 'code' and 'static_values.<anything>'



* feature/COR-871-variant-page-table (#4308)

* feat: updated CovidVariantenPage page component to update layout. updated VariantNameCell component to have a hover state configurable through props. updated getVariantTableData functionality to filter out irrelevant variants and map colors between graphs and tables.

* feat: updated PercentageBar component to correctly render the background color.

* feat: updated getVariantTableData functionality to 1) filter out 'other_graph' variants; 2) create a mapped sorting of variants based on the Greek alphabet; 3) correctly map colors for the 'other_table' variant; 4) simplify the final array filtering

* feat: small consistency fix

* feat: updated VariantNameCell component to rename hasHoverState to isTooltipEnabled; updated getVariantTableData functionality to restore filtering based on historical significance

* feat: reverted strict mapping between Greek alphabet and variants; removed TODO code; 'fixed' percentage mapping; 'fixed' color and order mapping

* feat: revert back to commit 0c0083d8 with changes applied

* feat: removed TODO; fixed comments

* feat: removed TODO; fixed comments

* feat: fix linting issues

* feat: update variant sorting algorithm with dedicated util method to always sort variants not in the map (omicron sub-variants for instance) to the back of the list;

* feat: updated colors so that they are in the correct order;

* feat: updated types for the different new omicron sub-variants (leveraging _-notation rather than .-notation); introduced temporary testing colors;

* feat: updated colors; started on the variants chart;

* chore: add Sanity keys for omicron variants

* feat: updated useSeriesConfig hook in VariantStackedAreaTileWithData component to properly handle new sub-variant names for the chart (i.e. omicron ba_2_12_1_percentage);

* feat: updated graph to remove 'other_graph' variants from the graph; updated chart to add date below the chart;

* feat: updated InteractiveLegend component to add a new GappedArea component to match with the chart appearance in regards to how data series and tooltip indicators are rendered;

* feat: updated getVariantTableData functionality to sort based on reversed Greek alphabet; did some prep-work for PR #4314

* feat: updated VariantsStackedAreaTile component to pass correct properties to metadata prop;

* feat: updated TooltipList styles to only use two columns when on certain breakpoints; updated TooltipContent styles to increase the maxWidth of the component;









* COR-949 Add vaccination campaign name localization (#4334)



* feat(vaccination-grade): add new keys for archived title and description (#4336)

* Adding new icons and fixing all icons to be compliant (#4367)

* Adding new icons and fixing all icons to be compiant

* PR feedback

(cherry picked from commit 3b3ee5b75e277400c7569ce85a42cfa348237507)

* Feature/cor 959 topical page redesign (#4376)

* Made a base file for a new topicalPage to work on in this ticket.

* COR-995 Topical page redesign schema (#4355)

* feat: setup schema for topical themes

* feat: first version of topcial page schema

* feat: support for new topical.json

* feat: implement multilang, cleanup schemas

* feat: extend schema with translations and indices

* feat: add valid icon values

* feat: implement loading of TOPICAL json file data

* feat: implement selectTopcialData

* feat: extend iconset

* fix: remove anys



* Feature/cor 959/dynamic icons (#4361)

* Get an icon dynamically

* feat: make dynamic icon work including typings

* fix: code cleanup

* feat: extend type info in icon build

* feat: add eye icon




* COR-990 the topical page component (#4363)

* the topical page component

* Restore old topical-tile component

* Fixed data input instead of static mockup

* fixed width and height

* set right padding for kpiIcon

* Update packages/app/src/domain/topical/components/topical-tile/index.ts

Thanks for noticing



* Update packages/app/src/domain/topical/components/topical-tile/topical-tile.tsx

Nice, I bet it's from some old mockup.





* COR-993 measurement tile (#4364)

* New measurement tile because of rebase issues

* Fixed data input instead of static mokup

* feat: redirect to vr/gm page instead of topical vr/gm

* fix: redirect topical GM/VR pages

* fix: layout of searchbox and footer

* Update eye.svg and generate script after rebase (on develop with the icon PR)

* Fix typing issues on icon cahnges

* Feature/cor 959/subjects-list (#4354)

* Feature/cor 959/page header (#4356)

* add topical-header

* Updated schema for index of dynamicDescription

* Combining components and setting the right spaces




* remove access import

* Added currentColor to all icons (#4370)

* added theme header

* Fixing issues.

* Remove replaced Component props

* all topical tile hover and link

* (responsive) spacing

* updated trend color, Updated Topical Footer, use consistant link and hover color, add alignment to measurement tile

* Fix hover state bug in link on topical tile

* icon size and alignment

* finetuning and set non link tile

* Feature/cor 959/dynamic icons (#4361)

* Get an icon dynamically

* feat: make dynamic icon work including typings

* fix: code cleanup

* feat: extend type info in icon build

* feat: add eye icon




* COR-990 the topical page component (#4363)

* the topical page component

* Restore old topical-tile component

* Fixed data input instead of static mockup

* fixed width and height

* set right padding for kpiIcon

* Update packages/app/src/domain/topical/components/topical-tile/index.ts

Thanks for noticing



* Update packages/app/src/domain/topical/components/topical-tile/topical-tile.tsx

Nice, I bet it's from some old mockup.





* link fix

* rounded corner for icon square, spacing finetuning

* Rename menu's from 'actueel' to 'maatregelen'

* update variants icon

* added menu name

* update uppercase typo name

* removed old topical page and cleaned up after

* updated grid and removed icon from other branch

* Rename menu's from 'maatregelen' to 'samenvatting'

* Generate icons.md + add IntensiveCareOpnames icon (#4374)

* feat: add new intensive-care-opnames icon and icon documentation

* feat: add documentation about all icons

* feat: add support for new IntensiveCareOpnames icon in schemas

* fix: svg configuration for IntensiveCareOpnames

* fix: use correct filename for icon

* fix: use white bg for icons in icons.md

* fix: use white bg for icons in icons.md



* bring removed components back for typechecking

* Add menu name change to mutations file

* fix: make icons visible on safari

* reset grid settings, nice word wrap, bring icon's back

* Measurement tile safari fix

* Restore minWidth

* navigation icon size fix





(cherry picked from commit c7fff4f3f99b6d9ff66a93d0c0a7256bb8245b6d)

# Conflicts:
#	packages/app/src/pages/actueel/gemeente/[code].tsx #	packages/app/src/pages/actueel/gemeente/index.tsx #	packages/app/src/pages/actueel/veiligheidsregio/[code].tsx #	packages/app/src/pages/actueel/veiligheidsregio/index.tsx #	packages/app/src/pages/index.tsx
#	packages/icons/src/svg/chevron_right.svg

* Bring back topical icons on safari (#4381)

* fix: make notification always black (#4384)



* removed anchor tag (#4385)

* fix: use correct icon for positive tests page

* fix: remove unused import

* fix: use correct icon for all positive tests page and sidebar

* feat(sidebar): Add hover state to sidebar items (#4393)

* Revert "feature(choropleth): sort tab-order by display name (#4377)"

This reverts commit 077208fa16949dc2051e819f26b9f141c384664e.

* fix: move back sanity key

* Merge branch 'feature/cor-937-consistent-links' of github.com:minvws/nl-covid19-data-dashboard into feature/cor-937-consistent-links

* fix merge conflict combo box

* New corona variant

* Update schema for new variant

* fix: add support for BA_4_6 (#4431)



* Updated types

* Revert sanity button

* Revert "Revert sanity button"

This reverts commit fe530cf6b4bd5cb178b507bed5d70e20d502c0f5.

* added new key to coverage tables

* release: 2.59.0

* feat(release): updated TrendIconWithIntensity to have an aria-label;

* fix: Apply a new width to the warning. (#4593)

* bugfix/COR-1348-summary-page-broken-article-links (#4594)

* bugfix(summary-page): removed outdated ContentTeaser and HighlightsTile components; added new TopicalArticleTeaser component (which is a stripped down version of ContentTeaser); updated TopicalArticleList component to refer to new TopicalArticleTeaser component;



* fix: wrong warning type

* fix: added keys manually

* fix: show based on the Gm and not on Shared (#4627)

(cherry picked from commit 55c7039faed34e7aaea50ed553310e6fa6bbabfd)

* hotfix(performance): added compression false flag to Next.js config as to prevent duplicate compression strategies; (#4652)



* fix(sanity): added new Sanity keys for breaking changes; updated key-mutations; (#4655)



* Feature/cor 1335 automate sanity topical dates (#4659)

* feat: setup date config logic hook

* feat: Add date logic hook to topical page

* feat: optimise find date range script

* test: update testing script

* test: updated test file

* feat: Add explanation to the math done. For reproducible code and understanding of whats going on.

* fix: add explanation to the math done in the function

* feat: added topical date config

* feat: Added fields in sanity

* feat: update sanity structure

* feat: add toggle

* feat: update typing and added document to sanity.

* feat: applying pair programming feedback

* feat: sanity tile date field

* fix: solved issues on custom sanity component.

* fix: also accept 0 as the day value.

* fix: inconsistent rendering

* fix: change iso week to just week

* Fix: remove file

* fix: merge conflict

* fix: apply descriptions based on input by communication

* fix: Update formatting

* fix: Updating dutch

* fix: PR feedback

* fix: PR feedback

* fix PR feedback, dutch grammar

* fix: PR feedback fix apply typing.

* Fix: PR feedback

(cherry picked from commit 016efc3229d83a39576ac3f1c240c77a2f6babd7)

# Conflicts:
#	packages/app/src/queries/query-types.ts
#	packages/cms/src/schemas/topical/theme-tile.ts

* bugfix: Redirect 3 unpublished articles to all articles page (#4665)


(cherry picked from commit 6bd21749825d0d0b8432f6dbdb7e91c601401b89)

* bugfix(images): temporary revert to basic img element to see if that fixes anything; (#4660)


(cherry picked from commit 730f510c38134d0765cda915bf542eed2944cccd)

* feat: Remove more info section from NL behaviour page. (#4661)


(cherry picked from commit 27db2abafc67016a39808e6b468038671488d218)

* Revert "bugfix(images): temporary revert to basic img element to see if that fixes anything; (#4660)" (#4663)

This reverts commit 730f510c38134d0765cda915bf542eed2944cccd.

(cherry picked from commit 78f13301ad639db71c783f594bf8449c57881b83)

* Feature/COR-1392-text-gm-positive-tests-is-in-bold-should-be-normal-text (#4662)

* feat: Make only variable bold and convert to markdown component.

* feat: Delete old keys

* feat: Revert addition of new keys.

* feat: One more conversion to markdown.

* feat: removed key mutations.

* feat: Delete unused keys, remove barrel file imports

* feat: Remove mutations, again.

---------


(cherry picked from commit a799daf483bf8bd1dc94ae980d58bd53128c9dde)

* chore(deps): bump ua-parser-js from 0.7.31 to 0.7.33 (#4631)

Bumps [ua-parser-js](https://github.com/faisalman/ua-parser-js) from 0.7.31 to 0.7.33.
- [Release notes](https://github.com/faisalman/ua-parser-js/releases)
- [Changelog](https://github.com/faisalman/ua-parser-js/blob/master/changelog.md)
- [Commits](https://github.com/faisalman/ua-parser-js/compare/0.7.31...0.7.33)

---
updated-dependencies:
- dependency-name: ua-parser-js dependency-type: indirect ...



(cherry picked from commit aec08773599034ca9d90f91eff701b4c86401c3e)

* chore(deps): bump simple-git from 3.15.1 to 3.16.0 (#4629)

Bumps [simple-git](https://github.com/steveukx/git-js/tree/HEAD/simple-git) from 3.15.1 to 3.16.0.
- [Release notes](https://github.com/steveukx/git-js/releases)
- [Changelog](https://github.com/steveukx/git-js/blob/main/simple-git/CHANGELOG.md)
- [Commits](https://github.com/steveukx/git-js/commits/simple-git@3.16.0/simple-git)

---
updated-dependencies:
- dependency-name: simple-git dependency-type: direct:production ...



(cherry picked from commit d453d0099cc9e4b8edcbe826b6017db2f894688b)

* fix: description and republishing (#4671)

(cherry picked from commit 63515ffb5c5d0997ac81cb846e2091546b6755d2)

* feat: sync after release (#4674)


(cherry picked from commit 45bbdd60ac570116188afc657ed82c4efdcad233)

* fix: solve pipeline error

(cherry picked from commit b169447d4f8b1ca926fe1a37bc61a0cfab5ab95e)

* feat: sync after release (#4674)


(cherry picked from commit 45bbdd60ac570116188afc657ed82c4efdcad233) (cherry picked from commit d1674c8e9559a9b9b6275429469c1e2eb4295bb4) (cherry picked from commit 93752eebb26c1f26c41004df2dac3ffd8a2971e4)

* Chore/COR 1431 remove recommended advices (#4681)

* chore: remove measure page

* chore: Add documentation, redirect to topical, and remove sanity keys

* fix: Typo - PR feedback

(cherry picked from commit f1d10ce62555bc81008d3dcf7e4731dd2abdd5a2) (cherry picked from commit 48558e3bf950f540cbb9be226bef58533ef4072f)

* feature/COR-1455-remove-topical-page-measure-theme-components (#4682)

* feat(topical-page): removed measure themes section from topical page; removed all measure theme component schemas from Sanity; updated topical page groq query and query types; updated theme schema to mark tiles and other properties as not-required, allowing for 'simple' themes without tiles or links; reverted removal of sizes export from theme, as this resulted in breaking changes;

---------


(cherry picked from commit 7d781b4b4074cbcd6df1dd7128d8a8f5d2a72d8d) (cherry picked from commit 3aa6757a08c61bb484b2b0fff31af102c1b9ccfa)

* Fix: remove redirects (#4685)

(cherry picked from commit b773fd8a30872414d2b221daa2d7e7cab8b5a766)

* bugfix(positive-tests): added self_test_overall as metric to metrics array; (#4730)



* Release/2.73.1 (#4765)

* feature/COR-1521-vulnerable-groups-page-optimizations-typefix (#4757)

* Removed the AgeDataType and ParsedCoverageData type based on PR feedback

* made TileData not exported anymore

---------


(cherry picked from commit d1dcbf791cdd2b687b0c485a06d3319e43347da9)

* Bugfix/cor 1627 restore bug from cor 1521 (#4764)

* fix: solve inconsistent usage of KpiTile

* fix: other pages with percentages

* fix: remove develop check

* fix: styling

* fix: PR feedback

* fix: component name

(cherry picked from commit 41e90932748e95173dbc19868abb67e2f0662c1c)

---------



* Release/2.76.1 (#4784)

* feat(data-explained-redesign): Adjusts rich text alignment, removes description component. (#4783)



* Sanity-updates-for-COR-1618-1620-1622-1624 (#4775)

* chore: sanity update for COR-1624

* chore: Sanity update for COR-1622

* chore: Sanity update for COR-1620

* chore: Sanity update for COR-1618

* fix: incorrect CSV file

* fix: PR feedback keys

---------




* COR-1696 - fix birtyear ranges in age group dropdown

* feat(COR-1772): Added missing date range for second KPI

* Bugfix/cor 1769 variants table and graph 2 (#4870)

* fix(COR-1769): Removed keys from schemas

* fix(COR-1769): Removed historical significance key

* fix(COR-1769): Update getter functions

* fix(COR-1769): Remove unused code from variants chart

* fix(COR-1769): Re-add destructuring based on suggestion

---------



* Hotfix/cor 1769 other variants on top (#4876)

* fix(COR-1769): Put other_variants at bottom of table

* fix(COR-1769): Add comment

* fix(COR-1769): Clean up code

* fix(COR-1769): Remove unused filter

---------



* fix(COR-1809): Remove unused variable replacement (#4879) (#4893)



* fix: corona thermometer mobile (#4899)



* fix: Set node version number to 18.18.2 (#4915)



* feat(COR-1896): Remove campaign banner and sanity keys from vaccine page (#4956)

* feat(COR-1896): Remove campaign banner and sanity keys from vaccine page (#4956)

* feature/fix ts node esm+upgrade sharp (#4952)

* change to node 18

* fix ts-node script with esm

* update sharp to 0.32.6

* format node-version

* remove duplication
