### PR TITLE
fix(COR-1931): Remove marker element

### DIFF
--- a/packages/app/src/components/aside/menu.tsx
+++ b/packages/app/src/components/aside/menu.tsx
@@ -109,24 +109,24 @@ export function MenuItemLink({ href, title, icon, isLinkForMainMenu = true }: Me
 
   if (!href) {
     return (
-      <li>
+      <StyledMenuItemLinkBox>
         <Unavailable>
           <AsideTitle title={title} />
         </Unavailable>
-      </li>
+      </StyledMenuItemLinkBox>
     );
   }
 
   const isActive = isActivePath(router, href);
 
   return (
-    <li>
+    <StyledMenuItemLinkBox>
       <Link href={href} passHref>
         <StyledAnchor isActive={breakpoints.md && isActive} isLinkForMainMenu={isLinkForMainMenu} aria-current={isActive ? 'page' : undefined}>
           <AsideTitle icon={icon} title={title} showArrow={!breakpoints.md || !isActive} />
         </StyledAnchor>
       </Link>
-    </li>
+    </StyledMenuItemLinkBox>
   );
 }
 
@@ -202,6 +202,14 @@ const StyledAnchor = styled(Anchor)<{ isActive: boolean; isLinkForMainMenu: bool
     },
   })
 );
+
+const StyledMenuItemLinkBox = styled.li`
+  list-style-type: none;
+
+  li:last-child div {
+    margin: 0;
+  }
+`;
 
 const Icon = ({ children }: { children: ReactNode }) => {
   return (


### PR DESCRIPTION
## Summary
 
* Removed default li element glyph from LI 
 
### Screenshots
#### Before
<details>
<summary>Toggle before screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/e4ab683a-16cc-4aba-a568-c65bb9c55826)

</details>
 
#### After
<details>
<summary>Toggle after screenshots</summary>
 
![image](https://github.com/minvws/nl-covid19-data-dashboard/assets/137172332/ec55741e-f29d-4d2c-a96b-3cc84b8fc2c3)

</details>