### PR TITLE
release/2.88.0.02

### DIFF
--- a/packages/app/src/components/page-information-block/components/metadata.tsx
+++ b/packages/app/src/components/page-information-block/components/metadata.tsx
@@ -140,7 +140,7 @@ function MetadataItem({ icon, label, items, referenceLink, accessibilityText, ac
             {`${label}: `}
             {items.map((item, index) => (
               <Fragment key={index + item.href}>
-                {index > 0 && index !== items.length && ', '}
+                {index > 0 && ', '}
                 {item.href && (
                   <ExternalLink
                     href={item.href}

--- a/packages/app/src/pages/gemeente/[code]/de-coronaprik.tsx
+++ b/packages/app/src/pages/gemeente/[code]/de-coronaprik.tsx
@@ -21,7 +21,6 @@ import { PageInformationBlock } from '~/components/page-information-block/page-i
 import { TileList } from '~/components/tile-list';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { Vaccinaties as VaccinatieIcon } from '@corona-dashboard/icons';
 import { VaccineCoverageChoropleth } from '~/domain/vaccine/vaccine-coverage-choropleth';
@@ -86,7 +85,6 @@ export const getStaticProps = createGetStaticProps(
 );
 
 export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) => {
-  const router = useRouter();
   const { pageText, archivedChoropleth, municipalityName, selectedGmData: currentData, selectedArchivedGmData: archivedData, content, lastGenerated } = props;
   const { commonTexts } = useIntl();
   const { formatPercentageAsNumber } = useFormatLokalizePercentage();
@@ -143,9 +141,9 @@ export const VaccinationsGmPage = (props: StaticProps<typeof getStaticProps>) =>
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textShared.bronnen.rivm],
               jsonSources: [
-                getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_municipality_json),
-                getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_archived_municipality_json),
-                jsonText.metrics_archived_gm_collection_json,
+                getMunicipalityJsonLink(reverseRouter.json.municipality(currentData.code), jsonText.metrics_municipality_json.text),
+                getMunicipalityJsonLink(reverseRouter.json.archivedMunicipality(currentData.code), jsonText.metrics_archived_municipality_json.text),
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
               ],
             }}
             vrNameOrGmName={municipalityName}

--- a/packages/app/src/pages/gemeente/[code]/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/gemeente/[code]/patienten-in-beeld.tsx
@@ -30,7 +30,6 @@ import { TimeSeriesChart } from '~/components/time-series-chart/time-series-char
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { Ziekenhuis } from '@corona-dashboard/icons';
 
@@ -79,7 +78,6 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
-  const router = useRouter();
   const { pageText, selectedArchivedGmData: data, archivedChoropleth, municipalityName, content, lastGenerated } = props;
   const [isArchivedContentShown, setIsArchivedContentShown] = useState<boolean>(false);
 
@@ -129,9 +127,9 @@ function IntakeHospital(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
               jsonSources: [
-                getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_municipality_json),
-                jsonText.metrics_gm_collection_json,
-                jsonText.metrics_archived_gm_collection_json,
+                getMunicipalityJsonLink(reverseRouter.json.municipality(data.code), jsonText.metrics_municipality_json.text),
+                { href: reverseRouter.json.gmCollection(), text: jsonText.metrics_gm_collection_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
               ],
             }}
             pageLinks={content.links}

--- a/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
+++ b/packages/app/src/pages/gemeente/[code]/positieve-testen.tsx
@@ -32,7 +32,6 @@ import { TimeSeriesChart } from '~/components/time-series-chart/time-series-char
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -81,7 +80,6 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
-  const router = useRouter();
   const { pageText, selectedGmData: data, selectedArchivedGmData: archivedData, archivedChoropleth, municipalityName, content, lastGenerated } = props;
   const [positivelyTestedPeopleTimeframe, setpositivelyTestedPeopleTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const { commonTexts, formatNumber, formatDateFromSeconds } = useIntl();
@@ -119,9 +117,9 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
               jsonSources: [
-                getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_municipality_json),
-                getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_archived_municipality_json),
-                jsonText.metrics_archived_gm_collection_json,
+                getMunicipalityJsonLink(reverseRouter.json.municipality(data.code), jsonText.metrics_municipality_json.text),
+                getMunicipalityJsonLink(reverseRouter.json.archivedMunicipality(data.code), jsonText.metrics_archived_municipality_json.text),
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
               ],
             }}
             vrNameOrGmName={municipalityName}

