### PR TITLE
feature/COR-1857-refactor-order-of-variants

### DIFF
--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -186,6 +186,7 @@ export interface StackedBarSeriesDefinition<T extends TimestampedValue> extends 
   shortLabel?: string;
   color: string;
   fillOpacity?: number;
+  order: number;
 }
 
 /**

--- a/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
@@ -20,7 +20,7 @@ export function getVariantBarChartData(variants: NlVariants) {
     return EMPTY_VALUES;
   }
 
-  const sortedVariants = variants.values.sort((a, b) => b.last_value.order - a.last_value.order);
+  const sortedVariants = variants.values.sort((a, b) => a.last_value.order - b.last_value.order);
 
   const firstVariantInList = sortedVariants.shift();
 

--- a/packages/app/src/domain/variants/data-selection/get-variant-orders.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-orders.ts
@@ -1,0 +1,21 @@
+import { NlVariants } from '@corona-dashboard/common';
+import { OrderMatch } from '~/domain/variants/data-selection/types';
+import { isDefined } from 'ts-is-present';
+
+export const getVariantOrders = (variants: NlVariants): OrderMatch[] => {
+  if (!isDefined(variants) || !isDefined(variants.values)) {
+    return [];
+  }
+
+  const order = variants.values
+    .sort((a, b) => a.last_value.order - b.last_value.order)
+    .map((variant) => {
+      const variantOrder = variant.last_value.order;
+      return {
+        variant: variant.variant_code,
+        order: variantOrder,
+      };
+    });
+
+  return order;
+};

--- a/packages/app/src/domain/variants/data-selection/index.ts
+++ b/packages/app/src/domain/variants/data-selection/index.ts
@@ -2,3 +2,4 @@ export * from './get-variant-bar-chart-data';
 export * from './get-archived-variant-chart-data';
 export * from './get-variant-order-colors';
 export * from './get-variant-table-data';
+export * from './get-variant-orders';

--- a/packages/app/src/domain/variants/data-selection/types.ts
+++ b/packages/app/src/domain/variants/data-selection/types.ts
@@ -9,6 +9,11 @@ export type ColorMatch = {
   color: string;
 };
 
+export type OrderMatch = {
+  variant: VariantCode;
+  order: number;
+};
+
 export type VariantTableData = ReturnType<typeof getVariantTableData>;
 
 export type VariantChartValue = {

--- a/packages/app/src/domain/variants/logic/reorder-and-filter.ts
+++ b/packages/app/src/domain/variants/logic/reorder-and-filter.ts
@@ -32,23 +32,11 @@ export const reorderAndFilter = <T, P>(context: TooltipData<VariantChartValue & 
     .filter(isDefined);
 
   // Sort variants by occurrence, always put 'other variants' at the end
-  // Todo: add user defined type guard to a and b
   const sortedConfigs = filteredConfigs.sort((a: any, b: any) => {
     if (a.metricProperty.includes('other_variants')) return 1;
     if (b.metricProperty.includes('other_variants')) return -1;
     return context.value[b.metricProperty] - context.value[a.metricProperty];
   });
-
-  /**
-   * {
-   *   "type": "stacked-bar",
-   *   "metricProperty": "JN_1_occurrence",
-   *   "color": "#C80000",
-   *   "label": "Omikron JN.1",
-   *   "fillOpacity": 1,
-   *   "shape": "gapped-area"
-   * }
-   */
 
   // Generate filtered tooltip context
   const reorderContext = {

--- a/packages/app/src/domain/variants/logic/reorder-and-filter.ts
+++ b/packages/app/src/domain/variants/logic/reorder-and-filter.ts
@@ -36,7 +36,7 @@ export const reorderAndFilter = <T, P>(context: TooltipData<VariantChartValue & 
         return 0;
       }
     })
