### PR TITLE
fix(COR-1914): Replace metric in replaceInaccurateLastValue function

### DIFF
--- a/packages/app/src/static-props/get-data.ts
+++ b/packages/app/src/static-props/get-data.ts
@@ -310,7 +310,7 @@ export function createGetArchivedChoroplethData<T1, T2>(settings?: {
  * This is meant to be a temporary fix until this is done on the backend.
  */
 function replaceInaccurateLastValue(data: any) {
-  const metricsInaccurateItems = ['intensive_care_nice', 'hospital_nice'];
+  const metricsInaccurateItems = ['intensive_care_nice', 'hospital_nice_archived_20240228'];
 
   const inaccurateMetricProperties = ['admissions_on_date_of_admission_moving_average_rounded', 'admissions_in_the_last_7_days'];
 


### PR DESCRIPTION
## Summary
 
* Updated metric name to archived metric in `replaceInaccurateLastValues()` function