--- a/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
+++ b/packages/app/src/pages/gemeente/[code]/rioolwater.tsx
@@ -26,7 +26,7 @@ import { TileList } from '~/components/tile-list';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
-import { useRouter } from 'next/router';
+import { useReverseRouter } from '~/utils';
 import { WarningTile } from '~/components/warning-tile';
 
 const pageMetrics = ['sewer_per_installation', 'sewer'];
@@ -63,7 +63,9 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
 
   const { commonTexts, formatNumber } = useIntl();
   const { textGm, textShared, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
-  const router = useRouter();
+
+  const reverseRouter = useReverseRouter();
+
   const sewerAverages = data.sewer;
   const sewerInstallationMeasurement = data.sewer_installation_measurement;
   const populationCountConnectedToRWZIS = data.static_values.population_count_connected_to_rwzis;
@@ -108,7 +110,7 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               },
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.bronnen.rivm],
-              jsonSources: [getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_municipality_json)],
+              jsonSources: [getMunicipalityJsonLink(reverseRouter.json.municipality(data.code), jsonText.metrics_municipality_json.text)],
             }}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}

--- a/packages/app/src/pages/gemeente/[code]/sterfte.tsx
+++ b/packages/app/src/pages/gemeente/[code]/sterfte.tsx
@@ -16,7 +16,7 @@ import { Languages, SiteText } from '~/locale';
 import { PageArticlesTile } from '~/components/articles/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block/page-information-block';
-import { replaceVariablesInText } from '~/utils';
+import { replaceVariablesInText, useReverseRouter } from '~/utils';
 import { StaticProps, createGetStaticProps } from '~/static-props/create-get-static-props';
 import { TileList } from '~/components/tile-list';
 import { TimeframeOption, TimeframeOptionsList, colors } from '@corona-dashboard/common';
@@ -24,7 +24,6 @@ import { TimeSeriesChart } from '~/components/time-series-chart/time-series-char
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
-import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -68,7 +67,8 @@ export const getStaticProps = createGetStaticProps(
 );
 
 const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
-  const router = useRouter();
+  const reverseRouter = useReverseRouter();
+
   const { pageText, municipalityName, selectedArchivedGmData: data, content, lastGenerated } = props;
 
   const [deceasedMunicipalTimeframe, setDeceasedMunicipalTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
@@ -107,7 +107,7 @@ const DeceasedMunicipalPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: data.deceased_rivm_archived_20221231.last_value.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textGm.section_deceased_rivm.bronnen.rivm],
-              jsonSources: [getMunicipalityJsonLink(router.query.code as string, jsonText.metrics_archived_municipality_json)],
+              jsonSources: [getMunicipalityJsonLink(reverseRouter.json.municipality(data.code), jsonText.metrics_archived_municipality_json.text)],
             }}
             vrNameOrGmName={municipalityName}
             warning={textGm.warning}

--- a/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
+++ b/packages/app/src/pages/landelijk/besmettelijke-mensen.tsx
@@ -1,24 +1,25 @@
-import { colors, getLastFilledValue } from '@corona-dashboard/common';
-import { Ziektegolf } from '@corona-dashboard/icons';
-import { GetStaticPropsContext } from 'next';
+import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { ChartTile } from '~/components/chart-tile';
+import { colors, getLastFilledValue } from '@corona-dashboard/common';
+import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectArchivedNlData } from '~/static-props/get-data';
+import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
+import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
+import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { GetStaticPropsContext } from 'next';
 import { InView } from '~/components/in-view';
+import { Languages, SiteText } from '~/locale';
+import { Layout } from '~/domain/layout/layout';
+import { NlLayout } from '~/domain/layout/nl-layout';
 import { PageArticlesTile } from '~/components/articles/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