-  );
+  ) as VariantChartValue;
 
   /**
    * Generate filtered tooltip context.

--- a/packages/app/src/domain/variants/logic/reorder-and-filter.ts
+++ b/packages/app/src/domain/variants/logic/reorder-and-filter.ts
@@ -31,23 +31,29 @@ export const reorderAndFilter = <T, P>(context: TooltipData<VariantChartValue & 
     })
     .filter(isDefined);
 
-  // Sort variants by occurrence
+  // Sort variants by occurrence, always put 'other variants' at the end
+  // Todo: add user defined type guard to a and b
   const sortedConfigs = filteredConfigs.sort((a: any, b: any) => {
+    if (a.metricProperty.includes('other_variants')) return 1;
+    if (b.metricProperty.includes('other_variants')) return -1;
     return context.value[b.metricProperty] - context.value[a.metricProperty];
   });
 
-  // Move config entry 'other variants' to end
-  sortedConfigs.push(
-    sortedConfigs.splice(
-      sortedConfigs.map((configEntry: any) => configEntry.metricProperty).findIndex((e) => e === 'other_variants_percentage' || e === 'other_variants_occurrence'),
-      1
-    )[0]
-  );
+  /**
+   * {
+   *   "type": "stacked-bar",
+   *   "metricProperty": "JN_1_occurrence",
+   *   "color": "#C80000",
+   *   "label": "Omikron JN.1",
+   *   "fillOpacity": 1,
+   *   "shape": "gapped-area"
+   * }
+   */
 
   // Generate filtered tooltip context
   const reorderContext = {
     ...context,
-    config: sortedConfigs.filter(isDefined),
+    config: sortedConfigs,
     value: !filterSelectionActive ? valuesFromContext : context.value,
   };
 

