### PR TITLE
feature/COR-1901-rwzi-municipal-pages

### DIFF
--- a/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/gapped-line-trend.tsx
@@ -5,6 +5,7 @@ import { LineTrend } from './line-trend';
 type GappedLinedTrendProps = {
   series: SeriesSingleValue[];
   color: string;
+  opacity?: number;
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   getX: (v: SeriesItem) => number;
@@ -14,7 +15,7 @@ type GappedLinedTrendProps = {
 };
 
 export function GappedLinedTrend(props: GappedLinedTrendProps) {
-  const { series, color, style, strokeWidth, getX, getY, curve, id } = props;
+  const { series, color, opacity, style, strokeWidth, getX, getY, curve, id } = props;
 
   /**
    * Here we loop through the series and each time a null value is encountered a
@@ -30,6 +31,7 @@ export function GappedLinedTrend(props: GappedLinedTrendProps) {
           key={index}
           series={series}
           color={color}
+          opacity={opacity}
           style={style}
           strokeWidth={strokeWidth}
           curve={curve}

--- a/packages/app/src/components/time-series-chart/components/line-trend.tsx
+++ b/packages/app/src/components/time-series-chart/components/line-trend.tsx
@@ -12,6 +12,7 @@ const DEFAULT_STROKE_WIDTH = 2;
 type LineTrendProps = {
   series: SeriesSingleValue[];
   color: string;
+  opacity?: number;
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   getX: (v: SeriesItem) => number;
@@ -20,7 +21,7 @@ type LineTrendProps = {
   id: string;
 };
 
-export function LineTrend({ series, style = DEFAULT_STYLE, strokeWidth = DEFAULT_STROKE_WIDTH, color, getX, getY, curve = 'linear', id }: LineTrendProps) {
+export function LineTrend({ series, style = DEFAULT_STYLE, strokeWidth = DEFAULT_STROKE_WIDTH, color, opacity, getX, getY, curve = 'linear', id }: LineTrendProps) {
   const nonNullSeries = useMemo(() => {
     let nonNull = series.filter((x) => isPresent(x.__value));
     if (nonNull.length === 1) {
@@ -48,6 +49,7 @@ export function LineTrend({ series, style = DEFAULT_STYLE, strokeWidth = DEFAULT
       x={getX}
       y={getY}
       stroke={color}
+      opacity={opacity}
       strokeWidth={strokeWidth}
       curve={curves[curve]}
       strokeDasharray={style === 'dashed' ? 4 : undefined}

--- a/packages/app/src/components/time-series-chart/components/series.tsx
+++ b/packages/app/src/components/time-series-chart/components/series.tsx
@@ -51,6 +51,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({ seriesConfig, seriesList
                   key={index}
                   series={series as SeriesSingleValue[]}
                   color={config.color}
+                  opacity={config.opacity}
                   style={config.style}
                   strokeWidth={config.strokeWidth}
                   curve={config.curve}
@@ -65,6 +66,7 @@ function SeriesUnmemoized<T extends TimestampedValue>({ seriesConfig, seriesList
                   key={index}
                   series={series as SeriesSingleValue[]}
                   color={config.color}
+                  opacity={config.opacity}
                   style={config.style}
                   strokeWidth={config.strokeWidth}
                   curve={config.curve}

--- a/packages/app/src/components/time-series-chart/logic/series.ts
+++ b/packages/app/src/components/time-series-chart/logic/series.ts
@@ -70,6 +70,7 @@ export interface GappedLineSeriesDefinition<T extends TimestampedValue> extends 
   label: string;
   shortLabel?: string;
   color: string;
+  opacity?: number;
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   curve?: 'linear' | 'step';
@@ -81,6 +82,7 @@ export interface LineSeriesDefinition<T extends TimestampedValue> extends Series
   label: string;
   shortLabel?: string;
   color: string;
+  opacity?: number;
   style?: 'solid' | 'dashed';
   strokeWidth?: number;
   curve?: 'linear' | 'step';

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -1,22 +1,22 @@
+import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
+import { Box } from '~/components/base';
+import { ChartTile } from '~/components/chart-tile';
+import { ChartTimeControls } from '~/components/chart-time-controls';
 import { colors, NlSewer, SewerPerInstallationData, TimeframeOption, TimeframeOptionsList } from '@corona-dashboard/common';
+import { isPresent } from 'ts-is-present';
+import { mediaQueries, space } from '~/style/theme';
+import { mergeData, useSewerStationSelectPropsSimplified } from './logic';
+import { RichContentSelect } from '~/components/rich-content-select';
+import styled from 'styled-components';
+import { Text } from '~/components/typography';
+import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
+import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
-import { isPresent } from 'ts-is-present';
-import { Warning } from '@corona-dashboard/icons';
-import { Box } from '~/components/base';
-import { Text } from '~/components/typography';
-import { ChartTile } from '~/components/chart-tile';
-import { RichContentSelect } from '~/components/rich-content-select';
-import { TimeSeriesChart } from '~/components/time-series-chart';
-import { AccessibilityDefinition } from '~/utils/use-accessibility-annotations';
-import { WarningTile } from '~/components/warning-tile';
-import { mergeData, useSewerStationSelectPropsSimplified } from './logic';
-import { useIntl } from '~/intl';
-import { mediaQueries, space } from '~/style/theme';
 import { useScopedWarning } from '~/utils/use-scoped-warning';
-import { TimelineEventConfig } from '~/components/time-series-chart/components/timeline';
-import { ChartTimeControls } from '~/components/chart-time-controls';
-import styled from 'styled-components';
+import { useIntl } from '~/intl';
+import { Warning } from '@corona-dashboard/icons';
+import { WarningTile } from '~/components/warning-tile';
 
 interface SewerChartProps {
   /**
@@ -183,16 +183,17 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
             seriesConfig={[
               {
                 type: 'line',
-                metricProperty: 'selected_installation_rna_normalized',
-                label: text.rwziLabel ? `${text.rwziLabel} ${selectedInstallation}` : selectedInstallation,
-                color: colors.orange1,
-              },
-              {
-                type: 'line',
                 metricProperty: 'average',
                 label: text.averagesLegendLabel,
                 shortLabel: text.averagesTooltipLabel,
                 color: colors.scale.blue[3],
+              },
+              {
+                type: 'line',
+                metricProperty: 'selected_installation_rna_normalized',
+                label: text.rwziLabel ? `${text.rwziLabel} ${selectedInstallation}` : selectedInstallation,
+                color: colors.orange4,
+                strokeWidth: 1,
               },
             ]}
             dataOptions={dataOptions}

--- a/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
+++ b/packages/app/src/domain/sewer/sewer-chart/sewer-chart.tsx
@@ -192,7 +192,8 @@ export const SewerChart = ({ accessibility, dataAverages, dataPerInstallation, t
                 type: 'line',
                 metricProperty: 'selected_installation_rna_normalized',
                 label: text.rwziLabel ? `${text.rwziLabel} ${selectedInstallation}` : selectedInstallation,
-                color: colors.orange4,
+                color: colors.orange1,
+                opacity: 0.7,
                 strokeWidth: 1,
               },
             ]}

--- a/packages/common/src/theme/colors.ts
+++ b/packages/common/src/theme/colors.ts
@@ -52,6 +52,7 @@ const colorDefinitions = {
   orange1: '#E37321',
   orange2: '#A14E00',
   orange3: '#F65234',
+  orange4: 'rgba(227,115,33,0.7)',
   //Yellow scales
   yellow1: '#FFF4C1',
   yellow2: '#fee670',

--- a/packages/common/src/theme/colors.ts
+++ b/packages/common/src/theme/colors.ts
@@ -52,7 +52,6 @@ const colorDefinitions = {
   orange1: '#E37321',
   orange2: '#A14E00',
   orange3: '#F65234',
-  orange4: 'rgba(227,115,33,0.7)',
   //Yellow scales
   yellow1: '#FFF4C1',
   yellow2: '#fee670',


### PR DESCRIPTION
## Summary
 
* Added `opacity` parameter to timeseries chart
* Moved orange line behind blue line in RWZI graphs
* Changed stroke width and opacity for RWZI line in virus particles through time graph
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/61b685c6-3480-4eca-b5f2-8cbb452b32ca)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/82739371-cdb5-4326-9576-b8c2c45dcbd6)

</details>