### PR TITLE
feature/COR-1899-archived-pages-accordion

### DIFF
--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -1,0 +1,89 @@
+import css from '@styled-system/css';
+import { Box } from '~/components/base';
+import styled from 'styled-components';
+import { colors } from '@corona-dashboard/common';
+import { space } from '~/style/theme';
+
+export const CategoryDropdownRoot = styled(Box)(
+  css({
+    position: 'relative',
+  })
+);
+
+export const CategoryDropdown = styled(Box)(
+  css({
+    cursor: 'default',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    minHeight: '36px',
+    paddingX: space[3],
+    paddingY: space[2],
+    borderColor: colors.gray3,
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    borderRadius: (theme) => theme.radii[1],
+    userSelect: 'none',
+    transition: '0.1s background-color',
+    '&[aria-expanded="true"]': {
+      bg: colors.white,
+      color: colors.black,
+      borderRadius: '5px 5px 0 0',
+      borderColor: colors.blue8,
+      '&:after': {
+        content: 'attr(data-color)',
+        position: 'absolute',
+        left: '1px',
+        right: '1px',
+        bottom: 0,
+        borderBottom: '1px solid',
+        borderColor: colors.white,
+      },
+    },
+    '&:hover, &:focus': {
+      bg: colors.gray1,
+    },
+    '&:hover': {
+      color: colors.blue8,
+      borderColor: colors.blue8,
+    },
+    '&:focus': {
+      bg: colors.white,
+      color: colors.black,
+    },
+  })
+);
+
+export const CategorySelectBox = styled(Box)(
+  css({
+    cursor: 'default',
+    display: 'flex',
+    alignItems: 'center',
+  })
+);
+
+export const CategoryListBox = styled(Box)(
+  css({
+    bg: 'white',
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    width: '100%',
+    overflowY: 'clip',
+    borderColor: colors.blue8,
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    borderTopWidth: 0,
+    display: 'none',
+    [`${CategoryDropdown}[aria-expanded="true"] + &`]: {
+      display: 'block',
+      borderRadius: '0 0 5px 5px',
+    },
+  })
+);
+
+export const CategoryListBoxOption = styled(Box)(
+  css({
+    cursor: 'default',
+  })
+);

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -1,20 +1,28 @@
 import { Box } from '~/components/base';
 import styled from 'styled-components';
 import { colors } from '@corona-dashboard/common';
-import { space } from '~/style/theme';
+import { mediaQueries, space } from '~/style/theme';
 
 export const CategoryDropdownRoot = styled(Box)`
+  @media ${mediaQueries.xl} {
+    margin: 0;
+  }
   position: relative;
   box-shadow: ${space[1]} 0 0 ${space[4]} ${colors.white};
+  margin: 0 8px;
 `;
 
 export const CategoryDropdown = styled(Box)`
+    @media ${mediaQueries.xl} {  
+      padding: ${space[2]} ${space[3]} ${space[2]} ${space[2]};
+      margin: 0;
+    }
     cursor: default;
     display: flex;
     justify-content: space-between;
     align-items: center;
     min-height: 36px;
-    padding: ${space[2]} ${space[2]};
+    padding: ${space[2]} ${space[1]} ${space[2]} ${space[1]};
     border-color: ${colors.gray3};
     border-style: solid;
     border-width: 1px;

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -1,7 +1,7 @@
 import { Box } from '~/components/base';
-import styled from 'styled-components';
 import { colors } from '@corona-dashboard/common';
-import { mediaQueries, space } from '~/style/theme';
+import { mediaQueries, radii, space } from '~/style/theme';
+import styled from 'styled-components';
 
 export const CategoryDropdownRoot = styled(Box)`
   @media ${mediaQueries.xl} {
@@ -9,7 +9,7 @@ export const CategoryDropdownRoot = styled(Box)`
   }
   position: relative;
   box-shadow: ${space[1]} 0 0 ${space[4]} ${colors.white};
-  margin: 0 8px;
+  margin: 0 ${space[2]};
 `;
 
 export const CategoryDropdown = styled(Box)`
@@ -17,43 +17,44 @@ export const CategoryDropdown = styled(Box)`
     padding: ${space[2]} ${space[3]} ${space[2]} ${space[2]};
     margin: 0;
   }