-import { WarningTile } from '~/components/warning-tile';
-import { Layout } from '~/domain/layout/layout';
-import { NlLayout } from '~/domain/layout/nl-layout';
-import { useIntl } from '~/intl';
-import { Languages, SiteText } from '~/locale';
-import { getArticleParts, getDataExplainedParts, getFaqParts, getPagePartsQuery } from '~/queries/get-page-parts-query';
-import { createGetStaticProps, StaticProps } from '~/static-props/create-get-static-props';
-import { createGetContent, getLastGeneratedDate, getLokalizeTexts, selectArchivedNlData } from '~/static-props/get-data';
-import { ArticleParts, PagePartQueryResult } from '~/types/cms';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
-import { getPageInformationHeaderContent } from '~/utils/get-page-information-header-content';
+import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
+import { WarningTile } from '~/components/warning-tile';
+import { Ziektegolf } from '@corona-dashboard/icons';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
   metadataTexts: siteText.pages.topical_page.nl.nationaal_metadata,
@@ -50,6 +51,8 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
   const { commonTexts } = useIntl();
   const { metadataTexts, textNl, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
+  const reverseRouter = useReverseRouter();
+
   const lastFullValue = getLastFilledValue(data.infectious_people_archived_20210709);
 
   const metadata = {
@@ -75,7 +78,7 @@ const InfectiousPeople = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: lastFullValue.date_unix,
               dateOfInsertionUnix: lastFullValue.date_of_insertion_unix,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/corona-thermometer.tsx
+++ b/packages/app/src/pages/landelijk/corona-thermometer.tsx
@@ -27,6 +27,7 @@ import { Timeline } from '~/components/severity-indicator-tile/components/timeli
 import { TimelineMarker } from '~/components/time-series-chart/components/timeline';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import styled from 'styled-components';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
@@ -68,6 +69,8 @@ const CoronaThermometer = (props: StaticProps<typeof getStaticProps>) => {
 
   const { textNl, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
 
+  const reverseRouter = useReverseRouter();
+
   const metadata = {
     ...textNl.metadata,
     title: textNl.metadata.title,
@@ -104,7 +107,7 @@ const CoronaThermometer = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: endDate,
               dateOfInsertionUnix: endDate,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/coronamelder.tsx
+++ b/packages/app/src/pages/landelijk/coronamelder.tsx
@@ -12,6 +12,7 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -32,6 +33,8 @@ export const getStaticProps = createGetStaticProps(
 const CoronamelderPage = (props: StaticProps<typeof getStaticProps>) => {
   const [coronamelderTimeframe, setCoronamelderTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const { commonTexts } = useIntl();
+
+  const reverseRouter = useReverseRouter();
 
   const { pageText, selectedArchivedNlData: data, lastGenerated } = props;
   const { corona_melder_app } = commonTexts;
@@ -62,7 +65,7 @@ const CoronamelderPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: warningLastValue.date_unix,
               dateOfInsertionUnix: warningLastValue.date_of_insertion_unix,
               dataSources: [corona_melder_app.header.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
           />
 

--- a/packages/app/src/pages/landelijk/de-coronaprik.tsx
+++ b/packages/app/src/pages/landelijk/de-coronaprik.tsx
@@ -181,10 +181,10 @@ function VaccinationPage(props: StaticProps<typeof getStaticProps>) {
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textShared.bronnen.rivm],
               jsonSources: [
-                jsonText.metrics_national_json,
-                jsonText.metrics_archived_national_json,
-                jsonText.metrics_gm_collection_json,
-                jsonText.metrics_archived_gm_collection_json,
+                { href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text },
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+                { href: reverseRouter.json.gmCollection(), text: jsonText.metrics_gm_collection_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
               ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({

--- a/packages/app/src/pages/landelijk/gedrag.tsx
+++ b/packages/app/src/pages/landelijk/gedrag.tsx
@@ -29,6 +29,7 @@ import { useBehaviorLookupKeys } from '~/domain/behavior/logic/use-behavior-look
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
 import { useMemo, useRef, useState } from 'react';
+import { useReverseRouter } from '~/utils';
 import { WarningTile } from '~/components/warning-tile';
 
 const pageMetrics = ['behavior_archived_20230411', 'behavior_annotations_archived_20230412', 'behavior_per_age_group_archived_20230411'];
@@ -66,6 +67,8 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
   const behaviorValues = data.behavior_archived_20230411.values;
   const behaviorAnnotations = data.behavior_annotations_archived_20230412;
   const behaviorPerAgeGroup = data.behavior_per_age_group_archived_20230411;
+
+  const reverseRouter = useReverseRouter();
 
   const { commonTexts, formatNumber, formatDateFromSeconds, formatPercentage, locale } = useIntl();
   const { metadataTexts, text, textNl, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
@@ -132,7 +135,7 @@ export default function BehaviorPage(props: StaticProps<typeof getStaticProps>) 
               },
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
+++ b/packages/app/src/pages/landelijk/gehandicaptenzorg.tsx
@@ -25,6 +25,7 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -75,6 +76,8 @@ export const getStaticProps = createGetStaticProps(
 function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedArchivedNlData: data, archivedChoropleth, lastGenerated, content } = props;
 
+  const reverseRouter = useReverseRouter();
+
   const [disabilityCareConfirmedCasesTimeframe, setDisabilityCareConfirmedCasesTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const [disabilityCareInfectedLocationsTimeframe, setDisabilityCareInfectedLocationsTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const [disabilityCareDeceasedTimeframe, setDisabilityCareDeceasedTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
@@ -109,7 +112,10 @@ function DisabilityCare(props: StaticProps<typeof getStaticProps>) {
               dateOrRange: lastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.positief_geteste_personen.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json, jsonText.metrics_archived_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/infectieradar.tsx
+++ b/packages/app/src/pages/landelijk/infectieradar.tsx
@@ -18,7 +18,7 @@ import { NlLayout } from '~/domain/layout/nl-layout';
 import { PageArticlesTile } from '~/components/articles/page-articles-tile';
 import { PageFaqTile } from '~/components/page-faq-tile';
 import { PageInformationBlock } from '~/components/page-information-block';
-import { replaceVariablesInText } from '~/utils';
+import { replaceVariablesInText, useReverseRouter } from '~/utils';
 import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
@@ -64,6 +64,8 @@ export const getStaticProps = createGetStaticProps(
 const InfectionRadar = (props: StaticProps<typeof getStaticProps>) => {
   const { pageText, selectedNlData: data, content, lastGenerated } = props;
 
+  const reverseRouter = useReverseRouter();
+
   const [confirmedCasesSelfTestedTimeframe, setConfirmedCasesSelfTestedTimeframe] = useState<TimeframeOption>(TimeframeOption.SIX_MONTHS);
 
   const [confirmedCasesCovidSymptomsPerAgeTimeFrame, setConfirmedCasesCovidSymptomsPerAgeTimeFrame] = useState<TimeframeOption>(TimeframeOption.THREE_MONTHS);
@@ -100,7 +102,7 @@ const InfectionRadar = (props: StaticProps<typeof getStaticProps>) => {
               },
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.rivm],
-              jsonSources: [jsonText.metrics_national_json],
+              jsonSources: [{ href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text }],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/klachten-bij-huisartsen.tsx
+++ b/packages/app/src/pages/landelijk/klachten-bij-huisartsen.tsx
@@ -11,6 +11,7 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { WarningTile } from '~/components/warning-tile';
 
 const selectLokalizeTexts = (siteText: SiteText) => ({
@@ -28,6 +29,8 @@ export const getStaticProps = createGetStaticProps(
 
 const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
   const { pageText, selectedArchivedNlData: archivedData, lastGenerated } = props;
+  const reverseRouter = useReverseRouter();
+
   const lastValue = archivedData.doctor_archived_20210903.last_value;
   const { metadataTexts, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
   const { commonTexts } = useIntl();
@@ -56,7 +59,7 @@ const SuspectedPatients = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: lastValue.date_end_unix,
               dateOfInsertionUnix: lastValue.date_of_insertion_unix,
               dataSources: [text.bronnen.nivel],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
           />
 

--- a/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/kwetsbare-groepen-70-plussers.tsx
@@ -31,6 +31,7 @@ import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -93,6 +94,8 @@ export const getStaticProps = createGetStaticProps(
 function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
   const { pageText, selectedArchivedNlData: data, archivedChoropleth, lastGenerated, content } = props;
 
+  const reverseRouter = useReverseRouter();
+
   const [nursingHomeConfirmedCasesTimeframe, setNursingHomeConfirmedCasesTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
   const [nursingHomeInfectedLocationsTimeframe, setNursingHomeInfectedLocationsTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
@@ -137,7 +140,10 @@ function VulnerableGroups(props: StaticProps<typeof getStaticProps>) {
               dateOrRange: vulnerableNursingHomeDataLastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [positiveTestedPeopleText.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json, jsonText.metrics_archived_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/patienten-in-beeld.tsx
@@ -150,7 +150,10 @@ const PatientsPage = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: lastValueNice.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.nice],
-              jsonSources: [jsonText.metrics_national_json, jsonText.metrics_archived_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
+              ],
             }}
             pageLinks={content.links}
             pageInformationHeader={getPageInformationHeaderContent({

--- a/packages/app/src/pages/landelijk/positieve-testen.tsx
+++ b/packages/app/src/pages/landelijk/positieve-testen.tsx
@@ -131,7 +131,10 @@ function PositivelyTestedPeople(props: StaticProps<typeof getStaticProps>) {
               dateOrRange: archivedDataOverallLastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json, jsonText.metrics_archived_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/reproductiegetal.tsx
+++ b/packages/app/src/pages/landelijk/reproductiegetal.tsx
@@ -23,6 +23,7 @@ import { TileList } from '~/components/tile-list';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { WarningTile } from '~/components/warning-tile';
 
 const pageMetrics = ['reproduction_archived_20230711'];
@@ -65,6 +66,8 @@ export const getStaticProps = createGetStaticProps(
 const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
   const { pageText, selectedArchivedNlData: data, content, lastGenerated } = props;
 
+  const reverseRouter = useReverseRouter();
+
   const reproductionLastValue = getLastFilledValue(data.reproduction_archived_20230711);
   const reproductionValues = data.reproduction_archived_20230711;
 
@@ -96,7 +99,7 @@ const ReproductionIndex = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: reproductionLastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json],
+              jsonSources: [{ href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text }],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/rioolwater.tsx
+++ b/packages/app/src/pages/landelijk/rioolwater.tsx
@@ -103,7 +103,10 @@ const SewerWater = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: sewerAverages.last_value.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_national_json, jsonText.metrics_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text },
+                { href: reverseRouter.json.gmCollection(), text: jsonText.metrics_gm_collection_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/sterfte.tsx
+++ b/packages/app/src/pages/landelijk/sterfte.tsx
@@ -27,6 +27,7 @@ import { TimeSeriesChart } from '~/components/time-series-chart';
 import { TwoKpiSection } from '~/components/two-kpi-section';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -75,6 +76,8 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
   const [deceasedOverTimeTimeframe, setDeceasedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
   const [isArchivedContentShown, setIsArchivedContentShown] = useState<boolean>(false);
 
+  const reverseRouter = useReverseRouter();
+
   const dataCbs = currentData.deceased_cbs;
   const dataRivm = archivedData.deceased_rivm_archived_20221231;
   const dataDeceasedPerAgeGroup = archivedData.deceased_rivm_per_age_group_archived_20221231;
@@ -110,7 +113,10 @@ const DeceasedNationalPage = (props: StaticProps<typeof getStaticProps>) => {
               },
               dateOfInsertionUnix: dataCbs.last_value.date_of_insertion_unix,
               dataSources: [textNl.section_sterftemonitor.bronnen.cbs],
-              jsonSources: [jsonText.metrics_national_json, jsonText.metrics_archived_national_json],
+              jsonSources: [
+                { href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text },
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/thuiswonende-70-plussers.tsx
+++ b/packages/app/src/pages/landelijk/thuiswonende-70-plussers.tsx
@@ -25,6 +25,7 @@ import { TileList } from '~/components/tile-list';
 import { TimeSeriesChart } from '~/components/time-series-chart';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { WarningTile } from '~/components/warning-tile';
 
@@ -69,6 +70,7 @@ export const getStaticProps = createGetStaticProps(
 );
 
 function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
+  const reverseRouter = useReverseRouter();
   const { pageText, selectedArchivedNlData: data, archivedChoropleth, lastGenerated, content } = props;
   const [elderlyAtHomeConfirmedCasesTimeframe, setElderlyAtHomeConfirmedCasesTimeframe] = useState<TimeframeOption>(TimeframeOption.ALL);
 
@@ -108,7 +110,10 @@ function ElderlyAtHomeNationalPage(props: StaticProps<typeof getStaticProps>) {
               dateOrRange: elderlyAtHomeData.last_value.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.section_positive_tested.bronnen.rivm],
-              jsonSources: [jsonText.metrics_archived_national_json, jsonText.metrics_archived_gm_collection_json],
+              jsonSources: [
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+                { href: reverseRouter.json.archivedGmCollection(), text: jsonText.metrics_archived_gm_collection_json.text },
+              ],
             }}
             pageInformationHeader={getPageInformationHeaderContent({
               dataExplained: content.dataExplained,

--- a/packages/app/src/pages/landelijk/varianten.tsx
+++ b/packages/app/src/pages/landelijk/varianten.tsx
@@ -18,6 +18,7 @@ import { StaticProps, createGetStaticProps } from '~/static-props/create-get-sta
 import { TileList } from '~/components/tile-list';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 import { VariantDynamicLabels } from '~/domain/variants/data-selection/types';
 import { Varianten } from '@corona-dashboard/icons';
@@ -91,6 +92,8 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
     dates,
   } = props;
 
+  const reverseRouter = useReverseRouter();
+
   const { commonTexts, locale } = useIntl();
   const { metadataTexts, textNl, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
   const [isArchivedContentShown, setIsArchivedContentShown] = useState<boolean>(false);
@@ -139,7 +142,10 @@ export default function CovidVariantenPage(props: StaticProps<typeof getStaticPr
               },
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.bronnen.rivm],
-              jsonSources: [jsonText.metrics_national_json, jsonText.metrics_archived_national_json],
+              jsonSources: [
+                { href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text },
+                { href: reverseRouter.json.archivedNational(), text: jsonText.metrics_archived_national_json.text },
+              ],
             }}
             pageLinks={content.links}
             pageInformationHeader={getPageInformationHeaderContent({

--- a/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
+++ b/packages/app/src/pages/landelijk/ziekenhuizen-in-beeld.tsx
@@ -23,6 +23,7 @@ import { TimeSeriesChart } from '~/components/time-series-chart';
 import { trimLeadingNullValues } from '~/utils/trim-leading-null-values';
 import { useDynamicLokalizeTexts } from '~/utils/cms/use-dynamic-lokalize-texts';
 import { useIntl } from '~/intl';
+import { useReverseRouter } from '~/utils';
 import { useState } from 'react';
 
 const pageMetrics = [
@@ -73,6 +74,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
   const { pageText, selectedNlData: data, content, lastGenerated } = props;
   const { metadataTexts, textNl, jsonText } = useDynamicLokalizeTexts<LokalizeTexts>(pageText, selectLokalizeTexts);
   const { commonTexts } = useIntl();
+  const reverseRouter = useReverseRouter();
 
   const [selectedBedsOccupiedOverTimeChart, setSelectedBedsOccupiedOverTimeChart] = useState<string>('beds_occupied_covid_hospital');
   const [hospitalBedsOccupiedOverTimeTimeframe, setHospitalBedsOccupiedOverTimeTimeframe] = useState<TimeframeOption>(TimeframeOption.THIRTY_DAYS);
@@ -130,7 +132,7 @@ const HospitalsAndCarePage = (props: StaticProps<typeof getStaticProps>) => {
               dateOrRange: hospitalLastValue.date_unix,
               dateOfInsertionUnix: lastInsertionDateOfPage,
               dataSources: [textNl.sources.lnaz],
-              jsonSources: [jsonText.metrics_national_json],
+              jsonSources: [{ href: reverseRouter.json.national(), text: jsonText.metrics_national_json.text }],
             }}
             pageLinks={content.links}
             pageInformationHeader={getPageInformationHeaderContent({

--- a/packages/app/src/utils/get-json-links.ts
+++ b/packages/app/src/utils/get-json-links.ts
@@ -1,14 +1,8 @@
-import { replaceVariablesInText } from './replace-variables-in-text';
-
 interface DataSource {
   href: string;
   text: string;
 }
 
-export const getMunicipalityJsonLink = (code: string, dataSource: DataSource): DataSource => {
-  if (code) {
-    dataSource.href = replaceVariablesInText(dataSource.href, { code: code });
-  }
-
-  return dataSource;
+export const getMunicipalityJsonLink = (dataSourceHref: string, dataSourceText: string): DataSource => {
+  return { href: dataSourceHref, text: dataSourceText };
 };

--- a/packages/cms/src/lokalize/key-mutations.csv
+++ b/packages/cms/src/lokalize/key-mutations.csv
@@ -21,3 +21,9 @@ timestamp,action,key,document_id,move_to
 2024-02-22T14:51:00.317Z,add,common.common.metadata.metrics_json_links.metrics_gm_collection_json.text,LEQIG0OTDngFQu9E9HHLOA,__
 2024-02-22T14:51:01.330Z,add,common.common.metadata.metrics_json_links.metrics_archived_gm_collection_json.href,VWkwBKrnqfeEle0Dvjc5hg,__
 2024-02-22T14:51:02.347Z,add,common.common.metadata.metrics_json_links.metrics_archived_gm_collection_json.text,CEYjXN3lO3X17pY2n57mro,__
+2024-03-05T12:31:49.299Z,delete,common.common.metadata.metrics_json_links.metrics_archived_gm_collection_json.href,VWkwBKrnqfeEle0Dvjc5hg,__
+2024-03-05T12:31:49.300Z,delete,common.common.metadata.metrics_json_links.metrics_archived_municipality_json.href,aFg4DQ8VnKtfWX3L7ofdtJ,__
+2024-03-05T12:31:49.300Z,delete,common.common.metadata.metrics_json_links.metrics_archived_national_json.href,BDRHgHFora2UCq5UG30sKP,__
+2024-03-05T12:31:49.301Z,delete,common.common.metadata.metrics_json_links.metrics_gm_collection_json.href,UTNNzvANEIshqW3hB5Uu1r,__
+2024-03-05T12:31:49.301Z,delete,common.common.metadata.metrics_json_links.metrics_municipality_json.href,CEYjXN3lO3X17pY2n57knM,__
+2024-03-05T12:31:49.301Z,delete,common.common.metadata.metrics_json_links.metrics_national_json.href,2z0g0X7Nweo2izzuiKMmnu,__

--- a/packages/common/src/data/reverse-router.ts
+++ b/packages/common/src/data/reverse-router.ts
@@ -46,6 +46,15 @@ export function getReverseRouter(isMobile: boolean) {
       deCoronaprik: (code: string) => `/gemeente/${code}/de-coronaprik`,
       lijstweergave: () => '/gemeente/lijstweergave',
     },
+
+    json: {
+      national: () => `/json/NL.json`,
+      archivedNational: () => `/json/archived/NL.json`,
+      municipality: (code: string) => `/json/${code}.json`,
+      archivedMunicipality: (code: string) => `/json/archived/${code}.json`,
+      gmCollection: () => `/json/GM_COLLECTION.json`,
+      archivedGmCollection: () => `/json/archived/GM_COLLECTION.json`,
+    },
   } as const;
 
   return reverseRouter;


### PR DESCRIPTION
## What's Changed
* feature/COR-1920_adjust-Y-axis-to-not-change-on-mobile by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4985
* task/COR-1948_add-comments-in-the-code-for-show-all-function by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4986
* chore(deps): bump ip from 1.1.5 to 1.1.9 by @dependabot in https://github.com/minvws/nl-covid19-data-dashboard/pull/4983
* feature(COR-1939): Added tooltip year for date range values by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4987
* feature/COR-1921_add-link-to-JSON-blobs-page-information-blocks by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4984
* feature/COR-1914_archive-view-on-patients-choropleth by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4982
* fix(COR-1914): Fixed wrong page metric target by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4990
* feature/COR-1917_site-archive-compatible-gemeente-map by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4989
* fix(COR-1914): Replace metric in replaceInaccurateLastValue function by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4991
* fix(COR-1931): Remove marker element by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4992
* fix(COR-1917): Fixed flex issue with new layout components by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4993
* chore(deps): bump es5-ext from 0.10.53 to 0.10.64 by @dependabot in https://github.com/minvws/nl-covid19-data-dashboard/pull/4994
* chore(deps): bump vite from 4.3.9 to 4.5.2 by @dependabot in https://github.com/minvws/nl-covid19-data-dashboard/pull/4971
* fix(COR-1917): Fixed automatic section open on letter click by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4995
* hotfix(COR-1921): Fixed missing comma for last json link by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/4997
* hotfix/COR-1921-fix-merged-json-links by @ben-van-eekelen in https://github.com/minvws/nl-covid19-data-dashboard/pull/4999
* fix(COR-1921): Fixed code being wrong in JSON metric links by @VWSCoronaDashboard30 in https://github.com/minvws/nl-covid19-data-dashboard/pull/5000


**Full Changelog**: https://github.com/minvws/nl-covid19-data-dashboard/compare/2.87.0...2.88.0