--- a/packages/app/src/domain/variants/logic/reorder-and-filter.ts
+++ b/packages/app/src/domain/variants/logic/reorder-and-filter.ts
@@ -35,6 +35,7 @@ export const reorderAndFilter = <T, P>(context: TooltipData<VariantChartValue & 
   const sortedConfigs = filteredConfigs.sort((a: any, b: any) => {
     if (a.metricProperty.includes('other_variants')) return 1;
     if (b.metricProperty.includes('other_variants')) return -1;
+    if (context.value[a.metricProperty] === context.value[b.metricProperty]) return b.order - a.order;
     return context.value[b.metricProperty] - context.value[a.metricProperty];
   });
 

--- a/packages/app/src/domain/variants/logic/use-bar-config.ts
+++ b/packages/app/src/domain/variants/logic/use-bar-config.ts
@@ -1,4 +1,4 @@
-import { ColorMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
+import { ColorMatch, OrderMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
 import { useMemo } from 'react';
 import { getValuesInTimeframe, TimeframeOption } from '@corona-dashboard/common';
 import { isPresent } from 'ts-is-present';
@@ -25,6 +25,7 @@ export const useBarConfig = (
   variantLabels: VariantDynamicLabels,
   tooltipLabels: VariantsOverTimeGraphText,
   colors: ColorMatch[],
+  orders: OrderMatch[],
   timeframe: TimeframeOption,
   today: Date
 ) => {
@@ -54,6 +55,8 @@ export const useBarConfig = (
 
       const color = colors.find((variantColors) => variantColors.variant === variantCodeName)?.color;
 
+      const order = orders.find((varianOrders) => varianOrders.variant === variantCodeName)?.order;
+
       if (variantDynamicLabel) {
         const barChartConfigEntry = {
           type: 'stacked-bar',
@@ -62,6 +65,7 @@ export const useBarConfig = (
           label: variantDynamicLabel,
           fillOpacity: 1,
           shape: 'gapped-area',
+          order: order,
         };
 
         barChartConfig.push(barChartConfigEntry as StackedBarSeriesDefinition<VariantChartValue>);
@@ -69,5 +73,5 @@ export const useBarConfig = (
     });
 
     return barChartConfig;
-  }, [values, tooltipLabels.tooltip_labels.other_percentage, variantLabels, colors, timeframe, today]);
+  }, [values, tooltipLabels.tooltip_labels.other_percentage, variantLabels, colors, orders, timeframe, today]);
 };

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -59,7 +59,7 @@ export const VariantsStackedBarChartTile = ({ title, description, tooltipLabels,
       timeframeInitialValue={TimeframeOption.THIRTY_DAYS}
       onSelectTimeframe={setVariantTimeFrame}
     >
-      <InteractiveLegend helpText={text.legend_help_text} selectOptions={interactiveLegendOptions} selection={list} onToggleItem={toggle} onReset={clear} />
+      <InteractiveLegend helpText={text.legend_help_text} selectOptions={interactiveLegendOptions.reverse()} selection={list} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
       <TimeSeriesChart
         accessibility={{

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -2,7 +2,7 @@ import { ChartTile, MetadataProps, TimeSeriesChart } from '~/components';
 import { Spacer } from '~/components/base';
 import { TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
-import { ColorMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
+import { ColorMatch, OrderMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
 import { useBarConfig } from '~/domain/variants/logic/use-bar-config';
 import { InteractiveLegend, SelectOption } from '~/components/interactive-legend';
 import { useList } from '~/utils/use-list';
@@ -13,13 +13,14 @@ import { reorderAndFilter } from '~/domain/variants/logic/reorder-and-filter';
 import { useIntl } from '~/intl';
 
 interface VariantsStackedBarChartTileProps {
-  title: string;
   description: string;
-  values: VariantChartValue[];
-  tooltipLabels: VariantsOverTimeGraphText;
-  variantLabels: VariantDynamicLabels;
-  variantColors: ColorMatch[];
   metadata: MetadataProps;
+  title: string;
+  tooltipLabels: VariantsOverTimeGraphText;
+  values: VariantChartValue[];
+  variantColors: ColorMatch[];
+  variantLabels: VariantDynamicLabels;
+  variantOrders: OrderMatch[];
 }
 
 const alwaysEnabled: (keyof VariantChartValue)[] = [];
@@ -35,12 +36,21 @@ const alwaysEnabled: (keyof VariantChartValue)[] = [];
  * @param metadata - Metadata block
  * @constructor
  */
-export const VariantsStackedBarChartTile = ({ title, description, tooltipLabels, values, variantLabels, variantColors, metadata }: VariantsStackedBarChartTileProps) => {
+export const VariantsStackedBarChartTile = ({
+  title,
+  description,
+  tooltipLabels,
+  values,
+  variantLabels,
+  variantColors,
+  variantOrders,
+  metadata,
+}: VariantsStackedBarChartTileProps) => {
   const today = useCurrentDate();
   const { commonTexts } = useIntl();
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
   const [variantTimeFrame, setVariantTimeFrame] = useState<TimeframeOption>(TimeframeOption.THIRTY_DAYS);
-  const barSeriesConfig = useBarConfig(values, variantLabels, tooltipLabels, variantColors, variantTimeFrame, today);
+  const barSeriesConfig = useBarConfig(values, variantLabels, tooltipLabels, variantColors, variantOrders, variantTimeFrame, today);
 
   const text = commonTexts.variants_page;
 

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -18,7 +18,7 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { useState } from 'react';
-import { getArchivedVariantChartData, getVariantBarChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/data-selection';
+import { getArchivedVariantChartData, getVariantBarChartData, getVariantOrderColors, getVariantOrders, getVariantTableData } from '~/domain/variants/data-selection';
 import { VariantsStackedAreaTile, VariantsStackedBarChartTile, VariantsTableTile } from '~/domain/variants';
 import { VariantDynamicLabels } from '~/domain/variants/data-selection/types';
 import { NlVariantsVariant } from '@corona-dashboard/common';
@@ -51,11 +51,14 @@ export const getStaticProps = createGetStaticProps(
 
     const variantColors = getVariantOrderColors(variants);
 
+    const variantOrders = getVariantOrders(variants);
+
     return {
       ...getVariantTableData(variants, data.selectedNlData.named_difference, variantColors),
       ...getVariantBarChartData(variants),
       ...getArchivedVariantChartData(variants_archived_20231101),
       variantColors,
+      variantOrders,
     };
   },
   async (context: GetStaticPropsContext) => {
@@ -83,6 +86,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
     variantChart,
     archivedVariantChart,
     variantColors,
+    variantOrders,
     dates,
   } = props;
 
@@ -173,6 +177,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               values={variantChart}
               variantLabels={variantLabels}
               variantColors={variantColors}
+              variantOrders={variantOrders}
               metadata={{
                 datumsText: textNl.datums,
                 date: getLastInsertionDateOfPage(data, ['variants']),


### PR DESCRIPTION
## Summary
 
* Reordered order of variants in stacked bar chart
* Reordered order of variants in tooltip on stacked bar chart and series chart
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>

**Order of variants on bar chart**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/51479775-4d57-4c52-8bc6-77100e3baeba)

**Order of variants in stacked bar chart tooltip**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/fee5b0b3-594f-4e12-a83c-39f07efc30f9)

**Order of variants in stacked area chart tooltip**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/e67e083a-fded-47d8-9951-aedec4ade369)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>

**Order of variants on bar chart**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/074699ea-e68f-4460-9a61-b7fdc82c3e6f)

**Order of variants in stacked bar chart tooltip**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/7c8f88ed-bca3-474f-a70f-7ea2ef3ac795)

**Order of variants in stacked area chart tooltip**
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/68315c2c-60e3-4342-8e31-b8bb3f925dfc)

</details>