-  cursor: default;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  min-height: 36px;
-  padding: ${space[2]} ${space[1]} ${space[2]} ${space[1]};
-  border-color: ${colors.gray3};
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 5px;
-  user-select: none;
-  transition: 0.1s background-color;
-  &[aria-expanded=true] {
-    background: ${colors.white};
-    color: ${colors.black};
-    border-radius: 5px 5px 0 0;
-    border-color: ${colors.blue8};
-    border-bottom-color: ${colors.white};
-    &:hover, &:focus {
-      border-bottom-color: ${colors.white};
-    },
-  },
-  &:hover, &:focus {
-    background: ${colors.gray1};
-  },
   &:hover {
-    color: ${colors.blue8};
+    cursor: pointer;
     border-color: ${colors.blue8};
+    color: ${colors.blue8};
   },
   &:focus {
     background: ${colors.white};
     color: ${colors.black};
   }
+  &:hover, &:focus {
+      background: ${colors.gray1};
+  },
+  cursor: default;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: ${space[2]};
+  padding: ${space[2]} ${space[1]} ${space[2]} ${space[1]};
+  border-color: ${colors.gray3};
+  border-style: solid;
+  border-width: 1px;
+  border-radius: ${radii[1]}px;
+  user-select: none;
+  transition: 0.1s background-color;
+  &[aria-expanded=true] {
+    background: ${colors.white};
+    color: ${colors.black};
+    border-radius: ${radii[1]}px ${radii[1]}px 0 0;
+    border-color: ${colors.blue8};
+    border-bottom-color: ${colors.white};
+    &:hover, &:focus {
+      border-bottom-color: ${colors.white};
+    },
+  }
 `;
 
 export const CategorySelectBox = styled(Box)`
