### PR TITLE
release/2.86.0

### DIFF
--- a/packages/app/schema/archived_nl/__index.json
+++ b/packages/app/schema/archived_nl/__index.json
@@ -51,7 +51,9 @@
     "repeating_shot_administered_20220713",
     "corona_melder_app_warning_archived_20220421",
     "corona_melder_app_download_archived_20220421",
-    "infectious_people_archived_20210709"
+    "infectious_people_archived_20210709",
+    "vaccine_campaigns_archived_20240117",
+    "vaccine_administered_last_timeframe_archived_20240117"
   ],
   "additionalProperties": false,
   "properties": {
@@ -201,6 +203,12 @@
     },
     "infectious_people_archived_20210709": {
       "$ref": "infectious_people.json"
+    },
+    "vaccine_administered_last_timeframe_archived_20240117": {
+      "$ref": "vaccine_administered_last_timeframe.json"
+    },
+    "vaccine_campaigns_archived_20240117": {
+      "$ref": "vaccine_campaigns.json"
     }
   },
   "$defs": {

--- a/packages/app/schema/archived_nl/vaccine_administered_last_timeframe.json
+++ b/packages/app/schema/archived_nl/vaccine_administered_last_timeframe.json
@@ -16,7 +16,7 @@
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_vaccine_administered_last_timeframe",
+  "title": "archived_nl_vaccine_administered_last_timeframe",
   "type": "object",
   "required": ["vaccine_types", "date_unix", "date_start_unix", "date_end_unix", "date_of_insertion_unix"],
   "additionalProperties": false,

--- a/packages/app/schema/archived_nl/vaccine_campaigns.json
+++ b/packages/app/schema/archived_nl/vaccine_campaigns.json
@@ -1,7 +1,7 @@
 {
   "definitions": {
     "vaccine_campaign": {
-      "title": "nl_vaccine_campaigns",
+      "title": "archived_nl_vaccine_campaigns",
       "type": "object",
       "required": ["vaccine_campaign_order", "vaccine_campaign_name_nl", "vaccine_campaign_name_en", "vaccine_administered_total", "vaccine_administered_last_timeframe"],
       "additionalProperties": false,
@@ -25,7 +25,7 @@
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "nl_vaccine_campaign",
+  "title": "archived_nl_vaccine_campaign",
   "type": "object",
   "required": ["vaccine_campaigns", "date_unix", "date_start_unix", "date_end_unix", "date_of_insertion_unix"],
   "additionalProperties": false,

--- a/packages/app/schema/nl/__index.json
+++ b/packages/app/schema/nl/__index.json
@@ -19,8 +19,6 @@
     "self_test_overall",
     "infectionradar_symptoms_trend_per_age_group_weekly",
     "sewer",
-    "vaccine_campaigns",
-    "vaccine_administered_last_timeframe",
     "variants"
   ],
   "additionalProperties": false,
@@ -66,12 +64,6 @@
     },
     "deceased_cbs": {
       "$ref": "deceased_cbs.json"
-    },
-    "vaccine_administered_last_timeframe": {
-      "$ref": "vaccine_administered_last_timeframe.json"
-    },
-    "vaccine_campaigns": {
-      "$ref": "vaccine_campaigns.json"
     },
     "variants": {
       "$ref": "variants.json"

--- a/packages/app/src/components/metadata.tsx
+++ b/packages/app/src/components/metadata.tsx
@@ -6,6 +6,8 @@ import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
 import { Box } from './base';
 import { InlineText, Text } from './typography';
 import { Markdown } from '~/components/markdown';
+import { External as ExternalLinkIcon } from '@corona-dashboard/icons';
+import React from 'react';
 
 type source = {
   text: string;
@@ -59,6 +61,7 @@ export function Metadata({ date, source, obtainedAt, isTileFooter, datumsText, m
           {`${dateString} - ${commonTexts.common.metadata.source}: `}
           <ExternalLink ariaLabel={source.aria_text} href={source.href}>
             {source.text}
+            <ExternalLinkIcon width={space[3]} height={space[2]} />
           </ExternalLink>
         </Text>
       )}

--- a/packages/app/src/components/page-information-block/components/metadata.tsx
+++ b/packages/app/src/components/page-information-block/components/metadata.tsx
@@ -1,7 +1,7 @@
 import { colors } from '@corona-dashboard/common';
-import { ChevronRight, Clock, Database, MeerInformatie } from '@corona-dashboard/icons';
+import { ChevronRight, Clock, Database, External as ExternalLinkIcon, MeerInformatie } from '@corona-dashboard/icons';
 import css from '@styled-system/css';
-import { Fragment } from 'react';
+import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import { Box } from '~/components/base';
 import { ExternalLink } from '~/components/external-link';
@@ -9,6 +9,7 @@ import { Anchor, InlineText, Text } from '~/components/typography';
 import { useIntl } from '~/intl';
 import { Link } from '~/utils/link';
 import { replaceVariablesInText } from '~/utils/replace-variables-in-text';
+import { space } from '~/style/theme';
 
 interface Datasource {
   href: string;
@@ -112,18 +113,11 @@ interface MetadataItemProps {
 }
 
 function MetadataItem({ icon, label, items, referenceLink, accessibilityText, accessibilitySubject }: MetadataItemProps) {
-  const { commonTexts } = useIntl();
-
   return (
-    <Box display="flex" alignItems="flex-start" color="gray7">
+    <Box display="flex" alignItems="flex-start" color={colors.gray7}>
       <Icon>{icon}</Icon>
 
       <Text variant="label1">
-        {referenceLink && !items && (
-          <Link href={referenceLink} passHref>
-            <a>{commonTexts.informatie_header.meer_informatie_link}</a>
-          </Link>
-        )}
         {items && referenceLink && (
           <>
             {`${label}: `}
@@ -146,6 +140,7 @@ function MetadataItem({ icon, label, items, referenceLink, accessibilityText, ac
                 {item.href && (
                   <ExternalLink
                     href={item.href}
+                    underline="hover"
                     ariaLabel={
                       accessibilityText && accessibilitySubject
                         ? replaceVariablesInText(accessibilityText, {
@@ -156,6 +151,7 @@ function MetadataItem({ icon, label, items, referenceLink, accessibilityText, ac
                     }
                   >
                     {item.text}
+                    <ExternalLinkIcon width={space[3]} height={space[2]} />
                   </ExternalLink>
                 )}
                 {!item.href && item.text}

--- a/packages/app/src/components/tables/components/wide-percentage-data.tsx
+++ b/packages/app/src/components/tables/components/wide-percentage-data.tsx
@@ -2,21 +2,21 @@ import { Box } from '~/components/base';
 import { BehaviorTrend } from '~/domain/behavior/components/behavior-trend';
 import { WidePercentage } from '~/components/tables/components/wide-percentage';
 import { space } from '~/style/theme';
-import { PercentageDataPoint } from '../types';
-import { tableColumnWidths } from '../wide-table';
+import { PercentageDataPoint, TableColumnWidths } from '../types';
 import { PercentageBarWithoutNumber } from './percentage-bar-without-number';
 import { Cell } from './shared-styled-components';
 
 interface PercentageDataProps {
   percentageDataPoints: PercentageDataPoint[];
+  columnWidths: TableColumnWidths;
 }
 
 // Component used to show percentages on wide screens.
-export const PercentageData = ({ percentageDataPoints }: PercentageDataProps) => {
+export const PercentageData = ({ percentageDataPoints, columnWidths }: PercentageDataProps) => {
   return (
     <>
       {percentageDataPoints.map((percentageDataPoint, index) => (
-        <Cell minWidth={tableColumnWidths.percentageColumn} border="0" key={index}>
+        <Cell minWidth={columnWidths.percentageColumn} border="0" key={index}>
           <WidePercentage
             value={
               percentageDataPoint.trendDirection ? (
@@ -31,7 +31,7 @@ export const PercentageData = ({ percentageDataPoints }: PercentageDataProps) =>
         </Cell>
       ))}
 
-      <Cell minWidth={tableColumnWidths.percentageBarColumn} border="0">
+      <Cell minWidth={columnWidths.percentageBarColumn} border="0">
         <Box display="flex" flexDirection="column">
           {percentageDataPoints.map((percentageDataPoint, index) => (
             // In some cases, the percentage value is a string so it needs to be parsed for the progress bar to be filled properly.

--- a/packages/app/src/components/tables/types.ts
+++ b/packages/app/src/components/tables/types.ts
@@ -3,6 +3,12 @@ import { BehaviorTrendType } from '~/domain/behavior/logic/behavior-types';
 
 type TrendDirection = BehaviorTrendType | null;
 
+export type TableColumnWidths = {
+  labelColumn: string;
+  percentageColumn: string;
+  percentageBarColumn: string;
+};
+
 export type PercentageDataPoint = {
   title: string;
   trendDirection?: TrendDirection;
@@ -34,6 +40,7 @@ export interface TableData extends BaseTableData {
 export type BaseCoverageTable = BaseTableData;
 
 export interface CommonTableProps {
+  tableColumnWidths?: TableColumnWidths;
   tableData: SingleCoverageTableData[] | TableData[];
   percentageData: PercentageDataPoint[][];
 }

--- a/packages/app/src/components/tables/wide-table.tsx
+++ b/packages/app/src/components/tables/wide-table.tsx
@@ -5,18 +5,18 @@ import { PercentageData } from './components/wide-percentage-data';
 import { Cell, HeaderCell, Table, TableHead } from './components/shared-styled-components';
 import { CommonTableProps } from './types';
 
-export const tableColumnWidths = {
+interface WideTableProps extends CommonTableProps {
+  headerText: { [key: string]: string };
+}
+
+const defaultColumnWidths = {
   labelColumn: '30%',
   percentageColumn: '20%',
   percentageBarColumn: '30%',
 };
 
-interface WideTableProps extends CommonTableProps {
-  headerText: { [key: string]: string };
-}
-
 // Component shown for tables on wide screens.
-export const WideTable = ({ tableData, headerText, percentageData }: WideTableProps) => {
+export const WideTable = ({ tableData, headerText, tableColumnWidths = defaultColumnWidths, percentageData }: WideTableProps) => {
   return (
     <Box overflow="auto">
       <Table>
@@ -47,7 +47,7 @@ export const WideTable = ({ tableData, headerText, percentageData }: WideTablePr
               <Cell minWidth={tableColumnWidths.labelColumn} border="0">
                 {item.firstColumnLabel}
               </Cell>
-              <PercentageData percentageDataPoints={percentageData[tableDataIndex]} key={`wide-${item.id}-${tableDataIndex}`} />
+              <PercentageData columnWidths={tableColumnWidths} percentageDataPoints={percentageData[tableDataIndex]} key={`wide-${item.id}-${tableDataIndex}`} />
             </Row>
           ))}
         </tbody>

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -186,6 +186,7 @@ export interface StackedBarSeriesDefinition<T extends TimestampedValue> extends 
   shortLabel?: string;
   color: string;
   fillOpacity?: number;
+  order: number;
 }
 
 /**

--- a/packages/app/src/domain/behavior/behavior-table-tile.tsx
+++ b/packages/app/src/domain/behavior/behavior-table-tile.tsx
@@ -47,6 +47,11 @@ export const BehaviorTableTile = ({ title, description, value, annotation, setCu
           }}
           tableData={behaviorsTableData}
           percentageData={percentageData}
+          tableColumnWidths={{
+            labelColumn: '35%',
+            percentageColumn: '20%',
+            percentageBarColumn: '30%',
+          }}
         />
       ) : (
         <NarrowTable tableData={behaviorsTableData} percentageData={percentageData} headerText={text.basisregels.header_basisregel} />

--- a/packages/app/src/domain/behavior/components/behavior-icon-with-label.tsx
+++ b/packages/app/src/domain/behavior/components/behavior-icon-with-label.tsx
@@ -6,6 +6,7 @@ import { Anchor } from '~/components/typography';
 import { fontWeights, mediaQueries, space } from '~/style/theme';
 import { BehaviorIdentifier } from '../logic/behavior-types';
 import { BehaviorIcon } from './behavior-icon';
+import { ChevronRight } from '@corona-dashboard/icons';
 
 type ScrollRef = { current: HTMLDivElement | null };
 
@@ -33,8 +34,9 @@ export const BehaviorIconWithLabel = ({ id, description, onClickConfig }: Behavi
       </Box>
 
       <BehaviorAnchor as="button" underline="hover" color={colors.black} onClick={() => anchorButtonClickHandler(id, onClickConfig.scrollRef)}>
-        <Box as="span" display="flex" alignItems="center" textAlign="left" flexWrap="wrap">
+        <Box as="span" display="flex" alignItems="center" textAlign="left" flexWrap="wrap" gridColumnGap={space[1]}>
           {description}
+          <ChevronRight width={space[2]} height={space[2]} />
         </Box>
       </BehaviorAnchor>
     </Box>

--- a/packages/app/src/domain/layout/gm-layout.tsx
+++ b/packages/app/src/domain/layout/gm-layout.tsx
@@ -77,7 +77,7 @@ export function GmLayout(props: GmLayoutProps) {
         hideBackButton={isMainRoute}
         searchComponent={
           <Box height="100%" maxWidth={{ _: '38rem', md: undefined }} marginX="auto">
-            <GmComboBox getLink={getLink} selectedGmCode={code} />
+            <GmComboBox getLink={getLink} selectedGmCode={code} shouldFocusInput={false} />
           </Box>
         }
         sidebarComponent={

--- a/packages/app/src/domain/layout/layout.tsx
+++ b/packages/app/src/domain/layout/layout.tsx
@@ -1,14 +1,14 @@
-import { ReactNode } from 'react';
+import { AppFooter } from '~/components/layout/app-footer';
+import { AppHeader } from '~/components/layout/app-header';
 import { Box } from '~/components/base/box';
 import { Breadcrumbs } from '~/components/breadcrumbs';
 import { BreadcrumbsDataProvider } from '~/components/breadcrumbs/logic/use-breadcrumbs';
-import { AppFooter } from '~/components/layout/app-footer';
-import { AppHeader } from '~/components/layout/app-header';
+import { CurrentDateProvider } from '~/utils/current-date-context';
 import { NotificationBanner } from '~/components/notification-banner';
+import { ReactNode } from 'react';
 import { SEOHead } from '~/components/seo-head';
 import { SkipLinkMenu } from '~/components/skip-link-menu';
 import { useIntl } from '~/intl';
-import { CurrentDateProvider } from '~/utils/current-date-context';
 
 interface LayoutProps {
   children: ReactNode;
@@ -30,12 +30,12 @@ export function Layout({ breadcrumbsData, children, title, description, openGrap
       <SkipLinkMenu
         ariaLabel={commonTexts.aria_labels.skip_links}
         links={[
-          { href: '#content', label: commonTexts.skiplinks.inhoud },
           { href: '#main-navigation', label: commonTexts.skiplinks.nav },
           {
             href: '#metric-navigation',
             label: commonTexts.skiplinks.metric_nav,
           },
+          { href: '#content', label: commonTexts.skiplinks.inhoud },
           {
             href: '#footer-navigation',
             label: commonTexts.skiplinks.footer_nav,

--- a/packages/app/src/domain/vaccine/autumn-2022-shot-coverage-per-age-group/autumn-2022-shot-coverage-per-age-group.tsx
+++ b/packages/app/src/domain/vaccine/autumn-2022-shot-coverage-per-age-group/autumn-2022-shot-coverage-per-age-group.tsx
@@ -51,6 +51,11 @@ export const Autumn2022ShotCoveragePerAgeGroup = ({ title, description, metadata
           }}
           tableData={sortedData}
           percentageData={percentageData}
+          tableColumnWidths={{
+            labelColumn: '10%',
+            percentageColumn: '20%',
+            percentageBarColumn: '30%',
+          }}
         />
       ) : (
         <NarrowTable headerText={text.headers.agegroup} tableData={sortedData} percentageData={percentageData} />

--- a/packages/app/src/domain/vaccine/primary-series-coverage-per-age-group/primary-series-coverage-per-age-group.tsx
+++ b/packages/app/src/domain/vaccine/primary-series-coverage-per-age-group/primary-series-coverage-per-age-group.tsx
@@ -51,6 +51,11 @@ export const PrimarySeriesShotCoveragePerAgeGroup = ({ title, description, metad
           }}
           tableData={sortedData}
           percentageData={percentageData}
+          tableColumnWidths={{
+            labelColumn: '10%',
+            percentageColumn: '20%',
+            percentageBarColumn: '30%',
+          }}
         />
       ) : (
         <NarrowTable headerText={text.headers.agegroup} tableData={sortedData} percentageData={percentageData} />

--- a/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-bar-chart-data.ts
@@ -20,7 +20,7 @@ export function getVariantBarChartData(variants: NlVariants) {
     return EMPTY_VALUES;
   }
 
-  const sortedVariants = variants.values.sort((a, b) => b.last_value.order - a.last_value.order);
+  const sortedVariants = variants.values.sort((a, b) => a.last_value.order - b.last_value.order);
 
   const firstVariantInList = sortedVariants.shift();
 

--- a/packages/app/src/domain/variants/data-selection/get-variant-orders.ts
+++ b/packages/app/src/domain/variants/data-selection/get-variant-orders.ts
@@ -1,0 +1,21 @@
+import { NlVariants } from '@corona-dashboard/common';
+import { OrderMatch } from '~/domain/variants/data-selection/types';
+import { isDefined } from 'ts-is-present';
+
+export const getVariantOrders = (variants: NlVariants): OrderMatch[] => {
+  if (!isDefined(variants) || !isDefined(variants.values)) {
+    return [];
+  }
+
+  const order = variants.values
+    .sort((a, b) => a.last_value.order - b.last_value.order)
+    .map((variant) => {
+      const variantOrder = variant.last_value.order;
+      return {
+        variant: variant.variant_code,
+        order: variantOrder,
+      };
+    });
+
+  return order;
+};

--- a/packages/app/src/domain/variants/data-selection/index.ts
+++ b/packages/app/src/domain/variants/data-selection/index.ts
@@ -2,3 +2,4 @@ export * from './get-variant-bar-chart-data';
 export * from './get-archived-variant-chart-data';
 export * from './get-variant-order-colors';
 export * from './get-variant-table-data';
+export * from './get-variant-orders';

--- a/packages/app/src/domain/variants/data-selection/types.ts
+++ b/packages/app/src/domain/variants/data-selection/types.ts
@@ -9,6 +9,11 @@ export type ColorMatch = {
   color: string;
 };
 
+export type OrderMatch = {
+  variant: VariantCode;
+  order: number;
+};
+
 export type VariantTableData = ReturnType<typeof getVariantTableData>;
 
 export type VariantChartValue = {

--- a/packages/app/src/domain/variants/logic/use-bar-config.ts
+++ b/packages/app/src/domain/variants/logic/use-bar-config.ts
@@ -1,4 +1,4 @@
-import { ColorMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
+import { ColorMatch, OrderMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
 import { useMemo } from 'react';
 import { getValuesInTimeframe, TimeframeOption } from '@corona-dashboard/common';
 import { isPresent } from 'ts-is-present';
@@ -25,6 +25,7 @@ export const useBarConfig = (
   variantLabels: VariantDynamicLabels,
   tooltipLabels: VariantsOverTimeGraphText,
   colors: ColorMatch[],
+  orders: OrderMatch[],
   timeframe: TimeframeOption,
   today: Date
 ) => {
@@ -54,6 +55,8 @@ export const useBarConfig = (
 
       const color = colors.find((variantColors) => variantColors.variant === variantCodeName)?.color;
 
+      const order = orders.find((varianOrders) => varianOrders.variant === variantCodeName)?.order;
+
       if (variantDynamicLabel) {
         const barChartConfigEntry = {
           type: 'stacked-bar',
@@ -62,6 +65,7 @@ export const useBarConfig = (
           label: variantDynamicLabel,
           fillOpacity: 1,
           shape: 'gapped-area',
+          order: order,
         };
 
         barChartConfig.push(barChartConfigEntry as StackedBarSeriesDefinition<VariantChartValue>);
@@ -69,5 +73,5 @@ export const useBarConfig = (
     });
 
     return barChartConfig;
-  }, [values, tooltipLabels.tooltip_labels.other_percentage, variantLabels, colors, timeframe, today]);
+  }, [values, tooltipLabels.tooltip_labels.other_percentage, variantLabels, colors, orders, timeframe, today]);
 };

--- a/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
+++ b/packages/app/src/domain/variants/variants-stacked-bar-chart-tile.tsx
@@ -2,7 +2,7 @@ import { ChartTile, MetadataProps, TimeSeriesChart } from '~/components';
 import { Spacer } from '~/components/base';
 import { TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
 import { useState } from 'react';
-import { ColorMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
+import { ColorMatch, OrderMatch, VariantChartValue, VariantDynamicLabels, VariantsOverTimeGraphText } from '~/domain/variants/data-selection/types';
 import { useBarConfig } from '~/domain/variants/logic/use-bar-config';
 import { InteractiveLegend, SelectOption } from '~/components/interactive-legend';
 import { useList } from '~/utils/use-list';
@@ -13,13 +13,14 @@ import { reorderAndFilter } from '~/domain/variants/logic/reorder-and-filter';
 import { useIntl } from '~/intl';
 
 interface VariantsStackedBarChartTileProps {
-  title: string;
   description: string;
-  values: VariantChartValue[];
-  tooltipLabels: VariantsOverTimeGraphText;
-  variantLabels: VariantDynamicLabels;
-  variantColors: ColorMatch[];
   metadata: MetadataProps;
+  title: string;
+  tooltipLabels: VariantsOverTimeGraphText;
+  values: VariantChartValue[];
+  variantColors: ColorMatch[];
+  variantLabels: VariantDynamicLabels;
+  variantOrders: OrderMatch[];
 }
 
 const alwaysEnabled: (keyof VariantChartValue)[] = [];
@@ -35,12 +36,21 @@ const alwaysEnabled: (keyof VariantChartValue)[] = [];
  * @param metadata - Metadata block
  * @constructor
  */
-export const VariantsStackedBarChartTile = ({ title, description, tooltipLabels, values, variantLabels, variantColors, metadata }: VariantsStackedBarChartTileProps) => {
+export const VariantsStackedBarChartTile = ({
+  title,
+  description,
+  tooltipLabels,
+  values,
+  variantLabels,
+  variantColors,
+  variantOrders,
+  metadata,
+}: VariantsStackedBarChartTileProps) => {
   const today = useCurrentDate();
   const { commonTexts } = useIntl();
   const { list, toggle, clear } = useList<keyof VariantChartValue>(alwaysEnabled);
   const [variantTimeFrame, setVariantTimeFrame] = useState<TimeframeOption>(TimeframeOption.THIRTY_DAYS);
-  const barSeriesConfig = useBarConfig(values, variantLabels, tooltipLabels, variantColors, variantTimeFrame, today);
+  const barSeriesConfig = useBarConfig(values, variantLabels, tooltipLabels, variantColors, variantOrders, variantTimeFrame, today);
 
   const text = commonTexts.variants_page;
 
@@ -59,7 +69,7 @@ export const VariantsStackedBarChartTile = ({ title, description, tooltipLabels,
       timeframeInitialValue={TimeframeOption.THIRTY_DAYS}
       onSelectTimeframe={setVariantTimeFrame}
     >
-      <InteractiveLegend helpText={text.legend_help_text} selectOptions={interactiveLegendOptions} selection={list} onToggleItem={toggle} onReset={clear} />
+      <InteractiveLegend helpText={text.legend_help_text} selectOptions={interactiveLegendOptions.reverse()} selection={list} onToggleItem={toggle} onReset={clear} />
       <Spacer marginBottom={space[2]} />
       <TimeSeriesChart
         accessibility={{

--- a/packages/app/src/pages/artikelen/index.tsx
+++ b/packages/app/src/pages/artikelen/index.tsx
@@ -1,23 +1,23 @@
-import { colors } from '@corona-dashboard/common';
-import { useRouter } from 'next/router';
-import { useCallback, useMemo } from 'react';
-import styled from 'styled-components';
+import { ArticleCategoryType, allPossibleArticleCategories } from '~/domain/topical/common/categories';
+import { ArticlesList } from '~/components/articles/articles-list';
 import { ArticleSummary } from '~/components/articles/article-teaser';
 import { Box } from '~/components/base';
-import { MaxWidth } from '~/components/max-width';
-import { RichContentSelect } from '~/components/rich-content-select';
-import { Heading, InlineText, Text } from '~/components/typography';
-import { ArticlesList } from '~/components/articles/articles-list';
-import { Layout } from '~/domain/layout/layout';
-import { ArticleCategoryType, allPossibleArticleCategories } from '~/domain/topical/common/categories';
-import { useIntl } from '~/intl';
-import { Languages, SiteText } from '~/locale';
-import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { colors } from '@corona-dashboard/common';
 import { createGetContent, getLastGeneratedDate, getLokalizeTexts } from '~/static-props/get-data';
-import { mediaQueries, space } from '~/style/theme';
-import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
-import { useBreakpoints } from '~/utils/use-breakpoints';
 import { getCategories } from '~/components/articles/logic/get-categories';
+import { Heading, InlineText, Text } from '~/components/typography';
+import { Languages, SiteText } from '~/locale';
+import { Layout } from '~/domain/layout/layout';
+import { MaxWidth } from '~/components/max-width';
+import { mediaQueries, space } from '~/style/theme';
+import { RichContentSelect } from '~/components/rich-content-select';
+import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
+import { useBreakpoints } from '~/utils/use-breakpoints';
+import { useCallback, useMemo } from 'react';
+import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
+import { useIntl } from '~/intl';
+import { useRouter } from 'next/router';
+import styled from 'styled-components';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   textShared: siteText.pages.topical_page.shared,
@@ -99,7 +99,7 @@ const Articles = (props: StaticProps<typeof getStaticProps>) => {
 
   return (
     <Layout {...commonTexts.articles_metadata} lastGenerated={lastGenerated}>
-      <Box as="section" backgroundColor="white" paddingY={{ _: space[4], md: space[5] }}>
+      <Box id="content" as="section" backgroundColor="white" paddingY={{ _: space[4], md: space[5] }}>
         <MaxWidth paddingX={{ _: space[3], lg: space[4] }}>
           <Box paddingBottom={space[2]}>
             <Heading level={2} as="h1">

--- a/packages/app/src/pages/landelijk/de-coronaprik.tsx
+++ b/packages/app/src/pages/landelijk/de-coronaprik.tsx
@@ -36,15 +36,7 @@ import { Languages, SiteText } from '~/locale';
 import { ElementsQueryResult, getElementsQuery, getTimelineEvents } from '~/queries/get-elements-query';
 import { getArticleParts, getDataExplainedParts, getFaqParts, getLinkParts, getPagePartsQuery, getRichTextParts } from '~/queries/get-page-parts-query';
 import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
-import {
-  createGetArchivedChoroplethData,
-  createGetContent,
-  getArchivedNlData,
-  getLastGeneratedDate,
-  getLokalizeTexts,
-  selectArchivedNlData,
-  selectNlData,
-} from '~/static-props/get-data';
+import { createGetArchivedChoroplethData, createGetContent, getArchivedNlData, getLastGeneratedDate, getLokalizeTexts, selectArchivedNlData } from '~/static-props/get-data';
 import { ArticleParts, LinkParts, PagePartQueryResult, RichTextParts } from '~/types/cms';
 import { replaceVariablesInText, useFormatLokalizePercentage } from '~/utils';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
@@ -57,7 +49,6 @@ const pageMetrics = [
   'vaccine_administered_hospitals_and_care_institutions',
   'vaccine_administered_planned_archived_20231004',
   'vaccine_administered_total_archived_20220324',
-  'vaccine_administered_last_timeframe',
   'vaccine_coverage_per_age_group',
   'vaccine_coverage_archived_20220518',
   'vaccine_delivery_per_supplier_archived_20211101',
@@ -65,17 +56,17 @@ const pageMetrics = [
   'vaccine_vaccinated_or_support_archived_20230411',
   'vaccine_coverage_per_age_group_estimated_fully_vaccinated',
   'vaccine_coverage_per_age_group_estimated_autumn_2022',
-  'vaccine_campaigns',
   'vaccine_planned_archived_20220908',
   'booster_coverage_archived_20220904',
   'booster_shot_administered_archived_20220904',
   'repeating_shot_administered_20220713',
+  'vaccine_administered_last_timeframe_archived_20240117',
+  'vaccine_campaigns_archived_20240117',
 ];
 
 export const getStaticProps = createGetStaticProps(
   ({ locale }: { locale: keyof Languages }) => getLokalizeTexts(selectLokalizeTexts, locale),
   getLastGeneratedDate,
-  selectNlData('vaccine_administered_last_timeframe', 'vaccine_campaigns'),
   selectArchivedNlData(
     'vaccine_administered_doctors_archived_20220324',
     'vaccine_administered_hospitals_and_care_institutions_archived_20220324',
@@ -96,7 +87,9 @@ export const getStaticProps = createGetStaticProps(
     'vaccine_coverage_archived_20220518',
     'vaccine_delivery_per_supplier_archived_20211101',
     'vaccine_stock_archived_20211024',
-    'vaccine_vaccinated_or_support_archived_20230411'
+    'vaccine_vaccinated_or_support_archived_20230411',
+    'vaccine_administered_last_timeframe_archived_20240117',
+    'vaccine_campaigns_archived_20240117'
   ),
   () => selectAdministrationData(getArchivedNlData().data.vaccine_administered_archived_20220914),
   async (context: GetStaticPropsContext) => {
@@ -138,7 +131,7 @@ const selectLokalizeTexts = (siteText: SiteText) => ({
 type LokalizeTexts = ReturnType<typeof selectLokalizeTexts>;
 
 function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
-  const { content, archivedChoropleth, selectedNlData: currentData, selectedArchivedNlData: archivedData, lastGenerated, administrationData } = props;
+  const { content, archivedChoropleth, selectedArchivedNlData: archivedData, lastGenerated, administrationData } = props;
   const { commonTexts } = useIntl();
   const reverseRouter = useReverseRouter();
 
@@ -169,7 +162,7 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
 
   const hasActiveWarningTile = textNl.belangrijk_bericht && !isEmpty(textNl.belangrijk_bericht);
 
-  const lastInsertionDateOfPage = getLastInsertionDateOfPage(currentData, pageMetrics);
+  const lastInsertionDateOfPage = getLastInsertionDateOfPage(archivedData, pageMetrics);
 
   return (
     <Layout {...metadata} lastGenerated={lastGenerated}>
@@ -200,15 +193,15 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               {
                 title: textNl.kpi_vaccinaties_de_coronaprik.tile_amount_administered_last_timeframe.title,
                 description: textNl.kpi_vaccinaties_de_coronaprik.tile_amount_administered_last_timeframe.omschrijving,
-                value: currentData.vaccine_campaigns.vaccine_campaigns[0].vaccine_administered_last_timeframe,
-                dateOrRange: { start: currentData.vaccine_campaigns.date_start_unix, end: currentData.vaccine_campaigns.date_end_unix },
+                value: archivedData.vaccine_campaigns_archived_20240117.vaccine_campaigns[0].vaccine_administered_last_timeframe,
+                dateOrRange: { start: archivedData.vaccine_campaigns_archived_20240117.date_start_unix, end: archivedData.vaccine_campaigns_archived_20240117.date_end_unix },
                 source: textShared.bronnen.rivm,
               },
               {
                 title: textNl.kpi_vaccinaties_de_coronaprik.tile_amount_administered_total.title,
                 description: textNl.kpi_vaccinaties_de_coronaprik.tile_amount_administered_total.omschrijving,
-                value: currentData.vaccine_campaigns.vaccine_campaigns[0].vaccine_administered_total,
-                dateOrRange: currentData.vaccine_campaigns.date_unix,
+                value: archivedData.vaccine_campaigns_archived_20240117.vaccine_campaigns[0].vaccine_administered_total,
+                dateOrRange: archivedData.vaccine_campaigns_archived_20240117.date_unix,
                 source: textShared.bronnen.rivm,
               },
             ]}
@@ -217,11 +210,14 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
           <VaccinationsPerSupplierOverLastTimeframeTile
             title={textNl.vaccinations_per_supplier_over_last_timeframe.title}
             description={textNl.vaccinations_per_supplier_over_last_timeframe.description}
-            data={currentData.vaccine_administered_last_timeframe.vaccine_types}
+            data={archivedData.vaccine_administered_last_timeframe_archived_20240117.vaccine_types}
             metadata={{
               source: textShared.bronnen.rivm,
-              date: { start: currentData.vaccine_administered_last_timeframe.date_start_unix, end: currentData.vaccine_administered_last_timeframe.date_end_unix },
-              obtainedAt: currentData.vaccine_administered_last_timeframe.date_of_insertion_unix,
+              date: {
+                start: archivedData.vaccine_administered_last_timeframe_archived_20240117.date_start_unix,
+                end: archivedData.vaccine_administered_last_timeframe_archived_20240117.date_end_unix,
+              },
+              obtainedAt: archivedData.vaccine_administered_last_timeframe_archived_20240117.date_of_insertion_unix,
             }}
           />
 

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -18,7 +18,7 @@ import { getLastInsertionDateOfPage } from '~/utils/get-last-insertion-date-of-p
 import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
 import { BorderedKpiSection } from '~/components/kpi/bordered-kpi-section';
 import { useState } from 'react';
-import { getArchivedVariantChartData, getVariantBarChartData, getVariantOrderColors, getVariantTableData } from '~/domain/variants/data-selection';
+import { getArchivedVariantChartData, getVariantBarChartData, getVariantOrderColors, getVariantOrders, getVariantTableData } from '~/domain/variants/data-selection';
 import { VariantsStackedAreaTile, VariantsStackedBarChartTile, VariantsTableTile } from '~/domain/variants';
 import { VariantDynamicLabels } from '~/domain/variants/data-selection/types';
 import { NlVariantsVariant } from '@corona-dashboard/common';
@@ -51,11 +51,14 @@ export const getStaticProps = createGetStaticProps(
 
     const variantColors = getVariantOrderColors(variants);
 
+    const variantOrders = getVariantOrders(variants);
+
     return {
       ...getVariantTableData(variants, data.selectedNlData.named_difference, variantColors),
       ...getVariantBarChartData(variants),
       ...getArchivedVariantChartData(variants_archived_20231101),
       variantColors,
+      variantOrders,
     };
   },
   async (context: GetStaticPropsContext) => {
@@ -83,6 +86,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
     variantChart,
     archivedVariantChart,
     variantColors,
+    variantOrders,
     dates,
   } = props;
 
@@ -173,6 +177,7 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               values={variantChart}
               variantLabels={variantLabels}
               variantColors={variantColors}
+              variantOrders={variantOrders}
               metadata={{
                 datumsText: textNl.datums,
                 date: getLastInsertionDateOfPage(data, ['variants']),

--- a/packages/app/src/pages/over.tsx
+++ b/packages/app/src/pages/over.tsx
@@ -1,17 +1,18 @@
-import Head from 'next/head';
-import styled from 'styled-components';
 import { Box } from '~/components/base';
 import { ContentImage } from '~/components/cms/content-image';
-import { RichContent } from '~/components/cms/rich-content';
+import { ContentLayout } from '~/domain/layout/content-layout';
+import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
 import { FullscreenChartTile } from '~/components/fullscreen-chart-tile';
 import { Heading } from '~/components/typography';
-import { ContentLayout } from '~/domain/layout/content-layout';
-import { Layout } from '~/domain/layout/layout';
-import { useIntl } from '~/intl';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
-import { mediaQueries, sizes, space } from '~/style/theme';
 import { ImageBlock, RichContentBlock } from '~/types/cms';
+import { Layout } from '~/domain/layout/layout';
+import { mediaQueries, sizes, space } from '~/style/theme';
+import { RichContent } from '~/components/cms/rich-content';
+import { useIntl } from '~/intl';
+import Head from 'next/head';
+import styled from 'styled-components';
+
 interface OverData {
   title: string | null;
   intro: RichContentBlock[];
@@ -66,7 +67,7 @@ const Over = (props: StaticProps<typeof getStaticProps>) => {
           <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
           <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
         </Head>
-        <Box paddingBottom={space[5]}>
+        <Box id="content" paddingBottom={space[5]}>
           <Box marginBottom={space[4]} maxWidth={sizes.maxWidthText}>
             <Heading variant="h2" level={1}>
               {content.title}

--- a/packages/app/src/pages/toegankelijkheid.tsx
+++ b/packages/app/src/pages/toegankelijkheid.tsx
@@ -1,20 +1,15 @@
+import { Box } from '~/components/base';
+import { Content } from '~/domain/layout/content';
+import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { Heading } from '~/components/typography';
+import { Layout } from '~/domain/layout/layout';
+import { RichContent } from '~/components/cms/rich-content';
+import { RichContentBlock } from '~/types/cms';
+import { useIntl } from '~/intl';
 import css from '@styled-system/css';
 import Head from 'next/head';
 import styled from 'styled-components';
-import { RichContent } from '~/components/cms/rich-content';
-import { Heading } from '~/components/typography';
-import { Content } from '~/domain/layout/content';
-import { Layout } from '~/domain/layout/layout';
-import { useIntl } from '~/intl';
-import {
-  createGetStaticProps,
-  StaticProps,
-} from '~/static-props/create-get-static-props';
-import {
-  createGetContent,
-  getLastGeneratedDate,
-} from '~/static-props/get-data';
-import { RichContentBlock } from '~/types/cms';
 
 interface AccessibilityPageData {
   title: string | null;
@@ -52,33 +47,17 @@ const AccessibilityPage = (props: StaticProps<typeof getStaticProps>) => {
   const { content, lastGenerated } = props;
 
   return (
-    <Layout
-      {...commonTexts.toegankelijkheid_metadata}
-      lastGenerated={lastGenerated}
-    >
+    <Layout {...commonTexts.toegankelijkheid_metadata} lastGenerated={lastGenerated}>
       <Head>
-        <link
-          key="dc-type"
-          rel="dcterms:type"
-          href="https://standaarden.overheid.nl/owms/terms/webpagina"
-        />
-        <link
-          key="dc-type-title"
-          rel="dcterms:type"
-          href="https://standaarden.overheid.nl/owms/terms/webpagina"
-          title="webpagina"
-        />
+        <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
+        <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
       </Head>
-
-      <Content>
-        {content.title && <Heading level={1}>{content.title}</Heading>}
-        {content.description && (
-          <RichContent
-            blocks={content.description}
-            contentWrapper={RichContentWrapper}
-          />
-        )}
-      </Content>
+      <Box id="content">
+        <Content>
+          {content.title && <Heading level={1}>{content.title}</Heading>}
+          {content.description && <RichContent blocks={content.description} contentWrapper={RichContentWrapper} />}
+        </Content>
+      </Box>
     </Layout>
   );
 };

--- a/packages/app/src/pages/veelgestelde-vragen.tsx
+++ b/packages/app/src/pages/veelgestelde-vragen.tsx
@@ -1,17 +1,17 @@
+import { Box } from '~/components/base/box';
+import { ContentLayout } from '~/domain/layout/content-layout';
+import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { FaqSection } from '~/components/faq/faq-section';
+import { FAQuestionAndAnswer, RichContentBlock } from '~/types/cms';
+import { Heading } from '~/components/typography';
+import { Layout } from '~/domain/layout/layout';
+import { mediaQueries, sizes, space } from '~/style/theme';
+import { RichContent } from '~/components/cms/rich-content';
+import { useIntl } from '~/intl';
 import groupBy from 'lodash/groupBy';
 import Head from 'next/head';
 import styled from 'styled-components';
-import { Box } from '~/components/base/box';
-import { RichContent } from '~/components/cms/rich-content';
-import { FaqSection } from '~/components/faq/faq-section';
-import { Heading } from '~/components/typography';
-import { ContentLayout } from '~/domain/layout/content-layout';
-import { Layout } from '~/domain/layout/layout';
-import { useIntl } from '~/intl';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetContent, getLastGeneratedDate } from '~/static-props/get-data';
-import { mediaQueries, sizes, space } from '~/style/theme';
-import { FAQuestionAndAnswer, RichContentBlock } from '~/types/cms';
 
 interface VeelgesteldeVragenData {
   title: string | null;
@@ -74,20 +74,21 @@ const Verantwoording = (props: StaticProps<typeof getStaticProps>) => {
           <link key="dc-type" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" />
           <link key="dc-type-title" rel="dcterms:type" href="https://standaarden.overheid.nl/owms/terms/webpagina" title="webpagina" />
         </Head>
+        <Box id="content">
+          <Box maxWidth={sizes.maxWidthText} marginBottom={space[4]} spacing={3}>
+            {content.title && (
+              <Heading variant="h2" level={1}>
+                {content.title}
+              </Heading>
+            )}
+            {content.description && <RichContent blocks={content.description} />}
+          </Box>
 
-        <Box maxWidth={sizes.maxWidthText} marginBottom={space[4]} spacing={3}>
-          {content.title && (
-            <Heading variant="h2" level={1}>
-              {content.title}
-            </Heading>
-          )}
-          {content.description && <RichContent blocks={content.description} />}
+          <FaqLayout>
+            <FaqSection section={firstHalf} />
+            <FaqSection section={secondHalf} />
+          </FaqLayout>
         </Box>
-
-        <FaqLayout>
-          <FaqSection section={firstHalf} />
-          <FaqSection section={secondHalf} />
-        </FaqLayout>
       </ContentLayout>
     </Layout>
   );

--- a/packages/cms/src/studio/constants.ts
+++ b/packages/cms/src/studio/constants.ts
@@ -44,7 +44,7 @@ export const titleByMetricName: Partial<Record<MetricName, string>> = {
   vaccine_administered_total_archived_20220324: 'Totaal aantal gezette prikken',
   vaccine_administered_archived_20220914: 'Gezette prikken',
   vaccine_campaigns_archived_20220908: 'Vaccinatie campagnes (archief per 08-09-2022)',
-  vaccine_campaigns: 'Vaccinatie campagnes',
+  vaccine_campaigns_archived_20240117: 'Vaccinatie campagnes',
   vaccine_coverage_per_age_group_archived_20220908: 'Vaccinatiegraad (per leeftijd) (archief per 08-09-2022)',
   vaccine_coverage_per_age_group_archived_20220622: 'Vaccinatiegraad (per leeftijd) (archief)',
   vaccine_coverage_per_age_group_estimated_archived_20220908: 'Vaccinatiegraad berekend (per leeftijd) (archief 08-09-2022)',

--- a/packages/common/src/types/data.ts
+++ b/packages/common/src/types/data.ts
@@ -236,6 +236,8 @@ export interface ArchivedNl {
   corona_melder_app_warning_archived_20220421: ArchivedNlCoronaMelderAppWarning;
   corona_melder_app_download_archived_20220421: ArchivedNlCoronaMelderAppDownload;
   infectious_people_archived_20210709: ArchivedNlInfectiousPeople;
+  vaccine_administered_last_timeframe_archived_20240117: ArchivedNlVaccineAdministeredLastTimeframe;
+  vaccine_campaigns_archived_20240117: ArchivedNlVaccineCampaign;
 }
 export interface ArchivedNlDifference {
   deceased_rivm__covid_daily_archived_20221231: DifferenceInteger;
@@ -892,6 +894,31 @@ export interface ArchivedNlInfectiousPeopleValue {
   date_unix: number;
   date_of_insertion_unix: number;
 }
+export interface ArchivedNlVaccineAdministeredLastTimeframe {
+  vaccine_types: NlVaccineType[];
+  date_unix: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  date_of_insertion_unix: number;
+}
+export interface NlVaccineType {
+  vaccine_type_name: string;
+  vaccine_type_value: number;
+}
+export interface ArchivedNlVaccineCampaign {
+  vaccine_campaigns: ArchivedNlVaccineCampaigns[];
+  date_unix: number;
+  date_start_unix: number;
+  date_end_unix: number;
+  date_of_insertion_unix: number;
+}
+export interface ArchivedNlVaccineCampaigns {
+  vaccine_campaign_order: number;
+  vaccine_campaign_name_nl: string;
+  vaccine_campaign_name_en: string;
+  vaccine_administered_total: number | null;
+  vaccine_administered_last_timeframe: number;
+}
 
 export type ArchivedVrCollectionId = 'VR_COLLECTION';
 
@@ -1050,8 +1077,6 @@ export interface Nl {
   hospital_lcps: NlHospitalLcps;
   intensive_care_lcps: NlIntensiveCareLcps;
   deceased_cbs: NlDeceasedCbs;
-  vaccine_administered_last_timeframe: NlVaccineAdministeredLastTimeframe;
-  vaccine_campaigns: NlVaccineCampaign;
   variants: NlVariants;
   self_test_overall: NlSelfTestOverall;
   infectionradar_symptoms_trend_per_age_group_weekly: NlInfectionradarSymptomsTrendPerAgeGroupWeekly;
@@ -1198,31 +1223,6 @@ export interface NlDeceasedCbsValue {
   date_start_unix: number;
   date_end_unix: number;
   date_of_insertion_unix: number;
-}
-export interface NlVaccineAdministeredLastTimeframe {
-  vaccine_types: NlVaccineType[];
-  date_unix: number;
-  date_start_unix: number;
-  date_end_unix: number;
-  date_of_insertion_unix: number;
-}
-export interface NlVaccineType {
-  vaccine_type_name: string;
-  vaccine_type_value: number;
-}
-export interface NlVaccineCampaign {
-  vaccine_campaigns: NlVaccineCampaigns[];
-  date_unix: number;
-  date_start_unix: number;
-  date_end_unix: number;
-  date_of_insertion_unix: number;
-}
-export interface NlVaccineCampaigns {
-  vaccine_campaign_order: number;
-  vaccine_campaign_name_nl: string;
-  vaccine_campaign_name_en: string;
-  vaccine_administered_total: number | null;
-  vaccine_administered_last_timeframe: number;
 }
 export interface NlVariants {
   values: NlVariantsVariant[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -18627,23 +18627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.2.4":
-  version: 1.14.8
-  resolution: "follow-redirects@npm:1.14.8"
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.2, follow-redirects@npm:^1.2.4":
+  version: 1.15.4
+  resolution: "follow-redirects@npm:1.15.4"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 40c67899c2e3149a27e8b6498a338ff27f39fe138fde8d7f0756cb44b073ba0bfec3d52af28f20c5bdd67263d564d0d8d7b5efefd431de95c18c42f7b4aef457
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.15.2":
-  version: 1.15.2
-  resolution: "follow-redirects@npm:1.15.2"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  checksum: e178d1deff8b23d5d24ec3f7a94cde6e47d74d0dc649c35fc9857041267c12ec5d44650a0c5597ef83056ada9ea6ca0c30e7c4f97dbf07d035086be9e6a5b7b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What's Changed
* Feature/cor 1866 sync master to dev by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4960
* remove duplication in theme-tile by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4962
* Master to dev by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4963
* Include development into the master branch by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4964
* chore(deps): bump follow-redirects from 1.14.8 to 1.15.4 by @dependabot in https://github.com/minvws/nl-covid19-data-dashboard/pull/4965
* feature/COR-1873-markup-links by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4966
* feature/COR-1875-restructure-skiplinks by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4968
* feature/COR-1874_navigability by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4969
* feature/COR-1857-refactor-order-of-variants by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4967
* COR-1895: archive vaccine keys by @yorickdevries in https://github.com/minvws/nl-covid19-data-dashboard/pull/4970


**Full Changelog**: https://github.com/minvws/nl-covid19-data-dashboard/compare/2.85.1...2.86.0