-  cursor: default;
+  cursor: pointer;
   display: flex;
   align-items: center;
 `;
@@ -69,7 +70,7 @@ export const CategoryListBox = styled(Box)`
   display: none;
   ${CategoryDropdown}[aria-expanded=true] + & {
     display: block;
-    border-radius: 0 0 5px 5px;
+    border-radius: 0 0 ${radii[1]}px ${radii[1]}px;
   }
 `;
 

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -20,7 +20,6 @@ export const CategoryDropdown = styled(Box)`
   &:hover {
     cursor: pointer;
     border-color: ${colors.blue8};
-    color: ${colors.blue8};
   },
   &:focus {
     background: ${colors.white};

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -13,43 +13,43 @@ export const CategoryDropdownRoot = styled(Box)`
 `;
 
 export const CategoryDropdown = styled(Box)`
-    @media ${mediaQueries.xl} {  
-      padding: ${space[2]} ${space[3]} ${space[2]} ${space[2]};
-      margin: 0;
-    }
-    cursor: default;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    min-height: 36px;
-    padding: ${space[2]} ${space[1]} ${space[2]} ${space[1]};
-    border-color: ${colors.gray3};
-    border-style: solid;
-    border-width: 1px;
-    border-radius: 5px;
-    user-select: none;
-    transition: 0.1s background-color;
-    &[aria-expanded=true] {
-      background: ${colors.white};
-      color: ${colors.black};
-      border-radius: 5px 5px 0 0;
-      border-color: ${colors.blue8};
-      border-bottom-color: ${colors.white};
-      &:hover, &:focus {
-        border-bottom-color: ${colors.white};
-      },
-    },
+  @media ${mediaQueries.xl} {  
+    padding: ${space[2]} ${space[3]} ${space[2]} ${space[2]};
+    margin: 0;
+  }
+  cursor: default;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 36px;
+  padding: ${space[2]} ${space[1]} ${space[2]} ${space[1]};
+  border-color: ${colors.gray3};
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 5px;
+  user-select: none;
+  transition: 0.1s background-color;
+  &[aria-expanded=true] {
+    background: ${colors.white};
+    color: ${colors.black};
+    border-radius: 5px 5px 0 0;
+    border-color: ${colors.blue8};
+    border-bottom-color: ${colors.white};
     &:hover, &:focus {
-      background: ${colors.gray1};
+      border-bottom-color: ${colors.white};
     },
-    &:hover {
-      color: ${colors.blue8};
-      border-color: ${colors.blue8};
-    },
-    &:focus {
-      background: ${colors.white};
-      color: ${colors.black};
-    }
+  },
+  &:hover, &:focus {
+    background: ${colors.gray1};
+  },
+  &:hover {
+    color: ${colors.blue8};
+    border-color: ${colors.blue8};
+  },
+  &:focus {
+    background: ${colors.white};
+    color: ${colors.black};
+  }
 `;
 
 export const CategorySelectBox = styled(Box)`
@@ -75,4 +75,10 @@ export const CategoryListBox = styled(Box)`
 
 export const CategoryListBoxOption = styled(Box)`
   cursor: default;
+  a {
+    @media ${mediaQueries.xl} {
+      padding: ${space[2]} ${space[2]} ${space[2]} 3rem;
+    }
+    padding: ${space[2]} 0 ${space[2]} ${space[4]};
+  }
 `;

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -30,14 +30,9 @@ export const CategoryDropdown = styled(Box)(
       color: colors.black,
       borderRadius: '5px 5px 0 0',
       borderColor: colors.blue8,
-      '&:after': {
-        content: 'attr(data-color)',
-        position: 'absolute',
-        left: '1px',
-        right: '1px',
-        bottom: 0,
-        borderBottom: '1px solid',
-        borderColor: colors.white,
+      borderBottomColor: colors.white,
+      '&:hover, &:focus': {
+        borderBottomColor: colors.white,
       },
     },
     '&:hover, &:focus': {
@@ -65,9 +60,6 @@ export const CategorySelectBox = styled(Box)(
 export const CategoryListBox = styled(Box)(
   css({
     bg: 'white',
-    position: 'absolute',
-    top: '100%',
-    left: 0,
     width: '100%',
     overflowY: 'clip',
     borderColor: colors.blue8,

--- a/packages/app/src/components/aside/components/CategoryDropdown.tsx
+++ b/packages/app/src/components/aside/components/CategoryDropdown.tsx
@@ -1,81 +1,70 @@
-import css from '@styled-system/css';
 import { Box } from '~/components/base';
 import styled from 'styled-components';
 import { colors } from '@corona-dashboard/common';
 import { space } from '~/style/theme';
 
-export const CategoryDropdownRoot = styled(Box)(
-  css({
-    position: 'relative',
-  })
-);
+export const CategoryDropdownRoot = styled(Box)`
+  position: relative;
+  box-shadow: ${space[1]} 0 0 ${space[4]} ${colors.white};
+`;
 
-export const CategoryDropdown = styled(Box)(
-  css({
-    cursor: 'default',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    minHeight: '36px',
-    paddingX: space[3],
-    paddingY: space[2],
-    borderColor: colors.gray3,
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    borderRadius: (theme) => theme.radii[1],
-    userSelect: 'none',
-    transition: '0.1s background-color',
-    '&[aria-expanded="true"]': {
-      bg: colors.white,
-      color: colors.black,
-      borderRadius: '5px 5px 0 0',
-      borderColor: colors.blue8,
-      borderBottomColor: colors.white,
-      '&:hover, &:focus': {
-        borderBottomColor: colors.white,
+export const CategoryDropdown = styled(Box)`
+    cursor: default;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 36px;
+    padding: ${space[2]} ${space[2]};
+    border-color: ${colors.gray3};
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 5px;
+    user-select: none;
+    transition: 0.1s background-color;
+    &[aria-expanded=true] {
+      background: ${colors.white};
+      color: ${colors.black};
+      border-radius: 5px 5px 0 0;
+      border-color: ${colors.blue8};
+      border-bottom-color: ${colors.white};
+      &:hover, &:focus {
+        border-bottom-color: ${colors.white};
       },
     },
-    '&:hover, &:focus': {
-      bg: colors.gray1,
+    &:hover, &:focus {
+      background: ${colors.gray1};
     },
-    '&:hover': {
-      color: colors.blue8,
-      borderColor: colors.blue8,
+    &:hover {
+      color: ${colors.blue8};
+      border-color: ${colors.blue8};
     },
-    '&:focus': {
-      bg: colors.white,
-      color: colors.black,
-    },
-  })
-);
+    &:focus {
+      background: ${colors.white};
+      color: ${colors.black};
+    }
+`;
 
-export const CategorySelectBox = styled(Box)(
-  css({
-    cursor: 'default',
-    display: 'flex',
-    alignItems: 'center',
-  })
-);
+export const CategorySelectBox = styled(Box)`
+  cursor: default;
+  display: flex;
+  align-items: center;
+`;
 
-export const CategoryListBox = styled(Box)(
-  css({
-    bg: 'white',
-    width: '100%',
-    overflowY: 'clip',
-    borderColor: colors.blue8,
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    borderTopWidth: 0,
-    display: 'none',
-    [`${CategoryDropdown}[aria-expanded="true"] + &`]: {
-      display: 'block',
-      borderRadius: '0 0 5px 5px',
-    },
-  })
-);
+export const CategoryListBox = styled(Box)`
+  background: white;
+  width: 100%;
+  overflow-y: clip;
+  border-color: ${colors.blue8};
+  border-style: solid;
+  border-width: 1px;
+  border-top-width: 0;
+  display: none;
+  ${CategoryDropdown}[aria-expanded=true] + & {
+    display: block;
+    border-radius: 0 0 5px 5px;
+  }
+`;
 
-export const CategoryListBoxOption = styled(Box)(
-  css({
-    cursor: 'default',
-  })
-);
+export const CategoryListBoxOption = styled(Box)`
+  cursor: default;
+`;

--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -59,23 +59,23 @@ export function Menu({ children, spacing }: { children: ReactNode; spacing?: Spa
 export function CollapsibleCategoryMenu({ title, children, icon }: { children: ReactNode; title?: string; icon: ReactNode; key: string }) {
   const router = useRouter();
   const archivedPaths = useArchivedPaths();
-  const collapsible = useCollapsible({ isOpen: isCurrentRouteArchivedPage(router, archivedPaths) });
+  const { button: collapsibleButton, content: collapsibleContent, chevron: collapseChevron } = useCollapsible({ isOpen: isCurrentRouteArchivedPage(router, archivedPaths) });
 
   return (
     <Box as="li" mt={space[4]} mb={space[4]}>
       <CategoryDropdownRoot>
         {title &&
           icon &&
-          collapsible.button(
+          collapsibleButton(
             <CategoryDropdown>
               <CategorySelectBox>
                 <Icon>{icon}</Icon>
                 <Heading level={5}>{title}</Heading>
               </CategorySelectBox>
-              {collapsible.chevron}
+              {collapseChevron}
             </CategoryDropdown>
           )}
-        <CategoryListBox as="ul">{collapsible.content(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
+        <CategoryListBox as="ul">{collapsibleContent(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
       </CategoryDropdownRoot>
     </Box>
   );

--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -16,6 +16,7 @@ import chevronUrl from '~/assets/chevron.svg';
 import css from '@styled-system/css';
 import styled from 'styled-components';
 import { ArchivedPath, useArchivedPaths } from '~/utils/use-archived-paths';
+import { CategoryDropdown, CategoryDropdownRoot, CategoryListBox, CategoryListBoxOption, CategorySelectBox } from '~/components/aside/components/CategoryDropdown';
 
 type Url = UrlObject | string;
 
@@ -55,28 +56,28 @@ export function Menu({ children, spacing }: { children: ReactNode; spacing?: Spa
   );
 }
 
-export function CollapsibleCategoryMenu({ title, children, icon }: { children: ReactNode; title?: string; icon: ReactNode; key: string }) {
+export function CollapsibleCategoryMenu({ title, children, icon }: { children: React.ReactNode; title?: string; icon: ReactNode; key: string }) {
   const router = useRouter();
+
   const archivedPaths = useArchivedPaths();
+
   const collapsible = useCollapsible({ isOpen: isCurrentRouteArchivedPage(router, archivedPaths) });
+
   return (
-    <Box as="li" spacing={2} borderTop={`1px solid ${colors.gray2}`}>
-      {title && icon && (
-        <>
-          <Box display="flex" flexDirection="row" flexWrap="nowrap" alignItems="center">
-            <Box width="100%">
-              <Box paddingX={space[2]} paddingTop={space[3]} display="flex" justifyContent="space-between" alignItems="center">
-                <Box display="flex" alignItems="center">
-                  <Icon>{icon}</Icon>
-                  <Heading level={5}>{title}</Heading>
-                </Box>
-                <Box pr={space[1]}>{collapsible.button()}</Box>
-              </Box>
-            </Box>
-          </Box>
-          {collapsible.content(<Menu>{children}</Menu>)}
-        </>
-      )}
+    <Box as="li" mt={space[4]} mb={space[4]}>
+      <CategoryDropdownRoot>
+        {collapsible.button(
+          <CategoryDropdown>
+            <CategorySelectBox>
+              <Icon>{icon}</Icon>
+              <Heading level={5}>{title}</Heading>
+            </CategorySelectBox>
+            {collapsible.chevron}
+          </CategoryDropdown>
+        )}
+
+        <CategoryListBox>{collapsible.content(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
+      </CategoryDropdownRoot>
     </Box>
   );
 }

--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -75,7 +75,6 @@ export function CollapsibleCategoryMenu({ title, children, icon }: { children: R
             {collapsible.chevron}
           </CategoryDropdown>
         )}
-
         <CategoryListBox>{collapsible.content(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
       </CategoryDropdownRoot>
     </Box>

--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -1,7 +1,11 @@
 import { Anchor, Heading } from '~/components/typography';
+import { ArchivedPath, useArchivedPaths } from '~/utils/use-archived-paths';
 import { AsideTitle } from './title';
 import { asResponsiveArray } from '~/style/utils';
 import { Box } from '~/components/base';
+import chevronUrl from '~/assets/chevron.svg';
+import css from '@styled-system/css';
+import { CategoryDropdown, CategoryDropdownRoot, CategoryListBox, CategoryListBoxOption, CategorySelectBox } from '~/components/aside/components/CategoryDropdown';
 import { colors } from '@corona-dashboard/common';
 import { ExpandedSidebarMap, Layout } from '~/domain/layout/logic/types';
 import { Link } from '~/utils/link';
@@ -9,14 +13,10 @@ import { NextRouter, useRouter } from 'next/router';
 import { ReactNode } from 'react';
 import { resolveHref } from 'next/dist/shared/lib/router/router';
 import { space, SpaceValue } from '~/style/theme';
+import styled from 'styled-components';
 import { UrlObject } from 'url';
 import { useBreakpoints } from '~/utils/use-breakpoints';
 import { useCollapsible } from '~/utils/use-collapsible';
-import chevronUrl from '~/assets/chevron.svg';
-import css from '@styled-system/css';
-import styled from 'styled-components';
-import { ArchivedPath, useArchivedPaths } from '~/utils/use-archived-paths';
-import { CategoryDropdown, CategoryDropdownRoot, CategoryListBox, CategoryListBoxOption, CategorySelectBox } from '~/components/aside/components/CategoryDropdown';
 
 type Url = UrlObject | string;
 
@@ -56,26 +56,26 @@ export function Menu({ children, spacing }: { children: ReactNode; spacing?: Spa
   );
 }
 
-export function CollapsibleCategoryMenu({ title, children, icon }: { children: React.ReactNode; title?: string; icon: ReactNode; key: string }) {
+export function CollapsibleCategoryMenu({ title, children, icon }: { children: ReactNode; title?: string; icon: ReactNode; key: string }) {
   const router = useRouter();
-
   const archivedPaths = useArchivedPaths();
-
   const collapsible = useCollapsible({ isOpen: isCurrentRouteArchivedPage(router, archivedPaths) });
 
   return (
     <Box as="li" mt={space[4]} mb={space[4]}>
       <CategoryDropdownRoot>
-        {collapsible.button(
-          <CategoryDropdown>
-            <CategorySelectBox>
-              <Icon>{icon}</Icon>
-              <Heading level={5}>{title}</Heading>
-            </CategorySelectBox>
-            {collapsible.chevron}
-          </CategoryDropdown>
-        )}
-        <CategoryListBox>{collapsible.content(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
+        {title &&
+          icon &&
+          collapsible.button(
+            <CategoryDropdown>
+              <CategorySelectBox>
+                <Icon>{icon}</Icon>
+                <Heading level={5}>{title}</Heading>
+              </CategorySelectBox>
+              {collapsible.chevron}
+            </CategoryDropdown>
+          )}
+        <CategoryListBox as="ul">{collapsible.content(<CategoryListBoxOption>{children}</CategoryListBoxOption>)}</CategoryListBox>
       </CategoryDropdownRoot>
     </Box>
   );


### PR DESCRIPTION
## Summary
 
* Re-styled archived pages dropdown into accordion
  * On desktop
  * On mobile

 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
_Desktop - Closed_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/8fd3cea9-8044-4d79-876d-80383c742e47)

_Desktop - Open_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/bdd3f3ec-ecf2-422d-8a8f-9b7549cf0d64)


_Mobile closed_

_Mobile open_
</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 _Desktop - Closed_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/f07c5ecd-64d0-4f47-bacc-41c616ddc83b)


_Desktop - Open_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/35b9f26d-d78c-4395-9e5e-c4849de0fe45)

_Mobile - closed_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/d44999d0-5d24-4e5c-903d-4d35e56260dc)

_Mobile - open_

![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/4d55b77f-e263-4d5c-929a-79253de5a209)


</details>